### PR TITLE
Update Diagrams to Open in Gtk.Notebook Pages

### DIFF
--- a/gaphor/plugins/checkmetamodel/checkmodelgui.py
+++ b/gaphor/plugins/checkmetamodel/checkmodelgui.py
@@ -117,8 +117,8 @@ class CheckModelWindow(object):
             except AttributeError:
                 presentation = element.namespace.presentation[0]
                 diagram = presentation.canvas.diagram
-            diagram_tab = main_window.show_diagram(diagram)
-            diagram_tab.view.focused_item = presentation
+            diagram_page = main_window.show_diagram(diagram)
+            diagram_page.view.focused_item = presentation
 
     def on_destroy(self, window):
         self.window = None

--- a/gaphor/plugins/checkmetamodel/checkmodelgui.py
+++ b/gaphor/plugins/checkmetamodel/checkmodelgui.py
@@ -3,19 +3,26 @@ A GUI for the checkmodel plugin.
 """
 from __future__ import print_function
 
+import logging
 from builtins import object
 
+import gi
+
+gi.require_version("Gtk", "3.0")
 from gi.repository import GObject
 from gi.repository import Gtk
 from zope.interface import implementer
 
 from gaphor.core import inject, action, build_action_group
+from gaphor.ui.diagrampage import DiagramPage
 from gaphor.interfaces import IService, IActionProvider
 from gaphor.plugins.checkmetamodel import checkmodel
 
 PYELEMENT_COLUMN = 0
 ELEMENT_COLUMN = 1
 REASON_COLUMN = 2
+
+log = logging.getLogger(__name__)
 
 
 @implementer(IService, IActionProvider)
@@ -110,14 +117,13 @@ class CheckModelWindow(object):
         element = self.model.get_value(iter, PYELEMENT_COLUMN)
         print("Looking for element", element)
         if element.presentation:
-            main_window = self.main_window
             presentation = element.presentation[0]
             try:
                 diagram = presentation.canvas.diagram
             except AttributeError:
                 presentation = element.namespace.presentation[0]
                 diagram = presentation.canvas.diagram
-            diagram_page = main_window.show_diagram(diagram)
+            diagram_page = DiagramPage(diagram)
             diagram_page.view.focused_item = presentation
 
     def on_destroy(self, window):

--- a/gaphor/services/diagramexportmanager.py
+++ b/gaphor/services/diagramexportmanager.py
@@ -56,7 +56,7 @@ class DiagramExportManager(object):
 
         self.logger.info("Updating")
 
-        tab = self.get_window().get_current_diagram_tab()
+        tab = self.get_window().get_current_diagram_page()
         self.sensitive = tab and True or False
 
     def save_dialog(self, diagram, title, ext):

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -34,7 +34,7 @@ from gaphor.ui.event import DiagramSelectionChange
 log = logging.getLogger(__name__)
 
 
-class DiagramTab(object):
+class DiagramPage(object):
 
     component_registry = inject("component_registry")
     element_factory = inject("element_factory")
@@ -112,7 +112,7 @@ class DiagramTab(object):
         view = GtkView(canvas=self.diagram.canvas)
         view.drag_dest_set(
             Gtk.DestDefaults.MOTION,
-            DiagramTab.VIEW_DND_TARGETS,
+            DiagramPage.VIEW_DND_TARGETS,
             Gdk.DragAction.MOVE | Gdk.DragAction.COPY | Gdk.DragAction.LINK,
         )
 
@@ -325,7 +325,7 @@ class DiagramTab(object):
         if (
             data
             and data.get_format() == 8
-            and info == DiagramTab.VIEW_TARGET_TOOLBOX_ACTION
+            and info == DiagramPage.VIEW_TARGET_TOOLBOX_ACTION
         ):
             tool = self.toolbox.get_tool(data.get_data().decode())
             tool.create_item((x, y))
@@ -333,7 +333,7 @@ class DiagramTab(object):
         elif (
             data
             and data.get_format() == 8
-            and info == DiagramTab.VIEW_TARGET_ELEMENT_ID
+            and info == DiagramPage.VIEW_TARGET_ELEMENT_ID
         ):
             # print('drag_data_received:', data.data, info)
             n, p = data.data.split("#")

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -84,7 +84,7 @@ class DiagramPage(object):
     def __init__(self, diagram):
         self.diagram = diagram
         self.view = None
-        # self.owning_window = owning_window
+        self.widget = None
         self.action_group = build_action_group(self)
         self.toolbox = None
         self.component_registry.register_handler(self._on_element_change)
@@ -121,6 +121,7 @@ class DiagramPage(object):
         scrolled_window.set_shadow_type(Gtk.ShadowType.IN)
         scrolled_window.add(view)
         scrolled_window.show_all()
+        self.widget = scrolled_window
 
         view.connect("focus-changed", self._on_view_selection_changed)
         view.connect("selection-changed", self._on_view_selection_changed)
@@ -132,12 +133,7 @@ class DiagramPage(object):
 
         self.toolbox = DiagramToolbox(self.diagram, view)
 
-        # item = DockItem(title=self.title, stock_id='gaphor-diagram')
-        # item.add(scrolled_window)
-        item = scrolled_window
-        self.widget = item
-
-        return item
+        return self.widget
 
     @component.adapter(IAttributeChangeEvent)
     def _on_element_change(self, event):

--- a/gaphor/ui/diagramtoolbox.py
+++ b/gaphor/ui/diagramtoolbox.py
@@ -172,7 +172,7 @@ def itemiter(toolbox_actions):
 
 class DiagramToolbox(object):
     """
-    Composite class for DiagramTab (diagramtab.py).
+    Composite class for DiagramPage (diagrampage.py).
     """
 
     element_factory = inject("element_factory")

--- a/gaphor/ui/event.py
+++ b/gaphor/ui/event.py
@@ -4,7 +4,7 @@ from zope.interface import implementer
 
 from gaphor.ui.interfaces import (
     IDiagramSelectionChange,
-    IDiagramTabChange,
+    IDiagramPageChange,
     IDiagramShow,
 )
 
@@ -15,11 +15,11 @@ class DiagramShow(object):
         self.diagram = diagram
 
 
-@implementer(IDiagramTabChange)
-class DiagramTabChange(object):
+@implementer(IDiagramPageChange)
+class DiagramPageChange(object):
     def __init__(self, item):
         self.item = item
-        self.diagram_tab = item.diagram_tab
+        self.diagram_page = item.diagram_page
 
 
 @implementer(IDiagramSelectionChange)

--- a/gaphor/ui/interfaces.py
+++ b/gaphor/ui/interfaces.py
@@ -13,14 +13,14 @@ class IDiagramShow(interface.Interface):
     diagram = interface.Attribute("The newly selected Diagram")
 
 
-class IDiagramTabChange(interface.Interface):
+class IDiagramPageChange(interface.Interface):
     """
     The selected diagram changes.
     """
 
     item = interface.Attribute("The newly selected Notebook pane")
 
-    diagram_tab = interface.Attribute("The newly selected diagram tab")
+    diagram_page = interface.Attribute("The newly selected diagram page")
 
 
 class IDiagramSelectionChange(interface.Interface):

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -839,6 +839,7 @@ class Diagrams(object):
 
         page_num = self._notebook.append_page(child=widget, tab_label=tab_box)
         self._notebook.set_current_page(page_num)
+        self._notebook.set_tab_reorderable(widget, True)
 
         button.connect("clicked", self.on_close_tab, widget)
         self.component_registry.handle(DiagramTabChange(widget))

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -290,9 +290,9 @@ class NamespaceModel(Gtk.GenericTreeModel):
             # Remove entry from old place
             if old_value in self._nodes:
                 try:
-                    path = self.path_from_element(old_value) + [
-                        self._nodes[old_value].index(element)
-                    ]
+                    path = self.path_from_element(old_value) + (
+                        self._nodes[old_value].index(element),
+                    )
                 except ValueError:
                     log.error(
                         "Unable to create path for element %s and old_value %s"

--- a/gaphor/ui/tests/test_diagrampage.py
+++ b/gaphor/ui/tests/test_diagrampage.py
@@ -2,11 +2,11 @@ import unittest
 
 from gaphor import UML
 from gaphor.application import Application
-from gaphor.ui.diagramtab import DiagramTab
+from gaphor.ui.diagrampage import DiagramPage
 from gaphor.ui.mainwindow import MainWindow
 
 
-class DiagramTabTestCase(unittest.TestCase):
+class DiagramPageTestCase(unittest.TestCase):
     def setUp(self):
         Application.init(
             services=[

--- a/gaphor/ui/tests/test_diagrampage.py
+++ b/gaphor/ui/tests/test_diagrampage.py
@@ -1,9 +1,11 @@
 import unittest
 
+from gaphas.examples import Box
+
 from gaphor import UML
 from gaphor.application import Application
-from gaphor.ui.diagrampage import DiagramPage
-from gaphor.ui.mainwindow import MainWindow
+from gaphor.diagram.comment import CommentItem
+from gaphor.ui.mainwindow import DiagramPage
 
 
 class DiagramPageTestCase(unittest.TestCase):
@@ -20,37 +22,30 @@ class DiagramPageTestCase(unittest.TestCase):
         )
         main_window = Application.get_service("main_window")
         main_window.open()
-        element_factory = Application.get_service("element_factory")
-        self.element_factory = element_factory
-        self.diagram = element_factory.create(UML.Diagram)
-        self.tab = main_window.show_diagram(self.diagram)
-        self.assertEqual(self.tab.diagram, self.diagram)
-        self.assertEqual(self.tab.view.canvas, self.diagram.canvas)
-        self.assertEqual(len(element_factory.lselect()), 1)
+        self.element_factory = Application.get_service("element_factory")
+        self.diagram = self.element_factory.create(UML.Diagram)
+        self.page = DiagramPage(self.diagram)
+        self.page.construct()
+        self.assertEqual(self.page.diagram, self.diagram)
+        self.assertEqual(self.page.view.canvas, self.diagram.canvas)
+        self.assertEqual(len(self.element_factory.lselect()), 1)
 
     def tearDown(self):
-        self.tab.close()
-        del self.tab
+        self.page.close()
+        del self.page
         self.diagram.unlink()
         del self.diagram
         Application.shutdown()
-        # assert len(self.element_factory.lselect()) == 0
+        assert len(self.element_factory.lselect()) == 0
 
     def test_creation(self):
         pass
 
     def test_placement(self):
-        tab = self.tab
-        diagram = self.diagram
-        from gaphas import Element
-        from gaphas.examples import Box
-
         box = Box()
-        diagram.canvas.add(box)
-        diagram.canvas.update_now()
-        tab.view.request_update([box])
-
-        from gaphor.diagram.comment import CommentItem
+        self.diagram.canvas.add(box)
+        self.diagram.canvas.update_now()
+        self.page.view.request_update([box])
 
         comment = self.diagram.create(
             CommentItem, subject=self.element_factory.create(UML.Comment)

--- a/gaphor/ui/tests/test_diagramtoolbox.py
+++ b/gaphor/ui/tests/test_diagramtoolbox.py
@@ -2,7 +2,7 @@ from builtins import object
 from gi.repository import Gtk
 from gaphor.tests.testcase import TestCase
 from gaphor.application import Application
-from gaphor.ui.diagramtab import DiagramTab
+from gaphor.ui.diagrampage import DiagramPage
 from gaphor.ui.diagramtoolbox import DiagramToolbox, TOOLBOX_ACTIONS
 from gaphor import UML
 
@@ -24,7 +24,7 @@ class DiagramToolboxTestCase(TestCase):
     def setUp(self):
         TestCase.setUp(self)
         diagram = self.diagram
-        tab = DiagramTab(WindowOwner())
+        tab = DiagramPage(WindowOwner())
         tab.diagram = diagram
         tab.construct()
         self.tab = tab


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->
Added to what @amolenaar started by completing some of the conversion to make the main window use a normal Gtk.Notebook. It now works to open and close multiple diagrams.

@amolenaar How do I launch the checkmetamodel plugin to test that it is working correctly? When I try to run `python checkmodelgui.py`, it immediately closes.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: continue work towards fixing #49 

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
