### PR TITLE
Create Event manager service for event handling

### DIFF
--- a/docs/generic/event_system.rst
+++ b/docs/generic/event_system.rst
@@ -3,7 +3,7 @@ Event system
 
 Generic library provides ``generic.event`` module which helps you implement
 event systems in your application. By event system I mean an API for
-*subscribing* for some types of events and to *fire* those events so previously
+*subscribing* for some types of events and to *handle* those events so previously
 subscribed *handlers* are being executed.
 
 .. contents::
@@ -29,12 +29,12 @@ Now you want to register handler for your event type::
   def print_comment(ev):
     print "Got new comment: %s" % ev.comment
 
-Then you just call ``generic.event.fire`` function with ``CommentAdded``
+Then you just call ``generic.event.handle`` function with ``CommentAdded``
 instance as its argument::
 
-  from generic.event import fire
+  from generic.event import handle
 
-  fire(CommentAdded(167, "Hello!")) # prints `Got new comment: Hello!`
+  handle(CommentAdded(167, "Hello!")) # prints `Got new comment: Hello!`
 
 This is how it works.
 
@@ -48,12 +48,12 @@ API reference
 -------------
 
 .. autoclass:: generic.event.Manager
-   :members: subscribe, subscriber, fire, unsubscribe
+   :members: subscribe, subscriber, handle, unsubscribe
 
 Functions below are just aliases for methods of globally instantiated
 manager:
 
 .. autofunction:: generic.event.subscribe(handler, event_type)
 .. autofunction:: generic.event.subscriber(event_type)
-.. autofunction:: generic.event.fire(event)
+.. autofunction:: generic.event.handle(event)
 .. autofunction:: generic.event.unsubscribe(handler, event_type)

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -2,9 +2,9 @@ UML datamodel
 =============
 
 Gaphor uses the UML metamodel specs as guidelines for its data storage.
-In fact, the datamodel is generated for a model file. 
+In fact, the datamodel is generated for a model file.
 
-The model is built using smart properties (descriptors). Those descriptors fire
+The model is built using smart properties (descriptors). Those descriptors handle
 events when they're changed. This allows the rest of the application (visuals,
 undo system) to update their state accordingly. The events are send using Zope
 (3)'s signalling mechanism, called Handlers.

--- a/gaphor/UML/elementfactory.py
+++ b/gaphor/UML/elementfactory.py
@@ -173,7 +173,7 @@ class ElementFactory:
 class ElementFactoryService(Service, ElementFactory):
     """Service version of the ElementFactory."""
 
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
 
     def __init__(self):
         super(ElementFactoryService, self).__init__()
@@ -234,4 +234,4 @@ class ElementFactoryService(Service, ElementFactory):
         Handle events coming from elements (used internally).
         """
         if not self._block_events:
-            self.component_registry.handle(event)
+            self.event_manager.handle(event)

--- a/gaphor/UML/tests/test_elementfactory.py
+++ b/gaphor/UML/tests/test_elementfactory.py
@@ -98,8 +98,8 @@ class ElementFactoryServiceTestCase(unittest.TestCase):
     def setUp(self):
         Application.init(["element_factory"])
         self.factory = Application.get_service("element_factory")
-        component_registry = Application.get_service("component_registry")
-        component_registry.register_handler(handler)
+        event_manager = Application.get_service("event_manager")
+        event_manager.subscribe(handler)
         clearEvents()
 
     def tearDown(self):

--- a/gaphor/core.py
+++ b/gaphor/core.py
@@ -5,7 +5,7 @@ An average module should only need to import this module.
 """
 
 from gaphor.application import inject, Application
-from gaphor.services.componentregistry import event_handler
+from gaphor.services.eventmanager import event_handler
 from gaphor.transaction import Transaction, transactional
 from gaphor.action import action, toggle_action, radio_action, build_action_group
 from gaphor.i18n import _

--- a/gaphor/misc/generic/event.py
+++ b/gaphor/misc/generic/event.py
@@ -2,7 +2,7 @@
 
 This module provides API for event management. There are two APIs provided:
 
-* Global event management API: subscribe, unsubscribe, fire.
+* Global event management API: subscribe, unsubscribe, handle.
 * Local event management API: Manager
 
 If you run only one instance of your application per Python
@@ -25,7 +25,7 @@ class Manager(object):
 
     Provides API for subscribing for and firing events. There's also global
     event manager instantiated at module level with functions
-    :func:`.subscribe`, :func:`.fire` and decorator :func:`.subscriber` aliased
+    :func:`.subscribe`, :func:`.handle` and decorator :func:`.subscriber` aliased
     to corresponding methods of class.
     """
 
@@ -46,7 +46,7 @@ class Manager(object):
         if handler_set and handler in handler_set:
             handler_set.remove(handler)
 
-    def fire(self, event):
+    def handle(self, event):
         """ Fire ``event``
 
         All subscribers will be executed with no determined order.
@@ -76,7 +76,7 @@ class Manager(object):
             ...     # handle event
             ...     return
 
-            >>> mymanager.fire(MyEvent())
+            >>> mymanager.handle(MyEvent())
 
         """
 

--- a/gaphor/misc/generic/tests/test_event.py
+++ b/gaphor/misc/generic/tests/test_event.py
@@ -19,7 +19,7 @@ class ManagerTests(unittest.TestCase):
         events = self.createManager()
         events.subscribe(self.makeHandler("handler1"), EventA)
         e = EventA()
-        events.fire(e)
+        events.handle(e)
         self.assertEqual(len(e.effects), 1)
         self.assertTrue("handler1" in e.effects)
 
@@ -27,7 +27,7 @@ class ManagerTests(unittest.TestCase):
         events = self.createManager()
         events.subscriber(EventA)(self.makeHandler("handler1"))
         e = EventA()
-        events.fire(e)
+        events.handle(e)
         self.assertEqual(len(e.effects), 1)
         self.assertTrue("handler1" in e.effects)
 
@@ -37,12 +37,12 @@ class ManagerTests(unittest.TestCase):
         events.subscribe(self.makeHandler("handler2"), EventB)
 
         ea = EventA()
-        events.fire(ea)
+        events.handle(ea)
         self.assertEqual(len(ea.effects), 1)
         self.assertTrue("handler1" in ea.effects)
 
         eb = EventB()
-        events.fire(eb)
+        events.handle(eb)
         self.assertEqual(len(eb.effects), 2)
         self.assertTrue("handler1" in eb.effects)
         self.assertTrue("handler2" in eb.effects)
@@ -54,17 +54,17 @@ class ManagerTests(unittest.TestCase):
         events.subscribe(self.makeHandler("handler3"), EventD)
 
         ea = EventA()
-        events.fire(ea)
+        events.handle(ea)
         self.assertEqual(len(ea.effects), 1)
         self.assertTrue("handler1" in ea.effects)
 
         ec = EventC()
-        events.fire(ec)
+        events.handle(ec)
         self.assertEqual(len(ec.effects), 1)
         self.assertTrue("handler2" in ec.effects)
 
         ed = EventD()
-        events.fire(ed)
+        events.handle(ed)
         self.assertEqual(len(ed.effects), 3)
         self.assertTrue("handler1" in ed.effects)
         self.assertTrue("handler2" in ed.effects)
@@ -74,7 +74,7 @@ class ManagerTests(unittest.TestCase):
         events = self.createManager()
 
         ea = EventA()
-        events.fire(ea)
+        events.handle(ea)
         self.assertEqual(len(ea.effects), 0)
 
     def test_subscribe_base_event(self):
@@ -82,7 +82,7 @@ class ManagerTests(unittest.TestCase):
         events.subscribe(self.makeHandler("handler1"), EventA)
 
         ea = EventB()
-        events.fire(ea)
+        events.handle(ea)
         self.assertEqual(len(ea.effects), 1)
         self.assertTrue("handler1" in ea.effects)
 
@@ -93,18 +93,18 @@ class ManagerTests(unittest.TestCase):
         events.subscribe(self.makeHandler("handler3"), EventE)
 
         ea = EventA()
-        events.fire(ea)
+        events.handle(ea)
         self.assertEqual(len(ea.effects), 1)
         self.assertTrue("handler1" in ea.effects)
 
         ed = EventD()
-        events.fire(ed)
+        events.handle(ed)
         self.assertEqual(len(ed.effects), 2)
         self.assertTrue("handler1" in ed.effects)
         self.assertTrue("handler2" in ed.effects)
 
         ee = EventE()
-        events.fire(ee)
+        events.handle(ee)
         self.assertEqual(len(ee.effects), 3)
         self.assertTrue("handler1" in ee.effects)
         self.assertTrue("handler2" in ee.effects)
@@ -116,7 +116,7 @@ class ManagerTests(unittest.TestCase):
         events.subscribe(self.makeHandler("handler2"), EventB)
 
         eb = EventB()
-        events.fire(eb)
+        events.handle(eb)
         self.assertEqual(len(eb.effects), 2)
         self.assertTrue("handler1" in eb.effects)
         self.assertTrue("handler2" in eb.effects)
@@ -127,7 +127,7 @@ class ManagerTests(unittest.TestCase):
         events.subscribe(handler, EventA)
         events.unsubscribe(handler, EventA)
         e = EventA()
-        events.fire(e)
+        events.handle(e)
         self.assertEqual(len(e.effects), 0)
 
     def test_unsubscribe_event_inheritance(self):
@@ -139,11 +139,11 @@ class ManagerTests(unittest.TestCase):
         events.unsubscribe(handler1, EventA)
 
         ea = EventA()
-        events.fire(ea)
+        events.handle(ea)
         self.assertEqual(len(ea.effects), 0)
 
         eb = EventB()
-        events.fire(eb)
+        events.handle(eb)
         self.assertEqual(len(eb.effects), 1)
         self.assertTrue("handler2" in eb.effects)
 

--- a/gaphor/plugins/alignment/__init__.py
+++ b/gaphor/plugins/alignment/__init__.py
@@ -8,7 +8,7 @@ from gaphor.ui.event import DiagramSelectionChange
 
 
 class Alignment(Service, ActionProvider):
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
 
     menu_xml = """
       <ui>
@@ -33,11 +33,11 @@ class Alignment(Service, ActionProvider):
         self._last_update = None
 
     def init(self, app):
-        self.component_registry.register_handler(self.update)
+        self.event_manager.subscribe(self.update)
         self.update()
 
     def shutdown(self):
-        self.component_registry.unregister_handler(self.update)
+        self.event_manager.unsubscribe(self.update)
 
     @event_handler(DiagramSelectionChange)
     def update(self, event=None):

--- a/gaphor/services/actionmanager.py
+++ b/gaphor/services/actionmanager.py
@@ -18,6 +18,7 @@ class ActionManager(Service):
     """
 
     component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
 
     def __init__(self):
         self.ui_manager = Gtk.UIManager()
@@ -29,13 +30,13 @@ class ActionManager(Service):
             logger.debug("Service is %s" % service)
             self.register_action_provider(service)
 
-        self.component_registry.register_handler(self._service_initialized_handler)
+        self.event_manager.subscribe(self._service_initialized_handler)
 
     def shutdown(self):
 
         logger.info("Shutting down")
 
-        self.component_registry.unregister_handler(self._service_initialized_handler)
+        self.event_manager.unsubscribe(self._service_initialized_handler)
 
     def execute(self, action_id, active=None):
 
@@ -44,7 +45,7 @@ class ActionManager(Service):
         a = self.get_action(action_id)
         if a:
             a.activate()
-            self.component_registry.handle(ActionExecuted(action_id, a))
+            self.event_manager.handle(ActionExecuted(action_id, a))
         else:
             logger.warning("Unknown action %s" % action_id)
 

--- a/gaphor/services/componentregistry.py
+++ b/gaphor/services/componentregistry.py
@@ -4,19 +4,6 @@ A registry for components (e.g. services) and event handling.
 
 from gaphor.abc import Service
 from gaphor.application import ComponentLookupError
-from gaphor.misc.generic.event import Manager
-
-
-def event_handler(*event_types):
-    """
-    Mark a function/method as an event handler for a particular type of event.
-    """
-
-    def wrapper(func):
-        func.__event_types__ = event_types
-        return func
-
-    return wrapper
 
 
 class ComponentRegistry(Service):
@@ -26,7 +13,6 @@ class ComponentRegistry(Service):
 
     def init(self, app):
         self._comp = set()
-        self._events = Manager()
 
     def shutdown(self):
         pass
@@ -57,33 +43,3 @@ class ComponentRegistry(Service):
 
     def all(self, base):
         return ((c, n) for c, n in self._comp if isinstance(c, base))
-
-    def register_handler(self, handler):
-        """
-        Register a handler. Handlers are triggered (executed) when specific
-        events are emitted through the handle() method.
-        """
-        event_types = getattr(handler, "__event_types__", None)
-        if not event_types:
-            raise Exception(f"No event types provided for function {handler}")
-
-        for et in event_types:
-            self._events.subscribe(handler, et)
-
-    def unregister_handler(self, handler=None, event_types=None):
-        """
-        Unregister a previously registered handler.
-        """
-        event_types = getattr(handler, "__event_types__", None)
-        if not event_types:
-            raise Exception(f"No event types provided for function {handler}")
-
-        for et in event_types:
-            self._events.unsubscribe(handler, et)
-
-    def handle(self, *events):
-        """
-        Send event notifications to registered handlers.
-        """
-        for e in events:
-            self._events.handle(e)

--- a/gaphor/services/componentregistry.py
+++ b/gaphor/services/componentregistry.py
@@ -86,4 +86,4 @@ class ComponentRegistry(Service):
         Send event notifications to registered handlers.
         """
         for e in events:
-            self._events.fire(e)
+            self._events.handle(e)

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -27,7 +27,7 @@ class CopyService(Service, ActionProvider):
       on the canvas and make the uml element visible again.
     """
 
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
     element_factory = inject("element_factory")
     main_window = inject("main_window")
 
@@ -52,11 +52,11 @@ class CopyService(Service, ActionProvider):
         self.action_group.get_action("edit-copy").props.sensitive = False
         self.action_group.get_action("edit-paste").props.sensitive = False
 
-        self.component_registry.register_handler(self._update)
+        self.event_manager.subscribe(self._update)
 
     def shutdown(self):
         self.copy_buffer = set()
-        self.component_registry.unregister_handler(self._update)
+        self.event_manager.unsubscribe(self._update)
 
     @event_handler(DiagramSelectionChange)
     def _update(self, event):

--- a/gaphor/services/elementdispatcher.py
+++ b/gaphor/services/elementdispatcher.py
@@ -99,7 +99,7 @@ class ElementDispatcher(Service):
 
     logger = getLogger("ElementDispatcher")
 
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
 
     def __init__(self):
         # Table used to fire events:
@@ -111,12 +111,12 @@ class ElementDispatcher(Service):
         self._reverse = dict()
 
     def init(self, app):
-        self.component_registry.register_handler(self.on_model_loaded)
-        self.component_registry.register_handler(self.on_element_change_event)
+        self.event_manager.subscribe(self.on_model_loaded)
+        self.event_manager.subscribe(self.on_element_change_event)
 
     def shutdown(self):
-        self.component_registry.unregister_handler(self.on_element_change_event)
-        self.component_registry.unregister_handler(self.on_model_loaded)
+        self.event_manager.unsubscribe(self.on_element_change_event)
+        self.event_manager.unsubscribe(self.on_model_loaded)
 
     def _path_to_properties(self, element, path):
         """

--- a/gaphor/services/elementdispatcher.py
+++ b/gaphor/services/elementdispatcher.py
@@ -55,7 +55,7 @@ class EventWatcher:
 
         for path, handler in self._watched_paths.items():
 
-            dispatcher.register_handler(handler, element, path)
+            dispatcher.subscribe(handler, element, path)
 
     def unregister_handlers(self, *args):
         """
@@ -67,7 +67,7 @@ class EventWatcher:
 
         for path, handler in self._watched_paths.items():
 
-            dispatcher.unregister_handler(handler)
+            dispatcher.unsubscribe(handler)
 
 
 class ElementDispatcher(Service):
@@ -85,7 +85,7 @@ class ElementDispatcher(Service):
     that's represented by this item (gaphor.UML.Transition), you can register
     a handler like this::
 
-      dispatcher.register_handler(element,
+      dispatcher.subscribe(element,
               'guard.specification<LiteralSpecification>.value', self._handler)
 
     Note the '<' and '>'. This is because guard references ValueSpecification,
@@ -214,7 +214,7 @@ class ElementDispatcher(Service):
         if not handlers:
             del self._handlers[key]
 
-    def register_handler(self, handler, element, path):
+    def subscribe(self, handler, element, path):
 
         # self.logger.info('Registering handler')
         # self.logger.debug('Handler is %s' % handler)
@@ -224,7 +224,7 @@ class ElementDispatcher(Service):
         props = self._path_to_properties(element, path)
         self._add_handlers(element, props, handler)
 
-    def unregister_handler(self, handler):
+    def unsubscribe(self, handler):
         """
         Unregister a handler from the registy.
         """

--- a/gaphor/services/eventmanager.py
+++ b/gaphor/services/eventmanager.py
@@ -1,0 +1,60 @@
+"""
+Event Manager.
+"""
+
+from gaphor.abc import Service
+from gaphor.misc.generic.event import Manager as _Manager
+
+
+def event_handler(*event_types):
+    """
+    Mark a function/method as an event handler for a particular type of event.
+    """
+
+    def wrapper(func):
+        func.__event_types__ = event_types
+        return func
+
+    return wrapper
+
+
+class EventManager(Service):
+    """
+    The Event Manager.
+    """
+
+    def init(self, app):
+        self._events = _Manager()
+
+    def shutdown(self):
+        pass
+
+    def subscribe(self, handler):
+        """
+        Register a handler. Handlers are triggered (executed) when specific
+        events are emitted through the handle() method.
+        """
+        event_types = getattr(handler, "__event_types__", None)
+        if not event_types:
+            raise Exception(f"No event types provided for function {handler}")
+
+        for et in event_types:
+            self._events.subscribe(handler, et)
+
+    def unsubscribe(self, handler, event_types=None):
+        """
+        Unregister a previously registered handler.
+        """
+        event_types = getattr(handler, "__event_types__", None)
+        if not event_types:
+            raise Exception(f"No event types provided for function {handler}")
+
+        for et in event_types:
+            self._events.unsubscribe(handler, et)
+
+    def handle(self, *events):
+        """
+        Send event notifications to registered handlers.
+        """
+        for e in events:
+            self._events.handle(e)

--- a/gaphor/services/filemanager.py
+++ b/gaphor/services/filemanager.py
@@ -38,7 +38,7 @@ class FileManager(Service, ActionProvider):
     The file service, responsible for loading and saving Gaphor models.
     """
 
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
     element_factory = inject("element_factory")
     main_window = inject("main_window")
     properties = inject("properties")
@@ -194,7 +194,7 @@ class FileManager(Service, ActionProvider):
         filename = self.recent_files[index]
 
         self.load(filename)
-        self.component_registry.handle(FileManagerStateChanged(self))
+        self.event_manager.handle(FileManagerStateChanged(self))
 
     def load(self, filename):
         """Load the Gaphor model from the supplied file name.  A status window
@@ -396,7 +396,7 @@ class FileManager(Service, ActionProvider):
         # main_window.select_element(diagram)
         # main_window.show_diagram(diagram)
 
-        self.component_registry.handle(FileManagerStateChanged(self))
+        self.event_manager.handle(FileManagerStateChanged(self))
 
     @action(name="file-new-template", label=_("New from template"))
     def action_new_from_template(self):
@@ -418,7 +418,7 @@ class FileManager(Service, ActionProvider):
         if filename:
             self.load(filename)
             self.filename = None
-            self.component_registry.handle(FileManagerStateChanged(self))
+            self.event_manager.handle(FileManagerStateChanged(self))
 
     @action(name="file-open", stock_id="gtk-open")
     def action_open(self):
@@ -439,7 +439,7 @@ class FileManager(Service, ActionProvider):
 
         if filename:
             self.load(filename)
-            self.component_registry.handle(FileManagerStateChanged(self))
+            self.event_manager.handle(FileManagerStateChanged(self))
 
     @action(name="file-save", stock_id="gtk-save")
     def action_save(self):
@@ -454,7 +454,7 @@ class FileManager(Service, ActionProvider):
 
         if filename:
             self.save(filename)
-            self.component_registry.handle(FileManagerStateChanged(self))
+            self.event_manager.handle(FileManagerStateChanged(self))
             return True
         else:
             return self.action_save_as()
@@ -478,7 +478,7 @@ class FileManager(Service, ActionProvider):
 
         if filename:
             self.save(filename)
-            self.component_registry.handle(FileManagerStateChanged(self))
+            self.event_manager.handle(FileManagerStateChanged(self))
             return True
 
         return False

--- a/gaphor/services/properties.py
+++ b/gaphor/services/properties.py
@@ -32,7 +32,7 @@ class Properties(Service):
 
     Properties are persisted to the local file system."""
 
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
 
     def __init__(self, backend=None):
         """Constructor.  Initialize the Gaphor application object, the
@@ -105,7 +105,7 @@ class Properties(Service):
 
         if value != old_value:
             resources[key] = value
-            self.component_registry.handle(PropertyChangeEvent(key, old_value, value))
+            self.event_manager.handle(PropertyChangeEvent(key, old_value, value))
             self._backend.update(resources, key, value)
 
 

--- a/gaphor/services/sanitizerservice.py
+++ b/gaphor/services/sanitizerservice.py
@@ -20,7 +20,7 @@ class SanitizerService(Service):
 
     logger = getLogger("Sanitizer")
 
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
     element_factory = inject("element_factory")
     property_dispatcher = inject("property_dispatcher")
 
@@ -28,16 +28,16 @@ class SanitizerService(Service):
         pass
 
     def init(self, app=None):
-        self.component_registry.register_handler(self._unlink_on_presentation_delete)
-        self.component_registry.register_handler(self._unlink_on_stereotype_delete)
-        self.component_registry.register_handler(self._unlink_on_extension_delete)
-        self.component_registry.register_handler(self._disconnect_extension_end)
+        self.event_manager.subscribe(self._unlink_on_presentation_delete)
+        self.event_manager.subscribe(self._unlink_on_stereotype_delete)
+        self.event_manager.subscribe(self._unlink_on_extension_delete)
+        self.event_manager.subscribe(self._disconnect_extension_end)
 
     def shutdown(self):
-        self.component_registry.unregister_handler(self._unlink_on_presentation_delete)
-        self.component_registry.unregister_handler(self._unlink_on_stereotype_delete)
-        self.component_registry.unregister_handler(self._unlink_on_extension_delete)
-        self.component_registry.unregister_handler(self._disconnect_extension_end)
+        self.event_manager.unsubscribe(self._unlink_on_presentation_delete)
+        self.event_manager.unsubscribe(self._unlink_on_stereotype_delete)
+        self.event_manager.unsubscribe(self._unlink_on_extension_delete)
+        self.event_manager.unsubscribe(self._disconnect_extension_end)
 
     @event_handler(AssociationDeleteEvent)
     def _unlink_on_presentation_delete(self, event):

--- a/gaphor/services/tests/test_elementdispatcher.py
+++ b/gaphor/services/tests/test_elementdispatcher.py
@@ -21,9 +21,7 @@ class ElementDispatcherTestCase(TestCase):
     def test_register_handler(self):
         dispatcher = self.dispatcher
         element = self.element_factory.create(UML.Class)
-        dispatcher.register_handler(
-            self._handler, element, "ownedOperation.parameter.name"
-        )
+        dispatcher.subscribe(self._handler, element, "ownedOperation.parameter.name")
         assert len(dispatcher._handlers) == 1
         assert list(dispatcher._handlers.keys())[0] == (
             element,
@@ -40,9 +38,7 @@ class ElementDispatcherTestCase(TestCase):
         )
         # 3:
         p.name = "func"
-        dispatcher.register_handler(
-            self._handler, element, "ownedOperation.parameter.name"
-        )
+        dispatcher.subscribe(self._handler, element, "ownedOperation.parameter.name")
         self.assertEqual(3, len(self.events))
         self.assertEqual(3, len(dispatcher._handlers))
 
@@ -59,24 +55,16 @@ class ElementDispatcherTestCase(TestCase):
         p = element.ownedOperation[0].formalParameter = self.element_factory.create(
             UML.Parameter
         )
-        dispatcher.register_handler(
-            self._handler, element, "ownedOperation.parameter.name"
-        )
+        dispatcher.subscribe(self._handler, element, "ownedOperation.parameter.name")
 
         n_handlers = len(dispatcher._handlers)
 
         self.assertEqual(0, len(self.events))
-        dispatcher.register_handler(
-            self._handler, element, "ownedOperation.parameter.name"
-        )
+        dispatcher.subscribe(self._handler, element, "ownedOperation.parameter.name")
         self.assertEqual(n_handlers, len(dispatcher._handlers))
-        dispatcher.register_handler(
-            self._handler, element, "ownedOperation.parameter.name"
-        )
+        dispatcher.subscribe(self._handler, element, "ownedOperation.parameter.name")
         self.assertEqual(n_handlers, len(dispatcher._handlers))
-        dispatcher.register_handler(
-            self._handler, element, "ownedOperation.parameter.name"
-        )
+        dispatcher.subscribe(self._handler, element, "ownedOperation.parameter.name")
         self.assertEqual(n_handlers, len(dispatcher._handlers))
 
         p.name = "func"
@@ -92,21 +80,19 @@ class ElementDispatcherTestCase(TestCase):
             UML.Parameter
         )
         p.name = "func"
-        dispatcher.register_handler(
-            self._handler, element, "ownedOperation.parameter.name"
-        )
+        dispatcher.subscribe(self._handler, element, "ownedOperation.parameter.name")
         assert len(dispatcher._handlers) == 3
         assert dispatcher._handlers[element, UML.Class.ownedOperation]
         assert dispatcher._handlers[o, UML.Operation.parameter]
         assert dispatcher._handlers[p, UML.Parameter.name]
 
-        dispatcher.unregister_handler(self._handler)
+        dispatcher.unsubscribe(self._handler)
 
         assert len(dispatcher._handlers) == 0, dispatcher._handlers
         assert len(dispatcher._reverse) == 0, dispatcher._reverse
         # assert dispatcher._handlers.keys()[0] == (element, UML.Class.ownedOperation)
         # Should not fail here too:
-        dispatcher.unregister_handler(self._handler)
+        dispatcher.unsubscribe(self._handler)
 
     def test_notification(self):
         """
@@ -119,9 +105,7 @@ class ElementDispatcherTestCase(TestCase):
             UML.Parameter
         )
         p.name = "func"
-        dispatcher.register_handler(
-            self._handler, element, "ownedOperation.parameter.name"
-        )
+        dispatcher.subscribe(self._handler, element, "ownedOperation.parameter.name")
         assert len(dispatcher._handlers) == 3
         assert not self.events
 
@@ -142,7 +126,7 @@ class ElementDispatcherTestCase(TestCase):
         dispatcher = self.dispatcher
         element = self.element_factory.create(UML.Transition)
         g = element.guard = self.element_factory.create(UML.Constraint)
-        dispatcher.register_handler(self._handler, element, "guard.specification")
+        dispatcher.subscribe(self._handler, element, "guard.specification")
         assert len(dispatcher._handlers) == 2
         assert not self.events
         assert (element.guard, UML.Constraint.specification) in list(
@@ -166,7 +150,7 @@ class ElementDispatcherTestCase(TestCase):
         dispatcher = self.dispatcher
         element = self.element_factory.create(UML.Transition)
         g = element.guard = self.element_factory.create(UML.Constraint)
-        dispatcher.register_handler(self._handler, element, "guard.specification")
+        dispatcher.subscribe(self._handler, element, "guard.specification")
         assert len(dispatcher._handlers) == 2
         assert not self.events
 
@@ -187,9 +171,7 @@ class ElementDispatcherTestCase(TestCase):
             UML.Constraint
         )
         p.name = "func"
-        dispatcher.register_handler(
-            self._handler, element, "ownedOperation.precondition.name"
-        )
+        dispatcher.subscribe(self._handler, element, "ownedOperation.precondition.name")
         assert len(dispatcher._handlers) == 3
         assert not self.events
 
@@ -203,7 +185,7 @@ class ElementDispatcherTestCase(TestCase):
         dispatcher = self.dispatcher
         element = self.element_factory.create(UML.Transition)
         g = element.guard = self.element_factory.create(UML.Constraint)
-        dispatcher.register_handler(self._handler, element, "guard.specification")
+        dispatcher.subscribe(self._handler, element, "guard.specification")
         assert len(dispatcher._handlers) == 2
         assert not self.events
         assert (element.guard, UML.Constraint.specification) in list(
@@ -257,9 +239,7 @@ class ElementDispatcherAsServiceTestCase(TestCase):
             UML.Parameter
         )
         p.name = "func"
-        dispatcher.register_handler(
-            self._handler, element, "ownedOperation.parameter.name"
-        )
+        dispatcher.subscribe(self._handler, element, "ownedOperation.parameter.name")
         assert len(dispatcher._handlers) == 3
         assert not self.events
 
@@ -285,7 +265,7 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         p2 = element.memberEnd = self.element_factory.create(UML.Property)
 
         assert len(element.memberEnd) == 2
-        dispatcher.register_handler(self._handler, element, "memberEnd.name")
+        dispatcher.subscribe(self._handler, element, "memberEnd.name")
         assert len(dispatcher._handlers) == 3, len(dispatcher._handlers)
         assert not self.events
 
@@ -317,11 +297,11 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         assert len(element.memberEnd) == 2
 
         base = "memberEnd<Property>."
-        dispatcher.register_handler(self._handler, element, base + "name")
-        dispatcher.register_handler(self._handler, element, base + "aggregation")
-        dispatcher.register_handler(self._handler, element, base + "classifier")
-        dispatcher.register_handler(self._handler, element, base + "lowerValue")
-        dispatcher.register_handler(self._handler, element, base + "upperValue")
+        dispatcher.subscribe(self._handler, element, base + "name")
+        dispatcher.subscribe(self._handler, element, base + "aggregation")
+        dispatcher.subscribe(self._handler, element, base + "classifier")
+        dispatcher.subscribe(self._handler, element, base + "lowerValue")
+        dispatcher.subscribe(self._handler, element, base + "upperValue")
 
         assert len(dispatcher._handlers) == 11, len(dispatcher._handlers)
         assert not self.events

--- a/gaphor/services/tests/test_undomanager.py
+++ b/gaphor/services/tests/test_undomanager.py
@@ -315,8 +315,8 @@ class TestUndoManager(TestCase):
         def handler(event, events=events):
             events.append(event)
 
-        compreg = Application.get_service("component_registry")
-        compreg.register_handler(handler)
+        em = Application.get_service("event_manager")
+        em.subscribe(handler)
         try:
             a = A(factory=self.element_factory)
 
@@ -338,7 +338,7 @@ class TestUndoManager(TestCase):
             assert events[1].property is A.a1
 
         finally:
-            compreg.unregister_handler(handler)
+            em.unsubscribe(handler)
             undo_manager.shutdown()
 
     def test_redo_stack(self):

--- a/gaphor/tests/test_transaction.py
+++ b/gaphor/tests/test_transaction.py
@@ -39,11 +39,11 @@ class TransactionTestCase(TestCase):
 
         Application.init(services=["component_registry"])
 
-        component_registry = Application.get_service("component_registry")
+        event_manager = Application.get_service("event_manager")
 
-        component_registry.register_handler(handle_begins)
-        component_registry.register_handler(handle_commits)
-        component_registry.register_handler(handle_rollback)
+        event_manager.subscribe(handle_begins)
+        event_manager.subscribe(handle_commits)
+        event_manager.subscribe(handle_rollback)
 
         del begins[:]
         del commits[:]
@@ -53,11 +53,11 @@ class TransactionTestCase(TestCase):
         """Finished with the test case.  Unregister event handlers that
         store transaction events."""
 
-        component_registry = Application.get_service("component_registry")
+        event_manager = Application.get_service("event_manager")
 
-        component_registry.unregister_handler(handle_begins)
-        component_registry.unregister_handler(handle_commits)
-        component_registry.unregister_handler(handle_rollback)
+        event_manager.unsubscribe(handle_begins)
+        event_manager.unsubscribe(handle_commits)
+        event_manager.unsubscribe(handle_rollback)
 
     def test_transaction_commit(self):
         """Test committing a transaction."""

--- a/gaphor/transaction.py
+++ b/gaphor/transaction.py
@@ -127,7 +127,7 @@ class Transaction:
         try:
             event_manager = self.event_manager
         except (application.NotInitializedError, application.ComponentLookupError):
-            log.warning("Could not lookup component_registry. Not emitting events.")
+            log.warning("Could not lookup event_manager. Not emitting events.")
         else:
             event_manager.handle(event)
 

--- a/gaphor/transaction.py
+++ b/gaphor/transaction.py
@@ -71,7 +71,7 @@ class Transaction:
     ...     pass
     """
 
-    component_registry = application.inject("component_registry")
+    event_manager = application.inject("event_manager")
 
     _stack = []
 
@@ -125,11 +125,11 @@ class Transaction:
 
     def _handle(self, event):
         try:
-            component_registry = self.component_registry
+            event_manager = self.event_manager
         except (application.NotInitializedError, application.ComponentLookupError):
             log.warning("Could not lookup component_registry. Not emitting events.")
         else:
-            component_registry.handle(event)
+            event_manager.handle(event)
 
     def __enter__(self):
         """Provide with-statement transaction support."""

--- a/gaphor/transaction.txt
+++ b/gaphor/transaction.txt
@@ -8,8 +8,8 @@ Transaction support is located in module gaphor.transaction:
 
 Do some basic initialization, so event emission will work:
 
-    >>> Application.init(services=['component_registry'])
-    >>> component_registry = Application.get_service('component_registry')
+    >>> Application.init(services=['event_manager'])
+    >>> event_manager = Application.get_service('event_manager')
 
 The Transaction class is used mainly to signal the begin and end of a transaction. This is done by the TransactionBegin, TransactionCommit and TransactionRollback events:
 
@@ -17,18 +17,18 @@ The Transaction class is used mainly to signal the begin and end of a transactio
     >>> @event_handler(transaction.TransactionBegin)
     ... def transaction_begin_handler(event):
     ...     print 'tx begin'
-    >>> component_registry.register_handler(transaction_begin_handler)
+    >>> event_manager.subscribe(transaction_begin_handler)
 
 Same goes for commit and rollback events:
 
     >>> @event_handler(transaction.TransactionCommit)
     ... def transaction_commit_handler(event):
     ...     print 'tx commit'
-    >>> component_registry.register_handler(transaction_commit_handler)
+    >>> event_manager.subscribe(transaction_commit_handler)
     >>> @event_handler(transaction.TransactionRollback)
     ... def transaction_rollback_handler(event):
     ...     print 'tx rollback'
-    >>> component_registry.register_handler(transaction_rollback_handler)
+    >>> event_manager.subscribe(transaction_rollback_handler)
 
 
 A Transaction is started by initiating a Transaction instance:

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -38,7 +38,7 @@ log = logging.getLogger(__name__)
 
 class DiagramPage(ActionProvider):
 
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
     element_factory = inject("element_factory")
     action_manager = inject("action_manager")
 
@@ -89,7 +89,7 @@ class DiagramPage(ActionProvider):
         self.widget = None
         self.action_group = build_action_group(self)
         self.toolbox = None
-        self.component_registry.register_handler(self._on_element_delete)
+        self.event_manager.subscribe(self._on_element_delete)
 
     title = property(lambda s: s.diagram and s.diagram.name or _("<None>"))
 
@@ -152,7 +152,7 @@ class DiagramPage(ActionProvider):
         be done if File->Close was pressed.
         """
         self.widget.destroy()
-        self.component_registry.unregister_handler(self._on_element_delete)
+        self.event_manager.unsubscribe(self._on_element_delete)
         self.view = None
 
     @action(name="diagram-zoom-in", stock_id="gtk-zoom-in")
@@ -276,7 +276,7 @@ class DiagramPage(ActionProvider):
                 self.delete_selected_items()
 
     def _on_view_selection_changed(self, view, selection_or_focus):
-        self.component_registry.handle(
+        self.event_manager.handle(
             DiagramSelectionChange(view, view.focused_item, view.selected_items)
         )
 

--- a/gaphor/ui/diagramtoolbox.py
+++ b/gaphor/ui/diagramtoolbox.py
@@ -173,7 +173,7 @@ class DiagramToolbox:
     """
 
     element_factory = inject("element_factory")
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
     properties = inject("properties")
 
     def __init__(self, diagram, view):
@@ -243,7 +243,7 @@ class DiagramToolbox:
     def _after_handler(self, new_item):
         if self.properties("reset-tool-after-create", False):
             self.action_group.get_action("toolbox-pointer").activate()
-        self.component_registry.handle(
+        self.event_manager.handle(
             DiagramItemCreateEvent(self.element_factory, new_item)
         )
 

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -22,7 +22,7 @@ class ElementEditor(UIComponent, ActionProvider):
 
     element_factory = inject("element_factory")
     main_window = inject("main_window")
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
 
     title = _("Element Editor")
     size = (275, -1)
@@ -85,8 +85,8 @@ class ElementEditor(UIComponent, ActionProvider):
                 self._selection_change(focused_item=focused_item)
 
         # Make sure we recieve
-        self.component_registry.register_handler(self._selection_change)
-        self.component_registry.register_handler(self._element_changed)
+        self.event_manager.subscribe(self._selection_change)
+        self.event_manager.subscribe(self._element_changed)
 
         window.connect("destroy", self.close)
 
@@ -96,8 +96,8 @@ class ElementEditor(UIComponent, ActionProvider):
         idempotent if set."""
 
         log.debug("ElementEditor.close")
-        self.component_registry.unregister_handler(self._selection_change)
-        self.component_registry.unregister_handler(self._element_changed)
+        self.event_manager.unsubscribe(self._selection_change)
+        self.event_manager.unsubscribe(self._element_changed)
         self.window = None
         self.vbox = None
         self._current_item = None

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -299,7 +299,7 @@ class Namespace(UIComponent, ActionProvider):
     title = _("Namespace")
     placement = ("left", "diagrams")
 
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
     element_factory = inject("element_factory")
     action_manager = inject("action_manager")
 
@@ -339,13 +339,13 @@ class Namespace(UIComponent, ActionProvider):
         # Event handler registration is in a separate function,
         # since putting it in with widget construction will cause
         # unit tests to fail, on macOS at least.
-        cr = self.component_registry
-        cr.register_handler(self._on_element_create)
-        cr.register_handler(self._on_element_delete)
-        cr.register_handler(self._on_model_factory)
-        cr.register_handler(self._on_flush_factory)
-        cr.register_handler(self._on_association_set)
-        cr.register_handler(self._on_attribute_change)
+        em = self.event_manager
+        em.subscribe(self._on_element_create)
+        em.subscribe(self._on_element_delete)
+        em.subscribe(self._on_model_factory)
+        em.subscribe(self._on_flush_factory)
+        em.subscribe(self._on_association_set)
+        em.subscribe(self._on_attribute_change)
 
     def open(self):
         self.init()
@@ -356,13 +356,13 @@ class Namespace(UIComponent, ActionProvider):
             self._namespace.destroy()
             self._namespace = None
 
-        cr = self.component_registry
-        cr.unregister_handler(self._on_element_create)
-        cr.unregister_handler(self._on_element_delete)
-        cr.unregister_handler(self._on_model_factory)
-        cr.unregister_handler(self._on_flush_factory)
-        cr.unregister_handler(self._on_association_set)
-        cr.unregister_handler(self._on_attribute_change)
+        em = self.event_manager
+        em.unsubscribe(self._on_element_create)
+        em.unsubscribe(self._on_element_delete)
+        em.unsubscribe(self._on_model_factory)
+        em.unsubscribe(self._on_flush_factory)
+        em.unsubscribe(self._on_association_set)
+        em.unsubscribe(self._on_attribute_change)
 
     def construct(self):
         sorted_model = Gtk.TreeModelSort(self.model)
@@ -567,7 +567,7 @@ class Namespace(UIComponent, ActionProvider):
         element = self._namespace.get_selected_element()
         # TODO: Candidate for adapter?
         if isinstance(element, UML.Diagram):
-            self.component_registry.handle(DiagramShow(element))
+            self.event_manager.handle(DiagramShow(element))
 
         else:
             log.debug("No action defined for element %s" % type(element).__name__)
@@ -602,7 +602,7 @@ class Namespace(UIComponent, ActionProvider):
             diagram.name = "New diagram"
 
         self.select_element(diagram)
-        self.component_registry.handle(DiagramShow(diagram))
+        self.event_manager.handle(DiagramShow(diagram))
         self.tree_view_rename_selected()
 
     @action(

--- a/gaphor/ui/tests/test_diagramtools.py
+++ b/gaphor/ui/tests/test_diagramtools.py
@@ -15,13 +15,14 @@ logging.basicConfig(level=logging.DEBUG)
 class DiagramItemConnectorTestCase(TestCase):
     services = TestCase.services + ["main_window", "action_manager", "properties"]
     component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
 
     def setUp(self):
         super(DiagramItemConnectorTestCase, self).setUp()
         mw = self.get_service("main_window")
         mw.open()
         self.main_window = mw
-        self.component_registry.handle(DiagramShow(self.diagram))
+        self.event_manager.handle(DiagramShow(self.diagram))
 
     def test_item_reconnect(self):
         # Setting the stage:

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -70,6 +70,7 @@ class HandleToolTestCase(unittest.TestCase):
     """
 
     component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
 
     def setUp(self):
         Application.init(
@@ -107,7 +108,7 @@ class HandleToolTestCase(unittest.TestCase):
         """
         element_factory = Application.get_service("element_factory")
         diagram = element_factory.create(UML.Diagram)
-        self.component_registry.handle(DiagramShow(diagram))
+        self.event_manager.handle(DiagramShow(diagram))
         comment = diagram.create(
             CommentItem, subject=element_factory.create(UML.Comment)
         )
@@ -147,7 +148,7 @@ class HandleToolTestCase(unittest.TestCase):
         """
         element_factory = Application.get_service("element_factory")
         diagram = element_factory.create(UML.Diagram)
-        self.component_registry.handle(DiagramShow(diagram))
+        self.event_manager.handle(DiagramShow(diagram))
         comment = diagram.create(
             CommentItem, subject=element_factory.create(UML.Comment)
         )

--- a/gaphor/ui/tests/test_mainwindow.py
+++ b/gaphor/ui/tests/test_mainwindow.py
@@ -14,6 +14,7 @@ class MainWindowTestCase(unittest.TestCase):
         )
 
     component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
 
     def tearDown(self):
         Application.shutdown()
@@ -34,5 +35,5 @@ class MainWindowTestCase(unittest.TestCase):
         element_factory = Application.get_service("element_factory")
         diagram = element_factory.create(UML.Diagram)
         main_w.open()
-        self.component_registry.handle(DiagramShow(diagram))
+        self.event_manager.handle(DiagramShow(diagram))
         self.assertEqual(self.get_current_diagram(), diagram)

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -32,7 +32,7 @@ class Toolbox(UIComponent, ActionProvider):
     title = _("Toolbox")
     placement = ("left", "diagrams")
 
-    component_registry = inject("component_registry")
+    event_manager = inject("event_manager")
     main_window = inject("main_window")
     properties = inject("properties")
 
@@ -63,14 +63,14 @@ class Toolbox(UIComponent, ActionProvider):
         self.main_window.window.connect_after(
             "key-press-event", self._on_key_press_event
         )
-        self.component_registry.register_handler(self._on_diagram_page_change)
+        self.event_manager.subscribe(self._on_diagram_page_change)
         return widget
 
     def close(self):
         if self._toolbox:
             self._toolbox.destroy()
             self._toolbox = None
-        self.component_registry.unregister_handler(self._on_diagram_page_change)
+        self.event_manager.unsubscribe(self._on_diagram_page_change)
 
     def construct(self):
         def toolbox_button(action_name, stock_id, label, shortcut):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ gaphorconvert = 'gaphor.tools.gaphorconvert:main'
 
 [tool.poetry.plugins."gaphor.services"]
 "component_registry" = "gaphor.services.componentregistry:ComponentRegistry"
+"event_manager" = "gaphor.services.eventmanager:EventManager"
 "properties" = "gaphor.services.properties:Properties"
 "undo_manager" = "gaphor.services.undomanager:UndoManager"
 "element_factory" = "gaphor.UML.elementfactory:ElementFactoryService"

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
         ],
         "gaphor.services": [
             "component_registry = gaphor.services.componentregistry:ComponentRegistry",
+            "event_manager = gaphor.services.eventmanager:EventManager",
             "properties = gaphor.services.properties:Properties",
             "undo_manager = gaphor.services.undomanager:UndoManager",
             "element_factory = gaphor.UML.elementfactory:ElementFactoryService",


### PR DESCRIPTION

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [X] Restructuring
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

The ComponentRegistry service both maintained a registry of services and application wide objects, as well as the event management logic.

### What is the new behavior?

The event management code has been split out into a separate service: `EventManager`.

In addition, the API for event subscription for both `EventManager` and `ElementDispatcher` has been changed from using `(un)register_handler` to `(un)subscribe`. I think this is clear and concise.

### Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

