### PR TITLE
Fix AttributeError When Opening Models with Python 3.8

### DIFF
--- a/gaphor/misc/gidlethread.py
+++ b/gaphor/misc/gidlethread.py
@@ -70,15 +70,14 @@ class GIdleThread:
         return idle_id
 
     def wait(self, timeout=0):
-        """Wait until the corouine is finished or return after timeout seconds.
+        """Wait until the coroutine is finished or return after timeout seconds.
         This is achieved by running the GTK+ main loop.
         """
-        clock = time.clock
-        start_time = clock()
+        start_time = time.perf_counter()
         main = GLib.main_context_default()
         while self.is_alive():
             main.iteration(False)
-            if timeout and (clock() - start_time >= timeout):
+            if timeout and (time.perf_counter() - start_time >= timeout):
                 return
 
     def interrupt(self):

--- a/gaphor/misc/gidlethread.py
+++ b/gaphor/misc/gidlethread.py
@@ -70,15 +70,25 @@ class GIdleThread:
         return idle_id
 
     def wait(self, timeout=0):
-        """Wait until the coroutine is finished or return after timeout seconds.
+        """Waits until finished or timeout.
+
+        Waits until the coroutine is finished or return after timeout seconds.
         This is achieved by running the GTK+ main loop.
+
+        Args:
+            timeout: A float timeout in seconds, default is no timeout.
+
+        Returns:
+            A bool, True for timeout, False for coroutine ending.
         """
+
         start_time = time.perf_counter()
-        main = GLib.main_context_default()
+        main_ctx = GLib.main_context_default()
         while self.is_alive():
-            main.iteration(False)
+            main_ctx.iteration(False)
             if timeout and (time.perf_counter() - start_time >= timeout):
-                return
+                return True
+        return False
 
     def interrupt(self):
         """Force the generator to stop running.

--- a/gaphor/misc/gidlethread.py
+++ b/gaphor/misc/gidlethread.py
@@ -82,11 +82,11 @@ class GIdleThread:
             A bool, True for timeout, False for coroutine ending.
         """
 
-        start_time = time.perf_counter()
+        start_time = time.monotonic()
         main_ctx = GLib.main_context_default()
         while self.is_alive():
             main_ctx.iteration(False)
-            if timeout and (time.perf_counter() - start_time >= timeout):
+            if timeout and (time.monotonic() - start_time >= timeout):
                 return True
         return False
 

--- a/gaphor/misc/tests/test_gidlethread.py
+++ b/gaphor/misc/tests/test_gidlethread.py
@@ -1,0 +1,31 @@
+from gaphor.misc.gidlethread import GIdleThread
+
+
+def test_wait_with_timeout():
+    # GIVEN a running gidlethread
+    def counter(max):
+        for x in range(max):
+            yield x
+
+    t = GIdleThread(counter(20000))
+    t.start()
+    assert t.is_alive()
+    # WHEN waiting for 0.01 sec timeout
+    wait_result = t.wait(0.01)
+    # THEN timeout
+    assert wait_result
+
+
+def test_wait_until_finished():
+    # GIVEN a short coroutine thread
+    def counter(max):
+        for x in range(max):
+            yield x
+
+    t = GIdleThread(counter(2))
+    t.start()
+    assert t.is_alive()
+    # WHEN wait for coroutine to finish
+    wait_result = t.wait(0.01)
+    # THEN coroutine finished
+    assert not wait_result

--- a/gaphor/misc/tests/test_gidlethread.py
+++ b/gaphor/misc/tests/test_gidlethread.py
@@ -10,11 +10,11 @@ def counter(count):
 
 @pytest.fixture
 def gidle_counter(request):
-    # Setup GIdle Thread with 0.01 sec timeout
+    # Setup GIdle Thread with 0.02 sec timeout
     t = GIdleThread(counter(request.param))
     t.start()
     assert t.is_alive()
-    wait_result = t.wait(0.01)
+    wait_result = t.wait(0.02)
     yield wait_result
     # Teardown GIdle Thread
     t.interrupt()

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -176,7 +176,7 @@ def load_elements_generator(elements, factory, gaphor_version):  # noqa: C901
     Load a file and create a model if possible.
     Exceptions: IOError, ValueError.
     """
-    log.debug("Loading %d elements..." % len(elements))
+    log.debug(f"Loading {len(elements)} elements")
 
     # The elements are iterated three times:
     size = len(elements) * 3
@@ -220,8 +220,7 @@ def load_elements_generator(elements, factory, gaphor_version):  # noqa: C901
                 create_canvasitems(elem.element, elem.canvas.canvasitems)
         elif not isinstance(elem, parser.canvasitem):
             raise ValueError(
-                'Item with id "%s" and type %s can not be instantiated'
-                % (id, type(elem))
+                f"Item with id {id} and type {type(elem)} can not be instantiated"
             )
 
     # load attributes and create references:
@@ -299,7 +298,7 @@ def load_generator(filename, factory):
     if isinstance(filename, io.IOBase):
         log.info("Loading file from file descriptor")
     else:
-        log.info("Loading file %s" % os.path.basename(filename))
+        log.info(f"Loading file {os.path.basename(filename).decode()}")
     try:
         # Use the incremental parser and yield the percentage of the file.
         loader = parser.GaphorLoader()
@@ -317,12 +316,10 @@ def load_generator(filename, factory):
 
     if version_lower_than(gaphor_version, (0, 17, 0)):
         raise ValueError(
-            "Gaphor model version should be at least 0.17.0 (found {})".format(
-                gaphor_version
-            )
+            f"Gaphor model version should be at least 0.17.0 (found {gaphor_version})"
         )
 
-    log.info("Read %d elements from file" % len(elements))
+    log.info(f"Read {len(elements)} elements from file")
 
     factory.flush()
     gc.collect()

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -298,7 +298,7 @@ def load_generator(filename, factory):
     if isinstance(filename, io.IOBase):
         log.info("Loading file from file descriptor")
     else:
-        log.info(f"Loading file {os.path.basename(filename).decode()}")
+        log.info(f"Loading file {os.fsdecode(os.path.basename(filename))}")
     try:
         # Use the incremental parser and yield the percentage of the file.
         loader = parser.GaphorLoader()


### PR DESCRIPTION
This PR fixes an AttributeError caused by the clock method in the time module being deprecated, and removed in Python 3.8.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
When opening `gaphor/UML/uml2.gaphor` I get the following error:
```
Traceback (most recent call last):
  File "/home/dan/Projects/gaphor/gaphor/ui/actiongroup.py", line 147, in _action_activate
    method()
  File "/home/dan/Projects/gaphor/gaphor/ui/filemanager.py", line 298, in action_open
    self.load(filename)
  File "/home/dan/Projects/gaphor/gaphor/ui/filemanager.py", line 87, in load
    worker.wait()
  File "/home/dan/Projects/gaphor/gaphor/misc/gidlethread.py", line 76, in wait
    clock = time.clock
AttributeError: module 'time' has no attribute 'clock'
```

Issue Number: N/A

### What is the new behavior?
No AttributeError. I replaced `clock()` with `monotonic()` which is the new relative monotonic clock added in Python 3.3 as part of [PEP418](https://www.python.org/dev/peps/pep-0418/). I also added some tests to cover the `wait` method as well.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
