### PR TITLE
Convert Some Profile Tests to Pytest

### DIFF
--- a/gaphor/diagram/profiles/tests/conftest.py
+++ b/gaphor/diagram/profiles/tests/conftest.py
@@ -1,1 +1,1 @@
-from gaphor.diagram.tests.fixtures import diagram, element_factory
+from gaphor.diagram.tests.fixtures import diagram, element_factory, event_manager

--- a/gaphor/diagram/profiles/tests/conftest.py
+++ b/gaphor/diagram/profiles/tests/conftest.py
@@ -1,0 +1,1 @@
+from gaphor.diagram.tests.fixtures import diagram, element_factory

--- a/gaphor/diagram/profiles/tests/test_extensionconnect.py
+++ b/gaphor/diagram/profiles/tests/test_extensionconnect.py
@@ -1,63 +1,58 @@
-"""
-Extension item connection adapter tests.
-"""
+"""Extension item connection adapter tests."""
 
 from gaphor import UML
 from gaphor.diagram.classes.klass import ClassItem
 from gaphor.diagram.profiles.extension import ExtensionItem
-from gaphor.tests import TestCase
+from gaphor.diagram.tests.fixtures import allow, connect
 
 
-class ExtensionConnectorTestCase(TestCase):
-    """
-    Extension item connection adapter tests.
-    """
+def test_glue(element_factory, diagram):
+    """Test extension item glue."""
 
-    def test_class_glue(self):
-        """Test extension item gluing to a class."""
+    ext = diagram.create(ExtensionItem)
+    st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
+    cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
-        ext = self.create(ExtensionItem)
-        cls = self.create(ClassItem, UML.Class)
+    glued = allow(ext, ext.tail, st)
+    assert glued
 
-        # cannot connect extension item tail to a class
-        glued = self.allow(ext, ext.tail, cls)
-        assert not glued
+    connect(ext, ext.tail, st)
 
-    def test_stereotype_glue(self):
-        """Test extension item gluing to a stereotype."""
+    glued = allow(ext, ext.head, cls)
+    assert glued
 
-        ext = self.create(ExtensionItem)
-        st = self.create(ClassItem, UML.Stereotype)
 
-        # test precondition
-        assert isinstance(st.subject, UML.Stereotype)
+def test_class_glue(element_factory, diagram):
+    """Test extension item gluing to a class."""
 
-        # can connect extension item head to a Stereotype UML metaclass,
-        # because it derives from Class UML metaclass
-        glued = self.allow(ext, ext.head, st)
-        assert glued
+    ext = diagram.create(ExtensionItem)
+    cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
-    def test_glue(self):
-        """Test extension item glue
-        """
-        ext = self.create(ExtensionItem)
-        st = self.create(ClassItem, UML.Stereotype)
-        cls = self.create(ClassItem, UML.Class)
+    # cannot connect extension item tail to a class
+    glued = allow(ext, ext.tail, cls)
+    assert not glued
 
-        glued = self.allow(ext, ext.tail, st)
-        assert glued
 
-        self.connect(ext, ext.tail, st)
+def test_stereotype_glue(element_factory, diagram):
+    """Test extension item gluing to a stereotype."""
 
-        glued = self.allow(ext, ext.head, cls)
-        assert glued
+    ext = diagram.create(ExtensionItem)
+    st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
 
-    def test_connection(self):
-        """Test extension item connection
-        """
-        ext = self.create(ExtensionItem)
-        st = self.create(ClassItem, UML.Stereotype)
-        cls = self.create(ClassItem, UML.Class)
+    # test precondition
+    assert isinstance(st.subject, UML.Stereotype)
 
-        self.connect(ext, ext.tail, st)
-        self.connect(ext, ext.head, cls)
+    # can connect extension item head to a Stereotype UML metaclass,
+    # because it derives from Class UML metaclass
+    glued = allow(ext, ext.head, st)
+    assert glued
+
+
+def test_connection(element_factory, diagram):
+    """Test extension item connection."""
+    ext = diagram.create(ExtensionItem)
+    st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
+    cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+
+    connect(ext, ext.tail, st)
+    connect(ext, ext.head, cls)

--- a/gaphor/diagram/profiles/tests/test_extensionconnect.py
+++ b/gaphor/diagram/profiles/tests/test_extensionconnect.py
@@ -9,50 +9,70 @@ from gaphor.diagram.tests.fixtures import allow, connect
 def test_glue(element_factory, diagram):
     """Test extension item glue."""
 
+    # GIVEN an ExtensionItem, Stereotype, and Class
     ext = diagram.create(ExtensionItem)
     st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
     cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
+    # WHEN we try to connect the ExtensionItem tail to the Stereotype
     glued = allow(ext, ext.tail, st)
-    assert glued
 
+    # THEN we allow the connection, and we connect them
+    assert glued
     connect(ext, ext.tail, st)
 
+    # WHEN we try to connect the ExtensionItem head to the Class
     glued = allow(ext, ext.head, cls)
+
+    # THEN we allow the connection
     assert glued
 
 
 def test_class_glue(element_factory, diagram):
     """Test extension item gluing to a class."""
 
+    # GIVEN an ExtensionItem and ClassItem
     ext = diagram.create(ExtensionItem)
     cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
-    # cannot connect extension item tail to a class
+    # WHEN we try to connect the ExtensionItem tail to a Class
     glued = allow(ext, ext.tail, cls)
+
+    # THEN we don't allow the connection
     assert not glued
 
 
 def test_stereotype_glue(element_factory, diagram):
-    """Test extension item gluing to a stereotype."""
+    """Test extension item gluing to a stereotype.
 
+    Connecting a Stereotype should work because it is derived from the UML
+    Class.
+    """
+
+    # GIVEN an ExtensionItem and Stereotype
     ext = diagram.create(ExtensionItem)
     st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
-
-    # test precondition
     assert isinstance(st.subject, UML.Stereotype)
 
-    # can connect extension item head to a Stereotype UML metaclass,
-    # because it derives from Class UML metaclass
+    # WHEN we try to connect the ExtensionItem head to a Stereotype
     glued = allow(ext, ext.head, st)
+
+    # THEN we allow the connection
     assert glued
 
 
 def test_connection(element_factory, diagram):
     """Test extension item connection."""
+
+    # GIVEN an ExtensionItem, a Stereotype, and a Class
     ext = diagram.create(ExtensionItem)
     st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
     cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
+    # WHEN we to connect the ExtensionItem tail to the Stereotype
+    # THEN the connection is made
     connect(ext, ext.tail, st)
+
+    # WHEN we to connect the ExtensionItem head to the Class
+    # THEN the connection is made
     connect(ext, ext.head, cls)

--- a/gaphor/diagram/profiles/tests/test_extensionconnect.py
+++ b/gaphor/diagram/profiles/tests/test_extensionconnect.py
@@ -9,36 +9,28 @@ from gaphor.diagram.tests.fixtures import allow, connect
 def test_glue(element_factory, diagram):
     """Test extension item glue."""
 
-    # GIVEN an ExtensionItem, Stereotype, and Class
     ext = diagram.create(ExtensionItem)
     st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
     cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
-    # WHEN we try to connect the ExtensionItem tail to the Stereotype
     glued = allow(ext, ext.tail, st)
 
-    # THEN we allow the connection, and we connect them
     assert glued
     connect(ext, ext.tail, st)
 
-    # WHEN we try to connect the ExtensionItem head to the Class
     glued = allow(ext, ext.head, cls)
 
-    # THEN we allow the connection
     assert glued
 
 
 def test_class_glue(element_factory, diagram):
     """Test extension item gluing to a class."""
 
-    # GIVEN an ExtensionItem and ClassItem
     ext = diagram.create(ExtensionItem)
     cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
-    # WHEN we try to connect the ExtensionItem tail to a Class
     glued = allow(ext, ext.tail, cls)
 
-    # THEN we don't allow the connection
     assert not glued
 
 
@@ -49,30 +41,22 @@ def test_stereotype_glue(element_factory, diagram):
     Class.
     """
 
-    # GIVEN an ExtensionItem and Stereotype
     ext = diagram.create(ExtensionItem)
     st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
     assert isinstance(st.subject, UML.Stereotype)
 
-    # WHEN we try to connect the ExtensionItem head to a Stereotype
     glued = allow(ext, ext.head, st)
 
-    # THEN we allow the connection
     assert glued
 
 
 def test_connection(element_factory, diagram):
     """Test extension item connection."""
 
-    # GIVEN an ExtensionItem, a Stereotype, and a Class
     ext = diagram.create(ExtensionItem)
     st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
     cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
-    # WHEN we to connect the ExtensionItem tail to the Stereotype
-    # THEN the connection is made
     connect(ext, ext.tail, st)
 
-    # WHEN we to connect the ExtensionItem head to the Class
-    # THEN the connection is made
     connect(ext, ext.head, cls)

--- a/gaphor/diagram/profiles/tests/test_metaclasspropertypage.py
+++ b/gaphor/diagram/profiles/tests/test_metaclasspropertypage.py
@@ -1,33 +1,56 @@
 """Test Metaclass Property Page."""
 
+import pytest
 from gi.repository import Gtk
 
 from gaphor import UML
 from gaphor.diagram.profiles.metaclasspropertypage import MetaclassPropertyPage
 
 
-def test_name_input_field_for_normal_class(element_factory):
+@pytest.fixture
+def class_(element_factory):
     class_ = element_factory.create(UML.Class)
     class_.name = "Class"
+    yield class_
+    del class_
+
+
+def test_name_input_field_for_normal_class(class_):
+    """Test Metaclass Property Page not create for normal Class."""
+
+    # GIVEN a Class
+    # WHEN we open a new Metaclass Property Page for the Class
     editor = MetaclassPropertyPage(class_)
     page = editor.construct()
+
+    # THEN we don't create a property page
     assert not page
 
 
-def test_name_selection_for_metaclass(element_factory):
-    metaclass = element_factory.create(UML.Class)
-    metaclass.name = "Class"
+def test_name_selection_for_metaclass(element_factory, class_):
+    """Test the creation of Metaclass Property Page."""
+
+    # GIVEN a Class with a Metaclass Extension
     stereotype = element_factory.create(UML.Stereotype)
     stereotype.name = "NewStereotype"
-    UML.model.create_extension(metaclass, stereotype)
+    UML.model.create_extension(class_, stereotype)
 
-    editor = MetaclassPropertyPage(metaclass)
+    # WHEN we open a new Metaclass Property Page
+    editor = MetaclassPropertyPage(class_)
     page = editor.construct()
+
+    # THEN we create a property page
     assert page
+
+    # WHEN we create a property page
     combo = page.get_children()[1]
-    assert Gtk.ComboBoxText is type(combo)
 
-    assert "Class" == combo.get_child().get_text()
+    # THEN the child is a Gtk ComboBox and its child has text "Class"
+    assert type(combo) is Gtk.ComboBoxText
+    assert combo.get_child().get_text() == "Class"
 
-    metaclass.name = "Blah"
-    assert "Blah" == combo.get_child().get_text()
+    # WHEN we change the metaclass name
+    class_.name = "Blah"
+
+    # THEN we also update the ComboBox child's text
+    assert combo.get_child().get_text() == "Blah"

--- a/gaphor/diagram/profiles/tests/test_metaclasspropertypage.py
+++ b/gaphor/diagram/profiles/tests/test_metaclasspropertypage.py
@@ -18,39 +18,29 @@ def class_(element_factory):
 def test_name_input_field_for_normal_class(class_):
     """Test Metaclass Property Page not create for normal Class."""
 
-    # GIVEN a Class
-    # WHEN we open a new Metaclass Property Page for the Class
     editor = MetaclassPropertyPage(class_)
     page = editor.construct()
 
-    # THEN we don't create a property page
     assert not page
 
 
 def test_name_selection_for_metaclass(element_factory, class_):
     """Test the creation of Metaclass Property Page."""
 
-    # GIVEN a Class with a Metaclass Extension
     stereotype = element_factory.create(UML.Stereotype)
     stereotype.name = "NewStereotype"
     UML.model.create_extension(class_, stereotype)
 
-    # WHEN we open a new Metaclass Property Page
     editor = MetaclassPropertyPage(class_)
     page = editor.construct()
 
-    # THEN we create a property page
     assert page
 
-    # WHEN we create a property page
     combo = page.get_children()[1]
 
-    # THEN the child is a Gtk ComboBox and its child has text "Class"
     assert type(combo) is Gtk.ComboBoxText
     assert combo.get_child().get_text() == "Class"
 
-    # WHEN we change the metaclass name
     class_.name = "Blah"
 
-    # THEN we also update the ComboBox child's text
     assert combo.get_child().get_text() == "Blah"

--- a/gaphor/diagram/profiles/tests/test_metaclasspropertypage.py
+++ b/gaphor/diagram/profiles/tests/test_metaclasspropertypage.py
@@ -1,33 +1,33 @@
+"""Test Metaclass Property Page."""
+
 from gi.repository import Gtk
 
 from gaphor import UML
 from gaphor.diagram.profiles.metaclasspropertypage import MetaclassPropertyPage
-from gaphor.tests import TestCase
 
 
-class MetaclassPropertyPageTest(TestCase):
-    def test_name_input_field_for_normal_class(self):
-        class_ = self.element_factory.create(UML.Class)
+def test_name_input_field_for_normal_class(element_factory):
+    class_ = element_factory.create(UML.Class)
+    class_.name = "Class"
+    editor = MetaclassPropertyPage(class_)
+    page = editor.construct()
+    assert not page
 
-        class_.name = "Class"
-        editor = MetaclassPropertyPage(class_)
-        page = editor.construct()
-        assert not page
 
-    def test_name_selection_for_metaclass(self):
-        metaclass = self.element_factory.create(UML.Class)
-        metaclass.name = "Class"
-        stereotype = self.element_factory.create(UML.Stereotype)
-        stereotype.name = "NewStereotype"
-        UML.model.create_extension(metaclass, stereotype)
+def test_name_selection_for_metaclass(element_factory):
+    metaclass = element_factory.create(UML.Class)
+    metaclass.name = "Class"
+    stereotype = element_factory.create(UML.Stereotype)
+    stereotype.name = "NewStereotype"
+    UML.model.create_extension(metaclass, stereotype)
 
-        editor = MetaclassPropertyPage(metaclass)
-        page = editor.construct()
-        assert page
-        combo = page.get_children()[1]
-        assert Gtk.ComboBoxText is type(combo)
+    editor = MetaclassPropertyPage(metaclass)
+    page = editor.construct()
+    assert page
+    combo = page.get_children()[1]
+    assert Gtk.ComboBoxText is type(combo)
 
-        assert "Class" == combo.get_child().get_text()
+    assert "Class" == combo.get_child().get_text()
 
-        metaclass.name = "Blah"
-        assert "Blah" == combo.get_child().get_text()
+    metaclass.name = "Blah"
+    assert "Blah" == combo.get_child().get_text()

--- a/gaphor/diagram/profiles/tests/test_stereotypepage.py
+++ b/gaphor/diagram/profiles/tests/test_stereotypepage.py
@@ -1,20 +1,37 @@
 """Test Stereotype Property Page."""
 
+import pytest
+
 from gaphor import UML
 from gaphor.diagram.classes.klass import ClassItem
 from gaphor.diagram.profiles.stereotypepropertypages import StereotypePage
 
 
-def test_stereotype_page_with_no_stereotype(element_factory, diagram):
-    ci = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
-    ci.subject.name = "Class"
-    editor = StereotypePage(ci)
+@pytest.fixture
+def class_(diagram, element_factory):
+    class_ = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    class_.name = "Class"
+    yield class_
+    del class_
+
+
+def test_stereotype_page_with_no_stereotype(diagram, class_):
+    """Test the Stereotype Property Page not created for a Class."""
+
+    # GIVEN a Class
+    # WHEN we open a Stereotype Property Page for the Class
+    editor = StereotypePage(class_)
     page = editor.construct()
+
+    # THEN we don't create a property page
     assert page is None
 
 
-def test_stereotype_page_with_stereotype(element_factory, diagram):
+def test_stereotype_page_with_stereotype(element_factory, diagram, class_):
+    """Test creation of a Stereotype Property Page."""
+
     # Create a stereotype applicable to Class types:
+    # GIVEN a Class with a MetaClass Extension, a Property, and a Class
     metaclass = element_factory.create(UML.Class)
     metaclass.name = "Class"
     stereotype = element_factory.create(UML.Stereotype)
@@ -22,13 +39,12 @@ def test_stereotype_page_with_stereotype(element_factory, diagram):
     UML.model.create_extension(metaclass, stereotype)
     attr = element_factory.create(UML.Property)
     attr.name = "Property"
-    # stereotype.ownedAttribute = attr
 
-    ci = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
-    ci.subject.name = "Foo"
-    editor = StereotypePage(ci)
+    # WHEN we open a new Stereotype Property Page
+    editor = StereotypePage(class_)
     page = editor.construct()
-
     editor.refresh()
+
+    # THEN we create an editor model, and a property page
     assert len(editor.model) == 1
     assert page is not None

--- a/gaphor/diagram/profiles/tests/test_stereotypepage.py
+++ b/gaphor/diagram/profiles/tests/test_stereotypepage.py
@@ -18,12 +18,9 @@ def class_(diagram, element_factory):
 def test_stereotype_page_with_no_stereotype(diagram, class_):
     """Test the Stereotype Property Page not created for a Class."""
 
-    # GIVEN a Class
-    # WHEN we open a Stereotype Property Page for the Class
     editor = StereotypePage(class_)
     page = editor.construct()
 
-    # THEN we don't create a property page
     assert page is None
 
 
@@ -31,7 +28,6 @@ def test_stereotype_page_with_stereotype(element_factory, diagram, class_):
     """Test creation of a Stereotype Property Page."""
 
     # Create a stereotype applicable to Class types:
-    # GIVEN a Class with a MetaClass Extension, a Property, and a Class
     metaclass = element_factory.create(UML.Class)
     metaclass.name = "Class"
     stereotype = element_factory.create(UML.Stereotype)
@@ -40,11 +36,9 @@ def test_stereotype_page_with_stereotype(element_factory, diagram, class_):
     attr = element_factory.create(UML.Property)
     attr.name = "Property"
 
-    # WHEN we open a new Stereotype Property Page
     editor = StereotypePage(class_)
     page = editor.construct()
     editor.refresh()
 
-    # THEN we create an editor model, and a property page
     assert len(editor.model) == 1
     assert page is not None

--- a/gaphor/diagram/profiles/tests/test_stereotypepage.py
+++ b/gaphor/diagram/profiles/tests/test_stereotypepage.py
@@ -1,33 +1,34 @@
+"""Test Stereotype Property Page."""
+
 from gaphor import UML
 from gaphor.diagram.classes.klass import ClassItem
 from gaphor.diagram.profiles.stereotypepropertypages import StereotypePage
-from gaphor.tests import TestCase
 
 
-class MetaclassEditorTest(TestCase):
-    def test_stereotype_page_with_no_stereotype(self):
-        ci = self.create(ClassItem, UML.Class)
-        ci.subject.name = "Class"
-        editor = StereotypePage(ci)
-        page = editor.construct()
-        assert page is None
+def test_stereotype_page_with_no_stereotype(element_factory, diagram):
+    ci = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    ci.subject.name = "Class"
+    editor = StereotypePage(ci)
+    page = editor.construct()
+    assert page is None
 
-    def test_stereotype_page_with_stereotype(self):
-        # Create an stereotype applicable to Class types:
-        metaclass = self.element_factory.create(UML.Class)
-        metaclass.name = "Class"
-        stereotype = self.element_factory.create(UML.Stereotype)
-        stereotype.name = "NewStereotype"
-        UML.model.create_extension(metaclass, stereotype)
-        attr = self.element_factory.create(UML.Property)
-        attr.name = "Property"
-        # stereotype.ownedAttribute = attr
 
-        ci = self.create(ClassItem, UML.Class)
-        ci.subject.name = "Foo"
-        editor = StereotypePage(ci)
-        page = editor.construct()
+def test_stereotype_page_with_stereotype(element_factory, diagram):
+    # Create a stereotype applicable to Class types:
+    metaclass = element_factory.create(UML.Class)
+    metaclass.name = "Class"
+    stereotype = element_factory.create(UML.Stereotype)
+    stereotype.name = "NewStereotype"
+    UML.model.create_extension(metaclass, stereotype)
+    attr = element_factory.create(UML.Property)
+    attr.name = "Property"
+    # stereotype.ownedAttribute = attr
 
-        editor.refresh()
-        assert len(editor.model) == 1
-        assert page is not None
+    ci = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    ci.subject.name = "Foo"
+    editor = StereotypePage(ci)
+    page = editor.construct()
+
+    editor.refresh()
+    assert len(editor.model) == 1
+    assert page is not None

--- a/gaphor/misc/tests/test_gidlethread.py
+++ b/gaphor/misc/tests/test_gidlethread.py
@@ -22,15 +22,9 @@ def gidle_counter(request):
 
 @pytest.mark.parametrize(argnames="gidle_counter", argvalues=[20000], indirect=True)
 def test_wait_with_timeout(gidle_counter):
-    # GIVEN a long coroutine thread
-    # WHEN waiting short timeout
-    # THEN timeout is True
     assert gidle_counter
 
 
 @pytest.mark.parametrize(argnames="gidle_counter", argvalues=[2], indirect=True)
 def test_wait_until_finished(gidle_counter):
-    # GIVEN a short coroutine thread
-    # WHEN wait for coroutine to finish
-    # THEN coroutine finished
     assert not gidle_counter


### PR DESCRIPTION
This PR continues conversion towards closure of #129.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
All profile tests are using unittest

Issue Number: #129 

### What is the new behavior?
Some profile tests are using PyTest

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
