### PR TITLE
Element factory to model

### DIFF
--- a/gaphor/UML/elementfactory.py
+++ b/gaphor/UML/elementfactory.py
@@ -158,11 +158,6 @@ class ElementFactory:
         except KeyError:
             pass
 
-    def swap_element(self, element, new_class):
-        assert element in list(self._elements.values())
-        if element.__class__ is not new_class:
-            element.__class__ = new_class
-
     def handle(self, event):
         """
         Handle events coming from elements.

--- a/gaphor/UML/modelfactory.py
+++ b/gaphor/UML/modelfactory.py
@@ -56,18 +56,20 @@ def stereotype_name(stereotype):
         return name[0].lower() + name[1:]
 
 
-def apply_stereotype(model, element, stereotype):
+def apply_stereotype(element, stereotype):
     """
     Apply a stereotype to an element.
 
     :Parameters:
-     model
-        UML metamodel model.
      element
         UML metamodel class instance.
      stereotype
         UML metamodel stereotype instance.
     """
+    assert (
+        element.model is stereotype.model
+    ), "Element and Stereotype are from different models"
+    model = element.model
     obj = model.create(InstanceSpecification)
     obj.classifier = stereotype
     element.appliedStereotype = obj
@@ -137,7 +139,7 @@ def create_extension(metaclass, stereotype):
     """
     assert (
         metaclass.model is stereotype.model
-    ), "Metaclass and Srtereotype are from different models"
+    ), "Metaclass and Stereotype are from different models"
 
     model = metaclass.model
     ext = model.create(Extension)

--- a/gaphor/UML/modelfactory.py
+++ b/gaphor/UML/modelfactory.py
@@ -339,4 +339,12 @@ def create_message(model, msg, inverted=False):
     return message
 
 
-# vim:sw=4:et:ai
+def swap_element(element, new_class):
+    """
+    A "trick" to swap the element type.
+
+    Used in certain cases where the underlaying element type
+    may change.
+    """
+    if element.__class__ is not new_class:
+        element.__class__ = new_class

--- a/gaphor/UML/modelfactory.py
+++ b/gaphor/UML/modelfactory.py
@@ -74,10 +74,11 @@ def apply_stereotype(model, element, stereotype):
     return obj
 
 
-def find_instances(model, element):
+def find_instances(element):
     """
     Find instance specification which extend classifier `element`.
     """
+    model = element.model
     return model.select(
         lambda e: e.isKindOf(InstanceSpecification)
         and e.classifier
@@ -102,10 +103,11 @@ def remove_stereotype(element, stereotype):
             break
 
 
-def get_stereotypes(model, element):
+def get_stereotypes(element):
     """
     Get sorted collection of possible stereotypes for specified element.
     """
+    model = element.model
     # UML specs does not allow to extend stereotypes with stereotypes
     if isinstance(element, Stereotype):
         return ()
@@ -129,10 +131,15 @@ def get_applied_stereotypes(element):
     return element.appliedStereotype[:].classifier
 
 
-def create_extension(model, metaclass, stereotype):
+def create_extension(metaclass, stereotype):
     """
     Create an Extension association between an metaclass and a stereotype.
     """
+    assert (
+        metaclass.model is stereotype.model
+    ), "Metaclass and Srtereotype are from different models"
+
+    model = metaclass.model
     ext = model.create(Extension)
     p = model.create(Property)
     ext_end = model.create(ExtensionEnd)
@@ -148,9 +155,6 @@ def create_extension(model, metaclass, stereotype):
     metaclass.ownedAttribute = ext_end
 
     return ext
-
-
-extend_with_stereotype = create_extension
 
 
 def is_metaclass(element):

--- a/gaphor/UML/modelfactory.py
+++ b/gaphor/UML/modelfactory.py
@@ -167,48 +167,70 @@ def is_metaclass(element):
     )
 
 
-def add_slot(model, instance, definingFeature):
+def add_slot(instance, definingFeature):
     """
     Add slot to instance specification for an attribute.
     """
+    assert (
+        instance.model is definingFeature.model
+    ), "Instance and Defining feature are from different models"
+    model = instance.model
     slot = model.create(Slot)
     slot.definingFeature = definingFeature
     instance.slot = slot
     return slot
 
 
-def create_dependency(model, supplier, client):
+def create_dependency(supplier, client):
+    assert (
+        supplier.model is client.model
+    ), "Supplier and Client are from different models"
+    model = supplier.model
     dep = model.create(Dependency)
     dep.supplier = supplier
     dep.client = client
     return dep
 
 
-def create_realization(model, realizingClassifier, abstraction):
+def create_realization(realizingClassifier, abstraction):
+    assert (
+        realizingClassifier.model is stereoabstractiontype.model
+    ), "Realizing classifier and Abstraction are from different models"
+    model = realizingClassifier.model
     dep = model.create(Realization)
     dep.realizingClassifier = realizingClassifier
     dep.abstraction = abstraction
     return dep
 
 
-def create_generalization(model, general, specific):
+def create_generalization(general, specific):
+    assert (
+        general.model is specific.model
+    ), "General and Specific are from different models"
+    model = general.model
     gen = model.create(Generalization)
     gen.general = general
     gen.specific = specific
     return gen
 
 
-def create_implementation(model, contract, implementatingClassifier):
+def create_implementation(contract, implementatingClassifier):
+    assert (
+        contract.model is implementatingClassifier.model
+    ), "Contract and Implementating classifier are from different models"
+    model = contract.model
     impl = model.create(Implementation)
     impl.contract = contract
     impl.implementatingClassifier = implementatingClassifier
     return impl
 
 
-def create_association(model, type_a, type_b):
+def create_association(type_a, type_b):
     """
     Create an association between two items.
     """
+    assert type_a.model is type_b.model, "Head and Tail end are from different models"
+    model = type_a.model
     assoc = model.create(Association)
     end_a = model.create(Property)
     end_b = model.create(Property)
@@ -315,12 +337,13 @@ def dependency_type(client, supplier):
     return dt
 
 
-def create_message(model, msg, inverted=False):
+def create_message(msg, inverted=False):
     """
     Create new message based on speciied message.
 
     If inverted is set to True, then inverted message is created.
     """
+    model = msg.model
     message = model.create(Message)
     send = None
     receive = None

--- a/gaphor/UML/tests/test_modelfactory.py
+++ b/gaphor/UML/tests/test_modelfactory.py
@@ -41,9 +41,9 @@ class StereotypesTestCase(TestCaseBase):
         s3.name = "s3"
 
         cls = self.factory.create(UML.Class)
-        UML.model.apply_stereotype(self.factory, cls, s1)
-        UML.model.apply_stereotype(self.factory, cls, s2)
-        UML.model.apply_stereotype(self.factory, cls, s3)
+        UML.model.apply_stereotype(cls, s1)
+        UML.model.apply_stereotype(cls, s2)
+        UML.model.apply_stereotype(cls, s3)
 
         assert (fmt % "s1, s2, s3") == UML.model.stereotypes_str(cls)
 
@@ -64,9 +64,9 @@ class StereotypesTestCase(TestCaseBase):
         s3.name = "s3"
 
         cls = self.factory.create(UML.Class)
-        UML.model.apply_stereotype(self.factory, cls, s1)
-        UML.model.apply_stereotype(self.factory, cls, s2)
-        UML.model.apply_stereotype(self.factory, cls, s3)
+        UML.model.apply_stereotype(cls, s1)
+        UML.model.apply_stereotype(cls, s2)
+        UML.model.apply_stereotype(cls, s3)
 
         result = UML.model.stereotypes_str(cls, ("test",))
         assert (fmt % "test, s1, s2, s3") == result
@@ -130,9 +130,9 @@ class StereotypesTestCase(TestCaseBase):
 
         c1 = self.factory.create(UML.Class)
         c2 = self.factory.create(UML.Class)
-        UML.model.apply_stereotype(self.factory, c1, s1)
-        UML.model.apply_stereotype(self.factory, c1, s2)
-        UML.model.apply_stereotype(self.factory, c2, s1)
+        UML.model.apply_stereotype(c1, s1)
+        UML.model.apply_stereotype(c1, s2)
+        UML.model.apply_stereotype(c2, s1)
 
         result = [e.classifier[0].name for e in UML.model.find_instances(s1)]
         assert 2 == len(result)

--- a/gaphor/UML/tests/test_modelfactory.py
+++ b/gaphor/UML/tests/test_modelfactory.py
@@ -90,11 +90,11 @@ class StereotypesTestCase(TestCaseBase):
         st2.name = "st2"
 
         # first extend with st2, to check sorting
-        UML.model.extend_with_stereotype(self.factory, cls, st2)
-        UML.model.extend_with_stereotype(self.factory, cls, st1)
+        UML.model.create_extension(cls, st2)
+        UML.model.create_extension(cls, st1)
 
         c1 = self.factory.create(UML.Class)
-        result = tuple(st.name for st in UML.model.get_stereotypes(self.factory, c1))
+        result = tuple(st.name for st in UML.model.get_stereotypes(c1))
         assert ("st1", "st2") == result
 
     def test_getting_stereotypes_unique(self):
@@ -110,14 +110,14 @@ class StereotypesTestCase(TestCaseBase):
         st2.name = "st2"
 
         # first extend with st2, to check sorting
-        UML.model.extend_with_stereotype(self.factory, cls1, st2)
-        UML.model.extend_with_stereotype(self.factory, cls1, st1)
+        UML.model.create_extension(cls1, st2)
+        UML.model.create_extension(cls1, st1)
 
-        UML.model.extend_with_stereotype(self.factory, cls2, st1)
-        UML.model.extend_with_stereotype(self.factory, cls2, st2)
+        UML.model.create_extension(cls2, st1)
+        UML.model.create_extension(cls2, st2)
 
         c1 = self.factory.create(UML.Component)
-        result = tuple(st.name for st in UML.model.get_stereotypes(self.factory, c1))
+        result = tuple(st.name for st in UML.model.get_stereotypes(c1))
         assert ("st1", "st2") == result
 
     def test_finding_stereotype_instances(self):
@@ -134,9 +134,7 @@ class StereotypesTestCase(TestCaseBase):
         UML.model.apply_stereotype(self.factory, c1, s2)
         UML.model.apply_stereotype(self.factory, c2, s1)
 
-        result = [
-            e.classifier[0].name for e in UML.model.find_instances(self.factory, s1)
-        ]
+        result = [e.classifier[0].name for e in UML.model.find_instances(s1)]
         assert 2 == len(result)
         assert "s1" in result, result
         assert "s2" not in result, result

--- a/gaphor/UML/tests/test_modelfactory.py
+++ b/gaphor/UML/tests/test_modelfactory.py
@@ -150,14 +150,14 @@ class AssociationTestCase(TestCaseBase):
         """
         c1 = self.factory.create(UML.Class)
         c2 = self.factory.create(UML.Class)
-        assoc = UML.model.create_association(self.factory, c1, c2)
+        assoc = UML.model.create_association(c1, c2)
         types = [p.type for p in assoc.memberEnd]
         assert c1 in types, assoc.memberEnd
         assert c2 in types, assoc.memberEnd
 
         c1 = self.factory.create(UML.Interface)
         c2 = self.factory.create(UML.Interface)
-        assoc = UML.model.create_association(self.factory, c1, c2)
+        assoc = UML.model.create_association(c1, c2)
         types = [p.type for p in assoc.memberEnd]
         assert c1 in types, assoc.memberEnd
         assert c2 in types, assoc.memberEnd
@@ -173,7 +173,7 @@ class AssociationEndNavigabilityTestCase(TestCaseBase):
         """
         c1 = self.factory.create(UML.Class)
         c2 = self.factory.create(UML.Class)
-        assoc = UML.model.create_association(self.factory, c1, c2)
+        assoc = UML.model.create_association(c1, c2)
 
         end = assoc.memberEnd[0]
         assert end.type is c1
@@ -224,7 +224,7 @@ class AssociationEndNavigabilityTestCase(TestCaseBase):
         """
         n1 = self.factory.create(UML.Node)
         n2 = self.factory.create(UML.Node)
-        assoc = UML.model.create_association(self.factory, n1, n2)
+        assoc = UML.model.create_association(n1, n2)
 
         end = assoc.memberEnd[0]
         assert end.type is n1
@@ -313,14 +313,11 @@ class MessageTestCase(TestCaseBase):
         m.sendEvent = send
         m.receiveEvent = receive
 
-        m1 = UML.model.create_message(self.factory, m, False)
-        m2 = UML.model.create_message(self.factory, m, True)
+        m1 = UML.model.create_message(m, False)
+        m2 = UML.model.create_message(m, True)
 
         assert m1.sendEvent.covered is sl
         assert m1.receiveEvent.covered is rl
 
         assert m2.sendEvent.covered is rl
         assert m2.receiveEvent.covered is sl
-
-
-# vim:sw=4:et

--- a/gaphor/UML/tests/test_uml2.py
+++ b/gaphor/UML/tests/test_uml2.py
@@ -391,7 +391,7 @@ class Uml2TestCase(unittest.TestCase):
         s = factory.create(UML.Stereotype)
         s.name = "Stereotype"
 
-        e = UML.model.create_extension(factory, c, s)
+        e = UML.model.create_extension(c, s)
 
         assert c == e.metaclass
 
@@ -405,7 +405,7 @@ class Uml2TestCase(unittest.TestCase):
         assert [] == c.extension
         assert [] == s.extension
 
-        e = UML.model.create_extension(factory, c, s)
+        e = UML.model.create_extension(c, s)
 
         print(e.memberEnd)
         assert [e] == c.extension

--- a/gaphor/UML/tests/test_uml2.py
+++ b/gaphor/UML/tests/test_uml2.py
@@ -359,7 +359,7 @@ class Uml2TestCase(unittest.TestCase):
 
         c1 = factory.create(UML.Class)
         c2 = factory.create(UML.Class)
-        a = UML.model.create_association(factory, c1, c2)
+        a = UML.model.create_association(c1, c2)
         assert a.memberEnd[0].navigability is None
         assert a.memberEnd[1].navigability is None
 

--- a/gaphor/diagram/actions/actionsgrouping.py
+++ b/gaphor/diagram/actions/actionsgrouping.py
@@ -19,7 +19,8 @@ class ActivityPartitionsGroup(AbstractGroup):
 
     def group(self):
         p = self.parent.subject
-        sp = self.element_factory.create(UML.ActivityPartition)
+        model = self.item.model
+        sp = model.create(UML.ActivityPartition)
         self.item.subject = sp
         sp.name = "Swimlane"
         if p:

--- a/gaphor/diagram/actions/flowconnect.py
+++ b/gaphor/diagram/actions/flowconnect.py
@@ -145,10 +145,10 @@ class FlowForkDecisionNodeConnect(FlowConnect):
                 flow_class = UML.ControlFlow
 
             UML.model.swap_element(join_node, join_node_cls)
-            fork_node = self.element_factory.create(fork_node_cls)
+            fork_node = element.model.create(fork_node_cls)
             for flow in list(join_node.outgoing):
                 flow.source = fork_node
-            flow = self.element_factory.create(flow_class)
+            flow = element.model.create(flow_class)
             flow.source = join_node
             flow.target = fork_node
 

--- a/gaphor/diagram/actions/flowconnect.py
+++ b/gaphor/diagram/actions/flowconnect.py
@@ -126,10 +126,10 @@ class FlowForkDecisionNodeConnect(FlowConnect):
         element = self.element
         subject = element.subject
         if len(subject.incoming) > 1 and len(subject.outgoing) < 2:
-            self.element_factory.swap_element(subject, join_node_cls)
+            UML.model.swap_element(subject, join_node_cls)
             element.request_update()
         elif len(subject.incoming) < 2 and len(subject.outgoing) > 1:
-            self.element_factory.swap_element(subject, fork_node_cls)
+            UML.model.swap_element(subject, fork_node_cls)
             element.request_update()
         elif (
             not element.combined
@@ -144,7 +144,7 @@ class FlowForkDecisionNodeConnect(FlowConnect):
             else:
                 flow_class = UML.ControlFlow
 
-            self.element_factory.swap_element(join_node, join_node_cls)
+            UML.model.swap_element(join_node, join_node_cls)
             fork_node = self.element_factory.create(fork_node_cls)
             for flow in list(join_node.outgoing):
                 flow.source = fork_node
@@ -180,7 +180,7 @@ class FlowForkDecisionNodeConnect(FlowConnect):
                 # swap subject to fork node if outgoing > 1
                 if len(join_node.outgoing) > 1:
                     assert len(join_node.incoming) < 2
-                    self.element_factory.swap_element(join_node, fork_node_cls)
+                    UML.model.swap_element(join_node, fork_node_cls)
                 element.combined = None
 
     def connect_subject(self, handle):

--- a/gaphor/diagram/classes/classconnect.py
+++ b/gaphor/diagram/classes/classconnect.py
@@ -118,7 +118,7 @@ class AssociationConnect(UnaryRelationshipConnect):
                     return
 
             # Create new association
-            relation = UML.model.create_association(element.model, head_type, tail_type)
+            relation = UML.model.create_association(head_type, tail_type)
             relation.package = element.canvas.diagram.namespace
 
             line.head_end.subject = relation.memberEnd[0]

--- a/gaphor/diagram/classes/classconnect.py
+++ b/gaphor/diagram/classes/classconnect.py
@@ -118,9 +118,7 @@ class AssociationConnect(UnaryRelationshipConnect):
                     return
 
             # Create new association
-            relation = UML.model.create_association(
-                self.element_factory, head_type, tail_type
-            )
+            relation = UML.model.create_association(element.model, head_type, tail_type)
             relation.package = element.canvas.diagram.namespace
 
             line.head_end.subject = relation.memberEnd[0]

--- a/gaphor/diagram/classes/classespropertypages.py
+++ b/gaphor/diagram/classes/classespropertypages.py
@@ -402,7 +402,7 @@ class DependencyPropertyPage(PropertyPageBase):
         self.item.dependency_type = cls
         subject = self.item.subject
         if subject:
-            subject.model.swap_element(self.item.subject, cls)
+            UML.model.swap_element(subject, cls)
             self.item.request_update()
 
     @transactional

--- a/gaphor/diagram/classes/classespropertypages.py
+++ b/gaphor/diagram/classes/classespropertypages.py
@@ -35,7 +35,7 @@ class ClassAttributes(EditableTreeModel):
                 yield [UML.format(attr), attr.isStatic, attr]
 
     def _create_object(self):
-        attr = self.element_factory.create(UML.Property)
+        attr = self._item.model.create(UML.Property)
         self._item.subject.ownedAttribute = attr
         return attr
 
@@ -70,7 +70,7 @@ class ClassOperations(EditableTreeModel):
             ]
 
     def _create_object(self):
-        operation = self.element_factory.create(UML.Operation)
+        operation = self._item.model.create(UML.Operation)
         self._item.subject.ownedOperation = operation
         return operation
 

--- a/gaphor/diagram/components/connectorconnect.py
+++ b/gaphor/diagram/components/connectorconnect.py
@@ -80,9 +80,9 @@ class ConnectorConnectBase(AbstractConnect):
         """
         connector.subject = assembly
 
-        end = self.element_factory.create(UML.ConnectorEnd)
+        end = connector.model.create(UML.ConnectorEnd)
         end.role = iface
-        end.partWithPort = self.element_factory.create(UML.Port)
+        end.partWithPort = connector.model.create(UML.Port)
         assembly.end = end
 
         component.subject.ownedPort = end.partWithPort
@@ -173,7 +173,7 @@ class ConnectorConnectBase(AbstractConnect):
                         break
 
                 if assembly is None:
-                    assembly = self.element_factory.create(UML.Connector)
+                    assembly = self.element.model.create(UML.Connector)
                     assembly.kind = "assembly"
                     for c in connections:
                         connector = c.item

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -8,7 +8,6 @@ gaphor.adapter package.
 import abc
 
 from gaphor import UML
-from gaphor.core import inject
 from gaphor.misc.generic.multidispatch import multidispatch
 
 
@@ -84,8 +83,6 @@ class AbstractConnect(ConnectBase):
     By convention the adapters are registered by (element, line) -- in that order.
 
     """
-
-    element_factory = inject("element_factory")
 
     def __init__(self, element, line):
         self.element = element
@@ -164,8 +161,6 @@ class UnaryRelationshipConnect(AbstractConnect):
     find an existing relationship in the model that does not yet exist
     on the canvas.
     """
-
-    element_factory = inject("element_factory")
 
     def relationship(self, required_type, head, tail):
         """

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -221,7 +221,7 @@ class UnaryRelationshipConnect(AbstractConnect):
         relation = self.relationship(type, head, tail)
         if not relation:
             line = self.line
-            relation = self.element_factory.create(type)
+            relation = line.model.create(type)
             setattr(relation, head.name, self.get_connected(line.head).subject)
             setattr(relation, tail.name, self.get_connected(line.tail).subject)
         return relation

--- a/gaphor/diagram/grouping.py
+++ b/gaphor/diagram/grouping.py
@@ -46,8 +46,6 @@ class AbstractGroup(metaclass=abc.ABCMeta):
         Item to be grouped.
     """
 
-    element_factory = inject("element_factory")
-
     def __init__(self, parent, item):
         self.parent = parent
         self.item = item

--- a/gaphor/diagram/grouping.py
+++ b/gaphor/diagram/grouping.py
@@ -17,7 +17,6 @@ to be aware that `AbstractGroup.item` can be null.
 import abc
 
 from gaphor import UML
-from gaphor.core import inject
 from gaphor.misc.generic.multidispatch import multidispatch
 
 

--- a/gaphor/diagram/interactions/interactionspropertypages.py
+++ b/gaphor/diagram/interactions/interactionspropertypages.py
@@ -1,7 +1,7 @@
 from gi.repository import Gtk
 
 from gaphor import UML
-from gaphor.core import _, inject, transactional
+from gaphor.core import _, transactional
 from gaphor.diagram.propertypages import (
     PropertyPages,
     NamedItemPropertyPage,
@@ -60,8 +60,6 @@ class MessagePropertyPage(NamedItemPropertyPage):
     When message is on communication diagram, then additional messages can
     be added. On sequence diagram sort of message can be changed.
     """
-
-    element_factory = inject("element_factory")
 
     NAME_LABEL = _("Message")
 

--- a/gaphor/diagram/interactions/interactionspropertypages.py
+++ b/gaphor/diagram/interactions/interactionspropertypages.py
@@ -39,7 +39,7 @@ class CommunicationMessageModel(EditableTreeModel):
     def _create_object(self):
         item = self._item
         subject = item.subject
-        message = UML.model.create_message(item.model, subject, self.inverted)
+        message = UML.model.create_message(subject, self.inverted)
         item.add_message(message, self.inverted)
         return message
 

--- a/gaphor/diagram/interactions/interactionspropertypages.py
+++ b/gaphor/diagram/interactions/interactionspropertypages.py
@@ -39,7 +39,7 @@ class CommunicationMessageModel(EditableTreeModel):
     def _create_object(self):
         item = self._item
         subject = item.subject
-        message = UML.model.create_message(self.element_factory, subject, self.inverted)
+        message = UML.model.create_message(item.model, subject, self.inverted)
         item.add_message(message, self.inverted)
         return message
 

--- a/gaphor/diagram/interactions/messageconnect.py
+++ b/gaphor/diagram/interactions/messageconnect.py
@@ -23,7 +23,7 @@ class MessageLifelineConnect(AbstractConnect):
 
         def get_subject():
             if not line.subject:
-                message = self.element_factory.create(UML.Message)
+                message = line.model.create(UML.Message)
                 message.name = "call()"
                 line.subject = message
             return line.subject
@@ -31,14 +31,14 @@ class MessageLifelineConnect(AbstractConnect):
         if send:
             message = get_subject()
             if not message.sendEvent:
-                event = self.element_factory.create(UML.MessageOccurrenceSpecification)
+                event = message.model.create(UML.MessageOccurrenceSpecification)
                 event.sendMessage = message
                 event.covered = send.subject
 
         if received:
             message = get_subject()
             if not message.receiveEvent:
-                event = self.element_factory.create(UML.MessageOccurrenceSpecification)
+                event = message.model.create(UML.MessageOccurrenceSpecification)
                 event.receiveMessage = message
                 event.covered = received.subject
 

--- a/gaphor/diagram/interactions/tests/test_messageconnect.py
+++ b/gaphor/diagram/interactions/tests/test_messageconnect.py
@@ -235,14 +235,14 @@ class DiagramModeMessageConnectionTestCase(TestCase):
         assert subject.sendEvent and subject.receiveEvent
 
         # add some more messages
-        m1 = UML.model.create_message(factory, subject)
-        m2 = UML.model.create_message(factory, subject)
+        m1 = UML.model.create_message(subject)
+        m2 = UML.model.create_message(subject)
         msg.add_message(m1, False)
         msg.add_message(m2, False)
 
         # add some inverted messages
-        m3 = UML.model.create_message(factory, subject, True)
-        m4 = UML.model.create_message(factory, subject, True)
+        m3 = UML.model.create_message(subject, True)
+        m4 = UML.model.create_message(subject, True)
         msg.add_message(m3, True)
         msg.add_message(m4, True)
 

--- a/gaphor/diagram/profiles/extensionconnect.py
+++ b/gaphor/diagram/profiles/extensionconnect.py
@@ -46,7 +46,7 @@ class ExtensionConnect(RelationshipConnect):
 
             # Find all associations and determine if the properties on
             # the association ends have a type that points to the class.
-            for assoc in self.element_factory.select():
+            for assoc in line.model.select():
                 if isinstance(assoc, UML.Extension):
                     end1 = assoc.memberEnd[0]
                     end2 = assoc.memberEnd[1]
@@ -63,9 +63,7 @@ class ExtensionConnect(RelationshipConnect):
                             return
             else:
                 # Create a new Extension relationship
-                relation = UML.model.extend_with_stereotype(
-                    self.element_factory, head_type, tail_type
-                )
+                relation = UML.model.create_extension(head_type, tail_type)
                 line.subject = relation
 
     def disconnect_subject(self, handle):

--- a/gaphor/diagram/profiles/metaclasspropertypage.py
+++ b/gaphor/diagram/profiles/metaclasspropertypage.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 from gaphor import UML
 from gaphor.diagram.propertypages import create_hbox_label, EventWatcher
-from gaphor.core import _, transactional
+from gaphor.core import _
 from gaphor.diagram.propertypages import PropertyPages, NamedElementPropertyPage
 from gaphor.diagram.classes import ClassItem
 

--- a/gaphor/diagram/profiles/stereotypepage.py
+++ b/gaphor/diagram/profiles/stereotypepage.py
@@ -85,7 +85,7 @@ class StereotypePage(PropertyPageBase):
         if subject is None:
             return None
 
-        stereotypes = UML.model.get_stereotypes(subject.model, subject)
+        stereotypes = UML.model.get_stereotypes(subject)
         if not stereotypes:
             return None
 
@@ -121,7 +121,7 @@ class StereotypePage(PropertyPageBase):
     def refresh(self):
         self.model.clear()
         subject = self.item.subject
-        stereotypes = UML.model.get_stereotypes(self.element_factory, subject)
+        stereotypes = UML.model.get_stereotypes(subject)
         instances = subject.appliedStereotype
 
         # shortcut map stereotype -> slot (InstanceSpecification)
@@ -175,7 +175,7 @@ class StereotypePage(PropertyPageBase):
 
         subject = self.item.subject
         if value:
-            UML.model.apply_stereotype(self.element_factory, subject, stereotype)
+            UML.model.apply_stereotype(self.item.model, subject, stereotype)
         else:
             UML.model.remove_stereotype(subject, stereotype)
 
@@ -200,7 +200,7 @@ class StereotypePage(PropertyPageBase):
             return  # nothing to do and don't create slot without value
 
         if slot is None:
-            slot = UML.model.add_slot(self.element_factory, obj, attr)
+            slot = UML.model.add_slot(self.item.model, obj, attr)
 
         assert slot
 

--- a/gaphor/diagram/profiles/stereotypepage.py
+++ b/gaphor/diagram/profiles/stereotypepage.py
@@ -175,7 +175,7 @@ class StereotypePage(PropertyPageBase):
 
         subject = self.item.subject
         if value:
-            UML.model.apply_stereotype(self.item.model, subject, stereotype)
+            UML.model.apply_stereotype(subject, stereotype)
         else:
             UML.model.remove_stereotype(subject, stereotype)
 

--- a/gaphor/diagram/profiles/stereotypepage.py
+++ b/gaphor/diagram/profiles/stereotypepage.py
@@ -200,7 +200,7 @@ class StereotypePage(PropertyPageBase):
             return  # nothing to do and don't create slot without value
 
         if slot is None:
-            slot = UML.model.add_slot(self.item.model, obj, attr)
+            slot = UML.model.add_slot(obj, attr)
 
         assert slot
 

--- a/gaphor/diagram/profiles/stereotypepage.py
+++ b/gaphor/diagram/profiles/stereotypepage.py
@@ -5,7 +5,7 @@ Stereotype property page.
 from gi.repository import GObject, Gtk
 
 from gaphor import UML
-from gaphor.core import _, inject, transactional
+from gaphor.core import _, transactional
 from gaphor.diagram.diagramitem import StereotypeSupport
 from gaphor.diagram.propertypages import PropertyPages, PropertyPageBase
 
@@ -72,8 +72,6 @@ class StereotypePage(PropertyPageBase):
 
     order = 40
     name = "Stereotypes"
-
-    element_factory = inject("element_factory")
 
     def __init__(self, item):
         self.item = item

--- a/gaphor/diagram/profiles/tests/test_classifier_stereotypes.py
+++ b/gaphor/diagram/profiles/tests/test_classifier_stereotypes.py
@@ -67,7 +67,7 @@ class StereotypesAttributesTestCase(TestCase):
         # test precondition
         assert not c._compartments[0].visible
 
-        slot = UML.model.add_slot(factory, obj, self.st1.ownedAttribute[0])
+        slot = UML.model.add_slot(obj, self.st1.ownedAttribute[0])
 
         compartment = c._compartments[0]
         assert compartment.visible
@@ -82,7 +82,7 @@ class StereotypesAttributesTestCase(TestCase):
         c.show_stereotypes_attrs = True
         obj = UML.model.apply_stereotype(c.subject, self.st1)
 
-        slot = UML.model.add_slot(factory, obj, self.st1.ownedAttribute[0])
+        slot = UML.model.add_slot(obj, self.st1.ownedAttribute[0])
 
         compartment = c._compartments[0]
         # test precondition
@@ -163,7 +163,7 @@ class StereotypesAttributesTestCase(TestCase):
         assert len(self.kindof(UML.Slot)) == 0
 
         attr = self.st1.ownedAttribute[0]
-        slot = UML.model.add_slot(factory, obj, attr)
+        slot = UML.model.add_slot(obj, attr)
         assert len(obj.slot) == 1
         assert len(self.kindof(UML.Slot)) == 1
         assert slot.definingFeature
@@ -188,7 +188,7 @@ class StereotypesAttributesTestCase(TestCase):
 
         # change attribute of 2nd stereotype
         attr = self.st2.ownedAttribute[0]
-        slot = UML.model.add_slot(self.element_factory, obj, attr)
+        slot = UML.model.add_slot(obj, attr)
         slot.value = "st2 test21"
 
         data = self.save()
@@ -219,9 +219,9 @@ class StereotypesAttributesTestCase(TestCase):
         assert attr3.name == "baseClass", attr3.name
 
         obj = c.subject.appliedStereotype[0]
-        slot = UML.model.add_slot(self.element_factory, obj, attr1)
+        slot = UML.model.add_slot(obj, attr1)
         slot.value = "st1 test1"
-        slot = UML.model.add_slot(self.element_factory, obj, attr2)
+        slot = UML.model.add_slot(obj, attr2)
         slot.value = "st1 test2"
 
         data = self.save()

--- a/gaphor/diagram/profiles/tests/test_classifier_stereotypes.py
+++ b/gaphor/diagram/profiles/tests/test_classifier_stereotypes.py
@@ -51,7 +51,7 @@ class StereotypesAttributesTestCase(TestCase):
 
         c.show_stereotypes_attrs = True
 
-        UML.model.apply_stereotype(factory, c.subject, self.st1)
+        UML.model.apply_stereotype(c.subject, self.st1)
         assert 1 == len(c._compartments)
         assert not c._compartments[0].visible
 
@@ -62,7 +62,7 @@ class StereotypesAttributesTestCase(TestCase):
         c = self.create(ComponentItem, UML.Component)
 
         c.show_stereotypes_attrs = True
-        obj = UML.model.apply_stereotype(factory, c.subject, self.st1)
+        obj = UML.model.apply_stereotype(c.subject, self.st1)
 
         # test precondition
         assert not c._compartments[0].visible
@@ -80,7 +80,7 @@ class StereotypesAttributesTestCase(TestCase):
         c = self.create(ComponentItem, UML.Component)
 
         c.show_stereotypes_attrs = True
-        obj = UML.model.apply_stereotype(factory, c.subject, self.st1)
+        obj = UML.model.apply_stereotype(c.subject, self.st1)
 
         slot = UML.model.add_slot(factory, obj, self.st1.ownedAttribute[0])
 
@@ -99,7 +99,7 @@ class StereotypesAttributesTestCase(TestCase):
 
         c.show_stereotypes_attrs = True
 
-        UML.model.apply_stereotype(factory, c.subject, self.st1)
+        UML.model.apply_stereotype(c.subject, self.st1)
 
         # test precondition
         assert len(c._compartments) == 1
@@ -117,7 +117,7 @@ class StereotypesAttributesTestCase(TestCase):
 
         st1 = self.st1
         ext1 = self.ext1
-        UML.model.apply_stereotype(factory, c.subject, st1)
+        UML.model.apply_stereotype(c.subject, st1)
 
         # test precondition
         assert len(c._compartments) == 1
@@ -136,7 +136,7 @@ class StereotypesAttributesTestCase(TestCase):
         c.show_stereotypes_attrs = True
 
         st1 = self.st1
-        UML.model.apply_stereotype(factory, c.subject, st1)
+        UML.model.apply_stereotype(c.subject, st1)
 
         # test precondition
         assert len(c._compartments) == 1
@@ -156,7 +156,7 @@ class StereotypesAttributesTestCase(TestCase):
 
         # test precondition
         assert len(c._compartments) == 0
-        obj = UML.model.apply_stereotype(factory, c.subject, self.st1)
+        obj = UML.model.apply_stereotype(c.subject, self.st1)
         # test precondition
         assert len(c._compartments) == 1
 
@@ -183,8 +183,8 @@ class StereotypesAttributesTestCase(TestCase):
         c = self.create(ComponentItem, UML.Component)
 
         c.show_stereotypes_attrs = True
-        UML.model.apply_stereotype(factory, c.subject, self.st1)
-        obj = UML.model.apply_stereotype(factory, c.subject, self.st2)
+        UML.model.apply_stereotype(c.subject, self.st1)
+        obj = UML.model.apply_stereotype(c.subject, self.st2)
 
         # change attribute of 2nd stereotype
         attr = self.st2.ownedAttribute[0]
@@ -205,13 +205,12 @@ class StereotypesAttributesTestCase(TestCase):
     def test_saving_stereotype_attributes(self):
         """Test stereotype attributes saving
         """
-        factory = self.element_factory
         c = self.create(ComponentItem, UML.Component)
 
         c.show_stereotypes_attrs = True
 
-        UML.model.apply_stereotype(factory, c.subject, self.st1)
-        UML.model.apply_stereotype(factory, c.subject, self.st2)
+        UML.model.apply_stereotype(c.subject, self.st1)
+        UML.model.apply_stereotype(c.subject, self.st2)
 
         assert 3 == len(self.st1.ownedAttribute)
         attr1, attr2, attr3 = self.st1.ownedAttribute

--- a/gaphor/diagram/profiles/tests/test_classifier_stereotypes.py
+++ b/gaphor/diagram/profiles/tests/test_classifier_stereotypes.py
@@ -33,8 +33,8 @@ class StereotypesAttributesTestCase(TestCase):
         attr.name = "st2_attr_1"
         st2.ownedAttribute = attr
 
-        self.ext1 = UML.model.extend_with_stereotype(factory, cls, st1)
-        self.ext2 = UML.model.extend_with_stereotype(factory, cls, st2)
+        self.ext1 = UML.model.create_extension(cls, st1)
+        self.ext2 = UML.model.create_extension(cls, st2)
 
     def tearDown(self):
         del self.st1

--- a/gaphor/diagram/profiles/tests/test_metaclasspropertypage.py
+++ b/gaphor/diagram/profiles/tests/test_metaclasspropertypage.py
@@ -26,7 +26,7 @@ class MetaclassPropertyPageTest(TestCase):
         metaclass.name = "Class"
         stereotype = self.element_factory.create(UML.Stereotype)
         stereotype.name = "NewStereotype"
-        UML.model.create_extension(self.element_factory, metaclass, stereotype)
+        UML.model.create_extension(metaclass, stereotype)
 
         editor = MetaclassNamePropertyPage(metaclass)
         page = editor.construct()

--- a/gaphor/diagram/profiles/tests/test_stereotypepage.py
+++ b/gaphor/diagram/profiles/tests/test_stereotypepage.py
@@ -18,7 +18,7 @@ class MetaclassEditorTest(TestCase):
         metaclass.name = "Class"
         stereotype = self.element_factory.create(UML.Stereotype)
         stereotype.name = "NewStereotype"
-        UML.model.create_extension(self.element_factory, metaclass, stereotype)
+        UML.model.create_extension(metaclass, stereotype)
         attr = self.element_factory.create(UML.Property)
         attr.name = "Property"
         # stereotype.ownedAttribute = attr

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -32,7 +32,7 @@ from gi.repository import Gdk
 from gi.repository import Gtk
 
 from gaphor import UML
-from gaphor.core import _, inject, transactional
+from gaphor.core import _, transactional
 from gaphor.services.elementdispatcher import EventWatcher
 
 
@@ -95,8 +95,6 @@ class EditableTreeModel(Gtk.ListStore):
     Attributes:
     - _item: diagram item owning tree model
     """
-
-    element_factory = inject("element_factory")
 
     def __init__(self, item, cols=None):
         """Create new model.

--- a/gaphor/diagram/states/vertexconnect.py
+++ b/gaphor/diagram/states/vertexconnect.py
@@ -32,7 +32,7 @@ class VertexConnect(RelationshipConnect):
         )
         self.line.subject = relation
         if relation.guard is None:
-            relation.guard = self.element_factory.create(UML.Constraint)
+            relation.guard = self.line.model.create(UML.Constraint)
 
 
 @IConnect.register(VertexItem, TransitionItem)

--- a/gaphor/services/tests/test_sanitizerservice.py
+++ b/gaphor/services/tests/test_sanitizerservice.py
@@ -44,7 +44,7 @@ class SanitizerServiceTest(TestCase):
         # ext = UML.model.create_extension(metaklass, stereotype)
 
         # Apply stereotype to class and create slot
-        instspec = UML.model.apply_stereotype(factory, klass, stereotype)
+        instspec = UML.model.apply_stereotype(klass, stereotype)
         slot = UML.model.add_slot(factory, instspec, st_attr)
 
         # Now, what happens if the attribute is deleted:
@@ -70,7 +70,7 @@ class SanitizerServiceTest(TestCase):
         ext = UML.model.create_extension(metaklass, stereotype)
 
         # Apply stereotype to class and create slot
-        instspec = UML.model.apply_stereotype(factory, klass, stereotype)
+        instspec = UML.model.apply_stereotype(klass, stereotype)
         slot = UML.model.add_slot(factory, instspec, st_attr)
 
         assert stereotype in klass.appliedStereotype[:].classifier
@@ -94,7 +94,7 @@ class SanitizerServiceTest(TestCase):
         ext = UML.model.create_extension(metaklass, stereotype)
 
         # Apply stereotype to class and create slot
-        instspec = UML.model.apply_stereotype(factory, klass, stereotype)
+        instspec = UML.model.apply_stereotype(klass, stereotype)
         slot = UML.model.add_slot(factory, instspec, st_attr)
 
         assert stereotype in klass.appliedStereotype[:].classifier
@@ -121,8 +121,8 @@ class SanitizerServiceTest(TestCase):
         ext2 = UML.model.create_extension(metaiface, stereotype)
 
         # Apply stereotype to class and create slot
-        instspec1 = UML.model.apply_stereotype(factory, klass, stereotype)
-        instspec2 = UML.model.apply_stereotype(factory, iface, stereotype)
+        instspec1 = UML.model.apply_stereotype(klass, stereotype)
+        instspec2 = UML.model.apply_stereotype(iface, stereotype)
         slot = UML.model.add_slot(factory, instspec1, st_attr)
 
         assert stereotype in klass.appliedStereotype[:].classifier
@@ -148,7 +148,7 @@ class SanitizerServiceTest(TestCase):
         ext = UML.model.create_extension(metaklass, stereotype)
 
         # Apply stereotype to class and create slot
-        instspec = UML.model.apply_stereotype(factory, klass, stereotype)
+        instspec = UML.model.apply_stereotype(klass, stereotype)
         slot = UML.model.add_slot(factory, instspec, st_attr)
 
         assert stereotype in klass.appliedStereotype[:].classifier

--- a/gaphor/services/tests/test_sanitizerservice.py
+++ b/gaphor/services/tests/test_sanitizerservice.py
@@ -45,7 +45,7 @@ class SanitizerServiceTest(TestCase):
 
         # Apply stereotype to class and create slot
         instspec = UML.model.apply_stereotype(klass, stereotype)
-        slot = UML.model.add_slot(factory, instspec, st_attr)
+        slot = UML.model.add_slot(instspec, st_attr)
 
         # Now, what happens if the attribute is deleted:
         self.assertTrue(st_attr in stereotype.ownedMember)
@@ -71,7 +71,7 @@ class SanitizerServiceTest(TestCase):
 
         # Apply stereotype to class and create slot
         instspec = UML.model.apply_stereotype(klass, stereotype)
-        slot = UML.model.add_slot(factory, instspec, st_attr)
+        slot = UML.model.add_slot(instspec, st_attr)
 
         assert stereotype in klass.appliedStereotype[:].classifier
 
@@ -95,7 +95,7 @@ class SanitizerServiceTest(TestCase):
 
         # Apply stereotype to class and create slot
         instspec = UML.model.apply_stereotype(klass, stereotype)
-        slot = UML.model.add_slot(factory, instspec, st_attr)
+        slot = UML.model.add_slot(instspec, st_attr)
 
         assert stereotype in klass.appliedStereotype[:].classifier
 
@@ -123,7 +123,7 @@ class SanitizerServiceTest(TestCase):
         # Apply stereotype to class and create slot
         instspec1 = UML.model.apply_stereotype(klass, stereotype)
         instspec2 = UML.model.apply_stereotype(iface, stereotype)
-        slot = UML.model.add_slot(factory, instspec1, st_attr)
+        slot = UML.model.add_slot(instspec1, st_attr)
 
         assert stereotype in klass.appliedStereotype[:].classifier
         assert klass in self.element_factory
@@ -149,7 +149,7 @@ class SanitizerServiceTest(TestCase):
 
         # Apply stereotype to class and create slot
         instspec = UML.model.apply_stereotype(klass, stereotype)
-        slot = UML.model.add_slot(factory, instspec, st_attr)
+        slot = UML.model.add_slot(instspec, st_attr)
 
         assert stereotype in klass.appliedStereotype[:].classifier
 

--- a/gaphor/services/tests/test_sanitizerservice.py
+++ b/gaphor/services/tests/test_sanitizerservice.py
@@ -41,7 +41,7 @@ class SanitizerServiceTest(TestCase):
         stereotype = create(UML.Stereotype)
         st_attr = self.element_factory.create(UML.Property)
         stereotype.ownedAttribute = st_attr
-        # ext = UML.model.create_extension(factory, metaklass, stereotype)
+        # ext = UML.model.create_extension(metaklass, stereotype)
 
         # Apply stereotype to class and create slot
         instspec = UML.model.apply_stereotype(factory, klass, stereotype)
@@ -67,7 +67,7 @@ class SanitizerServiceTest(TestCase):
         stereotype = create(UML.Stereotype)
         st_attr = self.element_factory.create(UML.Property)
         stereotype.ownedAttribute = st_attr
-        ext = UML.model.create_extension(factory, metaklass, stereotype)
+        ext = UML.model.create_extension(metaklass, stereotype)
 
         # Apply stereotype to class and create slot
         instspec = UML.model.apply_stereotype(factory, klass, stereotype)
@@ -91,7 +91,7 @@ class SanitizerServiceTest(TestCase):
         stereotype = create(UML.Stereotype)
         st_attr = self.element_factory.create(UML.Property)
         stereotype.ownedAttribute = st_attr
-        ext = UML.model.create_extension(factory, metaklass, stereotype)
+        ext = UML.model.create_extension(metaklass, stereotype)
 
         # Apply stereotype to class and create slot
         instspec = UML.model.apply_stereotype(factory, klass, stereotype)
@@ -117,8 +117,8 @@ class SanitizerServiceTest(TestCase):
         stereotype = create(UML.Stereotype)
         st_attr = self.element_factory.create(UML.Property)
         stereotype.ownedAttribute = st_attr
-        ext1 = UML.model.create_extension(factory, metaklass, stereotype)
-        ext2 = UML.model.create_extension(factory, metaiface, stereotype)
+        ext1 = UML.model.create_extension(metaklass, stereotype)
+        ext2 = UML.model.create_extension(metaiface, stereotype)
 
         # Apply stereotype to class and create slot
         instspec1 = UML.model.apply_stereotype(factory, klass, stereotype)
@@ -145,7 +145,7 @@ class SanitizerServiceTest(TestCase):
         stereotype = create(UML.Stereotype)
         st_attr = self.element_factory.create(UML.Property)
         stereotype.ownedAttribute = st_attr
-        ext = UML.model.create_extension(factory, metaklass, stereotype)
+        ext = UML.model.create_extension(metaklass, stereotype)
 
         # Apply stereotype to class and create slot
         instspec = UML.model.apply_stereotype(factory, klass, stereotype)

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -25,6 +25,7 @@ from gaphor.UML.event import (
     AttributeChangeEvent,
     ModelFactoryEvent,
 )
+from gaphor.UML.properties import association as association_property
 from gaphor.action import action, build_action_group
 from gaphor.core import inject, event_handler
 from gaphor.event import (
@@ -369,6 +370,8 @@ class UndoManager(Service, ActionProvider):
     @event_handler(AssociationSetEvent)
     def undo_association_set_event(self, event):
         association = event.property
+        if type(association) is not association_property:
+            return
         element = event.element
         value = event.old_value
         # print 'got new set event', association, element, value
@@ -383,6 +386,8 @@ class UndoManager(Service, ActionProvider):
     @event_handler(AssociationAddEvent)
     def undo_association_add_event(self, event):
         association = event.property
+        if type(association) is not association_property:
+            return
         element = event.element
         value = event.new_value
 
@@ -397,6 +402,8 @@ class UndoManager(Service, ActionProvider):
     @event_handler(AssociationDeleteEvent)
     def undo_association_delete_event(self, event):
         association = event.property
+        if type(association) is not association_property:
+            return
         element = event.element
         value = event.old_value
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, _with api changes_)
- [ ] Documentation content changes

### What is the current behavior?

Everything, including model elements are dependent on the _injected_ `ElementFactory`. Basically the application is dependent on a few singleton objects.

UML Elements, however, already have their own reference to the model (element-factory). This model reference should be used for diagram items (which inherit from `UML.Presentation`).

### What is the new behavior?

No more injecting of `element_factory`'s in any model related item.

`ElementDispatcher` is still a dependency that needs fixing.

Fixed errors in `UndoManager`: it was trying to set values for derived associations. It should only record and play back the original association state change.
 
### Does this PR introduce a breaking change?
- [X] Yes: API's
- [ ] No
