### PR TITLE
Fix Get Current Diagram and View Needs to Call Diagrams Class

### DIFF
--- a/gaphor/plugins/diagramlayout/__init__.py
+++ b/gaphor/plugins/diagramlayout/__init__.py
@@ -22,6 +22,7 @@ from gaphor.core import inject, action, build_action_group, transactional
 from gaphor.diagram import items
 from gaphor.interfaces import IService, IActionProvider
 from gaphor.plugins.diagramlayout import toposort
+from gaphor.ui.interfaces import IUIComponent
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ log = logging.getLogger(__name__)
 @implementer(IService, IActionProvider)
 class DiagramLayout(object):
 
+    component_registry = inject("component_registry")
     main_window = inject("main_window")
 
     menu_xml = """
@@ -50,13 +52,19 @@ class DiagramLayout(object):
         pass
 
     def update(self):
-        self.sensitive = bool(self.get_window().get_current_diagram())
+        self.sensitive = bool(
+            self.component_registry.get_utility(
+                IUIComponent, "diagrams"
+            ).get_current_diagram()
+        )
 
     @action(
         name="diagram-layout", label="La_yout diagram", tooltip="simple diagram layout"
     )
     def execute(self):
-        d = self.diagram.get_current_diagram()
+        d = self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_diagram()
         self.layout_diagram(d)
 
     @transactional

--- a/gaphor/plugins/diagramlayout/__init__.py
+++ b/gaphor/plugins/diagramlayout/__init__.py
@@ -51,20 +51,19 @@ class DiagramLayout(object):
     def shutdown(self):
         pass
 
+    def get_current_diagram(self):
+        return self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_diagram()
+
     def update(self):
-        self.sensitive = bool(
-            self.component_registry.get_utility(
-                IUIComponent, "diagrams"
-            ).get_current_diagram()
-        )
+        self.sensitive = bool(self.get_current_diagram())
 
     @action(
         name="diagram-layout", label="La_yout diagram", tooltip="simple diagram layout"
     )
     def execute(self):
-        d = self.component_registry.get_utility(
-            IUIComponent, "diagrams"
-        ).get_current_diagram()
+        d = self.get_current_diagram()
         self.layout_diagram(d)
 
     @transactional

--- a/gaphor/plugins/xmiexport/__init__.py
+++ b/gaphor/plugins/xmiexport/__init__.py
@@ -3,6 +3,7 @@ This plugin extends Gaphor with XMI export functionality.
 """
 
 from builtins import object
+from logging import getLogger
 
 from zope.interface import implementer
 
@@ -17,6 +18,7 @@ class XMIExport(object):
 
     element_factory = inject("element_factory")
     main_window = inject("main_window")
+    logger = getLogger(__name__)
 
     menu_xml = """
       <ui>
@@ -57,12 +59,14 @@ class XMIExport(object):
         filename = file_dialog.selection
 
         if filename and len(filename) > 0:
-            log.debug("Exporting XMI model to: %s" % filename)
+            self.logger.debug("Exporting XMI model to: %s" % filename)
             export = exportmodel.XMIExport(self.element_factory)
             try:
                 export.export(filename)
             except Exception as e:
-                log.error("Error while saving model to file %s: %s" % (filename, e))
+                self.logger.error(
+                    "Error while saving model to file %s: %s" % (filename, e)
+                )
 
 
 # vim:sw=4:et

--- a/gaphor/plugins/xmiexport/exportmodel.py
+++ b/gaphor/plugins/xmiexport/exportmodel.py
@@ -1,5 +1,7 @@
 from builtins import object
 from builtins import str
+from logging import getLogger
+
 from gaphor.misc.xmlwriter import XMLWriter
 
 
@@ -11,12 +13,14 @@ class XMIExport(object):
     XMI_PREFIX = "XMI"
     UML_PREFIX = "UML"
 
+    logger = getLogger(__name__)
+
     def __init__(self, element_factory):
         self.element_factory = element_factory
         self.handled_ids = list()
 
     def handle(self, xmi, element):
-        log.debug("Handling %s" % element.__class__.__name__)
+        self.logger.debug("Handling %s" % element.__class__.__name__)
         try:
             handler_name = "handle%s" % element.__class__.__name__
             handler = getattr(self, handler_name)
@@ -25,9 +29,13 @@ class XMIExport(object):
             if not idref:
                 self.handled_ids.append(element.id)
         except AttributeError as e:
-            log.warning("Missing handler for %s:%s" % (element.__class__.__name__, e))
+            self.logger.warning(
+                "Missing handler for %s:%s" % (element.__class__.__name__, e)
+            )
         except Exception as e:
-            log.error("Failed to handle %s:%s" % (element.__class__.__name__, e))
+            self.logger.error(
+                "Failed to handle %s:%s" % (element.__class__.__name__, e)
+            )
 
     def handlePackage(self, xmi, element, idref=False):
 
@@ -257,7 +265,7 @@ class XMIExport(object):
 
         xmi.endElement("XMI")
 
-        log.debug(self.handled_ids)
+        self.logger.debug(self.handled_ids)
 
     def select_package(self, element):
         return element.__class__.__name__ == "Package"

--- a/gaphor/services/diagramexportmanager.py
+++ b/gaphor/services/diagramexportmanager.py
@@ -55,6 +55,11 @@ class DiagramExportManager(object):
     def update(self):
         pass
 
+    def get_current_diagram(self):
+        return self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_diagram()
+
     def save_dialog(self, diagram, title, ext):
 
         filename = (diagram.name or "export") + ext
@@ -189,9 +194,7 @@ class DiagramExportManager(object):
     def save_svg_action(self):
         title = "Export diagram to SVG"
         ext = ".svg"
-        diagram = self.component_registry.get_utility(
-            IUIComponent, "diagrams"
-        ).get_current_diagram()
+        diagram = self.get_current_diagram()
         filename = self.save_dialog(diagram, title, ext)
         if filename:
             self.save_svg(filename, diagram.canvas)
@@ -204,9 +207,7 @@ class DiagramExportManager(object):
     def save_png_action(self):
         title = "Export diagram to PNG"
         ext = ".png"
-        diagram = self.component_registry.get_utility(
-            IUIComponent, "diagrams"
-        ).get_current_diagram()
+        diagram = self.get_current_diagram()
         filename = self.save_dialog(diagram, title, ext)
         if filename:
             self.save_png(filename, diagram.canvas)
@@ -219,9 +220,7 @@ class DiagramExportManager(object):
     def save_pdf_action(self):
         title = "Export diagram to PDF"
         ext = ".pdf"
-        diagram = self.component_registry.get_utility(
-            IUIComponent, "diagrams"
-        ).get_current_diagram()
+        diagram = self.get_current_diagram()
         filename = self.save_dialog(diagram, title, ext)
         if filename:
             self.save_pdf(filename, diagram.canvas)

--- a/gaphor/services/diagramexportmanager.py
+++ b/gaphor/services/diagramexportmanager.py
@@ -13,6 +13,7 @@ from zope.interface import implementer
 from gaphor.core import _, inject, action, build_action_group
 from gaphor.interfaces import IService, IActionProvider
 from gaphor.ui.filedialog import FileDialog
+from gaphor.ui.interfaces import IUIComponent
 from gaphor.ui.questiondialog import QuestionDialog
 
 
@@ -22,6 +23,7 @@ class DiagramExportManager(object):
     Service for exporting diagrams as images (SVG, PNG, PDF).
     """
 
+    component_registry = inject("component_registry")
     main_window = inject("main_window")
     properties = inject("properties")
     logger = getLogger("ExportManager")
@@ -51,11 +53,7 @@ class DiagramExportManager(object):
         pass
 
     def update(self):
-
-        self.logger.info("Updating")
-
-        tab = self.get_window().get_current_diagram_page()
-        self.sensitive = tab and True or False
+        pass
 
     def save_dialog(self, diagram, title, ext):
 
@@ -191,7 +189,9 @@ class DiagramExportManager(object):
     def save_svg_action(self):
         title = "Export diagram to SVG"
         ext = ".svg"
-        diagram = self.main_window.get_current_diagram()
+        diagram = self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_diagram()
         filename = self.save_dialog(diagram, title, ext)
         if filename:
             self.save_svg(filename, diagram.canvas)
@@ -204,7 +204,9 @@ class DiagramExportManager(object):
     def save_png_action(self):
         title = "Export diagram to PNG"
         ext = ".png"
-        diagram = self.main_window.get_current_diagram()
+        diagram = self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_diagram()
         filename = self.save_dialog(diagram, title, ext)
         if filename:
             self.save_png(filename, diagram.canvas)
@@ -217,7 +219,9 @@ class DiagramExportManager(object):
     def save_pdf_action(self):
         title = "Export diagram to PDF"
         ext = ".pdf"
-        diagram = self.main_window.get_current_diagram()
+        diagram = self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_diagram()
         filename = self.save_dialog(diagram, title, ext)
         if filename:
             self.save_pdf(filename, diagram.canvas)

--- a/gaphor/ui/event.py
+++ b/gaphor/ui/event.py
@@ -2,15 +2,11 @@ from builtins import object
 
 from zope.interface import implementer
 
-from gaphor.ui.interfaces import (
-    IDiagramSelectionChange,
-    IDiagramPageChange,
-    IDiagramShow,
-)
+from gaphor.ui.interfaces import IDiagramSelectionChange, IDiagramPageChange, IDiagram
 
 
-@implementer(IDiagramShow)
-class DiagramShow(object):
+@implementer(IDiagram)
+class Diagram(object):
     def __init__(self, diagram):
         self.diagram = diagram
 

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -20,9 +20,9 @@ class FileDialog(object):
         """Initialize the file dialog.  The title parameter is the title
         displayed in the dialog.  The filename parameter will set the current
         file name in the dialog.  The action is either open or save and changes
-        the buttons isplayed.  If the parent window parameter is supplied,
+        the buttons displayed.  If the parent window parameter is supplied,
         the file dialog is set to be transient for that window.  The multiple
-        parameter should be set to true if sultiple files can be opened at once.
+        parameter should be set to true if multiple files can be opened at once.
         This means that a list of filenames instead of a single filename string
         will be returned by the selection property.  The filters is a list
         of dictionaries that have a name and pattern key.  This restricts what
@@ -63,14 +63,14 @@ class FileDialog(object):
         by the selection property."""
 
         response = self.dialog.run()
-        selection = None
 
         if response == Gtk.ResponseType.OK:
-
             if self.multiple:
                 selection = self.dialog.get_filenames()
             else:
                 selection = self.dialog.get_filename()
+        else:
+            selection = ""
 
         return selection
 

--- a/gaphor/ui/interfaces.py
+++ b/gaphor/ui/interfaces.py
@@ -5,7 +5,7 @@ Interfaces related to the user interface.
 from zope import interface
 
 
-class IDiagramShow(interface.Interface):
+class IDiagram(interface.Interface):
     """
     Show a new diagram tab
     """

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -32,7 +32,7 @@ from gaphor.services.undomanager import UndoManagerStateChanged
 from gaphor.ui.accelmap import load_accel_map, save_accel_map
 from gaphor.ui.diagrampage import DiagramPage
 from gaphor.ui.diagramtoolbox import TOOLBOX_ACTIONS
-from gaphor.ui.event import DiagramPageChange, DiagramShow
+from gaphor.ui.event import DiagramPageChange, Diagram
 from gaphor.ui.interfaces import IDiagramPageChange
 from gaphor.ui.interfaces import IUIComponent
 from gaphor.ui.layout import deserialize
@@ -320,7 +320,7 @@ class MainWindow(object):
             lambda e: e.isKindOf(UML.Diagram)
             and not (e.namespace and e.namespace.namespace)
         ):
-            self.component_registry.handle(DiagramShow(diagram))
+            self.component_registry.handle(Diagram(diagram))
 
     @component.adapter(FileManagerStateChanged)
     def _on_file_manager_state_changed(self, event):
@@ -545,7 +545,7 @@ class Namespace(object):
         element = self._namespace.get_selected_element()
         # TODO: Candidate for adapter?
         if isinstance(element, UML.Diagram):
-            self.component_registry.handle(DiagramShow(element))
+            self.component_registry.handle(Diagram(element))
 
         else:
             log.debug("No action defined for element %s" % type(element).__name__)
@@ -579,7 +579,7 @@ class Namespace(object):
             diagram.name = "New diagram"
 
         self.select_element(diagram)
-        self.component_registry.handle(DiagramShow(diagram))
+        self.component_registry.handle(Diagram(diagram))
         self.tree_view_rename_selected()
 
     @action(
@@ -798,7 +798,7 @@ class Diagrams(object):
         """
         page_num = self._notebook.get_current_page()
         child_widget = self._notebook.get_nth_page(page_num)
-        return child_widget.diagram_page
+        return child_widget.diagram_page.get_diagram()
 
     def cb_close_tab(self, button, widget):
         """Callback to close the tab and remove the notebook page.
@@ -865,7 +865,7 @@ class Diagrams(object):
             widgets_on_pages.append((page, widget))
         return widgets_on_pages
 
-    @component.adapter(DiagramShow)
+    @component.adapter(Diagram)
     def _on_show_diagram(self, event):
         """Show a Diagram element in the Notebook.
 

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -775,17 +775,16 @@ class Diagrams(object):
 
         Returns:
             The Gtk.Notebook.
-
         """
+
         self._notebook = Gtk.Notebook()
         self._notebook.show()
         self.component_registry.register_handler(self._on_show_diagram)
         return self._notebook
 
     def close(self):
-        """Close the diagrams component.
+        """Close the diagrams component."""
 
-        """
         self.component_registry.unregister_handler(self._on_show_diagram)
         self._notebook.destroy()
         self._notebook = None
@@ -794,11 +793,24 @@ class Diagrams(object):
         """Returns the current page of the notebook.
 
         Returns (DiagramPage): The current diagram page.
-
         """
+
         page_num = self._notebook.get_current_page()
         child_widget = self._notebook.get_nth_page(page_num)
-        return child_widget.diagram_page.get_diagram()
+        if child_widget is not None:
+            return child_widget.diagram_page.get_diagram()
+        else:
+            return None
+
+    def get_current_view(self):
+        """Returns the current view of the diagram page.
+
+        Returns (GtkView): The current view.
+        """
+
+        page_num = self._notebook.get_current_page()
+        child_widget = self._notebook.get_nth_page(page_num)
+        return child_widget.diagram_page.get_view()
 
     def cb_close_tab(self, button, widget):
         """Callback to close the tab and remove the notebook page.
@@ -806,8 +818,8 @@ class Diagrams(object):
         Args:
             button (Gtk.Button): The button the callback is from.
             widget (Gtk.Widget): The child widget of the tab.
-
         """
+
         page_num = self._notebook.page_num(widget)
         # TODO why does Gtk.Notebook give a GTK-CRITICAL if you remove a page
         #   with set_show_tabs(True)?
@@ -824,8 +836,8 @@ class Diagrams(object):
         Args:
             title (str): The title of the tab, the diagram name.
             widget (Gtk.Widget): The child widget of the tab.
-
         """
+
         tab_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
         label = Gtk.Label(title)
         tab_box.pack_start(label)
@@ -856,8 +868,8 @@ class Diagrams(object):
 
         Returns:
             List of tuples (page, widget) of the currently open Notebook pages.
-
         """
+
         widgets_on_pages = []
         num_pages = self._notebook.get_n_pages()
         for page in range(0, num_pages):
@@ -874,8 +886,8 @@ class Diagrams(object):
 
         Args:
             event: The service event that is calling the method.
-
         """
+
         diagram = event.diagram
 
         # Try to find an existing diagram page and give it focus
@@ -897,9 +909,8 @@ class Diagrams(object):
 
     @toggle_action(name="diagram-drawing-style", label="Hand drawn style", active=False)
     def hand_drawn_style(self, active):
-        """
-        Toggle between straight diagrams and "hand drawn" diagram style.
-        """
+        """Toggle between straight diagrams and "hand drawn" diagram style."""
+
         if active:
             sloppiness = 0.5
         else:

--- a/gaphor/ui/tests/test_diagramtools.py
+++ b/gaphor/ui/tests/test_diagramtools.py
@@ -1,11 +1,13 @@
-from gi.repository import Gtk
 import logging
-from gaphor.tests import TestCase
-from gaphor import UML
-from gaphor.diagram import items
-from gaphas.canvas import Context
 
-Event = Context
+from gi.repository import Gdk
+
+from gaphor import UML
+from gaphor.core import inject
+from gaphor.diagram import items
+from gaphor.tests import TestCase
+from gaphor.ui.event import Diagram
+from gaphor.ui.interfaces import IUIComponent
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -17,13 +19,14 @@ class DiagramItemConnectorTestCase(TestCase):
         "action_manager",
         "properties",
     ]
+    component_registry = inject("component_registry")
 
     def setUp(self):
         super(DiagramItemConnectorTestCase, self).setUp()
         mw = self.get_service("main_window")
         mw.open()
-        mw.show_diagram(self.diagram)
         self.main_window = mw
+        self.component_registry.handle(Diagram(self.diagram))
 
     def test_item_reconnect(self):
         # Setting the stage:
@@ -41,19 +44,21 @@ class DiagramItemConnectorTestCase(TestCase):
         the_association = a.subject
 
         # The act: perform button press event and button release
-        view = self.main_window.get_current_diagram_view()
+        view = self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_view()
 
         self.assertSame(self.diagram.canvas, view.canvas)
 
         p = view.get_matrix_i2v(a).transform_point(*a.head.pos)
 
-        event = Event(x=p[0], y=p[1], type=Gdk.EventType.BUTTON_PRESS, state=0)
+        event = Gdk.Event(x=p[0], y=p[1], type=Gdk.EventType.BUTTON_PRESS, state=0)
 
         view.do_event(event)
 
         self.assertSame(the_association, a.subject)
 
-        event = Event(x=p[0], y=p[1], type=Gdk.BUTTON_RELEASE, state=0)
+        event = Gdk.Event(x=p[0], y=p[1], type=Gdk.BUTTON_RELEASE, state=0)
 
         view.do_event(event)
 

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -128,9 +128,7 @@ class HandleToolTestCase(unittest.TestCase):
 
         line = diagram.create(CommentLineItem)
 
-        view = self.component_registry.get_utility(
-            IUIComponent, "diagrams"
-        ).get_current_view()
+        view = self.get_diagram_view()
         assert view, "View should be available here"
 
         tool = ConnectHandleTool(view)
@@ -179,10 +177,7 @@ class HandleToolTestCase(unittest.TestCase):
         diagram.canvas.update_matrix(actor)
         line = diagram.create(CommentLineItem)
 
-        view = self.component_registry.get_utility(
-            IUIComponent, "diagrams"
-        ).get_current_view()
-
+        view = self.get_diagram_view()
         assert view, "View should be available here"
 
         tool = ConnectHandleTool(view)

--- a/gaphor/ui/tests/test_mainwindow.py
+++ b/gaphor/ui/tests/test_mainwindow.py
@@ -24,16 +24,16 @@ class MainWindowTestCase(unittest.TestCase):
     def tearDown(self):
         Application.shutdown()
 
+    def get_current_diagram(self):
+        return self.component_registry.get_utility(
+            IUIComponent, "diagrams"
+        ).get_current_diagram()
+
     def test_creation(self):
         # MainWindow should be created as resource
         main_w = Application.get_service("main_window")
         main_w.open()
-        self.assertEqual(
-            self.component_registry.get_utility(
-                IUIComponent, "diagrams"
-            ).get_current_diagram(),
-            None,
-        )
+        self.assertEqual(self.get_current_diagram(), None)
 
     def test_show_diagram(self):
         main_w = Application.get_service("main_window")
@@ -41,12 +41,7 @@ class MainWindowTestCase(unittest.TestCase):
         diagram = element_factory.create(UML.Diagram)
         main_w.open()
         self.component_registry.handle(Diagram(diagram))
-        self.assertEqual(
-            self.component_registry.get_utility(
-                IUIComponent, "diagrams"
-            ).get_current_diagram(),
-            diagram,
-        )
+        self.assertEqual(self.get_current_diagram(), diagram)
 
 
 # vim:sw=4:et:ai

--- a/gaphor/ui/tests/test_mainwindow.py
+++ b/gaphor/ui/tests/test_mainwindow.py
@@ -1,9 +1,10 @@
-from gi.repository import Gtk
 import unittest
 
-from gaphor.application import Application
-from gaphor.ui.mainwindow import MainWindow
 from gaphor import UML
+from gaphor.application import Application
+from gaphor.core import inject
+from gaphor.ui.event import Diagram
+from gaphor.ui.interfaces import IUIComponent
 
 
 class MainWindowTestCase(unittest.TestCase):
@@ -18,6 +19,8 @@ class MainWindowTestCase(unittest.TestCase):
             ]
         )
 
+    component_registry = inject("component_registry")
+
     def tearDown(self):
         Application.shutdown()
 
@@ -25,16 +28,25 @@ class MainWindowTestCase(unittest.TestCase):
         # MainWindow should be created as resource
         main_w = Application.get_service("main_window")
         main_w.open()
-        self.assertEqual(main_w.get_current_diagram(), None)
+        self.assertEqual(
+            self.component_registry.get_utility(
+                IUIComponent, "diagrams"
+            ).get_current_diagram(),
+            None,
+        )
 
     def test_show_diagram(self):
         main_w = Application.get_service("main_window")
         element_factory = Application.get_service("element_factory")
         diagram = element_factory.create(UML.Diagram)
         main_w.open()
-        self.assertEqual(main_w.get_current_diagram(), None)
-
-        main_w.show_diagram(diagram)
+        self.component_registry.handle(Diagram(diagram))
+        self.assertEqual(
+            self.component_registry.get_utility(
+                IUIComponent, "diagrams"
+            ).get_current_diagram(),
+            diagram,
+        )
 
 
 # vim:sw=4:et:ai

--- a/gaphor/ui/tests/test_namespace.py
+++ b/gaphor/ui/tests/test_namespace.py
@@ -133,7 +133,7 @@ class NewNamespaceTestCase(TestCase):
         m = factory.create(UML.Package)
         m.name = "m"
         assert m in ns._nodes
-        assert ns.path_from_element(m) == [1]
+        assert ns.path_from_element(m) == (1,)
         assert ns.element_from_path((1,)) is m
 
         a = factory.create(UML.Package)
@@ -141,8 +141,8 @@ class NewNamespaceTestCase(TestCase):
         assert a in ns._nodes
         assert a in ns._nodes[None]
         assert m in ns._nodes
-        assert ns.path_from_element(a) == [1], ns.path_from_element(a)
-        assert ns.path_from_element(m) == [2], ns.path_from_element(m)
+        assert ns.path_from_element(a) == (1,), ns.path_from_element(a)
+        assert ns.path_from_element(m) == (2,), ns.path_from_element(m)
 
         a.package = m
         assert a in ns._nodes
@@ -152,14 +152,14 @@ class NewNamespaceTestCase(TestCase):
         assert a.package is m
         assert a in m.ownedMember
         assert a.namespace is m
-        assert ns.path_from_element(a) == [1, 0], ns.path_from_element(a)
+        assert ns.path_from_element(a) == (1, 0), ns.path_from_element(a)
 
         c = factory.create(UML.Class)
         c.name = "c"
         assert c in ns._nodes
-        assert ns.path_from_element(c) == [1], ns.path_from_element(c)
-        assert ns.path_from_element(m) == [2], ns.path_from_element(m)
-        assert ns.path_from_element(a) == [2, 0], ns.path_from_element(a)
+        assert ns.path_from_element(c) == (1,), ns.path_from_element(c)
+        assert ns.path_from_element(m) == (2,), ns.path_from_element(m)
+        assert ns.path_from_element(a) == (2, 0), ns.path_from_element(a)
 
         c.package = m
         assert c in ns._nodes


### PR DESCRIPTION
The diagram exporter and diagram layout tools were using the get_current_diagram method from the MainWindow class, which was refactored into a new Diagrams class in previously merged changes. This PR cleans up some of that refactoring by fixing the diagram exporter and layout tools.

This PR also updates the tests to be compatible with the new Diagrams class and closes #74.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #74 

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
