### PR TITLE
Fix attribute errors when unloading a model

### DIFF
--- a/gaphor/UML/properties.py
+++ b/gaphor/UML/properties.py
@@ -545,13 +545,9 @@ class associationstub(umlproperty[T]):
         pass
 
     def unlink(self, obj):
-        try:
-            values = getattr(obj, self._name)
-        except AttributeError:
-            log.exception(f"Failed to unlink {self._name} from {obj}")
-        else:
-            for value in set(values):
-                self.association.__delete__(value, obj)
+        values = getattr(obj, self._name, [])
+        for value in set(values):
+            self.association.__delete__(value, obj)
 
     def _set(self, obj, value):
         try:


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [ ] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

When closing (flushing) a model (e.g. `gaphor/UML/uml2.gaphor`) a lot of errors show up:

    gaphor.UML.properties ERROR Failed to unlink _stub_7fb1e478f990 from <gaphor.UML.uml2.Class object at 0x7fb1e479cdd0>
    Traceback (most recent call last):
      File "/home/arjan/Development/gaphor/gaphor/UML/properties.py", line 549, in unlink
        values = getattr(obj, self._name)
    AttributeError: 'Class' object has no attribute '_stub_7fb1e478f990'


Issue Number: N/A

### What is the new behavior?

No more errors. This behavior is expected.
The code has been written in a way that expresses the intent more clearly.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
