### PR TITLE
Upgrade linux image to 18.04: latest LTS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,7 +165,6 @@ jobs:
       displayName: Install Python Dependencies
 
     - script: |
-        mkdir -p /home/vsts/.local/share # This can be removed once we merge back to master (config dir)
         source venv
         xvfb-run pytest
       displayName: 'PyTest'


### PR DESCRIPTION
I would assume 18.04 is the most used LTS version by now.

update: that did not work...