### PR TITLE
Interface folding

### DIFF
--- a/gaphor/diagram/classes/classconnect.py
+++ b/gaphor/diagram/classes/classconnect.py
@@ -30,10 +30,10 @@ class DependencyConnect(RelationshipConnect):
     def reconnect(self, handle, port):
         line = self.line
         dep = line.subject
-        if handle is line.head:
+        if dep and handle is line.head:
             for s in dep.supplier:
                 del dep.supplier[s]
-        elif handle is line.tail:
+        elif dep and handle is line.tail:
             for c in dep.client:
                 del dep.client[c]
         self.reconnect_relationship(

--- a/gaphor/diagram/classes/classespropertypages.py
+++ b/gaphor/diagram/classes/classespropertypages.py
@@ -21,7 +21,7 @@ from gaphor.diagram.classes import (
     ImplementationItem,
     Folded,
 )
-
+from gaphor.diagram.components.connector import ConnectorItem
 
 log = logging.getLogger(__name__)
 
@@ -144,16 +144,12 @@ class InterfacePropertyPage(NamedItemPropertyPage):
         hbox.pack_start(label, False, True, 0)
 
         button = Gtk.CheckButton(_("Folded"))
-        button.set_active(item.folded)
+        button.set_active(item.folded != Folded.NONE)
         button.connect("toggled", self._on_fold_change)
 
         connected_items = [c.item for c in item.canvas.get_connections(connected=item)]
-        allowed = (DependencyItem, ImplementationItem)
-        can_fold = (
-            len(connected_items) == 0
-            or len(connected_items) == 1
-            and isinstance(connected_items[0], allowed)
-        )
+        disallowed = (ConnectorItem,)
+        can_fold = not any(map(lambda i: isinstance(i, disallowed), connected_items))
 
         button.set_sensitive(can_fold)
         hbox.pack_start(button, True, True, 0)
@@ -165,12 +161,12 @@ class InterfacePropertyPage(NamedItemPropertyPage):
     def _on_fold_change(self, button):
         item = self.item
 
-        connected_items = [c.item for c in item.canvas.get_connections(connected=item)]
-        assert len(connected_items) <= 1
+        # connected_items = [c.item for c in item.canvas.get_connections(connected=item)]
+        # assert len(connected_items) <= 1
 
-        line = None
-        if len(connected_items) == 1:
-            line = connected_items[0]
+        # line = None
+        # if len(connected_items) == 1:
+        #     line = connected_items[0]
 
         fold = button.get_active()
 
@@ -179,15 +175,15 @@ class InterfacePropertyPage(NamedItemPropertyPage):
         else:
             item.folded = Folded.NONE
 
-        if line:
-            if fold and isinstance(line, DependencyItem):
-                item.folded = Folded.REQUIRED
+        # if line:
+        #     if fold and isinstance(line, DependencyItem):
+        #         item.folded = Folded.REQUIRED
 
-            assert line.canvas
-            constraint = line.canvas.get_connection(line.head).constraint
-            constraint.ratio_x = 0.5
-            constraint.ratio_y = 0.5
-            line.request_update()
+        #     assert line.canvas
+        #     constraint = line.canvas.get_connection(line.head).constraint
+        #     constraint.ratio_x = 0.5
+        #     constraint.ratio_y = 0.5
+        #     line.request_update()
 
 
 @PropertyPages.register(ClassItem)

--- a/gaphor/diagram/classes/classespropertypages.py
+++ b/gaphor/diagram/classes/classespropertypages.py
@@ -161,29 +161,12 @@ class InterfacePropertyPage(NamedItemPropertyPage):
     def _on_fold_change(self, button):
         item = self.item
 
-        # connected_items = [c.item for c in item.canvas.get_connections(connected=item)]
-        # assert len(connected_items) <= 1
-
-        # line = None
-        # if len(connected_items) == 1:
-        #     line = connected_items[0]
-
         fold = button.get_active()
 
         if fold:
             item.folded = Folded.PROVIDED
         else:
             item.folded = Folded.NONE
-
-        # if line:
-        #     if fold and isinstance(line, DependencyItem):
-        #         item.folded = Folded.REQUIRED
-
-        #     assert line.canvas
-        #     constraint = line.canvas.get_connection(line.head).constraint
-        #     constraint.ratio_x = 0.5
-        #     constraint.ratio_y = 0.5
-        #     line.request_update()
 
 
 @PropertyPages.register(ClassItem)

--- a/gaphor/diagram/classes/dependency.py
+++ b/gaphor/diagram/classes/dependency.py
@@ -80,7 +80,7 @@ class DependencyItem(LinePresentation):
         return (
             connection
             and isinstance(connection.port, InterfacePort)
-            and connection.connected.folded
+            and connection.connected.folded != Folded.NONE
         )
 
     def post_update(self, context):

--- a/gaphor/diagram/classes/dependency.py
+++ b/gaphor/diagram/classes/dependency.py
@@ -22,7 +22,7 @@ from gaphor.UML.modelfactory import stereotypes_str
 from gaphor.diagram.presentation import LinePresentation
 from gaphor.diagram.shapes import Text
 from gaphor.diagram.support import represents
-from gaphor.diagram.classes.interface import InterfacePort
+from gaphor.diagram.classes.interface import Folded, InterfacePort
 
 
 @represents(UML.Dependency)

--- a/gaphor/diagram/classes/implementation.py
+++ b/gaphor/diagram/classes/implementation.py
@@ -7,7 +7,7 @@ from gaphor.UML.modelfactory import stereotypes_str
 from gaphor.diagram.presentation import LinePresentation
 from gaphor.diagram.shapes import Text
 from gaphor.diagram.support import represents
-from gaphor.diagram.classes.interface import InterfacePort
+from gaphor.diagram.classes.interface import Folded, InterfacePort
 
 
 @represents(UML.Implementation)
@@ -26,7 +26,7 @@ class ImplementationItem(LinePresentation):
         return (
             connection
             and isinstance(connection.port, InterfacePort)
-            and connection.connected.folded
+            and connection.connected.folded != Folded.NONE
         )
 
     def post_update(self, context):

--- a/gaphor/diagram/classes/interface.py
+++ b/gaphor/diagram/classes/interface.py
@@ -304,11 +304,11 @@ class InterfaceItem(ElementPresentation, Classified):
 
     def pre_update(self, context):
         connected_items = [c.item for c in self.canvas.get_connections(connected=self)]
-        connector = any(
+        connectors = any(
             map(lambda i: isinstance(i.subject, UML.Connector), connected_items)
         )
-        if connector or self._folded != Folded.NONE:
-            provided = connector or any(
+        if connectors or self._folded != Folded.NONE:
+            provided = connectors or any(
                 map(
                     lambda i: isinstance(i.subject, UML.Implementation), connected_items
                 )
@@ -322,10 +322,10 @@ class InterfaceItem(ElementPresentation, Classified):
                 self.folded = Folded.REQUIRED
             else:
                 self.folded = Folded.PROVIDED
-            self.update_shapes()
+            self.update_shapes(connectors=connectors)
         super().pre_update(context)
 
-    def update_shapes(self, event=None):
+    def update_shapes(self, event=None, connectors=None):
         if self._folded == Folded.NONE:
             self.shape = Box(
                 Box(
@@ -370,6 +370,14 @@ class InterfaceItem(ElementPresentation, Classified):
                 draw=draw_border,
             )
         else:
+            if connectors is None:
+                # distinguish between None and []
+                connected_items = [
+                    c.item for c in self.canvas.get_connections(connected=self)
+                ]
+                connectors = any(
+                    map(lambda i: isinstance(i.subject, UML.Connector), connected_items)
+                )
             self.shape = IconBox(
                 Box(
                     style={"min-width": self.min_width, "min-height": self.min_height},
@@ -381,7 +389,11 @@ class InterfaceItem(ElementPresentation, Classified):
                 ),
                 EditableText(
                     text=lambda: self.subject.name or "",
-                    style={"font-weight": FontWeight.BOLD},
+                    style={
+                        "font-weight": FontWeight.NORMAL
+                        if connectors
+                        else FontWeight.BOLD
+                    },
                 ),
             )
 

--- a/gaphor/diagram/classes/interfaceconnect.py
+++ b/gaphor/diagram/classes/interfaceconnect.py
@@ -55,10 +55,10 @@ class DependencyInterfaceConnect(DependencyConnect):
         if handle is line.head:
             if self.element.folded != Folded.NONE:
                 self.element.folded = Folded.REQUIRED
-            # change interface angle even when it is unfolded, this way
+            # change interface side even when it is unfolded, this way
             # required interface will be rotated properly when folded by
             # user
-            self.element.angle = port.angle
+            self.element.side = port.side
             self.line.request_update()
 
     def disconnect(self, handle):

--- a/gaphor/diagram/classes/interfaceconnect.py
+++ b/gaphor/diagram/classes/interfaceconnect.py
@@ -53,12 +53,11 @@ class DependencyInterfaceConnect(DependencyConnect):
         # connecting to the interface, which is supplier - assuming usage
         # dependency
         if handle is line.head:
-            if self.element.folded != Folded.NONE:
-                self.element.folded = Folded.REQUIRED
             # change interface side even when it is unfolded, this way
             # required interface will be rotated properly when folded by
             # user
             self.element.side = port.side
+            self.element.request_update()
             self.line.request_update()
 
     def disconnect(self, handle):
@@ -69,9 +68,5 @@ class DependencyInterfaceConnect(DependencyConnect):
         """
         super().disconnect(handle)
         if handle is self.line.head:
-            iface = self.element
-            # don't change folding notation when interface is unfolded, see
-            # test_unfolded_interface_disconnection as well
-            if iface.folded:
-                iface.folded = Folded.PROVIDED
+            self.element.request_update()
             self.line.request_update()

--- a/gaphor/diagram/classes/tests/test_interfaceconnect.py
+++ b/gaphor/diagram/classes/tests/test_interfaceconnect.py
@@ -5,6 +5,7 @@ Test connections to folded interface.
 from gaphor import UML
 from gaphor.tests import TestCase
 from gaphor.diagram.classes.implementation import ImplementationItem
+from gaphor.diagram.classes.klass import ClassItem
 from gaphor.diagram.classes.interface import InterfaceItem, Folded
 from gaphor.diagram.classes.association import AssociationItem
 from gaphor.diagram.classes.dependency import DependencyItem
@@ -52,12 +53,17 @@ class DependencyTestCase(TestCase):
     def test_folded_interface_connection(self):
         """Test connecting dependency to folded interface
         """
+        clazz = self.create(ClassItem, UML.Class)
         iface = self.create(InterfaceItem, UML.Interface)
         iface.folded = Folded.PROVIDED
         dep = self.create(DependencyItem)
 
         self.connect(dep, dep.head, iface, iface.ports()[0])
+        self.connect(dep, dep.tail, clazz, clazz.ports()[0])
+        iface.request_update()
+        iface.canvas.update_now()
 
+        assert dep.subject
         assert not dep.style("dash-style")
         assert iface.folded == Folded.REQUIRED
 
@@ -82,68 +88,4 @@ class DependencyTestCase(TestCase):
         dep = self.create(DependencyItem)
 
         self.connect(dep, dep.head, iface, iface.ports()[0])
-        assert () == dep.style("dash-style")
-
-
-LINES = (
-    ImplementationItem,
-    DependencyItem,
-    GeneralizationItem,
-    AssociationItem,
-    CommentLineItem,
-)
-
-
-class FoldedInterfaceMultipleLinesTestCase(TestCase):
-    """
-    Test connection of additional diagram lines to folded interface,
-    which has already usage dependency or implementation connected.
-    """
-
-    def setUp(self):
-        super().setUp()
-
-        self.iface = self.create(InterfaceItem, UML.Interface)
-        self.iface.folded = Folded.PROVIDED
-
-    def test_interface_with_implementation(self):
-        """Test gluing different lines to folded interface with implementation."""
-
-        impl = self.create(ImplementationItem)
-        self.connect(impl, impl.head, self.iface, self.iface.ports()[0])
-
-        for cls in LINES:
-            line = self.create(cls)
-            glued = self.allow(line, line.head, self.iface)
-            # no additional lines (specified above) can be glued
-            assert not glued, f"gluing of {cls} should not be allowed"
-
-    def test_interface_with_dependency(self):
-        """Test gluing different lines to folded interface with dependency."""
-        dep = self.create(DependencyItem)
-        self.connect(dep, dep.head, self.iface, self.iface.ports()[0])
-
-        for cls in LINES:
-            line = self.create(cls)
-            glued = self.allow(line, line.head, self.iface)
-            # no additional lines (specified above) can be glued
-            assert not glued, f"gluing of {cls} should not be allowed"
-
-
-class FoldedInterfaceSingleLineTestCase(TestCase):
-    """
-    Test connection of diagram lines to folded interface. Any lines beside
-    implementation and dependency should be forbidden to connect.
-    """
-
-    def test_interface_with_forbidden_lines(self):
-        """Test gluing forbidden lines to folded interface."""
-
-        iface = self.create(InterfaceItem, UML.Interface)
-        iface.folded = Folded.PROVIDED
-
-        for cls in LINES[2:]:
-            line = self.create(cls)
-            glued = self.allow(line, line.head, iface)
-            # no additional lines (specified above) can be glued
-            assert not glued, f"gluing of {cls} should not be allowed"
+        assert (7.0, 5.0) == dep.style("dash-style")

--- a/gaphor/diagram/components/connector.py
+++ b/gaphor/diagram/components/connector.py
@@ -126,24 +126,16 @@ class ConnectorItem(LinePresentation, Named):
     def __init__(self, id=None, model=None):
         super().__init__(id, model)
 
-        def role_name():
-            try:
-                return self.subject.end["it.role", 0].role.name or ""
-            except (IndexError, AttributeError) as e:
-                return ""
-
         self.shape_middle = Box(
             Text(
                 text=lambda: stereotypes_str(self.subject),
                 style={"min-width": 0, "min-height": 0},
             ),
             EditableText(text=lambda: self.subject.name or ""),
-            Text(text=role_name, style={"min-width": 0, "min-height": 0}),
         )
 
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
-        self.watch("subject[Connector].end.role.name")
 
     def draw_tail(self, context):
         cr = context.cairo

--- a/gaphor/diagram/components/connectorconnect.py
+++ b/gaphor/diagram/components/connectorconnect.py
@@ -267,7 +267,7 @@ class InterfaceConnectorConnect(ConnectorConnectBase):
             pport.provided = True
             rport.required = True
 
-            iface.angle = rport.angle
+            iface.side = rport.side
 
             ports[(index + 1) % 4].connectable = False
             ports[(index + 3) % 4].connectable = False
@@ -279,7 +279,7 @@ class InterfaceConnectorConnect(ConnectorConnectBase):
         if len(list(self.get_connecting(iface))) == 1:
             ports = iface.ports()
             iface.folded = Folded.PROVIDED
-            iface.angle = ports[0].angle
+            iface.side = ports[0].side
             for p in ports:
                 p.connectable = True
                 p.provided = False

--- a/gaphor/diagram/components/connectorconnect.py
+++ b/gaphor/diagram/components/connectorconnect.py
@@ -181,6 +181,7 @@ class ConnectorConnectBase(AbstractConnect):
         else:
             c = self.get_component(line)
             self.drop_uml(line, c)
+        iface.request_update()
 
 
 @IConnect.register(ComponentItem, ConnectorItem)

--- a/gaphor/diagram/components/connectorconnect.py
+++ b/gaphor/diagram/components/connectorconnect.py
@@ -104,42 +104,16 @@ class ConnectorConnectBase(AbstractConnect):
         connector.subject = None
 
     def allow(self, handle, port):
-        glue_ok = super().allow(handle, port)
-
         iface = self.element
         component = self.get_connected(self.line.opposite(handle))
 
-        if isinstance(component, InterfaceItem):
+        if isinstance(component, InterfaceItem) or isinstance(iface, ComponentItem):
             component, iface = iface, component
-            port = self.get_connected_port(self.line.opposite(handle))
-
         # connect only components and interfaces but not two interfaces nor
         # two components
-        glue_ok = not (
-            isinstance(component, ComponentItem)
-            and isinstance(iface, ComponentItem)
-            or isinstance(component, InterfaceItem)
-            and isinstance(iface, InterfaceItem)
+        glue_ok = (not component or isinstance(component, ComponentItem)) and (
+            not iface or isinstance(iface, InterfaceItem)
         )
-
-        # if port type is known, then allow connection to proper port only
-        if (
-            glue_ok
-            and component is not None
-            and iface is not None
-            and (port.required or port.provided)
-        ):
-
-            assert isinstance(component, ComponentItem)
-            assert isinstance(iface, InterfaceItem)
-
-            glue_ok = (
-                port.provided
-                and iface.subject in component.subject.provided
-                or port.required
-                and iface.subject in component.subject.required
-            )
-            return glue_ok
 
         return glue_ok
 
@@ -160,32 +134,28 @@ class ConnectorConnectBase(AbstractConnect):
                 component, iface = iface, component
 
             connections = self.get_connecting(iface, both=True)
-            ports = {c.port for c in connections}
 
-            # to make an assembly at least two connector ends need to exist
-            # also, two different ports of interface need to be connected
-            if len(connections) > 1 and len(ports) == 2:
-                # find assembly connector
-                assembly = None
+            assembly = None
+            for c in connections:
+                if c.item.subject:
+                    assembly = c.item.subject
+                    assert assembly.kind == "assembly"
+                    break
+
+            if assembly is None:
+                assembly = self.element.model.create(UML.Connector)
+                assembly.kind = "assembly"
                 for c in connections:
-                    if c.item.subject:
-                        assembly = c.item.subject
-                        assert assembly.kind == "assembly"
-                        break
-
-                if assembly is None:
-                    assembly = self.element.model.create(UML.Connector)
-                    assembly.kind = "assembly"
-                    for c in connections:
-                        connector = c.item
-                        self.create_uml(
-                            connector,
-                            self.get_component(connector),
-                            assembly,
-                            iface.subject,
-                        )
-                else:
-                    self.create_uml(line, component, assembly, iface.subject)
+                    connector = c.item
+                    self.create_uml(
+                        connector,
+                        self.get_component(connector),
+                        assembly,
+                        iface.subject,
+                    )
+            else:
+                self.create_uml(line, component, assembly, iface.subject)
+            iface.request_update()
 
     def disconnect(self, handle):
         super().disconnect(handle)
@@ -198,12 +168,10 @@ class ConnectorConnectBase(AbstractConnect):
             iface = self.get_connected(line.tail)
 
         connections = list(self.get_connecting(iface, both=True))
-        # find ports, which will stay connected after disconnection
-        ports = {c.port for c in connections if c.item is not self.line}
 
         # destroy whole assembly if one connected item stays
         # or only one port will stay connected
-        if len(connections) == 2 or len(ports) == 1:
+        if len(connections) == 2:
             connector = line.subject
             for ci in connections:
                 c = self.get_component(ci.item)
@@ -227,60 +195,3 @@ class InterfaceConnectorConnect(ConnectorConnectBase):
     See also `AbstractConnect` class for exception of interface item
     connections.
     """
-
-    def allow(self, handle, port):
-        """Allow gluing to folded interface.
-
-        Only allow gluing when connectors are connected.
-        """
-
-        glue_ok = super().allow(handle, port)
-        iface = self.element
-        glue_ok = glue_ok and iface.folded != Folded.NONE
-        if glue_ok:
-            # find connected items, which are not connectors
-            canvas = self.element.canvas
-            connections = self.get_connecting(self.element)
-            lines = [
-                c.item for c in connections if not isinstance(c.item, ConnectorItem)
-            ]
-            glue_ok = len(lines) == 0
-
-        return glue_ok
-
-    def connect(self, handle, port):
-        super().connect(handle, port)
-
-        iface = self.element
-        iface.folded = Folded.ASSEMBLY
-
-        # determine required and provided ports
-        pport = port
-        ports = iface.ports()
-        index = ports.index(port)
-        rport = ports[(index + 2) % 4]
-        if not port.provided and not port.required:
-            component = self.get_connected(self.line.opposite(handle))
-            if component is not None and iface.subject in component.subject.required:
-                pport, rport = rport, pport
-
-            pport.provided = True
-            rport.required = True
-
-            iface.side = rport.side
-
-            ports[(index + 1) % 4].connectable = False
-            ports[(index + 3) % 4].connectable = False
-
-    def disconnect(self, handle):
-        super().disconnect(handle)
-        iface = self.element
-        # about to disconnect last connector
-        if len(list(self.get_connecting(iface))) == 1:
-            ports = iface.ports()
-            iface.folded = Folded.PROVIDED
-            iface.side = ports[0].side
-            for p in ports:
-                p.connectable = True
-                p.provided = False
-                p.required = False

--- a/gaphor/diagram/components/tests/test_connect.py
+++ b/gaphor/diagram/components/tests/test_connect.py
@@ -6,7 +6,7 @@ from gaphor.tests import TestCase
 from gaphor import UML
 from gaphor.diagram.components import ComponentItem
 from gaphor.diagram.components import ConnectorItem
-from gaphor.diagram.classes.interface import InterfaceItem, Folded
+from gaphor.diagram.classes.interface import InterfaceItem, Folded, Side
 from gaphor.diagram.classes.dependency import DependencyItem
 from gaphor.diagram.classes.implementation import ImplementationItem
 from gaphor.diagram.components.connectorconnect import ConnectorConnectBase
@@ -143,9 +143,7 @@ class InterfaceConnectTestCase(TestCase):
         assert not p1.required and not p1.provided and not p1.connectable
         assert not p2.required and not p2.provided and not p2.connectable
 
-    def test_connection_angle_change(self):
-        """Test angle after connection to an interface
-        """
+    def test_connection_side_adter_connecting_to_interface(self):
         iface = self.create(InterfaceItem, UML.Component)
         line = self.create(ConnectorItem)
 
@@ -156,10 +154,10 @@ class InterfaceConnectTestCase(TestCase):
         # test preconditions
         assert not pport.provided and not pport.required
         assert not rport.provided and not rport.required
-        assert iface.angle == 0.0
+        assert iface.side == Side.N
 
         self.connect(line, line.head, iface, pport)
-        assert rport.angle == iface.angle
+        assert rport.side == iface.side
 
     def test_connection_of_two_connectors_one_side(self):
         """Test connection of two connectors to required port of an interface
@@ -234,7 +232,7 @@ class InterfaceConnectTestCase(TestCase):
 
         self.disconnect(line, line.head)
         assert Folded.PROVIDED == iface.folded
-        assert iface.angle == 0
+        assert iface.side == Side.N
 
         assert not any(p.provided for p in iface.ports())
         assert not any(p.required for p in iface.ports())

--- a/gaphor/diagram/components/tests/test_connector.py
+++ b/gaphor/diagram/components/tests/test_connector.py
@@ -19,42 +19,6 @@ class ConnectorItemTestCase(TestCase):
         assert not conn.subject is None
         # self.assertTrue(conn.end is None)
 
-    def test_name(self):
-        """Test connected interface name
-        """
-        conn = self.create(ConnectorItem, UML.Connector)
-        end = self.element_factory.create(UML.ConnectorEnd)
-        iface = self.element_factory.create(UML.Interface)
-        interface_text = conn.shape_middle.children[-1]
-        end.role = iface
-        conn.subject.end = end
-        # conn.end = end
-        # self.assertTrue(conn._end is end)
-
-        self.assertEqual("", interface_text.text())
-
-        iface.name = "RedSea"
-        assert "RedSea" == interface_text.text()
-
-    def test_setting_end(self):
-        """Test creation of connector item
-        """
-        conn = self.create(ConnectorItem, UML.Connector)
-        end = self.element_factory.create(UML.ConnectorEnd)
-        iface = self.element_factory.create(UML.Interface)
-        interface_text = conn.shape_middle.children[-1]
-        end.role = iface
-        iface.name = "RedSea"
-        conn.subject.end = end
-        # conn.end = end
-        # self.assertTrue(conn._end is end)
-
-        self.assertEqual("RedSea", interface_text.text())
-
-        del conn.subject.end[end]
-        conn.end = None
-        assert "" == interface_text.text()
-
     def test_persistence(self):
         """Test connector item saving/loading
         """
@@ -70,5 +34,3 @@ class ConnectorItemTestCase(TestCase):
 
         connectors = self.diagram.canvas.select(lambda e: isinstance(e, ConnectorItem))
         ends = self.kindof(UML.ConnectorEnd)
-        # self.assertTrue(connectors[0].end is not None)
-        # self.assertTrue(connectors[0].end is ends[0])

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -130,17 +130,6 @@ class AbstractConnect(ConnectBase):
 
         Returns `True` if connection is allowed.
         """
-        from gaphor.diagram.classes.interface import InterfaceItem
-        from gaphor.diagram.classes.implementation import ImplementationItem
-        from gaphor.diagram.classes.dependency import DependencyItem
-
-        iface = self.element
-        if isinstance(iface, InterfaceItem) and iface.folded:
-            canvas = self.canvas
-            count = any(canvas.get_connections(connected=iface))
-            return not count and isinstance(
-                self.line, (DependencyItem, ImplementationItem)
-            )
         return True
 
     def connect(self, handle: Handle, port: Port) -> bool:


### PR DESCRIPTION
Simplify the way interfaces and (mainly) components interact.

This fixes the regression after the new item drawing model was implemented.

Fixes #193 

TODO:
- [x] Interface should not display it's name in folded mode when a Connector is attached. The name is displayed on the Connector line. At least the interface name should not be bold.
![image](https://user-images.githubusercontent.com/96249/66991890-2ae11e80-f0c9-11e9-98e2-bb315a6bafa7.png)
