### PR TITLE
Self contained uml package

### DIFF
--- a/gaphor/UML/collection.py
+++ b/gaphor/UML/collection.py
@@ -237,10 +237,7 @@ class collection(object):
             i2 = self.items.index(item2)
             self.items[i1], self.items[i2] = self.items[i2], self.items[i1]
 
-            # send a notification that this list has changed
-            factory = self.object.factory
-            if factory:
-                factory._handle(AssociationChangeEvent(self.object, self.property))
+            self.object.handle(AssociationChangeEvent(self.object, self.property))
             return True
         except IndexError as ex:
             return False

--- a/gaphor/UML/element.py
+++ b/gaphor/UML/element.py
@@ -8,6 +8,8 @@ __all__ = ["Element"]
 import threading
 import uuid
 
+from zope import component
+
 from gaphor.UML.properties import umlproperty
 
 
@@ -81,8 +83,8 @@ class Element(object):
             prop.postload(self)
 
     def unlink(self):
-
-        """Unlink the element. All the elements references are destroyed.
+        """
+        Unlink the element. All the elements references are destroyed.
 
         The unlink lock is acquired while unlinking this elements properties
         to avoid recursion problems."""
@@ -99,6 +101,16 @@ class Element(object):
 
             if self._factory:
                 self._factory._unlink_element(self)
+
+    def handle(self, event):
+        """
+        Propagate incoming events
+        """
+        factory = self._factory
+        if factory:
+            factory._handle(event)
+        else:
+            component.handle(event)
 
     # OCL methods: (from SMW by Ivan Porres (http://www.abo.fi/~iporres/smw))
 

--- a/gaphor/UML/element.py
+++ b/gaphor/UML/element.py
@@ -8,8 +8,6 @@ __all__ = ["Element"]
 import threading
 import uuid
 
-from zope import component
-
 from gaphor.UML.properties import umlproperty
 
 
@@ -109,8 +107,6 @@ class Element(object):
         factory = self._factory
         if factory:
             factory._handle(event)
-        else:
-            component.handle(event)
 
     # OCL methods: (from SMW by Ivan Porres (http://www.abo.fi/~iporres/smw))
 

--- a/gaphor/UML/element.py
+++ b/gaphor/UML/element.py
@@ -36,10 +36,6 @@ class Element(object):
 
     id = property(lambda self: self._id, doc="Id")
 
-    factory = property(
-        lambda self: self._factory, doc="The factory that created this element"
-    )
-
     def umlproperties(self):
         """
         Iterate over all UML properties

--- a/gaphor/UML/elementfactory.py
+++ b/gaphor/UML/elementfactory.py
@@ -169,8 +169,7 @@ class ElementFactory(object):
         """
         Handle events coming from elements.
         """
-        # Invoke default handler, so properties get updated.
-        component.handle(event)
+        pass
 
 
 @implementer(IService)

--- a/gaphor/UML/properties.py
+++ b/gaphor/UML/properties.py
@@ -50,11 +50,15 @@ class umlproperty(object):
 
     The subclasses should define a ``name`` attribute that contains the name
     of the property. Derived properties (derivedunion and redefine) can be
-    connected, they will be notified when the value changes.
+    connected, they will be notified when the value changes through
+    `propagate(self, event)`.
 
     In some cases properties call out and delegate actions to the ElementFactory,
     for example in the case of event handling.
     """
+
+    def __init__(self):
+        self._dependent_properties = set()
 
     def __get__(self, obj, class_=None):
         if obj:
@@ -84,6 +88,9 @@ class umlproperty(object):
         pass
 
     def handle(self, event):
+        for d in self._dependent_properties:
+            d.propagate(event)
+
         factory = event.element.factory
         if factory:
             factory._handle(event)
@@ -100,6 +107,7 @@ class attribute(umlproperty):
 
     # TODO: check if lower and upper are actually needed for attributes
     def __init__(self, name, type, default=None, lower=0, upper=1):
+        super().__init__()
         self.name = name
         self._name = "_" + name
         self.type = type
@@ -194,6 +202,7 @@ class enumeration(umlproperty):
     type = property(lambda s: str)
 
     def __init__(self, name, values, default):
+        super().__init__()
         self.name = name
         self._name = "_" + name
         self.values = values
@@ -243,7 +252,7 @@ class association(umlproperty):
     Association, both uni- and bi-directional.
 
     Element.assoc = association('assoc', Element, opposite='other')
-    
+
     A listerer is connected to the value added to the association. This
     will cause the association to be ended if the element on the other end
     of the association is unlinked.
@@ -253,6 +262,7 @@ class association(umlproperty):
     """
 
     def __init__(self, name, type, lower=0, upper="*", composite=False, opposite=None):
+        super().__init__()
         self.name = name
         self._name = "_" + name
         self.type = type
@@ -447,6 +457,7 @@ class associationstub(umlproperty):
     """
 
     def __init__(self, association):
+        super().__init__()
         self.association = association
         self._name = "_stub_%x" % id(self)
 
@@ -513,6 +524,7 @@ class derived(umlproperty):
     """
 
     def __init__(self, name, type, lower, upper, *subsets):
+        super().__init__()
         self.name = name
         self._name = "_" + name
         self.version = 1
@@ -522,7 +534,8 @@ class derived(umlproperty):
         self.subsets = set(subsets)
         self.single = len(subsets) == 1
 
-        component.provideHandler(self._association_changed)
+        for s in subsets:
+            s._dependent_properties.add(self)
 
     def load(self, obj, value):
         raise ValueError(
@@ -583,8 +596,7 @@ class derived(umlproperty):
     def _del(self, obj, value=None):
         raise AttributeError("Can not delete values on a union")
 
-    @component.adapter(IElementChangeEvent)
-    def _association_changed(self, event):
+    def propagate(self, event):
         """
         Re-emit state change for the derived properties as Derived*Event's.
 
@@ -595,7 +607,7 @@ class derived(umlproperty):
           send DerivedSetEvent if len(union) < 2
         if multiplicity is [*]:
           send DerivedAddEvent and DerivedDeleteEvent
-            if value not in derived union and 
+            if value not in derived union and
         """
         if event.property in self.subsets:
             # Make sure unions are created again
@@ -669,8 +681,7 @@ class derivedunion(derived):
     # Filter is our default filter
     filter = _union
 
-    @component.adapter(IElementChangeEvent)
-    def _association_changed(self, event):
+    def propagate(self, event):
         """
         Re-emit state change for the derived union (as Derived*Event's).
 
@@ -681,7 +692,7 @@ class derivedunion(derived):
           send DerivedSetEvent if len(union) < 2
         if multiplicity is [*]:
           send DerivedAddEvent and DerivedDeleteEvent
-            if value not in derived union and 
+            if value not in derived union and
         """
         if event.property in self.subsets:
             # Make sure unions are created again
@@ -753,13 +764,14 @@ class redefine(umlproperty):
     """
 
     def __init__(self, decl_class, name, type, original):
+        super().__init__()
         self.decl_class = decl_class
         self.name = name
         self._name = "_" + name
         self.type = type
         self.original = original
 
-        component.provideHandler(self._association_changed)
+        original._dependent_properties.add(self)
 
     upper = property(lambda s: s.original.upper)
     lower = property(lambda s: s.original.lower)
@@ -813,8 +825,7 @@ class redefine(umlproperty):
     def _del(self, obj, value, from_opposite=False):
         return self.original._del(obj, value, from_opposite)
 
-    @component.adapter(IAssociationChangeEvent)
-    def _association_changed(self, event):
+    def propagate(self, event):
         if event.property is self.original and isinstance(
             event.element, self.decl_class
         ):

--- a/gaphor/UML/properties.py
+++ b/gaphor/UML/properties.py
@@ -28,8 +28,6 @@ __all__ = ["attribute", "enumeration", "association", "derivedunion", "redefine"
 
 import logging
 
-from zope import component
-
 from gaphor.UML.collection import collection, collectionlist
 from gaphor.UML.event import AssociationAddEvent, AssociationDeleteEvent
 from gaphor.UML.event import AttributeChangeEvent, AssociationSetEvent
@@ -88,14 +86,9 @@ class umlproperty(object):
         pass
 
     def handle(self, event):
+        event.element.handle(event)
         for d in self._dependent_properties:
             d.propagate(event)
-
-        factory = event.element.factory
-        if factory:
-            factory._handle(event)
-        else:
-            component.handle(event)
 
 
 class attribute(umlproperty):

--- a/gaphor/diagram/actions/flow.py
+++ b/gaphor/diagram/actions/flow.py
@@ -1,5 +1,5 @@
 """
-Control flow and object flow implementation. 
+Control flow and object flow implementation.
 
 Contains also implementation to split flows using activity edge connectors.
 """
@@ -30,7 +30,7 @@ class FlowItem(NamedLine):
     __style__ = {"name-align": (ALIGN_RIGHT, ALIGN_TOP), "name-padding": (5, 15, 5, 5)}
 
     def __init__(self, id=None):
-        NamedLine.__init__(self, id)
+        super().__init__(id)
         self._guard = self.add_text("guard.value", editable=True)
         self.watch("subject<ControlFlow>.guard", self.on_control_flow_guard)
         self.watch("subject<ObjectFlow>.guard", self.on_control_flow_guard)
@@ -40,7 +40,7 @@ class FlowItem(NamedLine):
             self._guard.text = self.subject.guard.value
         except AttributeError as e:
             self._guard.text = ""
-        super(FlowItem, self).postload()
+        super().postload()
 
     def on_control_flow_guard(self, event):
         subject = self.subject

--- a/gaphor/diagram/actions/tests/test_flow.py
+++ b/gaphor/diagram/actions/tests/test_flow.py
@@ -33,9 +33,3 @@ class FlowTestCase(TestCase):
 
         flow.subject = None
         self.assertEqual("", flow._guard.text)
-
-    def test_persistence(self):
-        """
-        TODO: Test connector item saving/loading
-        """
-        pass

--- a/gaphor/diagram/classes/tests/test_association.py
+++ b/gaphor/diagram/classes/tests/test_association.py
@@ -20,7 +20,7 @@ class AssociationItemTestCase(TestCase):
     services = TestCase.services + ["element_dispatcher"]
 
     def setUp(self):
-        super(AssociationItemTestCase, self).setUp()
+        super().setUp()
         self.assoc = self.create(AssociationItem)
         self.class1 = self.create(ClassItem, UML.Class)
         self.class2 = self.create(ClassItem, UML.Class)

--- a/gaphor/diagram/diagramitem.py
+++ b/gaphor/diagram/diagramitem.py
@@ -150,9 +150,10 @@ class DiagramItem(
     """
 
     dispatcher = inject("element_dispatcher")
+    element_factory = inject("element_factory")
 
     def __init__(self, id=None):
-        UML.Presentation.__init__(self)
+        UML.Presentation.__init__(self, factory=self.element_factory)
         EditableTextSupport.__init__(self)
         StereotypeSupport.__init__(self)
 

--- a/gaphor/diagram/tests/test_diagramitem.py
+++ b/gaphor/diagram/tests/test_diagramitem.py
@@ -2,46 +2,57 @@
 Test basic diagram item functionality like styles, etc.
 """
 
-import unittest
+import pytest
+from gaphor import Application
 from gaphor.diagram.diagramitem import DiagramItem
 
 
-class ItemTestCase(unittest.TestCase):
-    def setUp(self):
-        class ItemA(DiagramItem):
-            __style__ = {"a-01": 1, "a-02": 2}
+@pytest.fixture
+def application(services=["element_factory"]):
+    Application.init(services=services)
+    yield Application
+    Application.shutdown()
 
-        self.ItemA = ItemA
 
-    def test_style_assign(self):
-        """
-        Test style assign
-        """
-        item_a = self.ItemA()
-        self.assertEqual(self.ItemA.style.a_01, 1)
-        self.assertEqual(self.ItemA.style.a_02, 2)
-        self.assertEqual(item_a.style.a_01, 1)
-        self.assertEqual(item_a.style.a_02, 2)
+@pytest.fixture
+def ItemA(application):
+    class ItemA(DiagramItem):
+        __style__ = {"a-01": 1, "a-02": 2}
 
-    def test_style_override(self):
-        """
-        Test style override
-        """
+    return ItemA
 
-        class ItemB(self.ItemA):
-            __style__ = {"b-01": 3, "b-02": 4, "a-01": 5}
 
-        item_b = ItemB()
-        self.assertEqual(ItemB.style.b_01, 3)
-        self.assertEqual(ItemB.style.b_02, 4)
-        self.assertEqual(ItemB.style.a_01, 5)
-        self.assertEqual(ItemB.style.a_02, 2)
-        self.assertEqual(item_b.style.b_01, 3)
-        self.assertEqual(item_b.style.b_02, 4)
-        self.assertEqual(item_b.style.a_01, 5)
-        self.assertEqual(item_b.style.a_02, 2)
+def test_style_assign(ItemA):
+    """
+    Test style assign
+    """
+    item_a = ItemA()
 
-        # check ItemA style, it should remain unaffected by ItemB style
-        # changes
-        self.assertEqual(self.ItemA.style.a_01, 1)
-        self.assertEqual(self.ItemA.style.a_02, 2)
+    assert ItemA.style.a_01 == 1
+    assert ItemA.style.a_02 == 2
+    assert item_a.style.a_01 == 1
+    assert item_a.style.a_02 == 2
+
+
+def test_style_override(ItemA):
+    """
+    Test style override
+    """
+
+    class ItemB(ItemA):
+        __style__ = {"b-01": 3, "b-02": 4, "a-01": 5}
+
+    item_b = ItemB()
+    assert ItemB.style.b_01 == 3
+    assert ItemB.style.b_02 == 4
+    assert ItemB.style.a_01 == 5
+    assert ItemB.style.a_02 == 2
+    assert item_b.style.b_01 == 3
+    assert item_b.style.b_02 == 4
+    assert item_b.style.a_01 == 5
+    assert item_b.style.a_02 == 2
+
+    # check ItemA style, it should remain unaffected by ItemB style
+    # changes
+    assert ItemA.style.a_01 == 1
+    assert ItemA.style.a_02 == 2

--- a/gaphor/services/componentregistry.py
+++ b/gaphor/services/componentregistry.py
@@ -36,9 +36,6 @@ class ZopeComponentRegistry(object):
         # Make sure component.handle() and query methods works.
         # TODO: eventually all queries should be done through the Application
         # instance.
-        # Used in collection.py, transaction.py, diagramtoolbox.py:
-        component.handle = self.handle
-        # component.getMultiAdapter = self._components.getMultiAdapter
         # Used all over the place:
         component.queryMultiAdapter = self._components.queryMultiAdapter
         # component.getAdapter = self._components.getAdapter

--- a/gaphor/services/tests/test_elementdispatcher.py
+++ b/gaphor/services/tests/test_elementdispatcher.py
@@ -6,21 +6,21 @@ from gaphor.services.elementdispatcher import ElementDispatcher
 
 class ElementDispatcherTestCase(TestCase):
     def setUp(self):
-        super(ElementDispatcherTestCase, self).setUp()
+        super().setUp()
         self.events = []
         self.dispatcher = ElementDispatcher()
         self.dispatcher.init(Application)
 
     def tearDown(self):
         self.dispatcher.shutdown()
-        super(ElementDispatcherTestCase, self).tearDown()
+        super().tearDown()
 
     def _handler(self, event):
         self.events.append(event)
 
     def test_register_handler(self):
         dispatcher = self.dispatcher
-        element = UML.Class()
+        element = self.element_factory.create(UML.Class)
         dispatcher.register_handler(
             self._handler, element, "ownedOperation.parameter.name"
         )
@@ -33,9 +33,11 @@ class ElementDispatcherTestCase(TestCase):
         # Add some properties:
 
         # 1:
-        element.ownedOperation = UML.Operation()
+        element.ownedOperation = self.element_factory.create(UML.Operation)
         # 2:
-        p = element.ownedOperation[0].formalParameter = UML.Parameter()
+        p = element.ownedOperation[0].formalParameter = self.element_factory.create(
+            UML.Parameter
+        )
         # 3:
         p.name = "func"
         dispatcher.register_handler(
@@ -49,12 +51,14 @@ class ElementDispatcherTestCase(TestCase):
         Multiple registrations have no effect.
         """
         dispatcher = self.dispatcher
-        element = UML.Class()
+        element = self.element_factory.create(UML.Class)
 
         # Add some properties:
 
-        element.ownedOperation = UML.Operation()
-        p = element.ownedOperation[0].formalParameter = UML.Parameter()
+        element.ownedOperation = self.element_factory.create(UML.Operation)
+        p = element.ownedOperation[0].formalParameter = self.element_factory.create(
+            UML.Parameter
+        )
         dispatcher.register_handler(
             self._handler, element, "ownedOperation.parameter.name"
         )
@@ -82,9 +86,11 @@ class ElementDispatcherTestCase(TestCase):
 
         # First some setup:
         dispatcher = self.dispatcher
-        element = UML.Class()
-        o = element.ownedOperation = UML.Operation()
-        p = element.ownedOperation[0].formalParameter = UML.Parameter()
+        element = self.element_factory.create(UML.Class)
+        o = element.ownedOperation = self.element_factory.create(UML.Operation)
+        p = element.ownedOperation[0].formalParameter = self.element_factory.create(
+            UML.Parameter
+        )
         p.name = "func"
         dispatcher.register_handler(
             self._handler, element, "ownedOperation.parameter.name"
@@ -107,9 +113,11 @@ class ElementDispatcherTestCase(TestCase):
         Test notifications with Class object.
         """
         dispatcher = self.dispatcher
-        element = UML.Class()
-        o = element.ownedOperation = UML.Operation()
-        p = element.ownedOperation[0].formalParameter = UML.Parameter()
+        element = self.element_factory.create(UML.Class)
+        o = element.ownedOperation = self.element_factory.create(UML.Operation)
+        p = element.ownedOperation[0].formalParameter = self.element_factory.create(
+            UML.Parameter
+        )
         p.name = "func"
         dispatcher.register_handler(
             self._handler, element, "ownedOperation.parameter.name"
@@ -117,7 +125,7 @@ class ElementDispatcherTestCase(TestCase):
         assert len(dispatcher._handlers) == 3
         assert not self.events
 
-        element.ownedOperation = UML.Operation()
+        element.ownedOperation = self.element_factory.create(UML.Operation)
         assert len(self.events) == 1, self.events
         assert len(dispatcher._handlers) == 4
 
@@ -132,8 +140,8 @@ class ElementDispatcherTestCase(TestCase):
         Test notifications with Transition object.
         """
         dispatcher = self.dispatcher
-        element = UML.Transition()
-        g = element.guard = UML.Constraint()
+        element = self.element_factory.create(UML.Transition)
+        g = element.guard = self.element_factory.create(UML.Constraint)
         dispatcher.register_handler(self._handler, element, "guard.specification")
         assert len(dispatcher._handlers) == 2
         assert not self.events
@@ -144,7 +152,7 @@ class ElementDispatcherTestCase(TestCase):
         g.specification = "x"
         assert len(self.events) == 1, self.events
 
-        element.guard = UML.Constraint()
+        element.guard = self.element_factory.create(UML.Constraint)
         assert len(self.events) == 2, self.events
         assert len(dispatcher._handlers) == 2, len(dispatcher._handlers)
         assert (element.guard, UML.Constraint.specification) in list(
@@ -156,8 +164,8 @@ class ElementDispatcherTestCase(TestCase):
         Test notifications with Transition object.
         """
         dispatcher = self.dispatcher
-        element = UML.Transition()
-        g = element.guard = UML.Constraint()
+        element = self.element_factory.create(UML.Transition)
+        g = element.guard = self.element_factory.create(UML.Constraint)
         dispatcher.register_handler(self._handler, element, "guard.specification")
         assert len(dispatcher._handlers) == 2
         assert not self.events
@@ -165,7 +173,7 @@ class ElementDispatcherTestCase(TestCase):
         g.specification = "x"
         assert len(self.events) == 1, self.events
 
-        element.guard = UML.Constraint()
+        element.guard = self.element_factory.create(UML.Constraint)
         assert len(self.events) == 2, self.events
 
     def test_notification_with_composition(self):
@@ -173,9 +181,11 @@ class ElementDispatcherTestCase(TestCase):
         Test unregister with composition. Use Class.ownedOperation.precondition.
         """
         dispatcher = self.dispatcher
-        element = UML.Class()
-        o = element.ownedOperation = UML.Operation()
-        p = element.ownedOperation[0].precondition = UML.Constraint()
+        element = self.element_factory.create(UML.Class)
+        o = element.ownedOperation = self.element_factory.create(UML.Operation)
+        p = element.ownedOperation[0].precondition = self.element_factory.create(
+            UML.Constraint
+        )
         p.name = "func"
         dispatcher.register_handler(
             self._handler, element, "ownedOperation.precondition.name"
@@ -191,8 +201,8 @@ class ElementDispatcherTestCase(TestCase):
         Test unregister with composition. Use Class.ownedOperation.precondition.
         """
         dispatcher = self.dispatcher
-        element = UML.Transition()
-        g = element.guard = UML.Constraint()
+        element = self.element_factory.create(UML.Transition)
+        g = element.guard = self.element_factory.create(UML.Constraint)
         dispatcher.register_handler(self._handler, element, "guard.specification")
         assert len(dispatcher._handlers) == 2
         assert not self.events
@@ -212,14 +222,6 @@ from gaphor.UML.properties import association
 from gaphor.services.elementdispatcher import EventWatcher
 
 
-class A(Element):
-    pass
-
-
-A.one = association("one", A, lower=0, upper=1, composite=True)
-A.two = association("two", A, lower=0, upper=2, composite=True)
-
-
 class ElementDispatcherAsServiceTestCase(TestCase):
 
     services = TestCase.services + ["element_dispatcher"]
@@ -228,6 +230,15 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         super(ElementDispatcherAsServiceTestCase, self).setUp()
         self.events = []
         self.dispatcher = Application.get_service("element_dispatcher")
+        element_factory = self.element_factory
+
+        class A(Element):
+            def __init__(self):
+                super().__init__(factory=element_factory)
+
+        A.one = association("one", A, lower=0, upper=1, composite=True)
+        A.two = association("two", A, lower=0, upper=2, composite=True)
+        self.A = A
 
     def tearDown(self):
         super(ElementDispatcherAsServiceTestCase, self).tearDown()
@@ -240,9 +251,11 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         Test notifications with Class object.
         """
         dispatcher = self.dispatcher
-        element = UML.Class()
-        o = element.ownedOperation = UML.Operation()
-        p = element.ownedOperation[0].formalParameter = UML.Parameter()
+        element = self.element_factory.create(UML.Class)
+        o = element.ownedOperation = self.element_factory.create(UML.Operation)
+        p = element.ownedOperation[0].formalParameter = self.element_factory.create(
+            UML.Parameter
+        )
         p.name = "func"
         dispatcher.register_handler(
             self._handler, element, "ownedOperation.parameter.name"
@@ -250,7 +263,7 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         assert len(dispatcher._handlers) == 3
         assert not self.events
 
-        element.ownedOperation = UML.Operation()
+        element.ownedOperation = self.element_factory.create(UML.Operation)
         assert len(self.events) == 1, self.events
         assert len(dispatcher._handlers) == 4
 
@@ -267,9 +280,9 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         Tricky case where no events are fired.
         """
         dispatcher = self.dispatcher
-        element = UML.Association()
-        p1 = element.memberEnd = UML.Property()
-        p2 = element.memberEnd = UML.Property()
+        element = self.element_factory.create(UML.Association)
+        p1 = element.memberEnd = self.element_factory.create(UML.Property)
+        p2 = element.memberEnd = self.element_factory.create(UML.Property)
 
         assert len(element.memberEnd) == 2
         dispatcher.register_handler(self._handler, element, "memberEnd.name")
@@ -293,9 +306,9 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         Tricky case where no events are fired.
         """
         dispatcher = self.dispatcher
-        element = UML.Association()
-        p1 = element.memberEnd = UML.Property()
-        p2 = element.memberEnd = UML.Property()
+        element = self.element_factory.create(UML.Association)
+        p1 = element.memberEnd = self.element_factory.create(UML.Property)
+        p2 = element.memberEnd = self.element_factory.create(UML.Property)
         p1.lowerValue = "0"
         p1.upperValue = "1"
         p2.lowerValue = "1"
@@ -324,6 +337,7 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         """
         Test diamond shaped dependencies a -> b -> c, a -> b' -> c
         """
+        A = self.A
         a = A()
         watcher = EventWatcher(a, self._handler)
         watcher.watch("one.two.one.two")
@@ -347,6 +361,7 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         """
         Test diamond shaped dependencies a -> b -> c -> d, a -> b' -> c' -> d
         """
+        A = self.A
         a = A()
         watcher = EventWatcher(a, self._handler)
         watcher.watch("one.two.one.two")
@@ -372,6 +387,7 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         """
         Test diamond shaped dependencies a -> b -> c -> d, a -> b' -> c' -> d
         """
+        A = self.A
         a = A()
         watcher = EventWatcher(a, self._handler)
         watcher.watch("one.two.one.two")
@@ -399,6 +415,7 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         """
         Test cyclic dependency a -> b -> c -> a.
         """
+        A = self.A
         a = A()
         watcher = EventWatcher(a, self._handler)
         watcher.watch("one.two.one.two")

--- a/gaphor/services/tests/test_undomanager.py
+++ b/gaphor/services/tests/test_undomanager.py
@@ -110,7 +110,7 @@ class TestUndoManager(TestCase):
         class A(Element):
             attr = attribute("attr", bytes, default="default")
 
-        a = A()
+        a = A(factory=self.element_factory)
         assert a.attr == "default", a.attr
         undo_manager.begin_transaction()
         a.attr = "five"
@@ -142,8 +142,8 @@ class TestUndoManager(TestCase):
         A.one = association("one", B, 0, 1, opposite="two")
         B.two = association("two", A, 0, 1)
 
-        a = A()
-        b = B()
+        a = A(factory=self.element_factory)
+        b = B(factory=self.element_factory)
 
         assert a.one is None
         assert b.two is None
@@ -194,10 +194,10 @@ class TestUndoManager(TestCase):
         A.one = association("one", B, lower=0, upper=1, opposite="two")
         B.two = association("two", A, lower=0, upper="*", opposite="one")
 
-        a1 = A()
-        a2 = A()
-        b1 = B()
-        b2 = B()
+        a1 = A(factory=self.element_factory)
+        a2 = A(factory=self.element_factory)
+        b1 = B(factory=self.element_factory)
+        b2 = B(factory=self.element_factory)
 
         undo_manager.begin_transaction()
         b1.two = a1
@@ -318,13 +318,13 @@ class TestUndoManager(TestCase):
         compreg = Application.get_service("component_registry")
         compreg.register_handler(handler)
         try:
-            a = A()
+            a = A(factory=self.element_factory)
 
             undo_manager = UndoManager()
             undo_manager.init(Application)
             undo_manager.begin_transaction()
 
-            a.a1 = A()
+            a.a1 = A(factory=self.element_factory)
             undo_manager.commit_transaction()
 
             assert len(events) == 1, events

--- a/gaphor/ui/diagramtoolbox.py
+++ b/gaphor/ui/diagramtoolbox.py
@@ -174,6 +174,7 @@ class DiagramToolbox(object):
     """
 
     element_factory = inject("element_factory")
+    component_registry = inject("component_registry")
     properties = inject("properties")
 
     def __init__(self, diagram, view):
@@ -243,7 +244,7 @@ class DiagramToolbox(object):
     def _after_handler(self, new_item):
         if self.properties("reset-tool-after-create", False):
             self.action_group.get_action("toolbox-pointer").activate()
-        component.handle(DiagramItemCreateEvent(new_item))
+        self.component_registry.handle(DiagramItemCreateEvent(new_item))
 
     ##
     ## Toolbox actions

--- a/gaphor/ui/tests/test_namespace.py
+++ b/gaphor/ui/tests/test_namespace.py
@@ -5,9 +5,7 @@ from gaphor.application import Application
 
 
 @pytest.fixture
-def application(
-    services=["element_factory", "component_registry", "ui_manager", "action_manager"]
-):
+def application(services=["element_factory", "action_manager"]):
     Application.init(services=services)
     yield Application
     Application.shutdown()


### PR DESCRIPTION
Reduce external dependencies for the UML module.

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

The `gaphor.UML` module is dependent on global state, namely the adapter registry of a global "site-manager" inside the zope.component module.

This is bad. First of all since global state in general is a bad idea, but it also means that our own `component_registry` has to do some monkey-patching to make sure the application works as expected.

Issue Number: N/A

### What is the new behavior?

The eventing mechanism for derived properties is baked in to the properties classes. The event handling itself is externalized, and delegated to the ElementFactory, who knows about components and stuff.


### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

Unless your plugin is using `component.handle`, that is.

### Other information

For now, elements should keep their reference to the element factory. It's needed in case properties are parsed and some delegated properties performa query on the factory.