### PR TITLE
Cleanup message item

### DIFF
--- a/gaphor/diagram/interactions/interactionspropertypages.py
+++ b/gaphor/diagram/interactions/interactionspropertypages.py
@@ -13,46 +13,6 @@ from gaphor.diagram.propertypages import (
 from gaphor.diagram.interactions import MessageItem
 
 
-class CommunicationMessageModel(EditableTreeModel):
-    """GTK tree model for list of messages on communication diagram."""
-
-    def __init__(self, item, cols=None, inverted=False):
-        self.inverted = inverted
-        super().__init__(item, cols)
-
-    def _get_rows(self):
-        if self.inverted:
-            for message in self._item._inverted_messages:
-                yield [message.name, message]
-        else:
-            for message in self._item._messages:
-                yield [message.name, message]
-
-    def remove(self, iter):
-        """Remove message from message item and destroy it."""
-
-        message = self._get_object(iter)
-        item = self._item
-        super().remove(iter)
-        item.remove_message(message, self.inverted)
-
-    def _create_object(self):
-        item = self._item
-        subject = item.subject
-        message = UML.model.clone_message(subject, self.inverted)
-        item.add_message(message, self.inverted)
-        return message
-
-    def _set_object_value(self, row, col, value):
-        message = row[-1]
-        message.name = value
-        row[0] = value
-        self._item.set_message_text(message, value, self.inverted)
-
-    def _swap_objects(self, o1, o2):
-        return self._item.swap_messages(o1, o2, self.inverted)
-
-
 @PropertyPages.register(MessageItem)
 class MessagePropertyPage(NamedItemPropertyPage):
     """Property page for editing message items.
@@ -81,21 +41,7 @@ class MessagePropertyPage(NamedItemPropertyPage):
         if not subject:
             return page
 
-        if item.is_communication():
-            self._messages = CommunicationMessageModel(item)
-            tree_view = create_tree_view(self._messages, (_("Message"),))
-            tree_view.set_headers_visible(False)
-            frame = Gtk.Frame.new(label=_("Additional Messages"))
-            frame.add(tree_view)
-            page.pack_start(frame, True, True, 0)
-
-            self._inverted_messages = CommunicationMessageModel(item, inverted=True)
-            tree_view = create_tree_view(self._inverted_messages, (_("Message"),))
-            tree_view.set_headers_visible(False)
-            frame = Gtk.Frame.new(label=_("Inverted Messages"))
-            frame.add(tree_view)
-            page.pack_end(frame, True, True, 0)
-        else:
+        if not item.is_communication():
             hbox = create_hbox_label(self, page, _("Message sort"))
 
             sort_data = self.MESSAGE_SORT

--- a/gaphor/diagram/interactions/message.py
+++ b/gaphor/diagram/interactions/message.py
@@ -74,23 +74,24 @@ class MessageItem(LinePresentation, Named):
     """
 
     def __init__(self, id=None, model=None):
-        super().__init__(id, model)
+        super().__init__(
+            id,
+            model,
+            shape_middle=Box(
+                Text(
+                    text=lambda: stereotypes_str(self.subject),
+                    style={"min-width": 0, "min-height": 0},
+                ),
+                EditableText(text=lambda: self.subject.name or ""),
+            ),
+        )
+
         self._is_communication = False
         self._arrow_pos = 0, 0
         self._arrow_angle = 0
 
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
-
-    def update_shapes(self):
-        self.shape_middle = Box(
-            Text(
-                text=lambda: stereotypes_str(self.subject),
-                style={"min-width": 0, "min-height": 0},
-            ),
-            EditableText(text=lambda: self.subject.name or ""),
-        )
-        self.request_update()
 
     def pre_update(self, context):
         """

--- a/gaphor/diagram/interactions/message.py
+++ b/gaphor/diagram/interactions/message.py
@@ -121,14 +121,6 @@ class MessageItem(LinePresentation, Named):
         angle = atan2(p1.y - p0.y, p1.x - p0.x)
         return pos, angle
 
-    def load(self, name, value):
-        if name == "message":
-            pass
-        elif name == "inverted":
-            pass
-        else:
-            super().load(name, value)
-
     def _draw_circle(self, cr):
         """
         Draw circle for lost/found messages.

--- a/gaphor/diagram/interactions/messageconnect.py
+++ b/gaphor/diagram/interactions/messageconnect.py
@@ -69,13 +69,6 @@ class MessageLifelineConnect(AbstractConnect):
             del line.subject
             if not message.presentation:
                 message.unlink()
-            for message in list(line._messages):
-                line.remove_message(message, False)
-                message.unlink()
-
-            for message in list(line._inverted_messages):
-                line.remove_message(message, True)
-                message.unlink()
 
     def allow(self, handle, port):
         """

--- a/gaphor/diagram/interactions/tests/test_message.py
+++ b/gaphor/diagram/interactions/tests/test_message.py
@@ -8,96 +8,15 @@ from gaphor.tests.testcase import TestCase
 
 
 class MessageTestCase(TestCase):
-    def test_adding_message(self):
-        factory = self.element_factory
-        item = self.create(MessageItem, UML.Message)
-
-        message = factory.create(UML.Message)
-        message.name = "test-message"
-
-        item.add_message(message, False)
-        assert message in item._messages
-        assert message not in item._inverted_messages
-        assert item.shape_middle.children[2].text() == "test-message"
-
-    def test_adding_inverted_message(self):
-        factory = self.element_factory
-        item = self.create(MessageItem, UML.Message)
-
-        message = factory.create(UML.Message)
-        message.name = "test-inverted-message"
-
-        item.add_message(message, True)
-        assert message in item._inverted_messages
-        assert message not in item._messages
-        assert item.shape_middle.children[2].text() == "test-inverted-message"
-
-    def test_message_removal(self):
-        factory = self.element_factory
-        item = self.create(MessageItem, UML.Message)
-
-        message = factory.create(UML.Message)
-        item.add_message(message, False)
-        assert message in item._messages
-
-        item.remove_message(message, False)
-        assert message not in item._messages
-
-    def test_inverted_message_removal(self):
-        factory = self.element_factory
-        item = self.create(MessageItem, UML.Message)
-
-        message = factory.create(UML.Message)
-        item.add_message(message, True)
-        assert message in item._inverted_messages
-
-        item.remove_message(message, True)
-        assert message not in item._inverted_messages
-
-    def test_messages_swapping(self):
-        """Test messages swapping
-        """
-        factory = self.element_factory
-        item = self.create(MessageItem, UML.Message)
-
-        m1 = factory.create(UML.Message)
-        m2 = factory.create(UML.Message)
-        item.add_message(m1, False)
-        item.add_message(m2, False)
-        item.swap_messages(m1, m2, False)
-
-        m1 = factory.create(UML.Message)
-        m2 = factory.create(UML.Message)
-        item.add_message(m1, True)
-        item.add_message(m2, True)
-        item.swap_messages(m1, m2, True)
-
     def test_message_persistence(self):
         """Test message saving/loading
         """
         factory = self.element_factory
         item = self.create(MessageItem, UML.Message)
 
-        m1 = factory.create(UML.Message)
-        m2 = factory.create(UML.Message)
-        m3 = factory.create(UML.Message)
-        m4 = factory.create(UML.Message)
-        m1.name = "m1"
-        m2.name = "m2"
-        m3.name = "m3"
-        m4.name = "m4"
-
-        item.add_message(m1, False)
-        item.add_message(m2, False)
-        item.add_message(m3, True)
-        item.add_message(m4, True)
-
         data = self.save()
         self.load(data)
 
         item = self.diagram.canvas.select(lambda e: isinstance(e, MessageItem))[0]
-        assert len(item._messages) == 2
-        assert len(item._inverted_messages) == 2
-        # check for loaded messages and order of messages
-        self.assertEqual(["m1", "m2"], [m.name for m in item._messages])
-        assert ["m3", "m4"] == [m.name for m in item._inverted_messages]
+
+        assert item

--- a/gaphor/diagram/interactions/tests/test_messageconnect.py
+++ b/gaphor/diagram/interactions/tests/test_messageconnect.py
@@ -234,38 +234,9 @@ class DiagramModeMessageConnectionTestCase(TestCase):
 
         assert subject.sendEvent and subject.receiveEvent
 
-        # add some more messages
-        m1 = UML.model.clone_message(subject)
-        m2 = UML.model.clone_message(subject)
-        msg.add_message(m1, False)
-        msg.add_message(m2, False)
-
-        # add some inverted messages
-        m3 = UML.model.clone_message(subject, True)
-        m4 = UML.model.clone_message(subject, True)
-        msg.add_message(m3, True)
-        msg.add_message(m4, True)
-
         messages = list(self.kindof(UML.Message))
         occurrences = set(self.kindof(UML.MessageOccurrenceSpecification))
 
         # verify integrity of messages
-        self.assertEqual(5, len(messages))
-        assert 10 == len(occurrences)
-        for m in messages:
-            assert m.sendEvent in occurrences
-            assert m.receiveEvent in occurrences
-
-        # lost/received messages
-        self.disconnect(msg, msg.head)
-        assert 5 == len(messages)
-
-        # verify integrity of messages
-        self.assertEqual(10, len(occurrences))
-        for m in messages:
-            assert m.sendEvent is None or m.sendEvent in occurrences
-            assert m.receiveEvent is None or m.receiveEvent in occurrences
-
-        # no message after full disconnection
-        self.disconnect(msg, msg.tail)
-        assert 0 == len(self.kindof(UML.Message))
+        self.assertEqual(1, len(messages))
+        assert 2 == len(occurrences)

--- a/gaphor/storage/parser.py
+++ b/gaphor/storage/parser.py
@@ -30,13 +30,16 @@ The generator parse_generator(filename, loader) may be used if the loading
 takes a long time. The yielded values are the percentage of the file read.
 """
 
-__all__ = ["parse", "ParserException"]
+from __future__ import annotations
 
-from typing import Dict, List, Union, Tuple, IO
+from typing import Dict, List, Optional, Union, Tuple, IO
 import os
 import io
 from xml.sax import handler
 from collections import OrderedDict
+
+
+__all__ = ["parse", "ParserException"]
 
 
 class base:
@@ -45,7 +48,7 @@ class base:
 
     def __init__(self):
         self.values: Dict[str, str] = {}
-        self.references: Dict[str, str] = {}
+        self.references: Dict[str, Union[str, List[str]]] = {}
 
     def __getattr__(self, key):
         try:
@@ -67,7 +70,7 @@ class base:
 
 
 class element(base):
-    def __init__(self, id, type, canvas=None):
+    def __init__(self, id: str, type: str, canvas: Optional[canvas] = None):
         base.__init__(self)
         self.id = id
         self.type = type
@@ -76,17 +79,19 @@ class element(base):
 
 
 class canvas(base):
-    def __init__(self, canvasitems=None):
+    def __init__(self, canvasitems: Optional[List[canvasitem]] = None):
         base.__init__(self)
-        self.canvasitems = canvasitems or []
+        self.canvasitems: List[canvasitem] = canvasitems or []
 
 
 class canvasitem(base):
-    def __init__(self, id, type, canvasitems=None):
+    def __init__(
+        self, id: str, type: str, canvasitems: Optional[List[canvasitem]] = None
+    ):
         base.__init__(self)
         self.id = id
         self.type = type
-        self.canvasitems = canvasitems or []
+        self.canvasitems: List[canvasitem] = canvasitems or []
 
 
 XMLNS = "http://gaphor.sourceforge.net/model"

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -219,6 +219,7 @@ def load_elements_generator(elements, factory, gaphor_version):
             # log.debug('Creating UML element for %s (%s)' % (elem, elem.id))
             elem.element = factory.create_as(cls, id)
             if isinstance(elem.element, UML.Diagram):
+                assert elem.canvas
                 elem.element.canvas.block_updates = True
                 create_canvasitems(elem.element, elem.canvas.canvasitems)
         elif not isinstance(elem, parser.canvasitem):

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -196,6 +196,12 @@ def load_elements_generator(elements, factory, gaphor_version):
         """
         Canvas is a read gaphas.Canvas, items is a list of parser.canvasitem's
         """
+        if version_lower_than(gaphor_version, (1, 1, 0)):
+            new_canvasitems = upgrade_message_item_to_1_1_0(canvasitems)
+            canvasitems.extend(new_canvasitems)
+            for item in new_canvasitems:
+                elements[item.id] = item
+
         for item in canvasitems:
             item = upgrade_canvas_item_to_1_0_2(item)
             if version_lower_than(gaphor_version, (1, 1, 0)):
@@ -410,3 +416,46 @@ def upgrade_presentation_item_to_1_1_0(item):
         del item.values["show-operations"]
 
     return item
+
+
+import uuid
+
+
+def clone_canvasitem(item, subject_id):
+    assert not item.canvasitems, "Can not clone a canvas item with children"
+    assert isinstance(item.references["subject"], str)
+    new_item = parser.canvasitem(str(uuid.uuid1()), item.type)
+    new_item.values = dict(item.values)
+    new_item.references = dict(item.references)
+    new_item.references["subject"] = subject_id
+    return new_item
+
+
+def upgrade_message_item_to_1_1_0(canvasitems):
+    """
+    Create new MessageItem's for each `message` and `inverted` message.
+    """
+    new_canvasitems = []
+    for item in canvasitems:
+        # new_canvasitems.append(item)
+        if item.type == "MessageItem" and item.references.get("subject"):
+            messages = item.references.get("message", [])
+            inverted = item.references.get("inverted", [])
+            if messages:
+                del item.references["message"]
+            if inverted:
+                del item.references["inverted"]
+            for m_id in messages:
+                new_item = clone_canvasitem(item, m_id)
+                new_canvasitems.append(new_item)
+            for m_id in inverted:
+                new_item = clone_canvasitem(item, m_id)
+                new_canvasitems.append(new_item)
+                # todo: invert handles, points will follow on connect
+                new_item.references["head-connection"], new_item.references[
+                    "tail-connection"
+                ] = (
+                    new_item.references["tail-connection"],
+                    new_item.references["head-connection"],
+                )
+    return new_canvasitems

--- a/gaphor/storage/tests/test_storage_message_item_upgrade.py
+++ b/gaphor/storage/tests/test_storage_message_item_upgrade.py
@@ -1,0 +1,44 @@
+import pytest
+import importlib_metadata
+
+from gaphor import UML
+from gaphor.application import Application
+from gaphor.storage.storage import load_elements
+from gaphor.storage.parser import parse
+from gaphor.storage import diagramitems
+
+
+@pytest.fixture
+def application():
+    Application.init(
+        services=["event_manager", "component_registry", "element_factory"]
+    )
+    yield Application
+    Application.shutdown()
+
+
+@pytest.fixture
+def element_factory(application):
+    return application.get_service("element_factory")
+
+
+def test_message_item_upgrade(element_factory):
+    """
+    """
+    dist = importlib_metadata.distribution("gaphor")
+    path = dist.locate_file("test-diagrams/multiple-messages.gaphor")
+
+    elements = parse(path)
+    load_elements(elements, element_factory)
+
+    diagram = element_factory.lselect(lambda e: e.isKindOf(UML.Diagram))[0]
+    items = diagram.canvas.get_root_items()
+    message_items = [i for i in items if isinstance(i, diagramitems.MessageItem)]
+    subjects = [m.subject for m in message_items]
+    messages = element_factory.lselect(lambda e: e.isKindOf(UML.Message))
+    presentations = [m.presentation for m in messages]
+
+    assert len(messages) == 6
+    assert all(subjects), subjects
+    assert len(message_items) == 6
+    assert all(presentations), presentations

--- a/gaphor/storage/tests/test_storage_message_item_upgrade.py
+++ b/gaphor/storage/tests/test_storage_message_item_upgrade.py
@@ -38,7 +38,7 @@ def test_message_item_upgrade(element_factory):
     messages = element_factory.lselect(lambda e: e.isKindOf(UML.Message))
     presentations = [m.presentation for m in messages]
 
-    assert len(messages) == 6
+    assert len(messages) == 10
     assert all(subjects), subjects
-    assert len(message_items) == 6
+    assert len(message_items) == 10
     assert all(presentations), presentations

--- a/gaphor/storage/tests/test_storage_upgrades.py
+++ b/gaphor/storage/tests/test_storage_upgrades.py
@@ -16,7 +16,7 @@ def loader(element_factory):
     def _loader(*parsed_items):
         parsed_data = {
             "1": element(
-                id="1", type="Diagram", canvas=canvas(canvasitems=parsed_items)
+                id="1", type="Diagram", canvas=canvas(canvasitems=list(parsed_items))
             ),
             **{p.id: p for p in parsed_items},
         }

--- a/test-diagrams/multiple-messages.gaphor
+++ b/test-diagrams/multiple-messages.gaphor
@@ -31,6 +31,9 @@
 <subject>
 <ref refid="e01b214d-ec69-11e9-be00-1b1265088194"/>
 </subject>
+<show_stereotypes_attrs>
+<val>0</val>
+</show_stereotypes_attrs>
 <lifetime-length>
 <val>49.685760498046875</val>
 </lifetime-length>
@@ -48,6 +51,9 @@
 <subject>
 <ref refid="e335b90b-ec69-11e9-be00-1b1265088194"/>
 </subject>
+<show_stereotypes_attrs>
+<val>0</val>
+</show_stereotypes_attrs>
 <lifetime-length>
 <val>59.7630615234375</val>
 </lifetime-length>
@@ -65,6 +71,9 @@
 <subject>
 <ref refid="e52ffb09-ec69-11e9-be00-1b1265088194"/>
 </subject>
+<show_stereotypes_attrs>
+<val>0</val>
+</show_stereotypes_attrs>
 <lifetime-length>
 <val>10.0</val>
 </lifetime-length>
@@ -82,6 +91,9 @@
 <subject>
 <ref refid="e663b9cf-ec69-11e9-be00-1b1265088194"/>
 </subject>
+<show_stereotypes_attrs>
+<val>0</val>
+</show_stereotypes_attrs>
 <lifetime-length>
 <val>10.0</val>
 </lifetime-length>
@@ -102,6 +114,9 @@
 <subject>
 <ref refid="f1cb0151-ec69-11e9-be00-1b1265088194"/>
 </subject>
+<show_stereotypes_attrs>
+<val>0</val>
+</show_stereotypes_attrs>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 278.8021545410156, 321.7596130371094)</val>
 </matrix>
@@ -125,6 +140,9 @@
 <subject>
 <ref refid="fa0fd503-ec69-11e9-be00-1b1265088194"/>
 </subject>
+<show_stereotypes_attrs>
+<val>0</val>
+</show_stereotypes_attrs>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 228.80215454101562, 222.56558227539062)</val>
 </matrix>
@@ -144,12 +162,105 @@
 <ref refid="e335b90c-ec69-11e9-be00-1b1265088194"/>
 </tail-connection>
 </item>
+<item id="c0650cd6-ece7-11e9-8bcd-ad626bcefd97" type="MessageItem">
+<subject>
+<ref refid="c2044e3a-ece7-11e9-8bcd-ad626bcefd97"/>
+</subject>
+<show_stereotypes_attrs>
+<val>0</val>
+</show_stereotypes_attrs>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 68.88897705078125, 316.7999267578125)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(0.0, 0.0), (109.91317749023438, -0.81158447265625)]</val>
+</points>
+<tail-connection>
+<ref refid="e52ffb0a-ec69-11e9-be00-1b1265088194"/>
+</tail-connection>
+</item>
+<item id="e43729e6-ece7-11e9-8bcd-ad626bcefd97" type="MessageItem">
+<subject>
+<ref refid="e4397264-ece7-11e9-8bcd-ad626bcefd97"/>
+</subject>
+<show_stereotypes_attrs>
+<val>0</val>
+</show_stereotypes_attrs>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 541.5436401367188, 320.08209228515625)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(0.0, 0.0), (113.11761474609375, 0.63360595703125)]</val>
+</points>
+<head-connection>
+<ref refid="e663b9d0-ec69-11e9-be00-1b1265088194"/>
+</head-connection>
+</item>
+<item id="ed8fe672-ece7-11e9-8bcd-ad626bcefd97" type="MessageItem">
+<subject>
+<ref refid="ee7b817c-ece7-11e9-8bcd-ad626bcefd97"/>
+</subject>
+<show_stereotypes_attrs>
+<val>0</val>
+</show_stereotypes_attrs>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 85.27548217773438, 220.683837890625)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(0.0, 0.0), (143.52667236328125, 0.720123291015625)]</val>
+</points>
+<tail-connection>
+<ref refid="e01b214e-ec69-11e9-be00-1b1265088194"/>
+</tail-connection>
+</item>
+<item id="ffc699e4-ece7-11e9-8bcd-ad626bcefd97" type="MessageItem">
+<subject>
+<ref refid="ffc937ee-ece7-11e9-8bcd-ad626bcefd97"/>
+</subject>
+<show_stereotypes_attrs>
+<val>0</val>
+</show_stereotypes_attrs>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 491.54364013671875, 235.90802001953125)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(0.0, 0.0), (150.16015625, 0.407928466796875)]</val>
+</points>
+<head-connection>
+<ref refid="e335b90c-ec69-11e9-be00-1b1265088194"/>
+</head-connection>
+</item>
 </canvas>
 </Diagram>
 <Lifeline id="e01b214d-ec69-11e9-be00-1b1265088194">
 <coveredBy>
 <reflist>
 <ref refid="fa0fd504-ec69-11e9-be00-1b1265088194"/>
+<ref refid="ee7e32b4-ece7-11e9-8bcd-ad626bcefd97"/>
 </reflist>
 </coveredBy>
 <name>
@@ -165,6 +276,7 @@
 <coveredBy>
 <reflist>
 <ref refid="fbb16056-ec69-11e9-be00-1b1265088194"/>
+<ref refid="ffcb0ee8-ece7-11e9-8bcd-ad626bcefd97"/>
 </reflist>
 </coveredBy>
 <name>
@@ -184,6 +296,7 @@
 <ref refid="0abcd18f-ec6a-11e9-be00-1b1265088194"/>
 <ref refid="0d3d46f1-ec6a-11e9-be00-1b1265088194"/>
 <ref refid="143b116d-ec6a-11e9-be00-1b1265088194"/>
+<ref refid="c206f57c-ece7-11e9-8bcd-ad626bcefd97"/>
 </reflist>
 </coveredBy>
 <name>
@@ -203,6 +316,7 @@
 <ref refid="0abcd190-ec6a-11e9-be00-1b1265088194"/>
 <ref refid="0d3d46f2-ec6a-11e9-be00-1b1265088194"/>
 <ref refid="143b116e-ec6a-11e9-be00-1b1265088194"/>
+<ref refid="e43b28b6-ece7-11e9-8bcd-ad626bcefd97"/>
 </reflist>
 </coveredBy>
 <name>
@@ -248,7 +362,7 @@
 </MessageOccurrenceSpecification>
 <Message id="fa0fd503-ec69-11e9-be00-1b1265088194">
 <name>
-<val>call()</val>
+<val>lifeline-call()</val>
 </name>
 <presentation>
 <reflist>
@@ -384,6 +498,90 @@
 </covered>
 <sendMessage>
 <ref refid="143b116c-ec6a-11e9-be00-1b1265088194"/>
+</sendMessage>
+</MessageOccurrenceSpecification>
+<Message id="c2044e3a-ece7-11e9-8bcd-ad626bcefd97">
+<name>
+<val>incoming()</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="c0650cd6-ece7-11e9-8bcd-ad626bcefd97"/>
+</reflist>
+</presentation>
+<receiveEvent>
+<ref refid="c206f57c-ece7-11e9-8bcd-ad626bcefd97"/>
+</receiveEvent>
+</Message>
+<MessageOccurrenceSpecification id="c206f57c-ece7-11e9-8bcd-ad626bcefd97">
+<covered>
+<ref refid="e52ffb09-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<receiveMessage>
+<ref refid="c2044e3a-ece7-11e9-8bcd-ad626bcefd97"/>
+</receiveMessage>
+</MessageOccurrenceSpecification>
+<Message id="e4397264-ece7-11e9-8bcd-ad626bcefd97">
+<name>
+<val>outgoing()</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="e43729e6-ece7-11e9-8bcd-ad626bcefd97"/>
+</reflist>
+</presentation>
+<sendEvent>
+<ref refid="e43b28b6-ece7-11e9-8bcd-ad626bcefd97"/>
+</sendEvent>
+</Message>
+<MessageOccurrenceSpecification id="e43b28b6-ece7-11e9-8bcd-ad626bcefd97">
+<covered>
+<ref refid="e663b9cf-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<sendMessage>
+<ref refid="e4397264-ece7-11e9-8bcd-ad626bcefd97"/>
+</sendMessage>
+</MessageOccurrenceSpecification>
+<Message id="ee7b817c-ece7-11e9-8bcd-ad626bcefd97">
+<name>
+<val>lifeline-in()</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="ed8fe672-ece7-11e9-8bcd-ad626bcefd97"/>
+</reflist>
+</presentation>
+<receiveEvent>
+<ref refid="ee7e32b4-ece7-11e9-8bcd-ad626bcefd97"/>
+</receiveEvent>
+</Message>
+<MessageOccurrenceSpecification id="ee7e32b4-ece7-11e9-8bcd-ad626bcefd97">
+<covered>
+<ref refid="e01b214d-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<receiveMessage>
+<ref refid="ee7b817c-ece7-11e9-8bcd-ad626bcefd97"/>
+</receiveMessage>
+</MessageOccurrenceSpecification>
+<Message id="ffc937ee-ece7-11e9-8bcd-ad626bcefd97">
+<name>
+<val>lifeline-out()</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="ffc699e4-ece7-11e9-8bcd-ad626bcefd97"/>
+</reflist>
+</presentation>
+<sendEvent>
+<ref refid="ffcb0ee8-ece7-11e9-8bcd-ad626bcefd97"/>
+</sendEvent>
+</Message>
+<MessageOccurrenceSpecification id="ffcb0ee8-ece7-11e9-8bcd-ad626bcefd97">
+<covered>
+<ref refid="e335b90b-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<sendMessage>
+<ref refid="ffc937ee-ece7-11e9-8bcd-ad626bcefd97"/>
 </sendMessage>
 </MessageOccurrenceSpecification>
 </gaphor>

--- a/test-diagrams/multiple-messages.gaphor
+++ b/test-diagrams/multiple-messages.gaphor
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="1.0.2">
+<Package id="dbb77d4e-ec69-11e9-be00-1b1265088194">
+<name>
+<val>New model</val>
+</name>
+<ownedDiagram>
+<reflist>
+<ref refid="dbb77d4f-ec69-11e9-be00-1b1265088194"/>
+</reflist>
+</ownedDiagram>
+</Package>
+<Diagram id="dbb77d4f-ec69-11e9-be00-1b1265088194">
+<name>
+<val>main</val>
+</name>
+<package>
+<ref refid="dbb77d4e-ec69-11e9-be00-1b1265088194"/>
+</package>
+<canvas>
+<item id="e01b214e-ec69-11e9-be00-1b1265088194" type="LifelineItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 178.80215454101562, 140.40814208984375)</val>
+</matrix>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>50.0</val>
+</height>
+<subject>
+<ref refid="e01b214d-ec69-11e9-be00-1b1265088194"/>
+</subject>
+<lifetime-length>
+<val>49.685760498046875</val>
+</lifetime-length>
+</item>
+<item id="e335b90c-ec69-11e9-be00-1b1265088194" type="LifelineItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 441.54364013671875, 140.40814208984375)</val>
+</matrix>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>50.0</val>
+</height>
+<subject>
+<ref refid="e335b90b-ec69-11e9-be00-1b1265088194"/>
+</subject>
+<lifetime-length>
+<val>59.7630615234375</val>
+</lifetime-length>
+</item>
+<item id="e52ffb0a-ec69-11e9-be00-1b1265088194" type="LifelineItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 178.80215454101562, 291.7999267578125)</val>
+</matrix>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>50.0</val>
+</height>
+<subject>
+<ref refid="e52ffb09-ec69-11e9-be00-1b1265088194"/>
+</subject>
+<lifetime-length>
+<val>10.0</val>
+</lifetime-length>
+</item>
+<item id="e663b9d0-ec69-11e9-be00-1b1265088194" type="LifelineItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 441.54364013671875, 291.7999267578125)</val>
+</matrix>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>50.0</val>
+</height>
+<subject>
+<ref refid="e663b9cf-ec69-11e9-be00-1b1265088194"/>
+</subject>
+<lifetime-length>
+<val>10.0</val>
+</lifetime-length>
+</item>
+<item id="f1cb0150-ec69-11e9-be00-1b1265088194" type="MessageItem">
+<message>
+<reflist>
+<ref refid="0836ec92-ec6a-11e9-be00-1b1265088194"/>
+<ref refid="0abcd18e-ec6a-11e9-be00-1b1265088194"/>
+</reflist>
+</message>
+<inverted>
+<reflist>
+<ref refid="0d3d46f0-ec6a-11e9-be00-1b1265088194"/>
+<ref refid="143b116c-ec6a-11e9-be00-1b1265088194"/>
+</reflist>
+</inverted>
+<subject>
+<ref refid="f1cb0151-ec69-11e9-be00-1b1265088194"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 278.8021545410156, 321.7596130371094)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(0.0, 0.0), (162.74148559570312, -3.962158203125)]</val>
+</points>
+<head-connection>
+<ref refid="e52ffb0a-ec69-11e9-be00-1b1265088194"/>
+</head-connection>
+<tail-connection>
+<ref refid="e663b9d0-ec69-11e9-be00-1b1265088194"/>
+</tail-connection>
+</item>
+<item id="fa0fd502-ec69-11e9-be00-1b1265088194" type="MessageItem">
+<subject>
+<ref refid="fa0fd503-ec69-11e9-be00-1b1265088194"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 228.80215454101562, 222.56558227539062)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(0.0, 0.0), (262.7414855957031, -0.126068115234375)]</val>
+</points>
+<head-connection>
+<ref refid="e01b214e-ec69-11e9-be00-1b1265088194"/>
+</head-connection>
+<tail-connection>
+<ref refid="e335b90c-ec69-11e9-be00-1b1265088194"/>
+</tail-connection>
+</item>
+</canvas>
+</Diagram>
+<Lifeline id="e01b214d-ec69-11e9-be00-1b1265088194">
+<coveredBy>
+<reflist>
+<ref refid="fa0fd504-ec69-11e9-be00-1b1265088194"/>
+</reflist>
+</coveredBy>
+<name>
+<val>NewLifeline</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="e01b214e-ec69-11e9-be00-1b1265088194"/>
+</reflist>
+</presentation>
+</Lifeline>
+<Lifeline id="e335b90b-ec69-11e9-be00-1b1265088194">
+<coveredBy>
+<reflist>
+<ref refid="fbb16056-ec69-11e9-be00-1b1265088194"/>
+</reflist>
+</coveredBy>
+<name>
+<val>NewLifeline</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="e335b90c-ec69-11e9-be00-1b1265088194"/>
+</reflist>
+</presentation>
+</Lifeline>
+<Lifeline id="e52ffb09-ec69-11e9-be00-1b1265088194">
+<coveredBy>
+<reflist>
+<ref refid="f1cb0152-ec69-11e9-be00-1b1265088194"/>
+<ref refid="0836ec93-ec6a-11e9-be00-1b1265088194"/>
+<ref refid="0abcd18f-ec6a-11e9-be00-1b1265088194"/>
+<ref refid="0d3d46f1-ec6a-11e9-be00-1b1265088194"/>
+<ref refid="143b116d-ec6a-11e9-be00-1b1265088194"/>
+</reflist>
+</coveredBy>
+<name>
+<val>NewLifeline</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="e52ffb0a-ec69-11e9-be00-1b1265088194"/>
+</reflist>
+</presentation>
+</Lifeline>
+<Lifeline id="e663b9cf-ec69-11e9-be00-1b1265088194">
+<coveredBy>
+<reflist>
+<ref refid="f3005fd4-ec69-11e9-be00-1b1265088194"/>
+<ref refid="0836ec94-ec6a-11e9-be00-1b1265088194"/>
+<ref refid="0abcd190-ec6a-11e9-be00-1b1265088194"/>
+<ref refid="0d3d46f2-ec6a-11e9-be00-1b1265088194"/>
+<ref refid="143b116e-ec6a-11e9-be00-1b1265088194"/>
+</reflist>
+</coveredBy>
+<name>
+<val>NewLifeline</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="e663b9d0-ec69-11e9-be00-1b1265088194"/>
+</reflist>
+</presentation>
+</Lifeline>
+<Message id="f1cb0151-ec69-11e9-be00-1b1265088194">
+<name>
+<val>call()</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="f1cb0150-ec69-11e9-be00-1b1265088194"/>
+</reflist>
+</presentation>
+<receiveEvent>
+<ref refid="f3005fd4-ec69-11e9-be00-1b1265088194"/>
+</receiveEvent>
+<sendEvent>
+<ref refid="f1cb0152-ec69-11e9-be00-1b1265088194"/>
+</sendEvent>
+</Message>
+<MessageOccurrenceSpecification id="f1cb0152-ec69-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e52ffb09-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<sendMessage>
+<ref refid="f1cb0151-ec69-11e9-be00-1b1265088194"/>
+</sendMessage>
+</MessageOccurrenceSpecification>
+<MessageOccurrenceSpecification id="f3005fd4-ec69-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e663b9cf-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<receiveMessage>
+<ref refid="f1cb0151-ec69-11e9-be00-1b1265088194"/>
+</receiveMessage>
+</MessageOccurrenceSpecification>
+<Message id="fa0fd503-ec69-11e9-be00-1b1265088194">
+<name>
+<val>call()</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="fa0fd502-ec69-11e9-be00-1b1265088194"/>
+</reflist>
+</presentation>
+<receiveEvent>
+<ref refid="fbb16056-ec69-11e9-be00-1b1265088194"/>
+</receiveEvent>
+<sendEvent>
+<ref refid="fa0fd504-ec69-11e9-be00-1b1265088194"/>
+</sendEvent>
+</Message>
+<MessageOccurrenceSpecification id="fa0fd504-ec69-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e01b214d-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<sendMessage>
+<ref refid="fa0fd503-ec69-11e9-be00-1b1265088194"/>
+</sendMessage>
+</MessageOccurrenceSpecification>
+<MessageOccurrenceSpecification id="fbb16056-ec69-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e335b90b-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<receiveMessage>
+<ref refid="fa0fd503-ec69-11e9-be00-1b1265088194"/>
+</receiveMessage>
+</MessageOccurrenceSpecification>
+<Message id="0836ec92-ec6a-11e9-be00-1b1265088194">
+<name>
+<val>msg1</val>
+</name>
+<receiveEvent>
+<ref refid="0836ec94-ec6a-11e9-be00-1b1265088194"/>
+</receiveEvent>
+<sendEvent>
+<ref refid="0836ec93-ec6a-11e9-be00-1b1265088194"/>
+</sendEvent>
+</Message>
+<MessageOccurrenceSpecification id="0836ec93-ec6a-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e52ffb09-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<sendMessage>
+<ref refid="0836ec92-ec6a-11e9-be00-1b1265088194"/>
+</sendMessage>
+</MessageOccurrenceSpecification>
+<MessageOccurrenceSpecification id="0836ec94-ec6a-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e663b9cf-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<receiveMessage>
+<ref refid="0836ec92-ec6a-11e9-be00-1b1265088194"/>
+</receiveMessage>
+</MessageOccurrenceSpecification>
+<Message id="0abcd18e-ec6a-11e9-be00-1b1265088194">
+<name>
+<val>msg2</val>
+</name>
+<receiveEvent>
+<ref refid="0abcd190-ec6a-11e9-be00-1b1265088194"/>
+</receiveEvent>
+<sendEvent>
+<ref refid="0abcd18f-ec6a-11e9-be00-1b1265088194"/>
+</sendEvent>
+</Message>
+<MessageOccurrenceSpecification id="0abcd18f-ec6a-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e52ffb09-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<sendMessage>
+<ref refid="0abcd18e-ec6a-11e9-be00-1b1265088194"/>
+</sendMessage>
+</MessageOccurrenceSpecification>
+<MessageOccurrenceSpecification id="0abcd190-ec6a-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e663b9cf-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<receiveMessage>
+<ref refid="0abcd18e-ec6a-11e9-be00-1b1265088194"/>
+</receiveMessage>
+</MessageOccurrenceSpecification>
+<Message id="0d3d46f0-ec6a-11e9-be00-1b1265088194">
+<name>
+<val>inv1</val>
+</name>
+<receiveEvent>
+<ref refid="0d3d46f1-ec6a-11e9-be00-1b1265088194"/>
+</receiveEvent>
+<sendEvent>
+<ref refid="0d3d46f2-ec6a-11e9-be00-1b1265088194"/>
+</sendEvent>
+</Message>
+<MessageOccurrenceSpecification id="0d3d46f1-ec6a-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e52ffb09-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<receiveMessage>
+<ref refid="0d3d46f0-ec6a-11e9-be00-1b1265088194"/>
+</receiveMessage>
+</MessageOccurrenceSpecification>
+<MessageOccurrenceSpecification id="0d3d46f2-ec6a-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e663b9cf-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<sendMessage>
+<ref refid="0d3d46f0-ec6a-11e9-be00-1b1265088194"/>
+</sendMessage>
+</MessageOccurrenceSpecification>
+<Message id="143b116c-ec6a-11e9-be00-1b1265088194">
+<name>
+<val>inv2</val>
+</name>
+<receiveEvent>
+<ref refid="143b116d-ec6a-11e9-be00-1b1265088194"/>
+</receiveEvent>
+<sendEvent>
+<ref refid="143b116e-ec6a-11e9-be00-1b1265088194"/>
+</sendEvent>
+</Message>
+<MessageOccurrenceSpecification id="143b116d-ec6a-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e52ffb09-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<receiveMessage>
+<ref refid="143b116c-ec6a-11e9-be00-1b1265088194"/>
+</receiveMessage>
+</MessageOccurrenceSpecification>
+<MessageOccurrenceSpecification id="143b116e-ec6a-11e9-be00-1b1265088194">
+<covered>
+<ref refid="e663b9cf-ec69-11e9-be00-1b1265088194"/>
+</covered>
+<sendMessage>
+<ref refid="143b116c-ec6a-11e9-be00-1b1265088194"/>
+</sendMessage>
+</MessageOccurrenceSpecification>
+</gaphor>


### PR DESCRIPTION
MessageItem was a weird one. Where each item (or part of it) references a model element (via `Presentation.subject` and the model element references the presentation item (via `Element.subject`), this was no the case for messages.

With the new drawing model it became clear that it's quite hard to draw a decent message with text. The solution is to make the MessageItem a *lot* simpler.


### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

It was possible to have multiple messages connected to a single MessageItem.

As a result, actions that concern the Message, had to be executed on a MessageItem class.

Issue Number: #195

### What is the new behavior?

The message has become simpler. Only a single message can be presented by one MessageItem.

A migration is made that creates multiple message items. One for each (additional) message previously linked to the message item.

### Does this PR introduce a breaking change?

Technically: no, functionally: yes.

### Other information
