### PR TITLE
Fix GTK Warnings - Versions not Specified before Import

### DIFF
--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -6,9 +6,14 @@ from enum import Enum
 from typing import Any, Dict, Tuple, TypeVar
 
 import cairo
+import gi
 from gaphas.freehand import FreeHandCairoContext
 from gaphas.painter import CairoBoundingBoxContext
-from gi.repository import GLib, Pango, PangoCairo
+
+# fmt: off
+gi.require_version('PangoCairo', '1.0')  # noqa: isort:skip
+from gi.repository import GLib, Pango, PangoCairo  # noqa: isort:skip
+# fmt: on
 
 Font = TypeVar("Font", Dict[str, object], str)
 

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -6,11 +6,14 @@ main screen and diagram windows.
 import importlib.resources
 
 import gi
-from gi.repository import Gdk, Gio, Gtk
 
 from gaphor.ui.actiongroup import apply_application_actions
 
-gi.require_version("Gtk", "3.0")
+# fmt: off
+gi.require_version("Gtk", "3.0")  # noqa: isort:skip
+gi.require_version("Gdk", "3.0")  # noqa: isort:skip
+from gi.repository import Gdk, Gio, Gtk  # noqa: isort:skip
+# fmt: on
 
 
 APPLICATION_ID = "org.gaphor.Gaphor"

--- a/gaphor/ui/actiongroup.py
+++ b/gaphor/ui/actiongroup.py
@@ -1,8 +1,13 @@
 from typing import NamedTuple
 
-from gi.repository import Gio, GLib, Gtk
+import gi
 
 from gaphor.abc import ActionProvider
+
+# fmt: off
+gi.require_version("Gtk", "3.0")  # noqa: isort:skip
+from gi.repository import Gio, GLib, Gtk  # noqa: isort:skip
+# fmt: on
 
 
 class ActionGroup(NamedTuple):


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

<!-- Please add an overview of the PR here -->
When running Gaphor:
```
/home/dan/Projects/gaphor/gaphor/ui/__init__.py:9: PyGIWarning: Gdk was imported without specifying a version first. Use gi.require_version('Gdk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gdk, Gio, Gtk
/home/dan/Projects/gaphor/gaphor/ui/__init__.py:9: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gdk, Gio, Gtk
/home/dan/Projects/gaphor/gaphor/diagram/text.py:11: PyGIWarning: PangoCairo was imported without specifying a version first. Use gi.require_version('PangoCairo', '1.0') before import to ensure that the right version gets loaded.
  from gi.repository import GLib, Pango, PangoCairo
```
This PR fixes those warnings.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
