### PR TITLE
Retain toolbox expanded/collapsed groups

### DIFF
--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -100,8 +100,16 @@ class Toolbox(UIComponent, ActionProvider):
         toolbox = Gtk.ToolPalette.new()
         toolbox.connect("destroy", self._on_toolbox_destroyed)
 
-        for title, items in self._toolbox_actions:
+        collapsed = self.properties.get("toolbox-collapsed", {})
+
+        def on_collapsed(widget, prop, index):
+            collapsed[index] = widget.get_property("collapsed")
+            self.properties.set("toolbox-collapsed", collapsed)
+
+        for index, (title, items) in enumerate(self._toolbox_actions):
             tool_item_group = Gtk.ToolItemGroup.new(title)
+            tool_item_group.set_property("collapsed", collapsed.get(index, False))
+            tool_item_group.connect("notify::collapsed", on_collapsed, index)
             for action_name, label, stock_id, shortcut in items:
                 button = toolbox_button(action_name, stock_id, label, shortcut)
                 tool_item_group.insert(button, -1)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
All toolbox sections were expanded on start.

Issue Number: N/A

### What is the new behavior?

The toolbox state is persisted. So next time Gaphor is started, the toolbox sections are restored.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
