### PR TITLE
Fix GTK Deprecation Warning

### DIFF
--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -450,7 +450,11 @@ class Diagrams(UIComponent, ActionProvider):
         )
         button = Gtk.Button()
         button.set_relief(Gtk.ReliefStyle.NONE)
-        button.set_focus_on_click(False)
+
+        # TODO: Call button.set_focus_on_click directly once PyGObject issue
+        #  #371 is fixed
+        Gtk.Widget.set_focus_on_click(button, False)
+
         button.add(close_image)
         button.connect("clicked", self.cb_close_tab, widget)
         tab_box.pack_start(child=button, expand=False, fill=False, padding=0)


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

<!-- Please add an overview of the PR here -->
Fixes `DeprecationWarning: Gtk.Button.set_focus_on_click is deprecated`
    `button.set_focus_on_click(False)`

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
