### PR TITLE
Fix TypeError with Distutils when building with Windows

### DIFF
--- a/utils/model/build_uml.py
+++ b/utils/model/build_uml.py
@@ -23,11 +23,11 @@ class build_uml(Command):
     boolean_options = ["force"]
 
     def initialize_options(self):
-        # self.build_lib = None
-        self.force = 0
+        self.force = None
 
     def finalize_options(self):
-        self.set_undefined_options(("force", "force"))
+        if self.force is None:
+            self.force = False
 
     def run(self):
         generate_uml2(self.force)


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

Fixes a TypeError: not all arguments converted during string formatting error when building with Windows. The code should have maintained the `"build"` string like so:
```
def finalize_options(self):
    self.set_undefined_options("build", ("force", "force"))
```
### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
When building gaphor for Windows, I was getting the following error:
```
running install
running bdist_egg
running egg_info
creating gaphor.egg-info
writing gaphor.egg-info/PKG-INFO
writing dependency_links to gaphor.egg-info/dependency_links.txt
writing entry points to gaphor.egg-info/entry_points.txt
writing requirements to gaphor.egg-info/requires.txt
writing top-level names to gaphor.egg-info/top_level.txt
writing manifest file 'gaphor.egg-info/SOURCES.txt'
reading manifest file 'gaphor.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'gaphor.egg-info/SOURCES.txt'
installing library code to build/bdist.mingw/egg
running install_lib
running build_py
running build_uml
Traceback (most recent call last):
  File "setup.py", line 148, in <module>
    "build_pot": {"all_linguas": ",".join(LINGUAS)},
  File "C:/tools/msys64/home/DYEAW/.local/lib/python3.7/site-packages\setuptools\__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\core.py", line 148, in setup
    dist.run_commands()
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\dist.py", line 985, in run_command
    cmd_obj.run()
  File "C:/tools/msys64/home/DYEAW/.local/lib/python3.7/site-packages\setuptools\command\install.py", line 67, in run
    self.do_egg_install()
  File "C:/tools/msys64/home/DYEAW/.local/lib/python3.7/site-packages\setuptools\command\install.py", line 109, in do_egg_install
    self.run_command('bdist_egg')
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\dist.py", line 985, in run_command
    cmd_obj.run()
  File "C:/tools/msys64/home/DYEAW/.local/lib/python3.7/site-packages\setuptools\command\bdist_egg.py", line 172, in run
    cmd = self.call_command('install_lib', warn_dir=0)
  File "C:/tools/msys64/home/DYEAW/.local/lib/python3.7/site-packages\setuptools\command\bdist_egg.py", line 158, in call_command
    self.run_command(cmdname)
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\dist.py", line 985, in run_command
    cmd_obj.run()
  File "C:/tools/msys64/home/DYEAW/.local/lib/python3.7/site-packages\setuptools\command\install_lib.py", line 11, in run
    self.build()
  File "C:\tools\msys64\home\dyeaw\gaphor\win-installer\_build_root\gaphor\utils\install_lib.py", line 6, in build
    _install_lib.build(self)
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\command\install_lib.py", line 105, in build
    self.run_command('build_py')
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\dist.py", line 985, in run_command
    cmd_obj.run()
  File "setup.py", line 33, in run
    self.run_command(cmd_name)
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\dist.py", line 984, in run_command
    cmd_obj.ensure_finalized()
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\cmd.py", line 107, in ensure_finalized
    self.finalize_options()
  File "C:\tools\msys64\home\dyeaw\gaphor\win-installer\_build_root\gaphor\utils\model\build_uml.py", line 30, in finalize_options
    self.set_undefined_options(("force", "force"))
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\cmd.py", line 286, in set_undefined_options
    src_cmd_obj = self.distribution.get_command_obj(src_cmd)
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\dist.py", line 857, in get_command_obj
    klass = self.get_command_class(command)
  File "C:/tools/msys64/home/DYEAW/.local/lib/python3.7/site-packages\setuptools\dist.py", line 841, in get_command_class
    return _Distribution.get_command_class(self, command)
  File "C:/tools/msys64/home/dyeaw/gaphor/win-installer/_build_root/mingw64/lib/python3.7\distutils\dist.py", line 843, in get_command_class
    raise DistutilsModuleError("invalid command '%s'" % command)
TypeError: not all arguments converted during string formatting
```
Issue Number: N/A

### What is the new behavior?
No TypeError.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

### Other information
Commit 6e0b384 which allowed for running build_uml standalone introduced a TypeError that cropped up when building gaphor for Windows. I went back to the command_template that distutils ships to fix the bug and simplify things. I don't think that set_undefined_options is still required.