### PR TITLE
Fix test flakiness by changing timeout to a longer value

### DIFF
--- a/gaphor/misc/tests/test_gidlethread.py
+++ b/gaphor/misc/tests/test_gidlethread.py
@@ -10,11 +10,11 @@ def counter(count):
 
 @pytest.fixture
 def gidle_counter(request):
-    # Setup GIdle Thread with 0.02 sec timeout
+    # Setup GIdle Thread with 0.05 sec timeout
     t = GIdleThread(counter(request.param))
     t.start()
     assert t.is_alive()
-    wait_result = t.wait(0.02)
+    wait_result = t.wait(0.05)
     yield wait_result
     # Teardown GIdle Thread
     t.interrupt()


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

Fixes issue introduced in #251. macOS is being flaky about passing the best. This fix increases the timeout to try to fix the issue.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
