### PR TITLE
Fix AttributeError when hitting F2 with no elements selected

### DIFF
--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -554,13 +554,14 @@ class Namespace(object):
     def tree_view_rename_selected(self):
         view = self._namespace
         element = view.get_selected_element()
-        path = view.get_model().path_from_element(element)
-        column = view.get_column(0)
-        cell = column.get_cells()[1]
-        cell.set_property("editable", 1)
-        cell.set_property("text", element.name)
-        view.set_cursor(path, column, True)
-        cell.set_property("editable", 0)
+        if element is not None:
+            path = view.get_model().path_from_element(element)
+            column = view.get_column(0)
+            cell = column.get_cells()[1]
+            cell.set_property("editable", 1)
+            cell.set_property("text", element.name)
+            view.set_cursor(path, column, True)
+            cell.set_property("editable", 0)
 
     @action(
         name="tree-view-create-diagram",


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

If you don't have any elements selected in the Namespace, and you hit F2, the MainWindow was throwing an AttributeError.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
