### PR TITLE
Fix Wayland Cursor TypeError: constructor returned NULL

### DIFF
--- a/gaphor/ui/diagramtools.py
+++ b/gaphor/ui/diagramtools.py
@@ -33,7 +33,7 @@ from gaphor.diagram.interfaces import IEditor, IConnect, IGroup
 IN_CURSOR = Gdk.Cursor.new(Gdk.CursorType.DIAMOND_CROSS)
 
 # cursor to indicate ungrouping
-OUT_CURSOR = Gdk.Cursor.new(Gdk.CursorType.SIZING)
+OUT_CURSOR = Gdk.Cursor.new(Gdk.CursorType.CROSSHAIR)
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

Currently when Gaphor is launched with Wayland it crashes. The issue is when using GDK CursorType SIZING, so I have updated it to use the CROSSHAIR one. I am currently not sure how to make use of this Group Placement tool, so I'm not positive if this is a suitable cursor to use in this situation.


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
TypeError: constructor returned NULL

Issue Number: #147 

### What is the new behavior?
No TypeError

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

### Other information
