### PR TITLE
Model maintenance

### DIFF
--- a/gaphor/UML/diagram.py
+++ b/gaphor/UML/diagram.py
@@ -90,12 +90,15 @@ class Diagram(Namespace, PackageableElement):
         parameter is the element class to create.  The new element also has an
         optional parent and subject."""
 
+        return self.create_as(type, str(uuid.uuid1()), parent, subject)
+
+    def create_as(self, type, id, parent=None, subject=None):
         assert issubclass(type, gaphas.Item)
-        obj = type(str(uuid.uuid1()), self.factory)
+        item = type(id, self.factory)
         if subject:
-            obj.subject = subject
-        self.canvas.add(obj, parent)
-        return obj
+            item.subject = subject
+        self.canvas.add(item, parent)
+        return item
 
     def unlink(self):
         """Unlink all canvas items then unlink this diagram."""

--- a/gaphor/UML/diagram.py
+++ b/gaphor/UML/diagram.py
@@ -91,7 +91,7 @@ class Diagram(Namespace, PackageableElement):
         optional parent and subject."""
 
         assert issubclass(type, gaphas.Item)
-        obj = type(str(uuid.uuid1()))
+        obj = type(str(uuid.uuid1()), self.factory)
         if subject:
             obj.subject = subject
         self.canvas.add(obj, parent)

--- a/gaphor/UML/element.py
+++ b/gaphor/UML/element.py
@@ -43,6 +43,8 @@ class Element:
 
     id = property(lambda self: self._id, doc="Id")
 
+    factory = property(lambda self: self._factory, doc="the owning element factory")
+
     def umlproperties(self):
         """
         Iterate over all UML properties

--- a/gaphor/UML/element.py
+++ b/gaphor/UML/element.py
@@ -127,25 +127,3 @@ class Element:
         Returns true if the object is of the same type as other.
         """
         return isinstance(self, type(other))
-
-    def __getstate__(self):
-        d = dict(self.__dict__)
-        try:
-            del d["_factory"]
-        except KeyError:
-            pass
-        return d
-
-    def __setstate__(self, state):
-        self._factory = None
-        self.__dict__.update(state)
-
-
-try:
-    import psyco
-except ImportError:
-    pass
-else:
-    psyco.bind(Element)
-
-# vim:sw=4:et

--- a/gaphor/UML/element.py
+++ b/gaphor/UML/element.py
@@ -10,6 +10,14 @@ import uuid
 from gaphor.UML.properties import umlproperty
 
 
+class UnlinkEvent:
+    """Used to tell event handlers this element should be unlinked.
+    """
+
+    def __init__(self, element):
+        self.element = element
+
+
 class Element:
     """
     Base class for UML data classes.
@@ -92,8 +100,7 @@ class Element:
 
                 prop.unlink(self)
 
-            if self._factory:
-                self._factory._unlink_element(self)
+            self.handle(UnlinkEvent(self))
         finally:
             self._unlink_lock -= 1
 

--- a/gaphor/UML/modelfactory.py
+++ b/gaphor/UML/modelfactory.py
@@ -129,9 +129,9 @@ def get_applied_stereotypes(element):
     return element.appliedStereotype[:].classifier
 
 
-def create_extension(factory, element, stereotype):
+def create_extension(factory, metaclass, stereotype):
     """
-    Extend an element with a stereotype.
+    Create an Extension association between an metaclass and a stereotype.
     """
     ext = factory.create(Extension)
     p = factory.create(Property)
@@ -142,9 +142,10 @@ def create_extension(factory, element, stereotype):
     ext.ownedEnd = ext_end
     ext_end.type = stereotype
     ext_end.aggregation = "composite"
-    p.type = element
+    p.type = metaclass
     p.name = "baseClass"
     stereotype.ownedAttribute = p
+    metaclass.ownedAttribute = ext_end
 
     return ext
 

--- a/gaphor/UML/properties.py
+++ b/gaphor/UML/properties.py
@@ -620,23 +620,28 @@ class derived(umlproperty):
             if self.upper == 1:
                 # This is a [0..1] event
                 # TODO: This is an error: [0..*] associations may be used for updating [0..1] associations
-                assert isinstance(event, AssociationSetEvent)
-                old_value, new_value = event.old_value, event.new_value
-                self.handle(DerivedSetEvent(event.element, self, old_value, new_value))
+                assert isinstance(
+                    event, AssociationSetEvent
+                ), f"Can only handle [0..1] set-events, not {event} for {event.element}"
+                self.handle(
+                    DerivedSetEvent(
+                        event.element, self, event.old_value, event.new_value
+                    )
+                )
             else:
                 if isinstance(event, AssociationSetEvent):
-                    old_value, new_value = event.old_value, event.new_value
-                    # Do a filter? Change to
-                    self.handle(DerivedDeleteEvent(event.element, self, old_value))
-                    self.handle(DerivedAddEvent(event.element, self, new_value))
+                    self.handle(
+                        DerivedDeleteEvent(event.element, self, event.old_value)
+                    )
+                    self.handle(DerivedAddEvent(event.element, self, event.new_value))
 
                 elif isinstance(event, AssociationAddEvent):
-                    new_value = event.new_value
-                    self.handle(DerivedAddEvent(event.element, self, new_value))
+                    self.handle(DerivedAddEvent(event.element, self, event.new_value))
 
                 elif isinstance(event, AssociationDeleteEvent):
-                    old_value = event.old_value
-                    self.handle(DerivedDeleteEvent(event.element, self, old_value))
+                    self.handle(
+                        DerivedDeleteEvent(event.element, self, event.old_value)
+                    )
 
                 elif isinstance(event, AssociationChangeEvent):
                     self.handle(DerivedChangeEvent(event.element, self))

--- a/gaphor/UML/uml2.gaphor
+++ b/gaphor/UML/uml2.gaphor
@@ -3949,10 +3949,10 @@ BehavioredClassifier.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 796.0, 114.0)</val>
 </matrix>
 <width>
-<val>472.0</val>
+<val>278.0</val>
 </width>
 <height>
-<val>294.0</val>
+<val>295.5</val>
 </height>
 <subject>
 <ref refid="DCE:7DDD179A-4B3D-11D7-B391-02BBFE4396CE"/>
@@ -4024,7 +4024,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (363.0, 0.7792642140468047)]</val>
+<val>[(0.0, 0.0), (363.0, 1.1454849498327633)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:6C8E65AC-4B3D-11D7-B391-02BBFE4396CE"/>
@@ -4053,7 +4053,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </drawing-style>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 845.6333333333332, 19.19999999999999)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 836.6333333333332, 17.19999999999999)</val>
 </matrix>
 <width>
 <val>168.0</val>
@@ -4076,7 +4076,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 930.3367149758458, 79.19999999999999)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 921.3367149758458, 77.19999999999999)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -4085,7 +4085,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (81.85116590102393, 34.8)]</val>
+<val>[(0.0, 0.0), (1.9942826592597385, 36.8)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:6F1514F4-4B53-11D7-A5E6-6257AF3C5118"/>
@@ -4137,7 +4137,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 796.0, 236.9096989966555)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 796.0, 237.53678929765886)</val>
 </matrix>
 <orthogonal>
 <val>1</val>
@@ -4146,7 +4146,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-164.0, 0.0), (-164.0, 53.09698996655521), (0.0, 53.09698996655521)]</val>
+<val>[(0.0, 0.0), (-164.0, 0.0), (-164.0, 53.36789297658862), (0.0, 53.36789297658862)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:7DDC7BDC-4B3D-11D7-B391-02BBFE4396CE"/>
@@ -4172,7 +4172,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 796.0, 330.3210702341137)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 796.0, 331.4247491638796)</val>
 </matrix>
 <orthogonal>
 <val>1</val>
@@ -4181,7 +4181,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-164.0, 0.0), (-164.0, 53.09698996655521), (0.0, 53.09698996655521)]</val>
+<val>[(0.0, 0.0), (-164.0, 0.0), (-164.0, 53.36789297658862), (0.0, 53.36789297658862)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:7DDC7BDC-4B3D-11D7-B391-02BBFE4396CE"/>
@@ -4216,7 +4216,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (211.0, 0.0), (211.0, 77.22916387959867), (308.0, 77.22916387959867)]</val>
+<val>[(0.0, 0.0), (211.0, 0.0), (211.0, 77.30441471571908), (308.0, 77.30441471571908)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:61913AB0-4B3D-11D7-B391-02BBFE4396CE"/>
@@ -4283,10 +4283,10 @@ BehavioredClassifier.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 331.9004524886878, 473.20000000000005)</val>
 </matrix>
 <width>
-<val>178.0</val>
+<val>100.0</val>
 </width>
 <height>
-<val>133.0</val>
+<val>50.0</val>
 </height>
 <subject>
 <ref refid="DCE:AB14F544-4B3A-11D7-B391-02BBFE4396CE"/>
@@ -4312,7 +4312,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-214.0, 0.0), (-214.0, 160.88571808741614), (-1.0995475113122097, 160.88571808741614)]</val>
+<val>[(0.0, 0.0), (-214.0, 0.0), (-214.0, 125.58186782003645), (-1.0995475113122097, 125.58186782003645)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:6C8E65AC-4B3D-11D7-B391-02BBFE4396CE"/>
@@ -4341,10 +4341,10 @@ BehavioredClassifier.</val>
 <val>0</val>
 </drawing-style>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1392.0, 115.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1440.0, 140.0)</val>
 </matrix>
 <width>
-<val>472.0</val>
+<val>195.0</val>
 </width>
 <height>
 <val>128.0</val>
@@ -4364,7 +4364,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1090.0, 114.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1074.0, 157.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -4373,7 +4373,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (302.0, 17.925619834710744)]</val>
+<val>[(0.0, 0.0), (366.0, -0.07438016528925573)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:7DDC7BDC-4B3D-11D7-B391-02BBFE4396CE"/>
@@ -4402,13 +4402,13 @@ BehavioredClassifier.</val>
 <val>0</val>
 </drawing-style>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1361.4027149321266, 13.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1422.5, 19.19999999999999)</val>
 </matrix>
 <width>
-<val>129.0</val>
+<val>101.0</val>
 </width>
 <height>
-<val>50.0</val>
+<val>51.80000000000001</val>
 </height>
 <subject>
 <ref refid="DCE:38CB97A8-45CF-11D7-B5CA-613352B2821F"/>
@@ -4428,10 +4428,10 @@ BehavioredClassifier.</val>
 <val>0</val>
 </drawing-style>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1498.1656184486374, 14.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1543.0, 13.0)</val>
 </matrix>
 <width>
-<val>156.0</val>
+<val>107.16561844863736</val>
 </width>
 <height>
 <val>58.0</val>
@@ -4451,7 +4451,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1428.532778280543, 63.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1475.0591968851943, 71.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -4460,7 +4460,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (49.386514797388145, 52.0)]</val>
+<val>[(0.0, 0.0), (0.43712122962892863, 69.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:38B9F838-4B56-11D7-A5E6-6257AF3C5118"/>
@@ -4477,7 +4477,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1576.7984978422126, 72.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1597.0175714782667, 71.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -4486,7 +4486,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (192.29173288870197, 43.0)]</val>
+<val>[(0.0, 0.0), (-1.2281753076558743, 69.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:4EDEF382-4B56-11D7-A5E6-6257AF3C5118"/>
@@ -4503,7 +4503,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1864.0, 179.5663716814159)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1635.0, 204.5663716814159)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -4512,7 +4512,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-131.0589390962673, -17.673514538558692)]</val>
+<val>[(0.0, 0.0), (106.9410609037327, -0.1367252408998354)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:F3BEEB38-4B55-11D7-A5E6-6257AF3C5118"/>
@@ -4538,7 +4538,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1090.0, 114.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1074.0, 209.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -4547,7 +4547,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (302.0, 79.28099173553719)]</val>
+<val>[(0.0, 0.0), (222.0, -1.0), (235.0, 15.0), (366.0, 15.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:7DDC7BDC-4B3D-11D7-B391-02BBFE4396CE"/>
@@ -4576,7 +4576,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </drawing-style>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1393.156186612576, 249.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 839.6333333333332, 535.0)</val>
 </matrix>
 <width>
 <val>174.0</val>
@@ -4599,7 +4599,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1393.156186612576, 273.83999999999986)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 925.4771467207572, 535.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -4608,7 +4608,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-303.156186612576, 134.16000000000014)]</val>
+<val>[(0.0, 0.0), (-0.48985858516402914, -125.5)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:B656013A-4B57-11D7-A5E6-6257AF3C5118"/>
@@ -4634,16 +4634,16 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1090.0, 408.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1043.0, 409.5)</val>
 </matrix>
 <orthogonal>
-<val>1</val>
+<val>0</val>
 </orthogonal>
 <horizontal>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (36.0, 0.0), (36.0, 0.0), (0.0, 0.0)]</val>
+<val>[(0.0, 0.0), (2.0, 70.5), (-37.0, 69.5), (-36.73305084745766, 0.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:7DDC7BDC-4B3D-11D7-B391-02BBFE4396CE"/>
@@ -4672,7 +4672,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </drawing-style>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1732.9410609037327, 145.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1741.9410609037327, 187.53678929765886)</val>
 </matrix>
 <width>
 <val>100.0</val>
@@ -4692,10 +4692,10 @@ BehavioredClassifier.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 403.0, 97.0)</val>
 </matrix>
 <width>
-<val>162.0</val>
+<val>160.83773413400422</val>
 </width>
 <height>
-<val>78.0</val>
+<val>54.0</val>
 </height>
 <subject>
 <ref refid="DCE:F65CB798-AE1F-11D8-8639-00C00C03A405"/>
@@ -4712,7 +4712,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1392.0, 237.49462365591398)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1440.0, 262.494623655914)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -4721,7 +4721,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-302.0, -123.49462365591398)]</val>
+<val>[(0.0, 0.0), (-366.0, 0.5053763440860166)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:F3BEEB38-4B55-11D7-A5E6-6257AF3C5118"/>
@@ -9604,7 +9604,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (205.0, 0.28000000000000114)]</val>
+<val>[(0.0, 0.0), (205.0, -1.7199999999999989)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:0D9DCE64-97BA-11D8-9E36-00C00C03A405"/>
@@ -9720,7 +9720,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </drawing-style>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 819.437119831, 24.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 836.937119831, 24.0)</val>
 </matrix>
 <width>
 <val>158.125760338</val>
@@ -9778,7 +9778,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (176.0, -1.0645161290322562)]</val>
+<val>[(0.0, 0.0), (176.0, -1.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:33965FE4-97BA-11D8-9E36-00C00C03A405"/>
@@ -9804,7 +9804,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 893.4282221095541, 74.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 910.9282221095541, 74.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -9813,7 +9813,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (16.696558580003966, 47.0)]</val>
+<val>[(0.0, 0.0), (0.071777890445901, 47.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:ECAB3CAE-97BA-11D8-9E38-00C00C03A405"/>
@@ -9833,7 +9833,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </drawing-style>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1070.0, 120.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 841.0, 349.0)</val>
 </matrix>
 <width>
 <val>136.0</val>
@@ -9859,7 +9859,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </drawing-style>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1072.0, 20.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 843.0665431725, 484.0)</val>
 </matrix>
 <width>
 <val>131.866913655</val>
@@ -9882,7 +9882,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1137.9273592177235, 78.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 910.0, 484.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -9891,7 +9891,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-0.562873236414589, 42.0)]</val>
+<val>[(0.0, 0.0), (1.0, -79.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:5EBD14E8-97BB-11D8-9E39-00C00C03A405"/>
@@ -9908,7 +9908,7 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1011.0, 145.51522035438435)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 914.0, 190.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -9917,7 +9917,7 @@ BehavioredClassifier.</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (59.0, 0.4847796456156459)]</val>
+<val>[(0.0, 0.0), (0.0, 159.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:F740EC70-97BA-11D8-9E38-00C00C03A405"/>
@@ -9943,16 +9943,16 @@ BehavioredClassifier.</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1124.0, 176.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 841.0, 373.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
 </orthogonal>
 <horizontal>
-<val>1</val>
+<val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (2.0, 195.0), (-466.0, 197.6785714285715)]</val>
+<val>[(0.0, 0.0), (-183.0, 0.6785714285715017)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:5264DEA4-97BB-11D8-9E39-00C00C03A405"/>
@@ -21918,10 +21918,10 @@ specially for Gaphor</val>
 <val>(1.0, 0.0, 0.0, 1.0, 501.0127388535032, 432.0)</val>
 </matrix>
 <width>
-<val>472.0</val>
+<val>197.0</val>
 </width>
 <height>
-<val>81.0</val>
+<val>86.0</val>
 </height>
 <subject>
 <ref refid="DCE:F10D682A-4A87-11D7-B08B-133D836EF880"/>
@@ -21938,7 +21938,7 @@ specially for Gaphor</val>
 <val>0</val>
 </show_stereotypes_attrs>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 501.0127388535032, 474.3050847457627)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 501.0127388535032, 476.91650973006904)</val>
 </matrix>
 <orthogonal>
 <val>1</val>
@@ -21947,7 +21947,7 @@ specially for Gaphor</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-310.70661640452363, 0.0), (-310.70661640452363, -52.30508474576271)]</val>
+<val>[(0.0, 0.0), (-310.70661640452363, 0.0), (-310.70661640452363, -54.91650973006904)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:B8514532-4B32-11D7-B391-02BBFE4396CE"/>
@@ -51613,7 +51613,7 @@ to accomodate simpleAttribute</val>
 <val>(1.0, 0.0, 0.0, 1.0, 149.0, 310.0)</val>
 </matrix>
 <width>
-<val>102.0</val>
+<val>107.0</val>
 </width>
 <height>
 <val>61.0</val>

--- a/gaphor/UML/uml2.override
+++ b/gaphor/UML/uml2.override
@@ -3,7 +3,7 @@ comment
 
   Parts are separated by '%%' (no training spaces) on a line.
   Comment parts start with 'comment' on the line below the percentage
-  symbols, 'override' is used to define a overridden variable. 
+  symbols, 'override' is used to define a overridden variable.
 
   Overrides may in their turn derive from other properties, in that case
   the 'derives' keyword may be used. It's only useful to declare the
@@ -55,6 +55,8 @@ Association.endType.filter = lambda self: [end.type for end in self.memberEnd if
 
 %%
 override Class.extension derives Extension.metaclass
+# See https://www.omg.org/spec/UML/2.5/PDF, section 11.8.3.6, page 219
+# It defines `Extension.allInstances()`, which basically means we have to query the element factory.
 def class_extension(self):
     return list(self._factory.select(lambda e: e.isKindOf(Extension) and self is e.metaclass))
 
@@ -69,14 +71,14 @@ are typed by the Class.""")
 del class_extension
 %%
 override Extension.metaclass derives Extension.ownedEnd Association.memberEnd
+# See https://www.omg.org/spec/UML/2.5/PDF, section 12.4.1.5, page 271
 def extension_metaclass(self):
     ownedEnd = self.ownedEnd
     metaend = [e for e in self.memberEnd if e is not ownedEnd]
     if metaend:
         return metaend[0].type
 
-# Don't use derived now, as derived() does not properly propagate the events
-# NOTE: let function return a list once this can be turned on
+# Don't use derived() now, it can not deal with a [0..1] property derived from a [0..*] property.
 #Extension.metaclass = derived('metaclass', Class, 0, 1, Extension.ownedEnd, Association.memberEnd)
 #Extension.metaclass.filter = extension_metaclass
 Extension.metaclass = property(extension_metaclass, doc=\
@@ -218,7 +220,7 @@ def component_provided(self):
     return tuple(set(itertools.chain(implementations, realizations, *rc_realizations)))
 
 Component.provided = property(component_provided, doc="""
-    Interfaces provided to component environment. 
+    Interfaces provided to component environment.
     """)
 del component_provided
 %%
@@ -233,7 +235,7 @@ def component_required(self):
     return tuple(set(itertools.chain(usages, *rc_usages)))
 
 Component.required = property(component_required, doc="""
-    Interfaces required by component. 
+    Interfaces required by component.
     """)
 del component_required
 %%

--- a/gaphor/UML/uml2.py
+++ b/gaphor/UML/uml2.py
@@ -1381,7 +1381,7 @@ ownedEnd.""",
 del extension_metaclass
 # 57: override Class.extension derives Extension.metaclass
 # See https://www.omg.org/spec/UML/2.5/PDF, section 11.8.3.6, page 219
-# It defines `Extension.allInstances()`, which basically beans we have to query the element factory.
+# It defines `Extension.allInstances()`, which basically means we have to query the element factory.
 def class_extension(self):
     return list(
         self._factory.select(lambda e: e.isKindOf(Extension) and self is e.metaclass)

--- a/gaphor/UML/uml2.py
+++ b/gaphor/UML/uml2.py
@@ -599,7 +599,7 @@ Property.aggregation = enumeration(
 Property.isDerivedUnion = attribute("isDerivedUnion", int, default=False)
 Property.isDerived = attribute("isDerived", int, default=False)
 Property.isReadOnly = attribute("isReadOnly", int, default=False)
-# 135: override Property.navigability
+# 137: override Property.navigability
 
 
 def property_navigability(self):
@@ -635,7 +635,7 @@ Comment.body = attribute("body", str)
 PackageImport.visibility = enumeration(
     "visibility", ("public", "private", "package", "protected"), "public"
 )
-# 240: override Message.messageKind
+# 242: override Message.messageKind
 
 
 def message_messageKind(self):
@@ -1153,7 +1153,7 @@ MultiplicityElement.upper = derived(
 )
 MultiplicityElement.upper.filter = lambda obj: [obj.upperValue]
 # MultiplicityElement.upper = MultiplicityElement.upperValue
-# 127: override Property.isComposite derives Property.aggregation
+# 129: override Property.isComposite derives Property.aggregation
 # Property.isComposite = property(lambda self: self.aggregation == 'composite')
 Property.isComposite = derivedunion("isComposite", bool, 0, 1, Property.aggregation)
 Property.isComposite.filter = lambda obj: [obj.aggregation == "composite"]
@@ -1208,7 +1208,7 @@ Feature.featuringClassifier = derivedunion(
     Property.datatype,
     Operation.interface_,
 )
-# 106: override Property.opposite
+# 108: override Property.opposite
 
 
 def property_opposite(self):
@@ -1322,7 +1322,7 @@ Namespace.ownedMember = derivedunion(
     Class.ownedReception,
     Interface.ownedReception,
 )
-# 91: override Classifier.general
+# 93: override Classifier.general
 def classifier_general(self):
     return [g.general for g in self.generalization]
 
@@ -1356,11 +1356,12 @@ Classifier.attribute = derivedunion(
     Actor.ownedAttribute,
     Signal.ownedAttribute,
 )
-# 132: override Constraint.context
+# 134: override Constraint.context
 Constraint.context = derivedunion("context", Namespace, 0, 1)
-# 160: override Operation.type
+# 162: override Operation.type
 Operation.type = derivedunion("type", DataType, 0, 1)
-# 71: override Extension.metaclass derives Extension.ownedEnd Association.memberEnd
+# 73: override Extension.metaclass derives Extension.ownedEnd Association.memberEnd
+# See https://www.omg.org/spec/UML/2.5/PDF, section 12.4.1.5, page 271
 def extension_metaclass(self):
     ownedEnd = self.ownedEnd
     metaend = [e for e in self.memberEnd if e is not ownedEnd]
@@ -1368,8 +1369,7 @@ def extension_metaclass(self):
         return metaend[0].type
 
 
-# Don't use derived now, as derived() does not properly propagate the events
-# NOTE: let function return a list once this can be turned on
+# Don't use derived() now, it can not deal with a [0..1] property derived from a [0..*] property.
 # Extension.metaclass = derived('metaclass', Class, 0, 1, Extension.ownedEnd, Association.memberEnd)
 # Extension.metaclass.filter = extension_metaclass
 Extension.metaclass = property(
@@ -1380,6 +1380,8 @@ ownedEnd.""",
 )
 del extension_metaclass
 # 57: override Class.extension derives Extension.metaclass
+# See https://www.omg.org/spec/UML/2.5/PDF, section 11.8.3.6, page 219
+# It defines `Extension.allInstances()`, which basically beans we have to query the element factory.
 def class_extension(self):
     return list(
         self._factory.select(lambda e: e.isKindOf(Extension) and self is e.metaclass)
@@ -1438,7 +1440,7 @@ ActivityGroup.superGroup = derivedunion("superGroup", ActivityGroup, 0, 1)
 ActivityGroup.subgroup = derivedunion(
     "subgroup", ActivityGroup, 0, "*", ActivityPartition.subpartition
 )
-# 88: override Classifier.inheritedMember
+# 90: override Classifier.inheritedMember
 Classifier.inheritedMember = derivedunion("inheritedMember", NamedElement, 0, "*")
 StructuredClassifier.role = derivedunion(
     "role",
@@ -1459,7 +1461,7 @@ Namespace.member = derivedunion(
     Classifier.inheritedMember,
     StructuredClassifier.role,
 )
-# 225: override Component.required
+# 227: override Component.required
 def component_required(self):
     usages = _pr_interface_deps(self, Usage)
 
@@ -1473,14 +1475,14 @@ def component_required(self):
 Component.required = property(
     component_required,
     doc="""
-    Interfaces required by component. 
+    Interfaces required by component.
     """,
 )
 del component_required
-# 103: override Namespace.importedMember
+# 105: override Namespace.importedMember
 Namespace.importedMember = derivedunion("importedMember", PackageableElement, 0, "*")
 Action.input = derivedunion("input", InputPin, 0, "*", SendSignalAction.target)
-# 189: override Component.provided
+# 191: override Component.provided
 import itertools
 
 
@@ -1528,11 +1530,11 @@ def component_provided(self):
 Component.provided = property(
     component_provided,
     doc="""
-    Interfaces provided to component environment. 
+    Interfaces provided to component environment.
     """,
 )
 del component_provided
-# 88: override Classifier.inheritedMember
+# 90: override Classifier.inheritedMember
 Classifier.inheritedMember = derivedunion("inheritedMember", NamedElement, 0, "*")
 Element.owner = derivedunion(
     "owner",
@@ -1591,7 +1593,7 @@ StructuredClassifier.role = derivedunion(
     Collaboration.collaborationRole,
 )
 ConnectorEnd.definingEnd = derivedunion("definingEnd", Property, 0, 1)
-# 259: override StructuredClassifier.part
+# 261: override StructuredClassifier.part
 def structuredclassifier_part(self):
     return tuple(a for a in self.ownedAttribute if a.isComposite)
 
@@ -1604,7 +1606,7 @@ StructuredClassifier.part = property(
 )
 del structuredclassifier_part
 Transition.redefintionContext = derivedunion("redefintionContext", Classifier, 1, 1)
-# 100: override Class.superClass
+# 102: override Class.superClass
 Class.superClass = Classifier.general
 ActivityNode.redefinedElement = redefine(
     ActivityNode, "redefinedElement", ActivityNode, RedefinableElement.redefinedElement
@@ -1645,12 +1647,12 @@ State.redefinedState = redefine(
 Transition.redefinedTransition = redefine(
     Transition, "redefinedTransition", Transition, RedefinableElement.redefinedElement
 )
-# 163: override Lifeline.parse
+# 165: override Lifeline.parse
 from gaphor.UML.umllex import parse_lifeline
 
 Lifeline.parse = parse_lifeline
 del parse_lifeline
-# 168: override Lifeline.render
+# 170: override Lifeline.render
 from gaphor.UML.umllex import render_lifeline
 
 Lifeline.render = render_lifeline

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -159,7 +159,7 @@ def parse_attribute(el, s):
             el.defaultValue = None
     else:
         g = m.group
-        create = el._factory.create
+        create = el.factory.create
         _set_visibility(el, g("vis"))
         el.isDerived = g("derived") and True or False
         el.name = g("name")
@@ -182,7 +182,7 @@ def parse_association_end(el, s):
     two strings. It is automatically figured out which string is fed to the
     parser.
     """
-    create = el._factory.create
+    create = el.factory.create
 
     # if no name, then clear as there could be some garbage
     # due to previous parsing (i.e. '[1'
@@ -258,7 +258,7 @@ def parse_operation(el, s):
         list(map(Parameter.unlink, list(el.formalParameter)))
     else:
         g = m.group
-        create = el._factory.create
+        create = el.factory.create
         _set_visibility(el, g("vis"))
         el.name = g("name")
         if not el.returnResult:

--- a/gaphor/diagram/__init__.py
+++ b/gaphor/diagram/__init__.py
@@ -4,8 +4,6 @@ The diagram package contains items (to be drawn on the diagram), tools
 diagram).
 """
 
-import uuid
-
 import gaphor.diagram.actions
 import gaphor.diagram.classes
 import gaphor.diagram.components
@@ -14,11 +12,3 @@ import gaphor.diagram.interactions
 import gaphor.diagram.profiles
 import gaphor.diagram.states
 import gaphor.diagram.usecases
-
-
-def create(type, factory):
-    return create_as(type, str(uuid.uuid1()), factory)
-
-
-def create_as(type, id, factory):
-    return type(id, factory)

--- a/gaphor/diagram/__init__.py
+++ b/gaphor/diagram/__init__.py
@@ -16,9 +16,9 @@ import gaphor.diagram.states
 import gaphor.diagram.usecases
 
 
-def create(type):
-    return create_as(type, str(uuid.uuid1()))
+def create(type, factory):
+    return create_as(type, str(uuid.uuid1()), factory)
 
 
-def create_as(type, id):
-    return type(id)
+def create_as(type, id, factory):
+    return type(id, factory)

--- a/gaphor/diagram/actions/activitynodes.py
+++ b/gaphor/diagram/actions/activitynodes.py
@@ -34,8 +34,8 @@ class ActivityNodeItem(NamedItem):
 
     __style__ = {"name-outside": True, "name-padding": (2, 2, 2, 2)}
 
-    def __init__(self, id=None):
-        NamedItem.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        NamedItem.__init__(self, id, factory)
         # Do not allow resizing of the node
         for h in self._handles:
             h.movable = False
@@ -129,8 +129,8 @@ class DecisionNodeItem(ActivityNodeItem):
 
     RADIUS = 15
 
-    def __init__(self, id=None):
-        ActivityNodeItem.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        ActivityNodeItem.__init__(self, id, factory)
         self._combined = None
         # self.set_prop_persistent('combined')
 
@@ -175,8 +175,6 @@ class ForkNodeItem(Item, DiagramItem):
     Representation of fork and join node.
     """
 
-    element_factory = inject("element_factory")
-
     __uml__ = UML.ForkNode
 
     __style__ = {
@@ -189,9 +187,9 @@ class ForkNodeItem(Item, DiagramItem):
 
     STYLE_TOP = {"text-align": (ALIGN_CENTER, ALIGN_TOP), "text-outside": True}
 
-    def __init__(self, id=None):
+    def __init__(self, id=None, factory=None):
         Item.__init__(self)
-        DiagramItem.__init__(self, id)
+        DiagramItem.__init__(self, id, factory)
 
         h1, h2 = Handle(), Handle()
         self._handles.append(h1)

--- a/gaphor/diagram/actions/flow.py
+++ b/gaphor/diagram/actions/flow.py
@@ -29,8 +29,8 @@ class FlowItem(NamedLine):
 
     __style__ = {"name-align": (ALIGN_RIGHT, ALIGN_TOP), "name-padding": (5, 15, 5, 5)}
 
-    def __init__(self, id=None):
-        super().__init__(id)
+    def __init__(self, id=None, factory=None):
+        super().__init__(id, factory)
         self._guard = self.add_text("guard.value", editable=True)
         self.watch("subject<ControlFlow>.guard", self.on_control_flow_guard)
         self.watch("subject<ObjectFlow>.guard", self.on_control_flow_guard)

--- a/gaphor/diagram/actions/objectnode.py
+++ b/gaphor/diagram/actions/objectnode.py
@@ -23,8 +23,6 @@ class ObjectNodeItem(NamedItem):
     Ordering information can be hidden by user.
     """
 
-    element_factory = inject("element_factory")
-
     __uml__ = UML.ObjectNode
 
     STYLE_BOTTOM = {

--- a/gaphor/diagram/actions/objectnode.py
+++ b/gaphor/diagram/actions/objectnode.py
@@ -33,8 +33,8 @@ class ObjectNodeItem(NamedItem):
         "text-align-group": "bottom",
     }
 
-    def __init__(self, id=None):
-        NamedItem.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        NamedItem.__init__(self, id, factory)
 
         self._show_ordering = False
 

--- a/gaphor/diagram/actions/partition.py
+++ b/gaphor/diagram/actions/partition.py
@@ -20,8 +20,8 @@ class PartitionItem(NamedItem):
 
     DELTA = 30
 
-    def __init__(self, id=None):
-        super(PartitionItem, self).__init__(id)
+    def __init__(self, id=None, factory=None):
+        super().__init__(id, factory)
         self._toplevel = False
         self._bottom = False
         self._subpart = False

--- a/gaphor/diagram/classes/association.py
+++ b/gaphor/diagram/classes/association.py
@@ -29,8 +29,8 @@ class AssociationItem(NamedLine):
 
     __uml__ = UML.Association
 
-    def __init__(self, id=None):
-        NamedLine.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        NamedLine.__init__(self, id, factory)
 
         # AssociationEnds are really inseperable from the AssociationItem.
         # We give them the same id as the association item.

--- a/gaphor/diagram/classes/dependency.py
+++ b/gaphor/diagram/classes/dependency.py
@@ -42,8 +42,8 @@ class DependencyItem(DiagramLine):
         "implements": lambda self: self._dependency_type == UML.Implementation,
     }
 
-    def __init__(self, id=None):
-        DiagramLine.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        DiagramLine.__init__(self, id, factory)
 
         self._dependency_type = UML.Dependency
         self.auto_dependency = True

--- a/gaphor/diagram/classes/generalization.py
+++ b/gaphor/diagram/classes/generalization.py
@@ -1,5 +1,5 @@
 """
-Generalization -- 
+Generalization --
 """
 
 from gi.repository import GObject
@@ -13,8 +13,8 @@ class GeneralizationItem(DiagramLine):
     __uml__ = UML.Generalization
     __relationship__ = "general", None, "specific", "generalization"
 
-    def __init__(self, id=None):
-        DiagramLine.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        DiagramLine.__init__(self, id, factory)
 
     def draw_head(self, context):
         cr = context.cairo

--- a/gaphor/diagram/classes/implementation.py
+++ b/gaphor/diagram/classes/implementation.py
@@ -10,8 +10,8 @@ class ImplementationItem(DiagramLine):
 
     __uml__ = UML.Implementation
 
-    def __init__(self, id=None):
-        DiagramLine.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        DiagramLine.__init__(self, id, factory)
         self._solid = False
 
     def draw_head(self, context):

--- a/gaphor/diagram/classes/interface.py
+++ b/gaphor/diagram/classes/interface.py
@@ -83,7 +83,7 @@ from gaphor.diagram.style import ALIGN_TOP, ALIGN_BOTTOM, ALIGN_CENTER
 class InterfacePort(LinePort):
     """
     Interface connection port.
-    
+
     It is simple line port, which changes glue behaviour depending on
     interface folded state. If interface is folded, then
     `InterfacePort.glue` method suggests connection in the middle of the
@@ -160,8 +160,8 @@ class InterfaceItem(ClassItem):
     # Folded mode, notation of assembly connector icon mode (ball&socket).
     FOLDED_ASSEMBLY = 3
 
-    def __init__(self, id=None):
-        ClassItem.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        ClassItem.__init__(self, id, factory)
         self._folded = self.FOLDED_NONE
         self._angle = 0
         old_f = self._name.is_visible

--- a/gaphor/diagram/classes/klass.py
+++ b/gaphor/diagram/classes/klass.py
@@ -49,14 +49,14 @@ class ClassItem(ClassifierItem):
         "abstract-feature-font": "sans italic 10",
     }
 
-    def __init__(self, id=None):
+    def __init__(self, id=None, factory=None):
         """Constructor.  Initialize the ClassItem.  This will also call the
 		ClassifierItem constructor.
 
 		The drawing style is set here as well.  The class item will create
 		two compartments - one for attributes and another for operations."""
 
-        ClassifierItem.__init__(self, id)
+        ClassifierItem.__init__(self, id, factory)
         self.drawing_style = self.DRAW_COMPARTMENT
         self._attributes = self.create_compartment("attributes")
         self._attributes.font = self.style.feature_font

--- a/gaphor/diagram/classes/package.py
+++ b/gaphor/diagram/classes/package.py
@@ -18,8 +18,8 @@ class PackageItem(NamedItem):
         "tab-y": 20,
     }
 
-    def __init__(self, id=None):
-        super(PackageItem, self).__init__(id)
+    def __init__(self, id=None, factory=None):
+        super(PackageItem, self).__init__(id, factory)
 
     def draw(self, context):
         super(PackageItem, self).draw(context)

--- a/gaphor/diagram/classifier.py
+++ b/gaphor/diagram/classifier.py
@@ -18,8 +18,8 @@ class ClassifierItem(CompartmentItem):
         "abstract-name-font": "sans bold italic 10",
     }
 
-    def __init__(self, id=None):
-        super(ClassifierItem, self).__init__(id)
+    def __init__(self, id=None, factory=None):
+        super(ClassifierItem, self).__init__(id, factory)
         self.watch("subject<Classifier>.isAbstract", self.on_classifier_is_abstract)
 
     def on_classifier_is_abstract(self, event):

--- a/gaphor/diagram/compartment.py
+++ b/gaphor/diagram/compartment.py
@@ -260,8 +260,8 @@ class CompartmentItem(NamedItem):
     ICON_MARGIN_X = 10
     ICON_MARGIN_Y = 10
 
-    def __init__(self, id=None):
-        NamedItem.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        NamedItem.__init__(self, id, factory)
         self._compartments = []
 
         self._drawing_style = CompartmentItem.DRAW_NONE

--- a/gaphor/diagram/components/artifact.py
+++ b/gaphor/diagram/components/artifact.py
@@ -15,8 +15,8 @@ class ArtifactItem(ClassifierItem):
 
     ICON_HEIGHT = 20
 
-    def __init__(self, id=None):
-        ClassifierItem.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        ClassifierItem.__init__(self, id, factory)
         self.height = 50
         self.width = 120
         # Set drawing style to compartment w/ small icon

--- a/gaphor/diagram/components/component.py
+++ b/gaphor/diagram/components/component.py
@@ -17,8 +17,8 @@ class ComponentItem(ClassifierItem):
     BAR_HEIGHT = 5
     BAR_PADDING = 5
 
-    def __init__(self, id=None):
-        ClassifierItem.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        ClassifierItem.__init__(self, id, factory)
         # Set drawing style to compartment w// small icon
         self.drawing_style = self.DRAW_COMPARTMENT_ICON
 

--- a/gaphor/diagram/components/connector.py
+++ b/gaphor/diagram/components/connector.py
@@ -130,8 +130,8 @@ class ConnectorItem(NamedLine):
     __uml__ = UML.Connector
     __style__ = {"name-align": (ALIGN_CENTER, ALIGN_BOTTOM), "name-outside": True}
 
-    def __init__(self, id=None):
-        super(ConnectorItem, self).__init__(id)
+    def __init__(self, id=None, factory=None):
+        super(ConnectorItem, self).__init__(id, factory)
         self._interface = self.add_text(
             "end.role.name", style={"text-align-group": "stereotype"}
         )

--- a/gaphor/diagram/components/node.py
+++ b/gaphor/diagram/components/node.py
@@ -29,8 +29,8 @@ class NodeItem(ClassifierItem):
 
     DEPTH = 10
 
-    def __init__(self, id=None):
-        ClassifierItem.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        ClassifierItem.__init__(self, id, factory)
         self.drawing_style = self.DRAW_COMPARTMENT
         self.height = 50
         self.width = 120

--- a/gaphor/diagram/diagramitem.py
+++ b/gaphor/diagram/diagramitem.py
@@ -203,14 +203,10 @@ class DiagramItem(
     @cvar style: styles information (derived from DiagramItemMeta)
     """
 
-    element_factory = inject("element_factory")
-
-    def __init__(self, id=None):
-        UML.Presentation.__init__(self, factory=self.element_factory)
+    def __init__(self, id=None, factory=None):
+        UML.Presentation.__init__(self, id, factory)
         EditableTextSupport.__init__(self)
         StereotypeSupport.__init__(self)
-
-        self._id = id
 
         # properties, which should be saved in file
         self._persistent_props = set()
@@ -224,8 +220,6 @@ class DiagramItem(
             "subject.appliedStereotype.classifier.name",
             self.on_element_applied_stereotype,
         )
-
-    id = property(lambda self: self._id, doc="Id")
 
     def set_prop_persistent(self, name):
         """

--- a/gaphor/diagram/diagramline.py
+++ b/gaphor/diagram/diagramline.py
@@ -17,9 +17,9 @@ class DiagramLine(gaphas.Line, DiagramItem):
     Base class for diagram lines.
     """
 
-    def __init__(self, id=None):
+    def __init__(self, id=None, factory=None):
         gaphas.Line.__init__(self)
-        DiagramItem.__init__(self, id)
+        DiagramItem.__init__(self, id, factory)
         self.fuzziness = 2
 
     head = property(lambda self: self._handles[0])
@@ -101,7 +101,7 @@ class DiagramLine(gaphas.Line, DiagramItem):
         Instant port finder.
 
         This is not the nicest place for such method.
-        
+
         TODO: figure out if part of this functionality can be provided by
         the storage code.
         """
@@ -208,8 +208,8 @@ class NamedLine(DiagramLine):
         "name-align-str": None,
     }
 
-    def __init__(self, id=None):
-        DiagramLine.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        DiagramLine.__init__(self, id, factory)
         self._name = self.add_text(
             "name",
             style={

--- a/gaphor/diagram/elementitem.py
+++ b/gaphor/diagram/elementitem.py
@@ -19,9 +19,9 @@ class ElementItem(gaphas.Element, DiagramItem):
         "background-gradient": ((0.8, 0.8, 0.8, 0.5), (1.0, 1.0, 1.0, 0.5)),
     }
 
-    def __init__(self, id=None):
+    def __init__(self, id=None, factory=None):
         gaphas.Element.__init__(self)
-        DiagramItem.__init__(self, id)
+        DiagramItem.__init__(self, id, factory)
 
         self.min_width = self.style.min_size[0]
         self.min_height = self.style.min_size[1]

--- a/gaphor/diagram/general/comment.py
+++ b/gaphor/diagram/general/comment.py
@@ -17,8 +17,8 @@ class CommentItem(ElementItem):
     EAR = 15
     OFFSET = 5
 
-    def __init__(self, id=None):
-        ElementItem.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        ElementItem.__init__(self, id, factory)
         self.min_width = CommentItem.EAR + 2 * CommentItem.OFFSET
         self.height = 50
         self.width = 100

--- a/gaphor/diagram/general/commentline.py
+++ b/gaphor/diagram/general/commentline.py
@@ -8,8 +8,8 @@ from gaphor.diagram.connectors import IConnect
 
 
 class CommentLineItem(DiagramLine):
-    def __init__(self, id=None):
-        DiagramLine.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        DiagramLine.__init__(self, id, factory)
 
     def save(self, save_func):
         DiagramLine.save(self, save_func)

--- a/gaphor/diagram/general/simpleitem.py
+++ b/gaphor/diagram/general/simpleitem.py
@@ -13,7 +13,7 @@ class Line(_Line):
 
     __style__ = {"line-width": 2, "line-color": (0, 0, 0, 1)}
 
-    def __init__(self, id=None):
+    def __init__(self, id=None, factory=None):
         super(Line, self).__init__()
         self.style = Style(Line.__style__)
         self._id = id
@@ -64,7 +64,7 @@ class Line(_Line):
 class Box(Element):
     """
     A Box has 4 handles (for a start)::
-     
+
     NW +---+ NE
     SW +---+ SE
     """
@@ -75,7 +75,7 @@ class Box(Element):
         "fill-color": (1, 1, 1, 0),
     }
 
-    def __init__(self, id=None):
+    def __init__(self, id=None, factory=None):
         super(Box, self).__init__(10, 10)
         self.style = Style(Box.__style__)
         self._id = id
@@ -120,7 +120,7 @@ class Ellipse(Element):
         "fill-color": (1, 1, 1, 0),
     }
 
-    def __init__(self, id=None):
+    def __init__(self, id=None, factory=None):
         super(Ellipse, self).__init__()
         self.style = Style(Ellipse.__style__)
         self._id = id

--- a/gaphor/diagram/interactions/lifeline.py
+++ b/gaphor/diagram/interactions/lifeline.py
@@ -150,8 +150,8 @@ class LifelineItem(NamedItem):
     __uml__ = UML.Lifeline
     __style__ = {"name-align": (ALIGN_CENTER, ALIGN_MIDDLE)}
 
-    def __init__(self, id=None):
-        NamedItem.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        NamedItem.__init__(self, id, factory)
 
         self.is_destroyed = False
 

--- a/gaphor/diagram/interactions/message.py
+++ b/gaphor/diagram/interactions/message.py
@@ -80,8 +80,8 @@ class MessageItem(NamedLine):
     # name padding on communication diagram
     CD_PADDING = (10, 10, 10, 10)
 
-    def __init__(self, id=None):
-        super(MessageItem, self).__init__(id)
+    def __init__(self, id=None, factory=None):
+        super().__init__(id, factory)
         self._is_communication = False
         self._arrow_pos = 0, 0
         self._arrow_angle = 0

--- a/gaphor/diagram/nameditem.py
+++ b/gaphor/diagram/nameditem.py
@@ -21,11 +21,11 @@ class NamedItem(ElementItem):
         "name-rotated": False,
     }
 
-    def __init__(self, id=None):
+    def __init__(self, id=None, factory=None):
         """
         Create named item.
         """
-        ElementItem.__init__(self, id)
+        ElementItem.__init__(self, id, factory)
 
         # create (from ...) text to distinguish diagram items from
         # different namespace

--- a/gaphor/diagram/profiles/extension.py
+++ b/gaphor/diagram/profiles/extension.py
@@ -12,15 +12,15 @@ from gaphor.diagram.diagramline import NamedLine
 
 class ExtensionItem(NamedLine):
     """
-    ExtensionItem represents associations. 
+    ExtensionItem represents associations.
     An ExtensionItem has two ExtensionEnd items. Each ExtensionEnd item
     represents a Property (with Property.association == my association).
     """
 
     __uml__ = UML.Extension
 
-    def __init__(self, id=None):
-        NamedLine.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        NamedLine.__init__(self, id, factory)
         self.watch("subject<Extension>.ownedEnd")
 
     def draw_head(self, context):

--- a/gaphor/diagram/states/finalstate.py
+++ b/gaphor/diagram/states/finalstate.py
@@ -21,8 +21,8 @@ class FinalStateItem(VertexItem):
     RADIUS_1 = 10
     RADIUS_2 = 15
 
-    def __init__(self, id=None):
-        super(FinalStateItem, self).__init__(id)
+    def __init__(self, id=None, factory=None):
+        super().__init__(id, factory)
         for h in self.handles():
             h.movable = False
 

--- a/gaphor/diagram/states/pseudostates.py
+++ b/gaphor/diagram/states/pseudostates.py
@@ -26,8 +26,8 @@ class InitialPseudostateItem(VertexItem):
 
     RADIUS = 10
 
-    def __init__(self, id=None):
-        super(InitialPseudostateItem, self).__init__(id)
+    def __init__(self, id=None, factory=None):
+        super().__init__(id, factory)
         for h in self.handles():
             h.movable = False
 
@@ -59,8 +59,8 @@ class HistoryPseudostateItem(VertexItem):
 
     RADIUS = 15
 
-    def __init__(self, id=None):
-        super(HistoryPseudostateItem, self).__init__(id)
+    def __init__(self, id=None, factory=None):
+        super().__init__(id, factory)
         for h in self.handles():
             h.movable = False
 

--- a/gaphor/diagram/states/state.py
+++ b/gaphor/diagram/states/state.py
@@ -27,7 +27,6 @@ class VertexItem(NamedItem):
 
 
 class StateItem(CompartmentItem, VertexItem):
-    element_factory = inject("element_factory")
     __uml__ = UML.State
     __style__ = {
         "min-size": (50, 30),
@@ -35,8 +34,8 @@ class StateItem(CompartmentItem, VertexItem):
         "extra-space": "compartment",
     }
 
-    def __init__(self, id=None):
-        super(StateItem, self).__init__(id)
+    def __init__(self, id=None, factory=None):
+        super().__init__(id, factory)
         self.drawing_style = self.DRAW_COMPARTMENT
         self._activities = self.create_compartment("activities")
         self._activities.use_extra_space = True
@@ -50,7 +49,7 @@ class StateItem(CompartmentItem, VertexItem):
     def _set_activity(self, act, attr, text):
         if text and act not in self._activities:
             self._activities.append(act)
-            act.subject = self.element_factory.create(UML.Activity)
+            act.subject = self.factory.create(UML.Activity)
             act.subject.name = text
             setattr(self.subject, attr, act.subject)
 

--- a/gaphor/diagram/states/transition.py
+++ b/gaphor/diagram/states/transition.py
@@ -17,10 +17,8 @@ class TransitionItem(NamedLine):
 
     __style__ = {"name-align": (ALIGN_RIGHT, ALIGN_TOP), "name-padding": (5, 15, 5, 5)}
 
-    element_factory = inject("element_factory")
-
-    def __init__(self, id=None):
-        NamedLine.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        NamedLine.__init__(self, id, factory)
         self._guard = self.add_text("guard.specification", editable=True)
         self.watch("subject<Transition>.guard<Constraint>.specification", self.on_guard)
 

--- a/gaphor/diagram/usecases/actor.py
+++ b/gaphor/diagram/usecases/actor.py
@@ -29,8 +29,8 @@ class ActorItem(ClassifierItem):
         "name-outside": True,
     }
 
-    def __init__(self, id=None):
-        ClassifierItem.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        ClassifierItem.__init__(self, id, factory)
 
         self.drawing_style = self.DRAW_ICON
 

--- a/gaphor/diagram/usecases/include.py
+++ b/gaphor/diagram/usecases/include.py
@@ -14,8 +14,8 @@ class IncludeItem(DiagramLine):
     __uml__ = UML.Include
     __stereotype__ = "include"
 
-    def __init__(self, id=None):
-        DiagramLine.__init__(self, id)
+    def __init__(self, id=None, factory=None):
+        DiagramLine.__init__(self, id, factory)
 
     def draw_head(self, context):
         cr = context.cairo

--- a/gaphor/diagram/usecases/usecase.py
+++ b/gaphor/diagram/usecases/usecase.py
@@ -18,8 +18,8 @@ class UseCaseItem(ClassifierItem):
     __uml__ = UML.UseCase
     __style__ = {"min-size": (50, 30), "name-align": (ALIGN_CENTER, ALIGN_MIDDLE)}
 
-    def __init__(self, id=None):
-        super(UseCaseItem, self).__init__(id)
+    def __init__(self, id=None, factory=None):
+        super().__init__(id, factory)
         self.drawing_style = -1
 
     def pre_update(self, context):

--- a/gaphor/services/elementdispatcher.py
+++ b/gaphor/services/elementdispatcher.py
@@ -23,7 +23,6 @@ class EventWatcher:
     element_dispatcher = inject("element_dispatcher")
 
     def __init__(self, element, default_handler=None):
-        super(EventWatcher, self).__init__()
         self.element = element
         self.default_handler = default_handler
         self._watched_paths = dict()
@@ -37,9 +36,8 @@ class EventWatcher:
         Watches should be set in the constructor, so they can be registered
         and unregistered in one shot.
 
-        This interface is fluent(returns self).
+        This interface is fluent (returns self).
         """
-
         if handler:
             self._watched_paths[path] = handler
         elif self.default_handler:
@@ -49,12 +47,10 @@ class EventWatcher:
         return self
 
     def register_handlers(self):
-
         dispatcher = self.element_dispatcher
         element = self.element
 
         for path, handler in self._watched_paths.items():
-
             dispatcher.subscribe(handler, element, path)
 
     def unregister_handlers(self, *args):
@@ -62,19 +58,17 @@ class EventWatcher:
         Unregister handlers. Extra arguments are ignored (makes connecting to
         destroy signals much easier though).
         """
-
         dispatcher = self.element_dispatcher
 
         for path, handler in self._watched_paths.items():
-
             dispatcher.unsubscribe(handler)
 
 
 class ElementDispatcher(Service):
     """
     The Element based Dispatcher allows handlers to receive only events
-    related to certain elements. Those elements should be registered to. Also
-    a path should be provided, that is used to find those changes.
+    related to certain elements. Those elements should be registered too.
+    A path should be provided, that is used to find those changes.
 
     The handlers are registered on their property attribute. This avoids
     subclass lookups and is pretty specific. As a result this dispatcher is
@@ -215,12 +209,6 @@ class ElementDispatcher(Service):
             del self._handlers[key]
 
     def subscribe(self, handler, element, path):
-
-        # self.logger.info('Registering handler')
-        # self.logger.debug('Handler is %s' % handler)
-        # self.logger.debug('Element is %s' % element)
-        # self.logger.debug('Path is %s' % path)
-
         props = self._path_to_properties(element, path)
         self._add_handlers(element, props, handler)
 
@@ -228,10 +216,6 @@ class ElementDispatcher(Service):
         """
         Unregister a handler from the registy.
         """
-
-        # self.logger.info('Unregistering handler')
-        # self.logger.debug('Handler is %s' % handler)
-
         try:
             reverse = reversed(self._reverse[handler])
         except KeyError:
@@ -253,19 +237,8 @@ class ElementDispatcher(Service):
 
     @event_handler(ElementChangeEvent)
     def on_element_change_event(self, event):
-
-        # self.logger.info('Handling ElementChangeEvent')
-        # self.logger.debug('Element is %s' % event.element)
-        # self.logger.debug('Property is %s' % event.property)
-
         handlers = self._handlers.get((event.element, event.property))
         if handlers:
-            # log.debug('')
-            # log.debug('Element change for %s %s [%s]' % (str(type(event)), event.element, event.property))
-            # if hasattr(event, 'old_value'):
-            #    log.debug('    old value: %s' % (event.old_value))
-            # if hasattr(event, 'new_value'):
-            #    log.debug('    new value: %s' % (event.new_value))
             for handler in handlers.keys():
                 try:
                     handler(event)

--- a/gaphor/services/tests/test_elementdispatcher.py
+++ b/gaphor/services/tests/test_elementdispatcher.py
@@ -204,23 +204,26 @@ from gaphor.UML.properties import association
 from gaphor.services.elementdispatcher import EventWatcher
 
 
+class A(Element):
+    def __init__(self, id=None, event_handler=None):
+        super().__init__(id, event_handler)
+
+
+A.one = association("one", A, lower=0, upper=1, composite=True)
+A.two = association("two", A, lower=0, upper=2, composite=True)
+
+
 class ElementDispatcherAsServiceTestCase(TestCase):
 
     services = TestCase.services + ["element_dispatcher"]
+
+    def A(self):
+        return self.element_factory.create(A)
 
     def setUp(self):
         super(ElementDispatcherAsServiceTestCase, self).setUp()
         self.events = []
         self.dispatcher = Application.get_service("element_dispatcher")
-        element_factory = self.element_factory
-
-        class A(Element):
-            def __init__(self):
-                super().__init__(factory=element_factory)
-
-        A.one = association("one", A, lower=0, upper=1, composite=True)
-        A.two = association("two", A, lower=0, upper=2, composite=True)
-        self.A = A
 
     def tearDown(self):
         super(ElementDispatcherAsServiceTestCase, self).tearDown()

--- a/gaphor/services/tests/test_undomanager.py
+++ b/gaphor/services/tests/test_undomanager.py
@@ -111,7 +111,7 @@ class TestUndoManager(TestCase):
         class A(Element):
             attr = attribute("attr", bytes, default="default")
 
-        a = A(factory=self.element_factory)
+        a = self.element_factory.create(A)
         assert a.attr == "default", a.attr
         undo_manager.begin_transaction()
         a.attr = "five"
@@ -143,8 +143,8 @@ class TestUndoManager(TestCase):
         A.one = association("one", B, 0, 1, opposite="two")
         B.two = association("two", A, 0, 1)
 
-        a = A(factory=self.element_factory)
-        b = B(factory=self.element_factory)
+        a = self.element_factory.create(A)
+        b = self.element_factory.create(B)
 
         assert a.one is None
         assert b.two is None
@@ -195,10 +195,10 @@ class TestUndoManager(TestCase):
         A.one = association("one", B, lower=0, upper=1, opposite="two")
         B.two = association("two", A, lower=0, upper="*", opposite="one")
 
-        a1 = A(factory=self.element_factory)
-        a2 = A(factory=self.element_factory)
-        b1 = B(factory=self.element_factory)
-        b2 = B(factory=self.element_factory)
+        a1 = self.element_factory.create(A)
+        a2 = self.element_factory.create(A)
+        b1 = self.element_factory.create(B)
+        b2 = self.element_factory.create(B)
 
         undo_manager.begin_transaction()
         b1.two = a1
@@ -318,13 +318,13 @@ class TestUndoManager(TestCase):
         em = Application.get_service("event_manager")
         em.subscribe(handler)
         try:
-            a = A(factory=self.element_factory)
+            a = self.element_factory.create(A)
 
             undo_manager = UndoManager()
             undo_manager.init(Application)
             undo_manager.begin_transaction()
 
-            a.a1 = A(factory=self.element_factory)
+            a.a1 = self.element_factory.create(A)
             undo_manager.commit_transaction()
 
             assert len(events) == 1, events

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -200,7 +200,7 @@ def load_elements_generator(elements, factory, gaphor_version=None):
         for item in canvasitems:
             item = upgrade_canvas_item_to_1_1_0(item)
             cls = getattr(diagramitems, item.type)
-            item.element = diagram.create_as(cls, item.id)
+            item.element = diagram.create_as(cls, item.id, factory)
             canvas.add(item.element, parent=parent)
             assert canvas.get_parent(item.element) is parent
             create_canvasitems(canvas, item.canvasitems, parent=item.element)

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -193,17 +193,15 @@ def load_elements_generator(elements, factory, gaphor_version=None):
     # First create elements and canvas items in the factory
     # The elements are stored as attribute 'element' on the parser objects:
 
-    def create_canvasitems(canvas, canvasitems, parent=None):
+    def create_canvasitems(diagram, canvasitems, parent=None):
         """
         Canvas is a read gaphas.Canvas, items is a list of parser.canvasitem's
         """
         for item in canvasitems:
             item = upgrade_canvas_item_to_1_1_0(item)
             cls = getattr(diagramitems, item.type)
-            item.element = diagram.create_as(cls, item.id, factory)
-            canvas.add(item.element, parent=parent)
-            assert canvas.get_parent(item.element) is parent
-            create_canvasitems(canvas, item.canvasitems, parent=item.element)
+            item.element = diagram.create_as(cls, item.id, parent=parent)
+            create_canvasitems(diagram, item.canvasitems, parent=item.element)
 
     for id, elem in list(elements.items()):
         st = update_status_queue()
@@ -215,7 +213,7 @@ def load_elements_generator(elements, factory, gaphor_version=None):
             elem.element = factory.create_as(cls, id)
             if elem.canvas is not None:
                 elem.element.canvas.block_updates = True
-                create_canvasitems(elem.element.canvas, elem.canvas.canvasitems)
+                create_canvasitems(elem.element, elem.canvas.canvasitems)
         elif not isinstance(elem, parser.canvasitem):
             raise ValueError(
                 'Item with id "%s" and type %s can not be instantiated'

--- a/gaphor/storage/tests/test_storage_upgrades.py
+++ b/gaphor/storage/tests/test_storage_upgrades.py
@@ -7,7 +7,7 @@ from gaphor.storage import diagramitems
 
 
 @pytest.fixture
-def application(services=["element_factory", "action_manager"]):
+def application(services=["element_factory"]):
     Application.init(services=services)
     yield Application
     Application.shutdown()


### PR DESCRIPTION
Some maintenance and clean up on the model side of things.

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the new behavior?

Element factory is passed to diagram items as well as model elements. This is more consistent now.

I tried getting rid of `ElementFactory` in model elements altogether, but that's not possible since some UML (model) queries require a scan on the model elements. Also, at least one diagram item requires a factory to create a new model element. I would have liked to have no reference to a model factory from the model itself, but that seems not possible, so I'll leave that as is.


Diagram items have a (somewhat implicit) dependency on `ElementDispatcher`. `ElementDispatcher` is injected, hence an "application" should have been initialized. This is a pitty, since we can not load a model without setting up an application. However, this is food for a future change.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
