### PR TITLE
Fix AttributeError when win action group is None

### DIFF
--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -10,7 +10,6 @@ from gaphor.UML import Element
 from gaphor.UML.collection import collection
 from gaphor.core import _, event_handler, action, transactional
 from gaphor.abc import Service, ActionProvider
-from gaphor.ui.actiongroup import set_action_state
 from gaphor.ui.event import DiagramSelectionChange
 
 
@@ -21,13 +20,13 @@ class CopyService(Service, ActionProvider):
     Store a list of DiagramItems that have to be copied in a global
     'copy-buffer'.
 
-    - in order to make copy/paste work, the load/save functions should be
-      generatlised to allow a subset to be saved/loaded (which is needed
+    - In order to make copy/paste work, the load/save functions should be
+      generalized to allow a subset to be saved/loaded (which is needed
       anyway for exporting/importing stereotype Profiles).
-    - How many data should be saved? (e.g. we copy a diagram item, remove it
+    - How much data should be saved? e.g. we copy a diagram item, remove it
       (the underlying UML element is removed) and the paste the copied item.
       The diagram should act as if we have placed a copy of the removed item
-      on the canvas and make the uml element visible again.
+      on the canvas and make the UML element visible again.
     """
 
     def __init__(self, event_manager, element_factory, diagrams):
@@ -45,9 +44,11 @@ class CopyService(Service, ActionProvider):
     @event_handler(DiagramSelectionChange)
     def _update(self, event):
         diagram_view = event.diagram_view
-        diagram_view.get_action_group("win").lookup_action("edit-copy").set_enabled(
-            bool(diagram_view.selected_items)
-        )
+        win_action_group = diagram_view.get_action_group("win")
+        if win_action_group is not None:
+            win_action_group.lookup_action("edit-copy").set_enabled(
+                bool(diagram_view.selected_items)
+            )
 
     def copy(self, items):
         if items:
@@ -131,9 +132,11 @@ class CopyService(Service, ActionProvider):
             for i in items:
                 copy_items.append(i)
             self.copy(copy_items)
-            view.get_action_group("win").lookup_action("edit-paste").set_enabled(
-                bool(self.copy_buffer)
-            )
+            win_action_group = view.get_action_group("win")
+            if win_action_group is not None:
+                win_action_group.lookup_action("edit-paste").set_enabled(
+                    bool(self.copy_buffer)
+                )
 
     @action(
         name="edit-paste", label="_Paste", icon_name="edit-paste", shortcut="<Primary>v"

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -45,7 +45,7 @@ class CopyService(Service, ActionProvider):
     def _update(self, event):
         diagram_view = event.diagram_view
         win_action_group = diagram_view.get_action_group("win")
-        if win_action_group is not None:
+        if win_action_group:
             win_action_group.lookup_action("edit-copy").set_enabled(
                 bool(diagram_view.selected_items)
             )
@@ -133,7 +133,7 @@ class CopyService(Service, ActionProvider):
                 copy_items.append(i)
             self.copy(copy_items)
             win_action_group = view.get_action_group("win")
-            if win_action_group is not None:
+            if win_action_group:
                 win_action_group.lookup_action("edit-paste").set_enabled(
                     bool(self.copy_buffer)
                 )

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -23,10 +23,10 @@ class CopyService(Service, ActionProvider):
     - In order to make copy/paste work, the load/save functions should be
       generalized to allow a subset to be saved/loaded (which is needed
       anyway for exporting/importing stereotype Profiles).
-    - How much data should be saved? e.g. we copy a diagram item, remove it
-      (the underlying UML element is removed) and the paste the copied item.
-      The diagram should act as if we have placed a copy of the removed item
-      on the canvas and make the UML element visible again.
+    - How much data should be saved? An example use case is to copy a diagram
+      item, remove it (the underlying UML element is removed), and then paste
+      the copied item. The diagram should act as if we have placed a copy of
+      the removed item on the canvas and make the UML element visible again.
     """
 
     def __init__(self, event_manager, element_factory, diagrams):


### PR DESCRIPTION
This fixes two errors caused during creating a new element on a diagram where it tries to look up an action on the win action group that doesn't yet exist, and when copying an item caused by the same issue. This fix adds a guard to check if the win action group is None before looking
up the action.

I am not sure if there is a more elegant fix than adding a guard to check for the None type.

Signed-off-by: Dan Yeaw <dan@yeaw.me>

<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Create a block and then click on it:
```
Traceback (most recent call last):
  File "/home/dan/Projects/gaphor/gaphor/ui/diagrampage.py", line 308, in _on_view_selection_changed
    DiagramSelectionChange(view, view.focused_item, view.selected_items)
  File "/home/dan/Projects/gaphor/gaphor/services/eventmanager.py", line 60, in handle
    self._events.handle(e)
  File "/home/dan/Projects/gaphor/gaphor/misc/generic/event.py", line 62, in handle
    handler(event)
  File "/home/dan/Projects/gaphor/gaphor/services/copyservice.py", line 48, in _update
    diagram_view.get_action_group("win").lookup_action("edit-copy").set_enabled(
AttributeError: 'NoneType' object has no attribute 'lookup_action'
```

Issue Number: N/A

### What is the new behavior?
No attribute error.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
