### PR TITLE
Allow nested searches on namespace view

### DIFF
--- a/gaphor/diagram/profiles/stereotypepage.py
+++ b/gaphor/diagram/profiles/stereotypepage.py
@@ -18,6 +18,7 @@ def create_stereotype_tree_view(model, toggle_stereotype, set_slot_value):
         Model, for which tree view is created.
     """
     tree_view = Gtk.TreeView.new_with_model(model)
+    tree_view.set_search_column(-1)
 
     # Stereotype/Attributes
     col = Gtk.TreeViewColumn.new()

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -344,6 +344,7 @@ def create_tree_view(model, names, tip="", ro_cols=None):
         ro_cols = set()
 
     tree_view = Gtk.TreeView(model=model)
+    tree_view.set_search_column(-1)
 
     n = model.get_n_columns() - 1
     for name, i in zip(names, list(range(n))):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Search was only possible on already expanded nodes in the tree view.

### What is the new behavior?

When searching, nodes that have matching children will expand, allowing for better searching.

It would probably need some sort of highlighting, to distinguish those nodes even better.

No elements are filtered out of the view.

searching has been completely disabled for tree/list views used in the Element editor.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
