### PR TITLE
Avoid creation of a virtualenv in CI with Windows

### DIFF
--- a/win-installer/msys2-install.sh
+++ b/win-installer/msys2-install.sh
@@ -18,4 +18,7 @@ pacman --noconfirm -S --needed \
     mingw-w64-$MSYS2_ARCH-python3-cairo \
     mingw-w64-$MSYS2_ARCH-python3-pip
 
-./venv -S
+pip install poetry==1.0.2
+poetry config virtualenvs.create false
+poetry install
+


### PR DESCRIPTION
This PR fixes the build which is failing in Windows.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
The Windows build was still using the venv script, and using virtualenvs in MSYS2 isn't working with Poetry > 1.0.0.

Issue Number: N/A

### What is the new behavior?
No virtualenv is created and builds pass.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
