### PR TITLE
Reset tool after creation by default

### DIFF
--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -215,7 +215,7 @@ class DiagramPage:
 
     @event_handler(DiagramItemCreated)
     def _on_diagram_item_created(self, event):
-        if self.properties("reset-tool-after-create", False):
+        if self.properties("reset-tool-after-create", True):
             self.widget.action_group.actions.lookup_action("select-tool").activate(
                 GLib.Variant.new_string("toolbox-pointer")
             )

--- a/gaphor/ui/preferences.py
+++ b/gaphor/ui/preferences.py
@@ -57,6 +57,6 @@ class Preferences(Service, ActionProvider):
             sloppiness = 0.0
         self.properties.set("diagram.sloppiness", sloppiness)
 
-    @action(name="pref.reset-tool-after-create", state=False)
+    @action(name="pref.reset-tool-after-create", state=True)
     def reset_tool_after_create(self, active):
         self.properties.set("reset-tool-after-create", active)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix

### What is the current behavior?

Tool is not reset. This makes things complex for newcomers when the pointer tool has scrolled out of the toolbox view.

Issue Number: N/A

### What is the new behavior?

Reset tool after creation.

I think we should release 1.1.1 to fix the issue.