### PR TITLE
Alignment: Add shortcuts for alignment options

### DIFF
--- a/gaphor/plugins/alignment/__init__.py
+++ b/gaphor/plugins/alignment/__init__.py
@@ -69,7 +69,7 @@ class Alignment(object):
         return [item.matrix[5] + item.height for item in items]
 
     @action(name='align-left', label='Left',
-            tooltip="Vertically align diagram elements on the left")
+            tooltip="Vertically align diagram elements on the left", accel='<control><shift>l')
     @transactional
     def align_left(self):
         items = self.get_items()
@@ -80,7 +80,7 @@ class Alignment(object):
             item.request_update()
 	
     @action(name='align-center', label='Center',
-            tooltip="Vertically align diagram elements on their centers")
+            tooltip="Vertically align diagram elements on their centers", accel='<control><shift>c')
     @transactional
     def align_center(self):
         items = self.get_items()
@@ -93,7 +93,7 @@ class Alignment(object):
             item.request_update()
 	
     @action(name='align-right', label='Right',
-            tooltip="Vertically align diagram elements on the right")
+            tooltip="Vertically align diagram elements on the right", accel='<control><shift>r')
     @transactional
     def align_right(self):
         items = self.get_items()
@@ -104,7 +104,7 @@ class Alignment(object):
             item.request_update()
 
     @action(name='align-top', label='Top',
-            tooltip="Horizontally align diagram elements on their tops")
+            tooltip="Horizontally align diagram elements on their tops", accel='<control><shift>t')
     @transactional
     def align_top(self):
         items = self.get_items()
@@ -115,7 +115,7 @@ class Alignment(object):
             item.request_update()
 	    
     @action(name='align-middle', label='Middle',
-            tooltip="Horizontally align diagram elements on their middles")
+            tooltip="Horizontally align diagram elements on their middles", accel='<control><shift>m')
     @transactional
     def align_middle(self):
         items = self.get_items()
@@ -128,7 +128,7 @@ class Alignment(object):
             item.request_update()
 	    
     @action(name='align-bottom', label='Bottom',
-            tooltip="Horizontally align diagram elements on their bottoms")
+            tooltip="Horizontally align diagram elements on their bottoms", accel='<control><shift>b')
     @transactional
     def align_bottom(self):
         items = self.get_items()


### PR DESCRIPTION
Shortcuts to access the alignment methods faster:

center: control-shift-c
left: control-shift-l
right: control-shift-r
top: control-shift-t
middle: control-shift-m
bottom: control-shift-b
