### PR TITLE
Fix get_current_diagram for Diagram Export and Layout

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -70,7 +70,7 @@ For a complete set of changes and fixes see:
 - improved items's connection adapters 
 - fixed comment line, comment, message and lifeline items connection
   adapters to implement UML specification more closely
-- items glueing speedup
+- items gluing speedup
 - property page is updated when association or other diagram line connects
   to appropriate diagram items
 - removing and reordering of class' attributes and operations is possible

--- a/docs/connect.txt
+++ b/docs/connect.txt
@@ -6,7 +6,7 @@ relationship, the connection is also made at semantic level (the model).
 From a GUI point of view it all starts with a button release event.
 
 With "item" I refer to objects in a diagram (graphical), with "element" I
-refer to symantic (model) objects.
+refer to semantic (model) objects.
 
 Is relation with this element allowed?
   No:

--- a/docs/win32.txt
+++ b/docs/win32.txt
@@ -38,7 +38,7 @@ Now you should be able to start Gaphor by executing ``C:\Program Files\PyGTK\Pyt
 
 
 If you're a developer and already have Python 2.4 installed you can, as an
-alternative, check out the ``gaphor-win32-libs`` module from Gaphors
+alternative, check out the ``gaphor-win32-libs`` module from Gaphor's
 subversion repository or download the zip file from http://svn.devjavu.com/gaphor/gaphor-win32-libs/zips/gaphor-win32-libs.zip.
 Follow the instructions in the ``README.txt`` file.
 

--- a/gaphor/UML/elementfactory.py
+++ b/gaphor/UML/elementfactory.py
@@ -185,9 +185,7 @@ class ElementFactory(object):
 
 @implementer(IService)
 class ElementFactoryService(ElementFactory):
-    """
-    Service version of the ElementFctory.
-    """
+    """Service version of the ElementFactory."""
 
     component_registry = inject("component_registry")
 
@@ -250,23 +248,17 @@ class ElementFactoryService(ElementFactory):
 
 
 @implementer(IEventFilter)
+@component.adapter(IElementChangeEvent)
 class ElementChangedEventBlocker(object):
-    """
-    Blocks all events of type IElementChangeEvent.
+    """Blocks all events of type IElementChangeEvent.
 
     This filter is placed when the the element factory flushes it's content.
     """
-
-    component.adapts(IElementChangeEvent)
 
     def __init__(self, event):
         self._event = event
 
     def filter(self):
-        """
-        Returns something that evaluates to `True` so events are blocked.
-        """
+        """Returns something that evaluates to `True` so events are blocked."""
+
         return "Blocked by ElementFactory.flush()"
-
-
-# vim:sw=4:et

--- a/gaphor/UML/properties.py
+++ b/gaphor/UML/properties.py
@@ -861,6 +861,3 @@ else:
     psyco.bind(association)
     psyco.bind(derivedunion)
     psyco.bind(redefine)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/UML/tests/test_collection.py
+++ b/gaphor/UML/tests/test_collection.py
@@ -14,6 +14,3 @@ class CollectionlistTestCase(unittest.TestCase):
         c.append("b")
         c.append("c")
         assert str(c) == "['a', 'b', 'c']"
-
-
-# vim:sw=4:et:ai

--- a/gaphor/UML/tests/test_elementfactory.py
+++ b/gaphor/UML/tests/test_elementfactory.py
@@ -133,6 +133,3 @@ class ElementFactoryServiceTestCase(unittest.TestCase):
         global handled
         ef.flush()
         self.assertTrue(IFlushFactoryEvent.providedBy(last_event))
-
-
-# vim:sw=4:et:ai

--- a/gaphor/UML/tests/test_modelfactory.py
+++ b/gaphor/UML/tests/test_modelfactory.py
@@ -183,14 +183,14 @@ class AssociationEndNavigabilityTestCase(TestCaseBase):
 
         UML.model.set_navigability(assoc, end, True)
 
-        # class/interface navigablity, Association.navigableOwnedEnd not
+        # class/interface navigability, Association.navigableOwnedEnd not
         # involved
         self.assertTrue(end not in assoc.navigableOwnedEnd)
         self.assertTrue(end not in assoc.ownedEnd)
         self.assertTrue(end in c2.ownedAttribute)
         self.assertTrue(end.navigability is True)
 
-        # uknown navigability
+        # unknown navigability
         UML.model.set_navigability(assoc, end, None)
         self.assertTrue(end not in assoc.navigableOwnedEnd)
         self.assertTrue(end in assoc.ownedEnd)
@@ -233,13 +233,13 @@ class AssociationEndNavigabilityTestCase(TestCaseBase):
 
         UML.model.set_navigability(assoc, end, True)
 
-        # class/interface navigablity, Association.navigableOwnedEnd not
+        # class/interface navigability, Association.navigableOwnedEnd not
         # involved
         self.assertTrue(end in assoc.navigableOwnedEnd)
         self.assertTrue(end not in assoc.ownedEnd)
         self.assertTrue(end.navigability is True)
 
-        # uknown navigability
+        # unknown navigability
         UML.model.set_navigability(assoc, end, None)
         self.assertTrue(end not in assoc.navigableOwnedEnd)
         self.assertTrue(end in assoc.ownedEnd)

--- a/gaphor/UML/tests/test_properties.py
+++ b/gaphor/UML/tests/test_properties.py
@@ -763,5 +763,3 @@ class PropertiesTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-# vim:sw=4:et:ai

--- a/gaphor/UML/tests/test_uml2.py
+++ b/gaphor/UML/tests/test_uml2.py
@@ -442,6 +442,3 @@ class Uml2TestCase(unittest.TestCase):
         c.unlink()
 
         self.assertEqual(0, len(factory.lselect()), factory.lselect())
-
-
-# vim:sw=4:et:ai

--- a/gaphor/UML/tests/test_umllex.py
+++ b/gaphor/UML/tests/test_umllex.py
@@ -227,6 +227,3 @@ class OperationTestCase(unittest.TestCase):
         o = factory.create(UML.Operation)
         UML.parse(o, "- myfunc2: myType2")
         self.assertEqual("- myfunc2: myType2", o.name)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/UML/uml2.override
+++ b/gaphor/UML/uml2.override
@@ -1,7 +1,5 @@
 comment
-  vim:sw=4:et:syntax=python
-
-  This is a file with custom definitions for Gaphors data model.
+  This is a file with custom definitions for Gaphor's data model.
 
   Parts are separated by '%%' (no training spaces) on a line.
   Comment parts start with 'comment' on the line below the percentage

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -229,6 +229,3 @@ def format_namedelement(el, pattern="%s"):
     Format named element.
     """
     return pattern % el.name
-
-
-# vim:sw=4:et:ai

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -182,7 +182,7 @@ def parse_attribute(el, s):
 def parse_association_end(el, s):
     """
     Parse the text at one end of an association. The association end holds
-    two strings. It is automattically figured out which string is fed to the
+    two strings. It is automatically figured out which string is fed to the
     parser.
     """
     create = el._factory.create
@@ -346,6 +346,3 @@ def parse_namedelement(el, text):
     Parse named element by simply assigning text to its name.
     """
     el.name = text
-
-
-# vim:sw=4:et:ai

--- a/gaphor/__init__.py
+++ b/gaphor/__init__.py
@@ -101,6 +101,3 @@ def main():
 
     else:
         launch(model)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/action.py
+++ b/gaphor/action.py
@@ -259,5 +259,3 @@ if __name__ == "__main__":
     import doctest
 
     doctest.testmod()
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/actions/flowconnect.py
+++ b/gaphor/adapters/actions/flowconnect.py
@@ -209,12 +209,9 @@ class FlowForkDecisionNodeConnect(FlowConnect):
             self.decombine_nodes()
 
 
+@component.adapter(items.ForkNodeItem, items.FlowItem)
 class FlowForkNodeConnect(FlowForkDecisionNodeConnect):
-    """
-    Connect Flow to a ForkNode.
-    """
-
-    component.adapts(items.ForkNodeItem, items.FlowItem)
+    """Connect Flow to a ForkNode."""
 
     fork_node_cls = UML.ForkNode
     join_node_cls = UML.JoinNode
@@ -223,18 +220,12 @@ class FlowForkNodeConnect(FlowForkDecisionNodeConnect):
 component.provideAdapter(FlowForkNodeConnect)
 
 
+@component.adapter(items.DecisionNodeItem, items.FlowItem)
 class FlowDecisionNodeConnect(FlowForkDecisionNodeConnect):
-    """
-    Connect Flow to a DecisionNode
-    """
-
-    component.adapts(items.DecisionNodeItem, items.FlowItem)
+    """Connect Flow to a DecisionNode."""
 
     fork_node_cls = UML.DecisionNode
     join_node_cls = UML.MergeNode
 
 
 component.provideAdapter(FlowDecisionNodeConnect)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/actions/partitionpage.py
+++ b/gaphor/adapters/actions/partitionpage.py
@@ -1,6 +1,5 @@
-"""
-Activity partition property page.
-"""
+"""Activity partition property page."""
+
 from zope import component
 
 from gi.repository import Gtk
@@ -15,12 +14,9 @@ from gaphor.ui.interfaces import IPropertyPage
 
 
 @implementer(IPropertyPage)
+@component.adapter(items.PartitionItem)
 class PartitionPropertyPage(NamedItemPropertyPage):
-    """
-    Partition property page.
-    """
-
-    component.adapts(items.PartitionItem)
+    """Partition property page."""
 
     element_factory = inject("element_factory")
 
@@ -55,6 +51,3 @@ class PartitionPropertyPage(NamedItemPropertyPage):
 
 
 component.provideAdapter(PartitionPropertyPage, name="Properties")
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/actions/tests/test_flow.py
+++ b/gaphor/adapters/actions/tests/test_flow.py
@@ -14,8 +14,8 @@ class FlowItemBasicNodesConnectionTestCase(TestCase):
     """
 
     def test_initial_node_glue(self):
-        """Test flow item glueing to initial node item
-        """
+        """Test flow item gluing to initial node item."""
+
         flow = self.create(items.FlowItem)
         node = self.create(items.InitialNodeItem, UML.InitialNode)
 
@@ -27,8 +27,8 @@ class FlowItemBasicNodesConnectionTestCase(TestCase):
         self.assertTrue(allowed)
 
     def test_flow_final_node_glue(self):
-        """Test flow item glueing to flow final node item
-        """
+        """Test flow item gluing to flow final node item."""
+
         flow = self.create(items.FlowItem)
         node = self.create(items.FlowFinalNodeItem, UML.FlowFinalNode)
 
@@ -40,7 +40,7 @@ class FlowItemBasicNodesConnectionTestCase(TestCase):
         self.assertTrue(allowed)
 
     def test_activity_final_node_glue(self):
-        """Test flow item glueing to activity final node item
+        """Test flow item gluing to activity final node item
         """
         flow = self.create(items.FlowItem)
         node = self.create(items.ActivityFinalNodeItem, UML.ActivityFinalNode)
@@ -59,8 +59,8 @@ class FlowItemObjectNodeTestCase(TestCase):
     """
 
     def test_glue(self):
-        """Test glueing to object node
-        """
+        """Test gluing to object node."""
+
         flow = self.create(items.FlowItem)
         onode = self.create(items.ObjectNodeItem, UML.ObjectNode)
         glued = self.allow(flow, flow.head, onode)
@@ -161,8 +161,8 @@ class FlowItemActionTestCase(TestCase):
     """
 
     def test_glue(self):
-        """Test flow item glueing to action items
-        """
+        """Test flow item gluing to action items."""
+
         flow = self.create(items.FlowItem)
         a1 = self.create(items.ActionItem, UML.Action)
         a2 = self.create(items.ActionItem, UML.Action)
@@ -493,6 +493,3 @@ class FlowItemDecisionNodeTestCase(FlowItemDesisionAndForkNodes, TestCase):
     item_cls = items.DecisionNodeItem
     fork_node_cls = UML.DecisionNode
     join_node_cls = UML.MergeNode
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/classes/classconnect.py
+++ b/gaphor/adapters/classes/classconnect.py
@@ -1,6 +1,5 @@
-"""
-Classes related (dependency, implementation) adapter connections.
-"""
+"""Classes related (dependency, implementation) adapter connections."""
+
 import logging
 
 from zope import component
@@ -12,12 +11,9 @@ from gaphor.diagram import items
 log = logging.getLogger(__name__)
 
 
+@component.adapter(items.NamedItem, items.DependencyItem)
 class DependencyConnect(RelationshipConnect):
-    """
-    Connect two NamedItem elements using a Dependency
-    """
-
-    component.adapts(items.NamedItem, items.DependencyItem)
+    """Connect two NamedItem elements using a Dependency."""
 
     def allow(self, handle, port):
         line = self.line
@@ -44,8 +40,9 @@ class DependencyConnect(RelationshipConnect):
 
     def connect_subject(self, handle):
         """
-        TODO: cleck for existing relationships (use self.relation())
+        TODO: check for existing relationships (use self.relation())
         """
+
         line = self.line
 
         if line.auto_dependency:
@@ -71,13 +68,9 @@ class DependencyConnect(RelationshipConnect):
 component.provideAdapter(DependencyConnect)
 
 
+@component.adapter(items.ClassifierItem, items.GeneralizationItem)
 class GeneralizationConnect(RelationshipConnect):
-    """
-    Connect Classifiers with a Generalization relationship.
-    """
-
-    # FixMe: Both ends of the generalization should be of the same  type?
-    component.adapts(items.ClassifierItem, items.GeneralizationItem)
+    """Connect Classifiers with a Generalization relationship."""
 
     def reconnect(self, handle, port):
         self.reconnect_relationship(
@@ -96,12 +89,9 @@ class GeneralizationConnect(RelationshipConnect):
 component.provideAdapter(GeneralizationConnect)
 
 
+@component.adapter(items.ClassifierItem, items.AssociationItem)
 class AssociationConnect(UnaryRelationshipConnect):
-    """
-    Connect association to classifier.
-    """
-
-    component.adapts(items.ClassifierItem, items.AssociationItem)
+    """Connect association to classifier."""
 
     def allow(self, handle, port):
         element = self.element
@@ -185,12 +175,9 @@ class AssociationConnect(UnaryRelationshipConnect):
 component.provideAdapter(AssociationConnect)
 
 
+@component.adapter(items.NamedItem, items.ImplementationItem)
 class ImplementationConnect(RelationshipConnect):
-    """
-    Connect Interface and a BehavioredClassifier using an Implementation.
-    """
-
-    component.adapts(items.NamedItem, items.ImplementationItem)
+    """Connect Interface and a BehavioredClassifier using an Implementation."""
 
     def allow(self, handle, port):
         line = self.line
@@ -236,5 +223,3 @@ class ImplementationConnect(RelationshipConnect):
 
 
 component.provideAdapter(ImplementationConnect)
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/classes/interfaceconnect.py
+++ b/gaphor/adapters/classes/interfaceconnect.py
@@ -18,13 +18,11 @@ from gaphor.adapters.classes.classconnect import (
 )
 
 
+@component.adapter(items.InterfaceItem, items.ImplementationItem)
 class ImplementationInterfaceConnect(ImplementationConnect):
-    """
-    Connect interface item and a behaviored classifier using an
+    """Connect interface item and a behaviored classifier using an
     implementation.
     """
-
-    component.adapts(items.InterfaceItem, items.ImplementationItem)
 
     def connect(self, handle, port):
         """
@@ -48,12 +46,9 @@ class ImplementationInterfaceConnect(ImplementationConnect):
 component.provideAdapter(ImplementationInterfaceConnect)
 
 
+@component.adapter(items.InterfaceItem, items.DependencyItem)
 class DependencyInterfaceConnect(DependencyConnect):
-    """
-    Connect interface item with dependency item.
-    """
-
-    component.adapts(items.InterfaceItem, items.DependencyItem)
+    """Connect interface item with dependency item."""
 
     def connect(self, handle, port):
         """
@@ -90,5 +85,3 @@ class DependencyInterfaceConnect(DependencyConnect):
 
 
 component.provideAdapter(DependencyInterfaceConnect)
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/classes/tests/test_class.py
+++ b/gaphor/adapters/classes/tests/test_class.py
@@ -179,8 +179,8 @@ class GeneralizationTestCase(TestCase):
     """
 
     def test_glue(self):
-        """Test generalization item glueing using two classes
-        """
+        """Test generalization item gluing using two classes."""
+
         gen = self.create(items.GeneralizationItem)
         c1 = self.create(items.ClassItem, UML.Class)
         c2 = self.create(items.ClassItem, UML.Class)
@@ -346,6 +346,3 @@ class AssociationConnectorTestCase(TestCase):
 
         # after disconnection: one diagram and two classes
         self.assertEqual(3, len(list(self.element_factory.select())))
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/classes/tests/test_implementation.py
+++ b/gaphor/adapters/classes/tests/test_implementation.py
@@ -9,8 +9,8 @@ from gaphor.tests import TestCase
 
 class ImplementationTestCase(TestCase):
     def test_non_interface_glue(self):
-        """Test non-interface glueing with implementation
-        """
+        """Test non-interface gluing with implementation."""
+
         impl = self.create(items.ImplementationItem)
         clazz = self.create(items.ClassItem, UML.Class)
 
@@ -19,7 +19,7 @@ class ImplementationTestCase(TestCase):
         self.assertFalse(glued)
 
     def test_interface_glue(self):
-        """Test interface glueing with implementation
+        """Test interface gluing with implementation
         """
         iface = self.create(items.InterfaceItem, UML.Interface)
         impl = self.create(items.ImplementationItem)
@@ -28,7 +28,7 @@ class ImplementationTestCase(TestCase):
         self.assertTrue(glued)
 
     def test_classifier_glue(self):
-        """Test classifier glueing with implementation
+        """Test classifier gluing with implementation
         """
         impl = self.create(items.ImplementationItem)
         clazz = self.create(items.ClassItem, UML.Class)
@@ -80,6 +80,3 @@ class ImplementationTestCase(TestCase):
             c1.subject not in impl.subject.implementatingClassifier,
             impl.subject.implementatingClassifier,
         )
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/classes/tests/test_interfaceconnect.py
+++ b/gaphor/adapters/classes/tests/test_interfaceconnect.py
@@ -102,8 +102,8 @@ class FoldedInterfaceMultipleLinesTestCase(TestCase):
         self.iface.folded = self.iface.FOLDED_PROVIDED
 
     def test_interface_with_implementation(self):
-        """Test glueing different lines to folded interface with implementation
-        """
+        """Test gluing different lines to folded interface with implementation."""
+
         impl = self.create(items.ImplementationItem)
         self.connect(impl, impl.head, self.iface, self.iface.ports()[0])
 
@@ -111,11 +111,10 @@ class FoldedInterfaceMultipleLinesTestCase(TestCase):
             line = self.create(cls)
             glued = self.allow(line, line.head, self.iface)
             # no additional lines (specified above) can be glued
-            self.assertFalse(glued, "Glueing of %s should not be allowed" % cls)
+            self.assertFalse(glued, "gluing of %s should not be allowed" % cls)
 
     def test_interface_with_dependency(self):
-        """Test glueing different lines to folded interface with dependency
-        """
+        """Test gluing different lines to folded interface with dependency."""
         dep = self.create(items.DependencyItem)
         self.connect(dep, dep.head, self.iface, self.iface.ports()[0])
 
@@ -123,7 +122,7 @@ class FoldedInterfaceMultipleLinesTestCase(TestCase):
             line = self.create(cls)
             glued = self.allow(line, line.head, self.iface)
             # no additional lines (specified above) can be glued
-            self.assertFalse(glued, "Glueing of %s should not be allowed" % cls)
+            self.assertFalse(glued, "gluing of %s should not be allowed" % cls)
 
 
 class FoldedInterfaceSingleLineTestCase(TestCase):
@@ -133,8 +132,8 @@ class FoldedInterfaceSingleLineTestCase(TestCase):
     """
 
     def test_interface_with_forbidden_lines(self):
-        """Test glueing forbidden lines to folded interface
-        """
+        """Test gluing forbidden lines to folded interface."""
+
         iface = self.create(items.InterfaceItem, UML.Interface)
         iface.folded = iface.FOLDED_PROVIDED
 
@@ -142,7 +141,4 @@ class FoldedInterfaceSingleLineTestCase(TestCase):
             line = self.create(cls)
             glued = self.allow(line, line.head, iface)
             # no additional lines (specified above) can be glued
-            self.assertFalse(glued, "Glueing of %s should not be allowed" % cls)
-
-
-# vim:sw=4:et:ai
+            self.assertFalse(glued, "gluing of %s should not be allowed" % cls)

--- a/gaphor/adapters/components/connectorconnect.py
+++ b/gaphor/adapters/components/connectorconnect.py
@@ -214,32 +214,30 @@ class ConnectorConnectBase(AbstractConnect):
             self.drop_uml(line, c)
 
 
+@component.adapter(items.ComponentItem, items.ConnectorItem)
 class ComponentConnectorConnect(ConnectorConnectBase):
-    """
-    Connection of connector item to a component.
-    """
+    """Connection of connector item to a component."""
 
-    component.adapts(items.ComponentItem, items.ConnectorItem)
+    pass
 
 
 component.provideAdapter(ComponentConnectorConnect)
 
 
+@component.adapter(items.InterfaceItem, items.ConnectorItem)
 class InterfaceConnectorConnect(ConnectorConnectBase):
-    """
-    Connect connector to an interface to maintain assembly connection.
+    """Connect connector to an interface to maintain assembly connection.
 
     See also `AbstractConnect` class for exception of interface item
     connections.
     """
 
-    component.adapts(items.InterfaceItem, items.ConnectorItem)
-
     def allow(self, handle, port):
+        """Allow gluing to folded interface.
+
+        Only allow gluing when connectors are connected.
         """
-        Allow glueing to folded interface only and when only connectors are
-        connected.
-        """
+
         glue_ok = super(InterfaceConnectorConnect, self).allow(handle, port)
         iface = self.element
         glue_ok = glue_ok and iface.folded != iface.FOLDED_NONE

--- a/gaphor/adapters/components/tests/test_connector.py
+++ b/gaphor/adapters/components/tests/test_connector.py
@@ -17,8 +17,8 @@ class ComponentConnectTestCase(TestCase):
     """
 
     def test_glue(self):
-        """Test glueing connector to component
-        """
+        """Test gluing connector to component."""
+
         component = self.create(items.ComponentItem, UML.Component)
         line = self.create(items.ConnectorItem)
 
@@ -36,8 +36,8 @@ class ComponentConnectTestCase(TestCase):
         # self.assertTrue(line.end is None)
 
     def test_glue_both(self):
-        """Test glueing connector to component when one is connected
-        """
+        """Test gluing connector to component when one is connected."""
+
         c1 = self.create(items.ComponentItem, UML.Component)
         c2 = self.create(items.ComponentItem, UML.Component)
         line = self.create(items.ConnectorItem)
@@ -53,8 +53,8 @@ class InterfaceConnectTestCase(TestCase):
     """
 
     def test_non_folded_glue(self):
-        """Test non-folded interface glueing
-        """
+        """Test non-folded interface gluing."""
+
         iface = self.create(items.InterfaceItem, UML.Component)
         line = self.create(items.ConnectorItem)
 
@@ -62,8 +62,8 @@ class InterfaceConnectTestCase(TestCase):
         self.assertFalse(glued)
 
     def test_folded_glue(self):
-        """Test folded interface glueing
-        """
+        """Test folded interface gluing."""
+
         iface = self.create(items.InterfaceItem, UML.Component)
         line = self.create(items.ConnectorItem)
 
@@ -72,8 +72,8 @@ class InterfaceConnectTestCase(TestCase):
         self.assertTrue(glued)
 
     def test_glue_when_dependency_connected(self):
-        """Test interface glueing, when dependency connected
-        """
+        """Test interface gluing, when dependency connected."""
+
         iface = self.create(items.InterfaceItem, UML.Component)
         dep = self.create(items.DependencyItem)
         line = self.create(items.ConnectorItem)
@@ -85,8 +85,8 @@ class InterfaceConnectTestCase(TestCase):
         self.assertFalse(glued)
 
     def test_glue_when_implementation_connected(self):
-        """Test interface glueing, when implementation connected
-        """
+        """Test interface gluing, when implementation connected."""
+
         iface = self.create(items.InterfaceItem, UML.Component)
         impl = self.create(items.ImplementationItem)
         line = self.create(items.ConnectorItem)
@@ -98,8 +98,8 @@ class InterfaceConnectTestCase(TestCase):
         self.assertFalse(glued)
 
     def test_glue_when_connector_connected(self):
-        """Test interface glueing, when connector connected
-        """
+        """Test interface gluing, when connector connected."""
+
         iface = self.create(items.InterfaceItem, UML.Component)
         iface.folded = iface.FOLDED_REQUIRED
 
@@ -351,8 +351,8 @@ class AssemblyConnectorTestCase(TestCase):
         #    '%s != %s' % (p2, c2.subject.ownedPort))
 
     def test_required_port_glue(self):
-        """Test if required port glueing works
-        """
+        """Test if required port gluing works."""
+
         conn1 = self.create(items.ConnectorItem)
         conn2 = self.create(items.ConnectorItem)
 
@@ -376,8 +376,8 @@ class AssemblyConnectorTestCase(TestCase):
         self.assertTrue(glued)
 
     def test_wrong_port_glue(self):
-        """Test if incorrect port glueing is forbidden
-        """
+        """Test if incorrect port gluing is forbidden."""
+
         conn1 = self.create(items.ConnectorItem)
         conn2 = self.create(items.ConnectorItem)
         conn3 = self.create(items.ConnectorItem)
@@ -609,6 +609,3 @@ class AssemblyConnectorTestCase(TestCase):
         self.assertEqual(0, len(self.kindof(UML.Connector)))
         self.assertEqual(0, len(self.kindof(UML.ConnectorEnd)))
         self.assertEqual(0, len(self.kindof(UML.Port)))
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/connectors.py
+++ b/gaphor/adapters/connectors.py
@@ -112,18 +112,13 @@ class AbstractConnect(object):
     #        raise NotImplementedError('Reconnection not implemented')
 
     def disconnect(self, handle):
-        """
-        Disconnect UML model level connections.
-        """
+        """Disconnect UML model level connections."""
         pass
 
 
+@component.adapter(items.ElementItem, items.CommentLineItem)
 class CommentLineElementConnect(AbstractConnect):
-    """
-    Connect a comment line to any element item.
-    """
-
-    component.adapts(items.ElementItem, items.CommentLineItem)
+    """Connect a comment line to any element item."""
 
     def allow(self, handle, port):
         """
@@ -195,7 +190,7 @@ class CommentLineElementConnect(AbstractConnect):
                     del hct.subject.annotatedElement[oct.subject]
             except ValueError:
                 logger.debug(
-                    "Invoked CommentLineElementConnect.disconnect() for nonexistant relationship"
+                    "Invoked CommentLineElementConnect.disconnect() for nonexistent relationship"
                 )
 
         super(CommentLineElementConnect, self).disconnect(handle)
@@ -204,12 +199,9 @@ class CommentLineElementConnect(AbstractConnect):
 component.provideAdapter(CommentLineElementConnect)
 
 
+@component.adapter(items.DiagramLine, items.CommentLineItem)
 class CommentLineLineConnect(AbstractConnect):
-    """
-    Connect a comment line to any diagram line.
-    """
-
-    component.adapts(items.DiagramLine, items.CommentLineItem)
+    """Connect a comment line to any diagram line."""
 
     def allow(self, handle, port):
         """
@@ -386,7 +378,7 @@ class UnaryRelationshipConnect(AbstractConnect):
     def disconnect_connected_items(self):
         """
         Cause items connected to @line to be disconnected.
-        This is nessesary if the subject of the @line is to be removed.
+        This is necessary if the subject of the @line is to be removed.
 
         Returns a list of (item, handle) pairs that were connected (this
         list can be used to connect items again with connect_connected_items()).
@@ -488,6 +480,3 @@ class RelationshipConnect(UnaryRelationshipConnect):
             return None
 
         return super(RelationshipConnect, self).allow(handle, port)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/editors.py
+++ b/gaphor/adapters/editors.py
@@ -36,12 +36,9 @@ def editable_slot(el):
 
 
 @implementer(IEditor)
+@component.adapter(items.CommentItem)
 class CommentItemEditor(object):
-    """
-    Text edit support for Comment item.
-    """
-
-    component.adapts(items.CommentItem)
+    """Text edit support for Comment item."""
 
     def __init__(self, item):
         self._item = item
@@ -66,12 +63,9 @@ component.provideAdapter(CommentItemEditor)
 
 
 @implementer(IEditor)
+@component.adapter(items.NamedItem)
 class NamedItemEditor(object):
-    """
-    Text edit support for Named items.
-    """
-
-    component.adapts(items.NamedItem)
+    """Text edit support for Named items."""
 
     def __init__(self, item):
         self._item = item
@@ -99,12 +93,9 @@ component.provideAdapter(NamedItemEditor)
 
 
 @implementer(IEditor)
+@component.adapter(items.DiagramItem)
 class DiagramItemTextEditor(object):
-    """
-    Text edit support for diagram items containing text elements.
-    """
-
-    component.adapts(items.DiagramItem)
+    """Text edit support for diagram items containing text elements."""
 
     def __init__(self, item):
         self._item = item
@@ -141,12 +132,9 @@ component.provideAdapter(DiagramItemTextEditor)
 
 
 @implementer(IEditor)
+@component.adapter(items.CompartmentItem)
 class CompartmentItemEditor(object):
-    """
-    Text editor support for compartment items.
-    """
-
-    component.adapts(items.CompartmentItem)
+    """Text editor support for compartment items."""
 
     def __init__(self, item):
         self._item = item
@@ -177,9 +165,8 @@ component.provideAdapter(CompartmentItemEditor)
 
 
 @implementer(IEditor)
+@component.adapter(items.AssociationItem)
 class AssociationItemEditor(object):
-    component.adapts(items.AssociationItem)
-
     def __init__(self, item):
         self._item = item
         self._edit = None
@@ -225,11 +212,9 @@ component.provideAdapter(AssociationItemEditor)
 
 
 @implementer(IEditor)
+@component.adapter(items.ForkNodeItem)
 class ForkNodeItemEditor(object):
-    """Text edit support for fork node join specification.
-    """
-
-    component.adapts(items.ForkNodeItem)
+    """Text edit support for fork node join specification."""
 
     element_factory = inject("element_factory")
 
@@ -264,5 +249,3 @@ class ForkNodeItemEditor(object):
 
 
 component.provideAdapter(ForkNodeItemEditor)
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/interactions/messageconnect.py
+++ b/gaphor/adapters/interactions/messageconnect.py
@@ -1,6 +1,4 @@
-"""
-Message item connection adapters.
-"""
+"""Message item connection adapters."""
 
 from gaphor.adapters.connectors import AbstractConnect
 from zope import interface, component
@@ -8,9 +6,9 @@ from gaphor import UML
 from gaphor.diagram import items
 
 
+@component.adapter(items.LifelineItem, items.MessageItem)
 class MessageLifelineConnect(AbstractConnect):
-    """
-    Connect lifeline with a message.
+    """Connect lifeline with a message.
 
     A message can connect to both the lifeline's head (the rectangle)
     or the lifetime line. In case it's added to the head, the message
@@ -18,11 +16,9 @@ class MessageLifelineConnect(AbstractConnect):
     added to a lifetime line, it's considered a sequence diagram.
     """
 
-    component.adapts(items.LifelineItem, items.MessageItem)
-
     def connect_lifelines(self, line, send, received):
         """
-        Always create a new Message with two EventOccurence instances.
+        Always create a new Message with two EventOccurrence instances.
         """
 
         def get_subject():

--- a/gaphor/adapters/interactions/tests/test_message.py
+++ b/gaphor/adapters/interactions/tests/test_message.py
@@ -54,12 +54,12 @@ class BasicMessageConnectionsTestCase(TestCase):
         self.assertEqual(msg.subject.messageKind, "lost")
 
         messages = self.kindof(UML.Message)
-        occurences = self.kindof(UML.MessageOccurrenceSpecification)
+        occurrences = self.kindof(UML.MessageOccurrenceSpecification)
 
         self.assertEqual(1, len(messages))
-        self.assertEqual(1, len(occurences))
+        self.assertEqual(1, len(occurrences))
         self.assertTrue(messages[0] is msg.subject)
-        self.assertTrue(occurences[0] is msg.subject.sendEvent)
+        self.assertTrue(occurrences[0] is msg.subject.sendEvent)
 
     def test_found_message_connection(self):
         """Test found message connection
@@ -74,12 +74,12 @@ class BasicMessageConnectionsTestCase(TestCase):
         self.assertEqual(msg.subject.messageKind, "found")
 
         messages = self.kindof(UML.Message)
-        occurences = self.kindof(UML.MessageOccurrenceSpecification)
+        occurrences = self.kindof(UML.MessageOccurrenceSpecification)
 
         self.assertEqual(1, len(messages))
-        self.assertEqual(1, len(occurences))
+        self.assertEqual(1, len(occurrences))
         self.assertTrue(messages[0] is msg.subject)
-        self.assertTrue(occurences[0] is msg.subject.receiveEvent)
+        self.assertTrue(occurrences[0] is msg.subject.receiveEvent)
 
     def test_complete_message_connection(self):
         """Test complete message connection
@@ -168,7 +168,7 @@ class BasicMessageConnectionsTestCase(TestCase):
         ll.lifetime.visible = True
 
         # connect message to lifeline's lifetime, lifeline's lifetime
-        # visibility and connectivity should unchange
+        # visibility and connectivity should be unchanged
         self.connect(msg, msg.head, ll, ll.lifetime.port)
         self.assertTrue(ll.lifetime.connectable)
         self.assertEqual(ll.lifetime.MIN_LENGTH_VISIBLE, ll.lifetime.min_length)
@@ -182,8 +182,8 @@ class BasicMessageConnectionsTestCase(TestCase):
 
 class DiagramModeMessageConnectionTestCase(TestCase):
     def test_message_glue_cd(self):
-        """Test glueing message on communication diagram
-        """
+        """Test gluing message on communication diagram."""
+
         lifeline1 = self.create(items.LifelineItem)
         lifeline2 = self.create(items.LifelineItem)
         message = self.create(items.MessageItem)
@@ -200,8 +200,8 @@ class DiagramModeMessageConnectionTestCase(TestCase):
         self.assertFalse(glued)
 
     def test_message_glue_sd(self):
-        """Test glueing message on sequence diagram
-        """
+        """Test gluing message on sequence diagram."""
+
         msg = self.create(items.MessageItem)
         ll1 = self.create(items.LifelineItem)
         ll2 = self.create(items.LifelineItem)
@@ -246,28 +246,25 @@ class DiagramModeMessageConnectionTestCase(TestCase):
         msg.add_message(m4, True)
 
         messages = list(self.kindof(UML.Message))
-        occurences = set(self.kindof(UML.MessageOccurrenceSpecification))
+        occurrences = set(self.kindof(UML.MessageOccurrenceSpecification))
 
         # verify integrity of messages
         self.assertEqual(5, len(messages))
-        self.assertEqual(10, len(occurences))
+        self.assertEqual(10, len(occurrences))
         for m in messages:
-            self.assertTrue(m.sendEvent in occurences)
-            self.assertTrue(m.receiveEvent in occurences)
+            self.assertTrue(m.sendEvent in occurrences)
+            self.assertTrue(m.receiveEvent in occurrences)
 
         # lost/received messages
         self.disconnect(msg, msg.head)
         self.assertEqual(5, len(messages))
 
         # verify integrity of messages
-        self.assertEqual(10, len(occurences))
+        self.assertEqual(10, len(occurrences))
         for m in messages:
-            self.assertTrue(m.sendEvent is None or m.sendEvent in occurences)
-            self.assertTrue(m.receiveEvent is None or m.receiveEvent in occurences)
+            self.assertTrue(m.sendEvent is None or m.sendEvent in occurrences)
+            self.assertTrue(m.receiveEvent is None or m.receiveEvent in occurrences)
 
         # no message after full disconnection
         self.disconnect(msg, msg.tail)
         self.assertEqual(0, len(self.kindof(UML.Message)))
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/profiles/extensionconnect.py
+++ b/gaphor/adapters/profiles/extensionconnect.py
@@ -5,12 +5,9 @@ from gaphor.adapters.connectors import RelationshipConnect
 from gaphor.diagram import items
 
 
+@component.adapter(items.ClassifierItem, items.ExtensionItem)
 class ExtensionConnect(RelationshipConnect):
-    """
-    Connect class and stereotype items using an extension item.
-    """
-
-    component.adapts(items.ClassifierItem, items.ExtensionItem)
+    """Connect class and stereotype items using an extension item."""
 
     def allow(self, handle, port):
         line = self.line

--- a/gaphor/adapters/profiles/metaclasseditor.py
+++ b/gaphor/adapters/profiles/metaclasseditor.py
@@ -93,5 +93,3 @@ class MetaclassNameEditor(object):
 component.provideAdapter(
     MetaclassNameEditor, adapts=[items.MetaclassItem], name="Properties"
 )
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/profiles/tests/test_extension.py
+++ b/gaphor/adapters/profiles/tests/test_extension.py
@@ -13,8 +13,8 @@ class ExtensionConnectorTestCase(TestCase):
     """
 
     def test_class_glue(self):
-        """Test extension item glueing to a class
-        """
+        """Test extension item gluing to a class."""
+
         ext = self.create(items.ExtensionItem)
         cls = self.create(items.ClassItem, UML.Class)
 
@@ -23,8 +23,8 @@ class ExtensionConnectorTestCase(TestCase):
         self.assertFalse(glued)
 
     def test_stereotype_glue(self):
-        """Test extension item glueing to a stereotype
-        """
+        """Test extension item gluing to a stereotype."""
+
         ext = self.create(items.ExtensionItem)
         st = self.create(items.ClassItem, UML.Stereotype)
 

--- a/gaphor/adapters/profiles/tests/test_metaclasseditor.py
+++ b/gaphor/adapters/profiles/tests/test_metaclasseditor.py
@@ -19,6 +19,3 @@ class MetaclassEditorTest(TestCase):
 
         ci.subject.name = "Blah"
         self.assertEqual("Blah", combo.get_child().get_text())
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/relationships.py
+++ b/gaphor/adapters/relationships.py
@@ -40,6 +40,3 @@ from zope import component
 ###                    else:
 ###                        return assoc
 ###        return None
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/states/propertypages.py
+++ b/gaphor/adapters/states/propertypages.py
@@ -1,5 +1,4 @@
-"""
-State items property pages.
+"""State items property pages.
 
 To register property pages implemented in this module, it is imported in
 gaphor.adapter package.
@@ -14,14 +13,11 @@ from zope import interface, component
 from gaphor.adapters.propertypages import NamedItemPropertyPage, create_hbox_label
 
 
+@component.adapter(items.TransitionItem)
 class TransitionPropertyPage(NamedItemPropertyPage):
-    """
-    Transition property page allows to edit guard specification.
-    """
+    """Transition property page allows to edit guard specification."""
 
     element_factory = inject("element_factory")
-
-    component.adapts(items.TransitionItem)
 
     def construct(self):
         page = super(TransitionPropertyPage, self).construct()
@@ -64,14 +60,11 @@ class TransitionPropertyPage(NamedItemPropertyPage):
 component.provideAdapter(TransitionPropertyPage, name="Properties")
 
 
+@component.adapter(items.StateItem)
 class StatePropertyPage(NamedItemPropertyPage):
-    """
-    State property page.
-    """
+    """State property page."""
 
     element_factory = inject("element_factory")
-
-    component.adapts(items.StateItem)
 
     def construct(self):
         page = super(StatePropertyPage, self).construct()

--- a/gaphor/adapters/states/tests/test_transition_connect.py
+++ b/gaphor/adapters/states/tests/test_transition_connect.py
@@ -140,8 +140,8 @@ class TransitionConnectorTestCase(TestCase):
         self.assertFalse(self.get_connected(t.head))
 
     def test_initial_pseudostate_tail_glue(self):
-        """Test transition tail and initial pseudostate glueing
-        """
+        """Test transition tail and initial pseudostate gluing."""
+
         v1 = self.create(items.InitialPseudostateItem, UML.Pseudostate)
         t = self.create(items.TransitionItem)
         assert t.subject is None
@@ -182,6 +182,3 @@ class TransitionConnectorTestCase(TestCase):
 
         glued = self.allow(t, t.head, v)
         self.assertFalse(glued)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/states/vertexconnect.py
+++ b/gaphor/adapters/states/vertexconnect.py
@@ -32,12 +32,9 @@ class VertexConnect(RelationshipConnect):
             relation.guard = self.element_factory.create(UML.Constraint)
 
 
+@component.adapter(items.VertexItem, items.TransitionItem)
 class TransitionConnect(VertexConnect):
-    """
-    Connect two state vertices using transition item.
-    """
-
-    component.adapts(items.VertexItem, items.TransitionItem)
+    """Connect two state vertices using transition item."""
 
     def allow(self, handle, port):
         """
@@ -62,15 +59,13 @@ class TransitionConnect(VertexConnect):
 component.provideAdapter(TransitionConnect)
 
 
+@component.adapter(items.InitialPseudostateItem, items.TransitionItem)
 class InitialPseudostateTransitionConnect(VertexConnect):
-    """
-    Connect initial pseudostate using transition item.
+    """Connect initial pseudostate using transition item.
 
     It modifies InitialPseudostateItem._connected attribute to disallow
     connection of more than one transition.
     """
-
-    component.adapts(items.InitialPseudostateItem, items.TransitionItem)
 
     def allow(self, handle, port):
         """
@@ -97,15 +92,13 @@ class InitialPseudostateTransitionConnect(VertexConnect):
 component.provideAdapter(InitialPseudostateTransitionConnect)
 
 
+@component.adapter(items.HistoryPseudostateItem, items.TransitionItem)
 class HistoryPseudostateTransitionConnect(VertexConnect):
-    """
-    Connect history pseudostate using transition item.
+    """Connect history pseudostate using transition item.
 
     It modifies InitialPseudostateItem._connected attribute to disallow
     connection of more than one transition.
     """
-
-    component.adapts(items.HistoryPseudostateItem, items.TransitionItem)
 
     def allow(self, handle, port):
         """
@@ -114,5 +107,3 @@ class HistoryPseudostateTransitionConnect(VertexConnect):
 
 
 component.provideAdapter(HistoryPseudostateTransitionConnect)
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/tests/test_comment.py
+++ b/gaphor/adapters/tests/test_comment.py
@@ -28,8 +28,8 @@ class CommentLineTestCase(TestCase):
         self.assertFalse(comment.subject.annotatedElement)
 
     def test_commentline_same_comment_glue(self):
-        """Test comment line item glueing to already connected comment item
-        """
+        """Test comment line item gluing to already connected comment item."""
+
         comment = self.create(items.CommentItem, UML.Comment)
         line = self.create(items.CommentLineItem)
 
@@ -113,7 +113,7 @@ class CommentLineTestCase(TestCase):
 
         self.assertTrue(line.canvas)
 
-        # FixMe: This should invoke the disconnnect handler of the line's
+        # FixMe: This should invoke the disconnect handler of the line's
         #  handles.
 
         line.unlink()
@@ -144,7 +144,7 @@ class CommentLineTestCase(TestCase):
 
         clazz_subject = clazz.subject
 
-        # FixMe: This should invoke the disconnnect handler of the line's
+        # FixMe: This should invoke the disconnect handler of the line's
         #  handles.
 
         clazz.unlink()
@@ -177,7 +177,7 @@ class CommentLineTestCase(TestCase):
         self.assertTrue(gen.subject in comment.subject.annotatedElement)
         self.assertTrue(comment.subject in gen.subject.ownedComment)
 
-        # FixMe: This should invoke the disconnnect handler of the line's
+        # FixMe: This should invoke the disconnect handler of the line's
         #  handles.
 
         gen.unlink()

--- a/gaphor/adapters/tests/test_connector.py
+++ b/gaphor/adapters/tests/test_connector.py
@@ -14,5 +14,3 @@ class ConnectorTestCase(TestCase):
 
 
 # fixme: relationship test moved from multi dependency test
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/tests/test_editor.py
+++ b/gaphor/adapters/tests/test_editor.py
@@ -137,6 +137,3 @@ class EditorTestCase(TestCase):
         self.assertEqual("+ o(in blah)", tree_view.get_model()[0][0])
 
         page.destroy()
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/usecases/tests/test_extend.py
+++ b/gaphor/adapters/usecases/tests/test_extend.py
@@ -9,8 +9,8 @@ from gaphor.diagram import items
 
 class ExtendItemTestCase(TestCase):
     def test_use_case_glue(self):
-        """Test "extend" glueing to use cases
-        """
+        """Test "extend" gluing to use cases."""
+
         uc1 = self.create(items.UseCaseItem, UML.UseCase)
         extend = self.create(items.ExtendItem)
 
@@ -66,6 +66,3 @@ class ExtendItemTestCase(TestCase):
 
         self.disconnect(extend, extend.tail)
         self.assertTrue(self.get_connected(extend.tail) is None)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/usecases/tests/test_include.py
+++ b/gaphor/adapters/usecases/tests/test_include.py
@@ -9,8 +9,8 @@ from gaphor.diagram import items
 
 class IncludeItemTestCase(TestCase):
     def test_use_case_glue(self):
-        """Test "include" glueing to use cases
-        """
+        """Test "include" gluing to use cases."""
+
         uc1 = self.create(items.UseCaseItem, UML.UseCase)
         include = self.create(items.IncludeItem)
 
@@ -66,6 +66,3 @@ class IncludeItemTestCase(TestCase):
 
         self.disconnect(include, include.tail)
         self.assertTrue(self.get_connected(include.tail) is None)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/adapters/usecases/usecaseconnect.py
+++ b/gaphor/adapters/usecases/usecaseconnect.py
@@ -8,12 +8,9 @@ from gaphor.diagram import items
 from gaphor.adapters.connectors import RelationshipConnect
 
 
+@component.adapter(items.UseCaseItem, items.IncludeItem)
 class IncludeConnect(RelationshipConnect):
-    """
-    Connect use cases with an include item relationship.
-    """
-
-    component.adapts(items.UseCaseItem, items.IncludeItem)
+    """Connect use cases with an include item relationship."""
 
     def allow(self, handle, port):
         line = self.line
@@ -39,12 +36,9 @@ class IncludeConnect(RelationshipConnect):
 component.provideAdapter(IncludeConnect)
 
 
+@component.adapter(items.UseCaseItem, items.ExtendItem)
 class ExtendConnect(RelationshipConnect):
-    """
-    Connect use cases with an extend item relationship.
-    """
-
-    component.adapts(items.UseCaseItem, items.ExtendItem)
+    """Connect use cases with an extend item relationship."""
 
     def allow(self, handle, port):
         line = self.line
@@ -68,5 +62,3 @@ class ExtendConnect(RelationshipConnect):
 
 
 component.provideAdapter(ExtendConnect)
-
-# vim:sw=4:et:ai

--- a/gaphor/application.py
+++ b/gaphor/application.py
@@ -176,6 +176,3 @@ class inject(object):
         # if self._s is None:
         #    self._s = _Application.get_service(self._name)
         # return self._s
-
-
-# vim:sw=4:et:ai

--- a/gaphor/core.py
+++ b/gaphor/core.py
@@ -14,6 +14,3 @@ from gaphor.action import (
     build_action_group,
 )
 from gaphor.i18n import _
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/actions/action.py
+++ b/gaphor/diagram/actions/action.py
@@ -86,6 +86,3 @@ class AcceptEventActionItem(NamedItem):
         c.close_path()
 
         c.stroke()
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/actions/flow.py
+++ b/gaphor/diagram/actions/flow.py
@@ -577,5 +577,3 @@ class ACItem(object):
 #    cos_angle = cos(angle)
 #    return (cos_angle * a - sin_angle * b + x,
 #            sin_angle * a + cos_angle * b + y)
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/actions/tests/test_flow.py
+++ b/gaphor/diagram/actions/tests/test_flow.py
@@ -39,6 +39,3 @@ class FlowTestCase(TestCase):
         TODO: Test connector item saving/loading
         """
         pass
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/classes/generalization.py
+++ b/gaphor/diagram/classes/generalization.py
@@ -24,6 +24,3 @@ class GeneralizationItem(DiagramLine):
         cr.close_path()
         cr.stroke()
         cr.move_to(15, 0)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/classes/interface.py
+++ b/gaphor/diagram/classes/interface.py
@@ -285,6 +285,3 @@ class InterfaceItem(ClassItem):
             cr.arc(cx, cy, self.RADIUS_PROVIDED, 0, pi * 2)
         cr.stroke()
         super(InterfaceItem, self).draw(context)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/classes/tests/test_association.py
+++ b/gaphor/diagram/classes/tests/test_association.py
@@ -107,6 +107,3 @@ class AssociationItemTestCase(TestCase):
             pass  # Expected, hanve only 2 handles, need 3 or more
         else:
             assert False, "Can not set line to orthogonal with less than 3 handles"
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/classes/tests/test_class.py
+++ b/gaphor/diagram/classes/tests/test_class.py
@@ -141,6 +141,3 @@ class ClassTestCase(TestCase):
 
         width = klass.width
         self.assertGreater(width, 170.0)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/classes/tests/test_feature.py
+++ b/gaphor/diagram/classes/tests/test_feature.py
@@ -33,6 +33,3 @@ class FeatureTestCase(TestCase):
 
         self.diagram.canvas.update()
         self.assertTrue(size < item.get_size())
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/classes/tests/test_interface.py
+++ b/gaphor/diagram/classes/tests/test_interface.py
@@ -84,6 +84,3 @@ class InterfaceTestCase(TestCase):
         # recreated later, i.e. required folded mode will be set when
         # implementation connects to the interface
         self.assertEqual(iface.FOLDED_PROVIDED, interfaces[0].folded)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/comment.py
+++ b/gaphor/diagram/comment.py
@@ -74,6 +74,3 @@ class CommentItem(ElementItem):
                 self.width - ear,
                 self.height,
             )
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/compartment.py
+++ b/gaphor/diagram/compartment.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 class FeatureItem(object):
     """
-    FeatureItems are model elements who recide inside a ClassifierItem, such
+    FeatureItems are model elements who reside inside a ClassifierItem, such
     as methods and attributes. Those items can have comments attached, but only
     on the left and right side.
     Note that features can also be used inside objects.

--- a/gaphor/diagram/diagramitem.py
+++ b/gaphor/diagram/diagramitem.py
@@ -137,7 +137,7 @@ class DiagramItem(
     """
     Basic functionality for all model elements (lines and elements!).
 
-    This class contains common functionallity for model elements and
+    This class contains common functionality for model elements and
     relationships.
     It provides an interface similar to UML.Element for connecting and
     disconnecting signals.
@@ -276,6 +276,3 @@ class DiagramItem(
 
     def unregister_handlers(self):
         self.watcher.unregister_handlers()
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/elementitem.py
+++ b/gaphor/diagram/elementitem.py
@@ -101,6 +101,3 @@ class ElementItem(gaphas.Element, DiagramItem):
         x, y = get_text_point(extents, self.width, self.height, align, padding, outside)
 
         return x, y
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/extension.py
+++ b/gaphor/diagram/extension.py
@@ -32,6 +32,3 @@ class ExtensionItem(NamedLine):
         cr.set_source_rgb(0, 0, 0)
         cr.fill()
         cr.move_to(15, 0)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/states/__init__.py
+++ b/gaphor/diagram/states/__init__.py
@@ -6,8 +6,8 @@ Pseudostates
 There are some similarities between activities and state machines, for example
     - initial node and initial psuedostate
     - final node and final state
-Of course, they differ in many aspects, but the similarites drive user
-interface of state machines. This is with respect of minimalization of the set
+Of course, they differ in many aspects, but the similarities drive user
+interface of state machines. This is with respect of minimization of the set
 of diagram items (i.e. there is only one diagram item for both join and fork
 nodes in activities implemented in Gaphor).
 

--- a/gaphor/diagram/states/tests/test_pseudostates.py
+++ b/gaphor/diagram/states/tests/test_pseudostates.py
@@ -28,6 +28,3 @@ class InitialPseudostate(TestCase):
         # history setting is done in the DiagramToolbox factory:
         item.subject.kind = "shallowHistory"
         self.assertEqual("shallowHistory", item.subject.kind)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/states/tests/test_transition.py
+++ b/gaphor/diagram/states/tests/test_transition.py
@@ -31,6 +31,3 @@ class TransitionTestCase(TestCase):
 
         c.specification = "foo"
         assert item._guard.text == "foo", item._guard.text
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/states/transition.py
+++ b/gaphor/diagram/states/transition.py
@@ -48,6 +48,3 @@ class TransitionItem(NamedLine):
         cr.move_to(15, -6)
         cr.line_to(0, 0)
         cr.line_to(15, 6)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/tests/test_activitynodes.py
+++ b/gaphor/diagram/tests/test_activitynodes.py
@@ -63,6 +63,3 @@ class ActivityNodesTestCase(TestCase):
         ]
         self.assertTrue(item.combined is not None, item.combined)
         self.assertTrue(isinstance(item.combined, UML.JoinNode))
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/tests/test_connector.py
+++ b/gaphor/diagram/tests/test_connector.py
@@ -69,6 +69,3 @@ class ConnectorItemTestCase(TestCase):
         ends = self.kindof(UML.ConnectorEnd)
         # self.assertTrue(connectors[0].end is not None)
         # self.assertTrue(connectors[0].end is ends[0])
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/tests/test_diagramitem.py
+++ b/gaphor/diagram/tests/test_diagramitem.py
@@ -41,7 +41,7 @@ class ItemTestCase(unittest.TestCase):
         self.assertEqual(item_b.style.a_01, 5)
         self.assertEqual(item_b.style.a_02, 2)
 
-        # check ItemA style, it should remaing unaffected by ItemB style
+        # check ItemA style, it should remain unaffected by ItemB style
         # changes
         self.assertEqual(self.ItemA.style.a_01, 1)
         self.assertEqual(self.ItemA.style.a_02, 2)

--- a/gaphor/diagram/tests/test_objectnode.py
+++ b/gaphor/diagram/tests/test_objectnode.py
@@ -43,6 +43,3 @@ class ObjectNodeTestCase(TestCase):
         TODO: Test connector item saving/loading
         """
         pass
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/tests/test_simpleitem.py
+++ b/gaphor/diagram/tests/test_simpleitem.py
@@ -29,6 +29,3 @@ class SimpleItemTestCase(TestCase):
         """
         """
         self.diagram.create(Ellipse)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/diagram/textelement.py
+++ b/gaphor/diagram/textelement.py
@@ -476,6 +476,3 @@ class TextElement(object):
             cr.rectangle(x - 5, y - 1, width + 10, height + 2)
             cr.stroke()
         cr.restore()
-
-
-# vim:sw=4:et:ai

--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -43,7 +43,7 @@ class TransactionBegin(object):
 class TransactionCommit(object):
     """
     This event is emitted when a transaction (toplevel) is successfully
-    commited.
+    committed.
     """
 
     pass
@@ -63,12 +63,9 @@ class TransactionRollback(object):
 @implementer(IActionExecutedEvent)
 class ActionExecuted(object):
     """
-    Once an operation has succesfully been executed this event is raised.
+    Once an operation has successfully been executed this event is raised.
     """
 
     def __init__(self, name, action):
         self.name = name
         self.action = action
-
-
-# vim:sw=4:et:ai

--- a/gaphor/misc/colorbutton.py
+++ b/gaphor/misc/colorbutton.py
@@ -30,6 +30,3 @@ class ColorButton(Gtk.ColorButton):
         )
 
     color = property(lambda s: s.get_color_float())
-
-
-# vim:sw=4:et:ai

--- a/gaphor/misc/console.py
+++ b/gaphor/misc/console.py
@@ -386,5 +386,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-# vim:sw=4:et:ai

--- a/gaphor/misc/errorhandler.py
+++ b/gaphor/misc/errorhandler.py
@@ -1,10 +1,10 @@
-# vim:sw=4:et
 """A generic way to handle errors in GUI applications.
 
-This module also contains a ErrorHandlerAspect, which can be easely attached
+This module also contains a ErrorHandlerAspect, which can be easily attached
 to a class' method and will raise the error dialog when the method exits with
 an exception.
 """
+
 from gi.repository import Gtk
 import sys
 import pdb
@@ -19,7 +19,7 @@ def error_handler(message=None, exc_info=None):
         return
 
     if not message:
-        message = _("An error occured.")
+        message = _("An error occurred.")
 
     buttons = Gtk.ButtonsType.OK
     message = "%s\n\nTechnical details:\n\t%s\n\t%s" % (message, exc_type, exc_value)
@@ -41,6 +41,3 @@ def error_handler(message=None, exc_info=None):
     dialog.destroy()
     if answer == Gtk.ResponseType.YES:
         pdb.post_mortem(exc_traceback)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/misc/rattr.py
+++ b/gaphor/misc/rattr.py
@@ -74,6 +74,3 @@ def rsetattr(obj, attr, val):
         for name in attrs[1:-1]:
             obj = getattr(obj, name)
     setattr(obj, attrs[-1], val)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/misc/tests/test_xmlwriter.py
+++ b/gaphor/misc/tests/test_xmlwriter.py
@@ -83,6 +83,3 @@ class XMLWriterTestCase(unittest.TestCase):
             % sys.getdefaultencoding()
         )
         assert w.s == xml, w.s
-
-
-# vim:sw=4:et:ai

--- a/gaphor/misc/xmlwriter.py
+++ b/gaphor/misc/xmlwriter.py
@@ -143,6 +143,3 @@ class XMLWriter(xml.sax.handler.ContentHandler):
     def endCDATA(self):
         self._write(u"]]>")
         self._in_cdata = False
-
-
-# vim:sw=4:et:ai

--- a/gaphor/plugins/alignment/__init__.py
+++ b/gaphor/plugins/alignment/__init__.py
@@ -172,6 +172,3 @@ class Alignment(object):
             y = target_y - item.height - item.matrix[5]
             item.matrix.translate(0, y)
             item.request_update()
-
-
-# vim:sw=4:et:ai

--- a/gaphor/plugins/diagramlayout/__init__.py
+++ b/gaphor/plugins/diagramlayout/__init__.py
@@ -22,6 +22,7 @@ from gaphor.core import inject, action, build_action_group, transactional
 from gaphor.diagram import items
 from gaphor.interfaces import IService, IActionProvider
 from gaphor.plugins.diagramlayout import toposort
+from gaphor.ui.interfaces import IUIComponent
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ log = logging.getLogger(__name__)
 @implementer(IService, IActionProvider)
 class DiagramLayout(object):
 
+    component_registry = inject("component_registry")
     main_window = inject("main_window")
 
     menu_xml = """
@@ -50,13 +52,19 @@ class DiagramLayout(object):
         pass
 
     def update(self):
-        self.sensitive = bool(self.get_window().get_current_diagram())
+        self.sensitive = bool(
+            self.component_registry.get_utility(
+                IUIComponent, "diagrams"
+            ).get_current_diagram()
+        )
 
     @action(
         name="diagram-layout", label="La_yout diagram", tooltip="simple diagram layout"
     )
     def execute(self):
-        d = self.diagram.get_current_diagram()
+        d = self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_diagram()
         self.layout_diagram(d)
 
     @transactional

--- a/gaphor/plugins/diagramlayout/tests/test_diagramlayout.py
+++ b/gaphor/plugins/diagramlayout/tests/test_diagramlayout.py
@@ -29,6 +29,3 @@ class DiagramLayoutTestCase(TestCase):
         c2.request_update()
 
         diagram_layout.layout_diagram(diagram)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/plugins/pynsource/__init__.py
+++ b/gaphor/plugins/pynsource/__init__.py
@@ -266,6 +266,3 @@ class PyNSource(object):
         element = filelist.remove(iter)
 
         self.remove_button.set_property("sensitive", False)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/plugins/pynsource/pynsource.py
+++ b/gaphor/plugins/pynsource/pynsource.py
@@ -587,7 +587,7 @@ class HandleClassStaticAttrs(HandleComposites):
     def __AddAttrModuleLevel(self):
         # Should re-use the logic in HandleClassAttributes for both parsing
         # (getting more info on multiplicity but not static - cos static not relevant?) and
-        # also should be able to resuse most of _AddAttr()
+        # also should be able to reuse most of _AddAttr()
         #
         classentry = self.classlist[self.currclass]
         attrtype = ["static"]
@@ -642,7 +642,7 @@ class HandleModuleLevelDefsAndAttrs(HandleClassStaticAttrs):
 
         # Should re-use the logic in HandleClassAttributes for both parsing
         # (getting more info on multiplicity but not static - cos static not relevant?) and
-        # also should be able to resuse most of _AddAttr()
+        # also should be able to reuse most of _AddAttr()
         #
         classentry = self.classlist[self.moduleasclass]
         attrtype = ["normal"]

--- a/gaphor/plugins/xmiexport/__init__.py
+++ b/gaphor/plugins/xmiexport/__init__.py
@@ -3,6 +3,7 @@ This plugin extends Gaphor with XMI export functionality.
 """
 
 from builtins import object
+from logging import getLogger
 
 from zope.interface import implementer
 
@@ -17,6 +18,7 @@ class XMIExport(object):
 
     element_factory = inject("element_factory")
     main_window = inject("main_window")
+    logger = getLogger(__name__)
 
     menu_xml = """
       <ui>
@@ -57,12 +59,14 @@ class XMIExport(object):
         filename = file_dialog.selection
 
         if filename and len(filename) > 0:
-            log.debug("Exporting XMI model to: %s" % filename)
+            self.logger.debug("Exporting XMI model to: %s" % filename)
             export = exportmodel.XMIExport(self.element_factory)
             try:
                 export.export(filename)
             except Exception as e:
-                log.error("Error while saving model to file %s: %s" % (filename, e))
+                self.logger.error(
+                    "Error while saving model to file %s: %s" % (filename, e)
+                )
 
 
 # vim:sw=4:et

--- a/gaphor/plugins/xmiexport/exportmodel.py
+++ b/gaphor/plugins/xmiexport/exportmodel.py
@@ -1,5 +1,7 @@
 from builtins import object
 from builtins import str
+from logging import getLogger
+
 from gaphor.misc.xmlwriter import XMLWriter
 
 
@@ -11,12 +13,14 @@ class XMIExport(object):
     XMI_PREFIX = "XMI"
     UML_PREFIX = "UML"
 
+    logger = getLogger(__name__)
+
     def __init__(self, element_factory):
         self.element_factory = element_factory
         self.handled_ids = list()
 
     def handle(self, xmi, element):
-        log.debug("Handling %s" % element.__class__.__name__)
+        self.logger.debug("Handling %s" % element.__class__.__name__)
         try:
             handler_name = "handle%s" % element.__class__.__name__
             handler = getattr(self, handler_name)
@@ -25,9 +29,13 @@ class XMIExport(object):
             if not idref:
                 self.handled_ids.append(element.id)
         except AttributeError as e:
-            log.warning("Missing handler for %s:%s" % (element.__class__.__name__, e))
+            self.logger.warning(
+                "Missing handler for %s:%s" % (element.__class__.__name__, e)
+            )
         except Exception as e:
-            log.error("Failed to handle %s:%s" % (element.__class__.__name__, e))
+            self.logger.error(
+                "Failed to handle %s:%s" % (element.__class__.__name__, e)
+            )
 
     def handlePackage(self, xmi, element, idref=False):
 
@@ -257,7 +265,7 @@ class XMIExport(object):
 
         xmi.endElement("XMI")
 
-        log.debug(self.handled_ids)
+        self.logger.debug(self.handled_ids)
 
     def select_package(self, element):
         return element.__class__.__name__ == "Package"

--- a/gaphor/services/actionmanager.py
+++ b/gaphor/services/actionmanager.py
@@ -111,6 +111,3 @@ class UIManager(Gtk.UIManager):
 
     def shutdown(self):
         pass
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/adapterloader.py
+++ b/gaphor/services/adapterloader.py
@@ -16,6 +16,3 @@ class AdapterLoader(object):
 
     def shutdown(self):
         pass
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/componentregistry.py
+++ b/gaphor/services/componentregistry.py
@@ -163,6 +163,3 @@ class ZopeComponentRegistry(object):
         objects = self._filter(events)
         if objects:
             list(map(self._components.handle, events))
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -28,7 +28,7 @@ class CopyService(object):
       generatlised to allow a subset to be saved/loaded (which is needed
       anyway for exporting/importing stereotype Profiles).
     - How many data should be saved? (e.g. we copy a diagram item, remove it
-      (the underlaying UML element is removed) and the paste the copied item.
+      (the underlying UML element is removed) and the paste the copied item.
       The diagram should act as if we have placed a copy of the removed item
       on the canvas and make the uml element visible again.
     """
@@ -78,7 +78,7 @@ class CopyService(object):
 
     def copy_func(self, name, value, reference=False):
         """
-        Copy an element, preferbly from the list of new items,
+        Copy an element, preferably from the list of new items,
         otherwise from the element factory.
         If it does not exist there, do not copy it!
         """
@@ -124,7 +124,7 @@ class CopyService(object):
 
         # Copy attributes and references. References should be
         #  1. in the ElementFactory (hence they are model elements)
-        #  2. refered to in new_items
+        #  2. referred to in new_items
         #  3. canvas property is overridden
         for ci in copy_items:
             self._item = self._new_items[ci.id]
@@ -166,6 +166,3 @@ class CopyService(object):
 
         for item in list(self._new_items.values()):
             view.select_item(item)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/diagramexportmanager.py
+++ b/gaphor/services/diagramexportmanager.py
@@ -13,6 +13,7 @@ from zope.interface import implementer
 from gaphor.core import _, inject, action, build_action_group
 from gaphor.interfaces import IService, IActionProvider
 from gaphor.ui.filedialog import FileDialog
+from gaphor.ui.interfaces import IUIComponent
 from gaphor.ui.questiondialog import QuestionDialog
 
 
@@ -22,6 +23,7 @@ class DiagramExportManager(object):
     Service for exporting diagrams as images (SVG, PNG, PDF).
     """
 
+    component_registry = inject("component_registry")
     main_window = inject("main_window")
     properties = inject("properties")
     logger = getLogger("ExportManager")
@@ -51,11 +53,7 @@ class DiagramExportManager(object):
         pass
 
     def update(self):
-
-        self.logger.info("Updating")
-
-        tab = self.get_window().get_current_diagram_page()
-        self.sensitive = tab and True or False
+        pass
 
     def save_dialog(self, diagram, title, ext):
 
@@ -191,7 +189,9 @@ class DiagramExportManager(object):
     def save_svg_action(self):
         title = "Export diagram to SVG"
         ext = ".svg"
-        diagram = self.main_window.get_current_diagram()
+        diagram = self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_diagram()
         filename = self.save_dialog(diagram, title, ext)
         if filename:
             self.save_svg(filename, diagram.canvas)
@@ -204,7 +204,9 @@ class DiagramExportManager(object):
     def save_png_action(self):
         title = "Export diagram to PNG"
         ext = ".png"
-        diagram = self.main_window.get_current_diagram()
+        diagram = self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_diagram()
         filename = self.save_dialog(diagram, title, ext)
         if filename:
             self.save_png(filename, diagram.canvas)
@@ -217,7 +219,9 @@ class DiagramExportManager(object):
     def save_pdf_action(self):
         title = "Export diagram to PDF"
         ext = ".pdf"
-        diagram = self.main_window.get_current_diagram()
+        diagram = self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_diagram()
         filename = self.save_dialog(diagram, title, ext)
         if filename:
             self.save_pdf(filename, diagram.canvas)

--- a/gaphor/services/diagramexportmanager.py
+++ b/gaphor/services/diagramexportmanager.py
@@ -1,6 +1,4 @@
-"""
-Service dedicated to exporting diagrams to a varyity of file formats.
-"""
+"""Service dedicated to exporting diagrams to a variety of file formats."""
 
 import os
 from builtins import object
@@ -117,7 +115,7 @@ class DiagramExportManager(object):
 
         self.update_painters(view)
 
-        # Update bounding boxes with a temporaly CairoContext
+        # Update bounding boxes with a temporary CairoContext
         # (used for stuff like calculating font metrics)
         tmpsurface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 0, 0)
         tmpcr = cairo.Context(tmpsurface)

--- a/gaphor/services/elementdispatcher.py
+++ b/gaphor/services/elementdispatcher.py
@@ -343,5 +343,3 @@ class ElementDispatcher(object):
 
 #        for h in self._reverse.iterkeys():
 #            h(None)
-
-# vim:sw=4:et:ai

--- a/gaphor/services/filemanager.py
+++ b/gaphor/services/filemanager.py
@@ -486,6 +486,3 @@ class FileManager(object):
             return True
 
         return False
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/helpservice.py
+++ b/gaphor/services/helpservice.py
@@ -128,6 +128,3 @@ class HelpService(object):
         vbox.show_all()
         about.run()
         about.destroy()
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/propertydispatcher.py
+++ b/gaphor/services/propertydispatcher.py
@@ -81,6 +81,3 @@ class PropertyDispatcher(object):
                 handler(event)
             except Exception as e:
                 log.error("problem executing handler %s" % handler, exc_info=True)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/sanitizerservice.py
+++ b/gaphor/services/sanitizerservice.py
@@ -128,6 +128,3 @@ class SanitizerService(object):
         if event.property is UML.InstanceSpecification.classifier:
             if isinstance(event.old_value, UML.Stereotype):
                 event.element.unlink()
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/tests/test_copyservice.py
+++ b/gaphor/services/tests/test_copyservice.py
@@ -109,6 +109,3 @@ class CopyServiceTestCase(TestCase):
 
         self.assertEqual(3, len(self.diagram.canvas.get_all_items()))
         self.assertFalse(orphan_references(self.element_factory))
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/tests/test_diagramexportmanager.py
+++ b/gaphor/services/tests/test_diagramexportmanager.py
@@ -26,6 +26,3 @@ class DiagramExportManagerTestCase(unittest.TestCase):
     def test_init_from_application(self):
         Application.get_service("diagram_export_manager")
         Application.get_service("main_window")
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/tests/test_properties.py
+++ b/gaphor/services/tests/test_properties.py
@@ -51,6 +51,3 @@ class TestProperties(TestCase):
 #
 #        assert 3 == prop('test2', 3)
 #        assert 3 == prop('test2', 4)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/tests/test_sanitizerservice.py
+++ b/gaphor/services/tests/test_sanitizerservice.py
@@ -156,6 +156,3 @@ class SanitizerServiceTest(TestCase):
         stereotype.unlink()
 
         self.assertEqual([], list(klass.appliedStereotype))
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/tests/test_undomanager.py
+++ b/gaphor/services/tests/test_undomanager.py
@@ -396,6 +396,3 @@ class TestUndoManager(TestCase):
         assert p in ef.lselect()
 
         undo_manager.shutdown()
-
-
-# vim:sw=4:et:ai

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -202,12 +202,12 @@ class UndoManager(object):
         # Store stacks
         undo_stack = list(self._undo_stack)
 
-        errorous_tx = self._current_transaction
+        erroneous_tx = self._current_transaction
         self._current_transaction = None
         try:
             with Transaction():
                 try:
-                    errorous_tx.execute()
+                    erroneous_tx.execute()
                 except Exception as e:
                     self.logger.error("Could not roolback transaction")
                     self.logger.error(e)
@@ -377,7 +377,7 @@ class UndoManager(object):
         # print 'got new set event', association, element, value
         def _undo_association_set_event():
             # print 'undoing action', element, value
-            # Tell the assoctaion it should not need to let the opposite
+            # Tell the association it should not need to let the opposite
             # side connect (it has it's own signal)
             association._set(element, value, from_opposite=True)
 
@@ -391,7 +391,7 @@ class UndoManager(object):
 
         def _undo_association_add_event():
             # print 'undoing action', element, value
-            # Tell the assoctaion it should not need to let the opposite
+            # Tell the association it should not need to let the opposite
             # side connect (it has it's own signal)
             association._del(element, value, from_opposite=True)
 
@@ -410,6 +410,3 @@ class UndoManager(object):
             association._set(element, value, from_opposite=True)
 
         self.add_undo_action(_undo_association_delete_event)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/storage/parser.py
+++ b/gaphor/storage/parser.py
@@ -358,6 +358,3 @@ def parse_file(filename, parser):
 
     if not is_fd:
         file_obj.close()
-
-
-# vim:sw=4:et:ai

--- a/gaphor/storage/tests/test_storage.py
+++ b/gaphor/storage/tests/test_storage.py
@@ -489,6 +489,3 @@ class FileUpgradeTestCase(TestCase):
         m = find("rlost1()")
         self.assertTrue(m.sendEvent is None)
         self.assertTrue(m.receiveEvent.covered is l1.subject)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/storage/tests/test_verify.py
+++ b/gaphor/storage/tests/test_verify.py
@@ -19,6 +19,3 @@ class VerifyTestCase(TestCase):
         assert m in c.ownedComment
 
         assert orphan_references(factory)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/storage/verify.py
+++ b/gaphor/storage/verify.py
@@ -80,6 +80,3 @@ def orphan_references(factory):
         e.save(verify_element)
 
     return [r[1] for r in refs if not r[0] in elements]
-
-
-# vim:sw=4:et:ai

--- a/gaphor/tests/test_action.py
+++ b/gaphor/tests/test_action.py
@@ -10,5 +10,3 @@ if __name__ == "__main__":
     import unittest
 
     unittest.main(defaultTest="test_suite")
-
-# vim:sw=4:et:ai

--- a/gaphor/tests/testcase.py
+++ b/gaphor/tests/testcase.py
@@ -209,5 +209,3 @@ class TestCase(TestCaseExtras, unittest.TestCase):
 
 
 main = unittest.main
-
-# vim:sw=4:et:ai

--- a/gaphor/tools/gaphorconvert.py
+++ b/gaphor/tools/gaphorconvert.py
@@ -150,6 +150,3 @@ for model in args:
 
 def main():
     pass
-
-
-# vim:sw=4:et:ai

--- a/gaphor/ui/consolewindow.py
+++ b/gaphor/ui/consolewindow.py
@@ -41,9 +41,8 @@ class ConsoleWindow(object):
         self.ui_manager = None  # injected
 
     def load_console_py(self):
-        """
-        Load default script for console. Saves some repetative typing.
-        """
+        """Load default script for console. Saves some repetitive typing."""
+
         console_py = os.path.join(get_user_data_dir(), "console.py")
         try:
             with open(console_py) as f:

--- a/gaphor/ui/event.py
+++ b/gaphor/ui/event.py
@@ -2,15 +2,11 @@ from builtins import object
 
 from zope.interface import implementer
 
-from gaphor.ui.interfaces import (
-    IDiagramSelectionChange,
-    IDiagramPageChange,
-    IDiagramShow,
-)
+from gaphor.ui.interfaces import IDiagramSelectionChange, IDiagramPageChange, IDiagram
 
 
-@implementer(IDiagramShow)
-class DiagramShow(object):
+@implementer(IDiagram)
+class Diagram(object):
     def __init__(self, diagram):
         self.diagram = diagram
 

--- a/gaphor/ui/event.py
+++ b/gaphor/ui/event.py
@@ -28,6 +28,3 @@ class DiagramSelectionChange(object):
         self.diagram_view = diagram_view
         self.focused_item = focused_item
         self.selected_items = selected_items
-
-
-# vim:sw=4:et:ai

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -20,9 +20,9 @@ class FileDialog(object):
         """Initialize the file dialog.  The title parameter is the title
         displayed in the dialog.  The filename parameter will set the current
         file name in the dialog.  The action is either open or save and changes
-        the buttons isplayed.  If the parent window parameter is supplied,
+        the buttons displayed.  If the parent window parameter is supplied,
         the file dialog is set to be transient for that window.  The multiple
-        parameter should be set to true if sultiple files can be opened at once.
+        parameter should be set to true if multiple files can be opened at once.
         This means that a list of filenames instead of a single filename string
         will be returned by the selection property.  The filters is a list
         of dictionaries that have a name and pattern key.  This restricts what
@@ -63,14 +63,14 @@ class FileDialog(object):
         by the selection property."""
 
         response = self.dialog.run()
-        selection = None
 
         if response == Gtk.ResponseType.OK:
-
             if self.multiple:
                 selection = self.dialog.get_filenames()
             else:
                 selection = self.dialog.get_filename()
+        else:
+            selection = ""
 
         return selection
 

--- a/gaphor/ui/interfaces.py
+++ b/gaphor/ui/interfaces.py
@@ -5,7 +5,7 @@ Interfaces related to the user interface.
 from zope import interface
 
 
-class IDiagramShow(interface.Interface):
+class IDiagram(interface.Interface):
     """
     Show a new diagram tab
     """

--- a/gaphor/ui/interfaces.py
+++ b/gaphor/ui/interfaces.py
@@ -78,6 +78,3 @@ class IPropertyPage(interface.Interface):
         """
         Destroy the page and clean up signal handlers and stuff.
         """
-
-
-# vim:sw=4:et:ai

--- a/gaphor/ui/layout.py
+++ b/gaphor/ui/layout.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# vim:sw=4:et:ai
 
 # Copyright © 2010 etkdocking Contributors
 #

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -32,7 +32,7 @@ from gaphor.services.undomanager import UndoManagerStateChanged
 from gaphor.ui.accelmap import load_accel_map, save_accel_map
 from gaphor.ui.diagrampage import DiagramPage
 from gaphor.ui.diagramtoolbox import TOOLBOX_ACTIONS
-from gaphor.ui.event import DiagramPageChange, DiagramShow
+from gaphor.ui.event import DiagramPageChange, Diagram
 from gaphor.ui.interfaces import IDiagramPageChange
 from gaphor.ui.interfaces import IUIComponent
 from gaphor.ui.layout import deserialize
@@ -320,7 +320,7 @@ class MainWindow(object):
             lambda e: e.isKindOf(UML.Diagram)
             and not (e.namespace and e.namespace.namespace)
         ):
-            self.component_registry.handle(DiagramShow(diagram))
+            self.component_registry.handle(Diagram(diagram))
 
     @component.adapter(FileManagerStateChanged)
     def _on_file_manager_state_changed(self, event):
@@ -545,7 +545,7 @@ class Namespace(object):
         element = self._namespace.get_selected_element()
         # TODO: Candidate for adapter?
         if isinstance(element, UML.Diagram):
-            self.component_registry.handle(DiagramShow(element))
+            self.component_registry.handle(Diagram(element))
 
         else:
             log.debug("No action defined for element %s" % type(element).__name__)
@@ -579,7 +579,7 @@ class Namespace(object):
             diagram.name = "New diagram"
 
         self.select_element(diagram)
-        self.component_registry.handle(DiagramShow(diagram))
+        self.component_registry.handle(Diagram(diagram))
         self.tree_view_rename_selected()
 
     @action(
@@ -798,7 +798,7 @@ class Diagrams(object):
         """
         page_num = self._notebook.get_current_page()
         child_widget = self._notebook.get_nth_page(page_num)
-        return child_widget.diagram_page
+        return child_widget.diagram_page.get_diagram()
 
     def cb_close_tab(self, button, widget):
         """Callback to close the tab and remove the notebook page.
@@ -865,7 +865,7 @@ class Diagrams(object):
             widgets_on_pages.append((page, widget))
         return widgets_on_pages
 
-    @component.adapter(DiagramShow)
+    @component.adapter(Diagram)
     def _on_show_diagram(self, event):
         """Show a Diagram element in the Notebook.
 

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -775,17 +775,16 @@ class Diagrams(object):
 
         Returns:
             The Gtk.Notebook.
-
         """
+
         self._notebook = Gtk.Notebook()
         self._notebook.show()
         self.component_registry.register_handler(self._on_show_diagram)
         return self._notebook
 
     def close(self):
-        """Close the diagrams component.
+        """Close the diagrams component."""
 
-        """
         self.component_registry.unregister_handler(self._on_show_diagram)
         self._notebook.destroy()
         self._notebook = None
@@ -794,11 +793,24 @@ class Diagrams(object):
         """Returns the current page of the notebook.
 
         Returns (DiagramPage): The current diagram page.
-
         """
+
         page_num = self._notebook.get_current_page()
         child_widget = self._notebook.get_nth_page(page_num)
-        return child_widget.diagram_page.get_diagram()
+        if child_widget is not None:
+            return child_widget.diagram_page.get_diagram()
+        else:
+            return None
+
+    def get_current_view(self):
+        """Returns the current view of the diagram page.
+
+        Returns (GtkView): The current view.
+        """
+
+        page_num = self._notebook.get_current_page()
+        child_widget = self._notebook.get_nth_page(page_num)
+        return child_widget.diagram_page.get_view()
 
     def cb_close_tab(self, button, widget):
         """Callback to close the tab and remove the notebook page.
@@ -806,8 +818,8 @@ class Diagrams(object):
         Args:
             button (Gtk.Button): The button the callback is from.
             widget (Gtk.Widget): The child widget of the tab.
-
         """
+
         page_num = self._notebook.page_num(widget)
         # TODO why does Gtk.Notebook give a GTK-CRITICAL if you remove a page
         #   with set_show_tabs(True)?
@@ -824,8 +836,8 @@ class Diagrams(object):
         Args:
             title (str): The title of the tab, the diagram name.
             widget (Gtk.Widget): The child widget of the tab.
-
         """
+
         tab_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
         label = Gtk.Label(title)
         tab_box.pack_start(label)
@@ -856,8 +868,8 @@ class Diagrams(object):
 
         Returns:
             List of tuples (page, widget) of the currently open Notebook pages.
-
         """
+
         widgets_on_pages = []
         num_pages = self._notebook.get_n_pages()
         for page in range(0, num_pages):
@@ -874,8 +886,8 @@ class Diagrams(object):
 
         Args:
             event: The service event that is calling the method.
-
         """
+
         diagram = event.diagram
 
         # Try to find an existing diagram page and give it focus
@@ -897,9 +909,8 @@ class Diagrams(object):
 
     @toggle_action(name="diagram-drawing-style", label="Hand drawn style", active=False)
     def hand_drawn_style(self, active):
-        """
-        Toggle between straight diagrams and "hand drawn" diagram style.
-        """
+        """Toggle between straight diagrams and "hand drawn" diagram style."""
+
         if active:
             sloppiness = 0.5
         else:

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -907,6 +907,3 @@ class Diagrams(object):
         for page, widget in self.get_widgets_on_pages():
             widget.diagram_page.set_drawing_style(sloppiness)
         self.properties.set("diagram.sloppiness", sloppiness)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/ui/tests/test_diagrampage.py
+++ b/gaphor/ui/tests/test_diagrampage.py
@@ -51,6 +51,3 @@ class DiagramPageTestCase(unittest.TestCase):
             CommentItem, subject=self.element_factory.create(UML.Comment)
         )
         self.assertEqual(len(self.element_factory.lselect()), 2)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/ui/tests/test_diagramtools.py
+++ b/gaphor/ui/tests/test_diagramtools.py
@@ -1,11 +1,13 @@
-from gi.repository import Gtk
 import logging
-from gaphor.tests import TestCase
-from gaphor import UML
-from gaphor.diagram import items
-from gaphas.canvas import Context
 
-Event = Context
+from gi.repository import Gdk
+
+from gaphor import UML
+from gaphor.core import inject
+from gaphor.diagram import items
+from gaphor.tests import TestCase
+from gaphor.ui.event import Diagram
+from gaphor.ui.interfaces import IUIComponent
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -17,13 +19,14 @@ class DiagramItemConnectorTestCase(TestCase):
         "action_manager",
         "properties",
     ]
+    component_registry = inject("component_registry")
 
     def setUp(self):
         super(DiagramItemConnectorTestCase, self).setUp()
         mw = self.get_service("main_window")
         mw.open()
-        mw.show_diagram(self.diagram)
         self.main_window = mw
+        self.component_registry.handle(Diagram(self.diagram))
 
     def test_item_reconnect(self):
         # Setting the stage:
@@ -41,19 +44,21 @@ class DiagramItemConnectorTestCase(TestCase):
         the_association = a.subject
 
         # The act: perform button press event and button release
-        view = self.main_window.get_current_diagram_view()
+        view = self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_view()
 
         self.assertSame(self.diagram.canvas, view.canvas)
 
         p = view.get_matrix_i2v(a).transform_point(*a.head.pos)
 
-        event = Event(x=p[0], y=p[1], type=Gdk.EventType.BUTTON_PRESS, state=0)
+        event = Gdk.Event(x=p[0], y=p[1], type=Gdk.EventType.BUTTON_PRESS, state=0)
 
         view.do_event(event)
 
         self.assertSame(the_association, a.subject)
 
-        event = Event(x=p[0], y=p[1], type=Gdk.BUTTON_RELEASE, state=0)
+        event = Gdk.Event(x=p[0], y=p[1], type=Gdk.BUTTON_RELEASE, state=0)
 
         view.do_event(event)
 

--- a/gaphor/ui/tests/test_diagramtools.py
+++ b/gaphor/ui/tests/test_diagramtools.py
@@ -58,6 +58,3 @@ class DiagramItemConnectorTestCase(TestCase):
         view.do_event(event)
 
         self.assertSame(the_association, a.subject)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -322,6 +322,3 @@ class HandleToolTestCase(unittest.TestCase):
         self.assertTrue(cinfo is None)
         # self.assertTrue(handle.connection_data is None)
         self.assertEqual(len(comment.subject.annotatedElement), 0)
-
-
-# vim:sw=4:et:ai

--- a/gaphor/ui/tests/test_mainwindow.py
+++ b/gaphor/ui/tests/test_mainwindow.py
@@ -1,9 +1,10 @@
-from gi.repository import Gtk
 import unittest
 
-from gaphor.application import Application
-from gaphor.ui.mainwindow import MainWindow
 from gaphor import UML
+from gaphor.application import Application
+from gaphor.core import inject
+from gaphor.ui.event import Diagram
+from gaphor.ui.interfaces import IUIComponent
 
 
 class MainWindowTestCase(unittest.TestCase):
@@ -18,6 +19,8 @@ class MainWindowTestCase(unittest.TestCase):
             ]
         )
 
+    component_registry = inject("component_registry")
+
     def tearDown(self):
         Application.shutdown()
 
@@ -25,16 +28,25 @@ class MainWindowTestCase(unittest.TestCase):
         # MainWindow should be created as resource
         main_w = Application.get_service("main_window")
         main_w.open()
-        self.assertEqual(main_w.get_current_diagram(), None)
+        self.assertEqual(
+            self.component_registry.get_utility(
+                IUIComponent, "diagrams"
+            ).get_current_diagram(),
+            None,
+        )
 
     def test_show_diagram(self):
         main_w = Application.get_service("main_window")
         element_factory = Application.get_service("element_factory")
         diagram = element_factory.create(UML.Diagram)
         main_w.open()
-        self.assertEqual(main_w.get_current_diagram(), None)
-
-        main_w.show_diagram(diagram)
+        self.component_registry.handle(Diagram(diagram))
+        self.assertEqual(
+            self.component_registry.get_utility(
+                IUIComponent, "diagrams"
+            ).get_current_diagram(),
+            diagram,
+        )
 
 
 # vim:sw=4:et:ai

--- a/gaphor/ui/tests/test_namespace.py
+++ b/gaphor/ui/tests/test_namespace.py
@@ -133,7 +133,7 @@ class NewNamespaceTestCase(TestCase):
         m = factory.create(UML.Package)
         m.name = "m"
         assert m in ns._nodes
-        assert ns.path_from_element(m) == [1]
+        assert ns.path_from_element(m) == (1,)
         assert ns.element_from_path((1,)) is m
 
         a = factory.create(UML.Package)
@@ -141,8 +141,8 @@ class NewNamespaceTestCase(TestCase):
         assert a in ns._nodes
         assert a in ns._nodes[None]
         assert m in ns._nodes
-        assert ns.path_from_element(a) == [1], ns.path_from_element(a)
-        assert ns.path_from_element(m) == [2], ns.path_from_element(m)
+        assert ns.path_from_element(a) == (1,), ns.path_from_element(a)
+        assert ns.path_from_element(m) == (2,), ns.path_from_element(m)
 
         a.package = m
         assert a in ns._nodes
@@ -152,14 +152,14 @@ class NewNamespaceTestCase(TestCase):
         assert a.package is m
         assert a in m.ownedMember
         assert a.namespace is m
-        assert ns.path_from_element(a) == [1, 0], ns.path_from_element(a)
+        assert ns.path_from_element(a) == (1, 0), ns.path_from_element(a)
 
         c = factory.create(UML.Class)
         c.name = "c"
         assert c in ns._nodes
-        assert ns.path_from_element(c) == [1], ns.path_from_element(c)
-        assert ns.path_from_element(m) == [2], ns.path_from_element(m)
-        assert ns.path_from_element(a) == [2, 0], ns.path_from_element(a)
+        assert ns.path_from_element(c) == (1,), ns.path_from_element(c)
+        assert ns.path_from_element(m) == (2,), ns.path_from_element(m)
+        assert ns.path_from_element(a) == (2, 0), ns.path_from_element(a)
 
         c.package = m
         assert c in ns._nodes

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -103,4 +103,4 @@ class Toolbox(Gtk.ToolPalette):
         data.set(type=data.get_target(), format=8, data=button.action_name.encode())
 
 
-# vim:sw=4:et:ai
+Gtk.Box.new(orientation=Gtk.Orientation.VERTICAL, spacing=0)

--- a/gaphor/ui/toplevelwindow.py
+++ b/gaphor/ui/toplevelwindow.py
@@ -74,6 +74,3 @@ class ToplevelWindow(object):
             # Create a simple window.
             self.window.add(self.ui_component())
         self.window.show()
-
-
-# vim:sw=4:et:ai

--- a/setup.py
+++ b/setup.py
@@ -138,5 +138,3 @@ It uses the GTK+ environment for user interaction.
         build_mo=dict(all_linguas=",".join(LINGUAS)),
     ),
 )
-
-# vim:sw=4:et:ai

--- a/tests/test_action_issue.py
+++ b/tests/test_action_issue.py
@@ -80,6 +80,3 @@ class ActionIssueTestCase(TestCase):
             self.assertTrue(p)
             self.assertTrue(canvas.get_parent(a.presentation[0]))
             self.assertSame(canvas.get_parent(a.presentation[0]), p.presentation[0])
-
-
-# vim:sw=4:et:ai

--- a/tests/test_gen_uml.py
+++ b/tests/test_gen_uml.py
@@ -55,6 +55,3 @@ SubClass.name4 = redefine(SubClass, 'name4', D, name2)
 
 # # 'SubClass.value' is a simple attribute
 # SubClass.value = attribute('value', str, lower=f9124094-3f14-11de-9595-00224128e79d)
-
-
-# vim:sw=4:et:ai

--- a/tests/test_issue_53.py
+++ b/tests/test_issue_53.py
@@ -75,6 +75,3 @@ class PackageWithStereotypesRemovalTestCase(unittest.TestCase):
         self.assertEqual(
             2, len(element_factory.lselect(lambda e: e.isKindOf(UML.Diagram)))
         )
-
-
-# vim:sw=4:et:ai

--- a/tests/test_issue_gaphas.py
+++ b/tests/test_issue_gaphas.py
@@ -33,6 +33,3 @@ class GaphasTest(TestCase):
         c1.unlink()
 
         self.diagram.canvas.update_now()
-
-
-# vim:sw=4:et:ai

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -58,6 +58,3 @@ class UndoTest(TestCase):
             self.assertEqual(ci2, self.get_connected(a.tail))
 
             undo_manager.redo_transaction()
-
-
-# vim:sw=4:et:ai

--- a/utils/command/gen_uml.py
+++ b/utils/command/gen_uml.py
@@ -625,5 +625,3 @@ if __name__ == "__main__":
 
     doctest.testmod()
     generate("uml2.gaphor")
-
-# vim:sw=4:et:ai

--- a/utils/command/install_lib.py
+++ b/utils/command/install_lib.py
@@ -6,6 +6,3 @@ class install_lib(_install_lib):
         _install_lib.build(self)
         self.run_command("build_uml")
         self.run_command("build_mo")
-
-
-# vim:sw=4:et:ai

--- a/utils/command/override.py
+++ b/utils/command/override.py
@@ -109,6 +109,3 @@ class Overrides(object):
         fp.write(line)
         fp.write(data)
         return True
-
-
-# vim:sw=4:et:ai


### PR DESCRIPTION
The diagram exporter and diagram layout tools were using the get_current_diagram method from the MainWindow class, which was refactored into a new Diagrams class in previously merged changes. This PR cleans up some of that refactoring by fixing the diagram exporter and layout tools.

This PR also updates the tests to be compatible with the new Diagrams class and closes #74.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
