### PR TITLE
Fix MSYS2 Package Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ To setup a development environment in Windows:
 1) Run ``C:\msys64\mingw64.exe`` - a terminal window should pop up
 ```bash
 $ pacman -Suy
-$ pacman -S git mingw-w64-x86-64-gcc mingw-w64-x86-64-gtk3 \
-mingw-w64-x86-64-pkg-config mingw-w64-x86-64-cairo \
-mingw-w64-x86-64-gobject-introspection mingw-w64-x86-64-python3 \
-mingw-w64-x86-64-python3-gobject mingw-w64-x86-64-python3-cairo \
-mingw-w64-x86-64-python3-pip mingw-w64-x86-64-python3-setuptools
+$ pacman -S git mingw-w64-x86_64-gcc mingw-w64-x86_64-gtk3 \
+mingw-w64-x86_64-pkg-config mingw-w64-x86_64-cairo \
+mingw-w64-x86_64-gobject-introspection mingw-w64-x86_64-python \
+mingw-w64-x86_64-python-gobject mingw-w64-x86_64-python-cairo \
+mingw-w64-x86_64-python-pip
 ```
 
 Ensure `/mingw64/bin` is added to your `PATH`:

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -8,13 +8,11 @@ To setup a development environment in Windows:
 1) Run ``C:\msys64\mingw64.exe`` - a terminal window should pop up
 ```bash
 $ pacman -Suy
-$ pacman -S git mingw-w64-x86-64-gcc mingw-w64-x86-64-gtk3 \
-mingw-w64-x86-64-pkg-config mingw-w64-x86-64-cairo \
-mingw-w64-x86-64-gobject-introspection mingw-w64-x86-64-python3 \
-mingw-w64-x86-64-python3-importlib-metadata mingw-w64-x86-64-python3-gobject \
-mingw-w64-x86-64-python3-cairo mingw-w64-x86-64-python3-pip \
-mingw-w64-x86-64-python3-setuptools mingw-w64-x86-64-python3-zope.interface \
-mingw-w64-x86-64-python3-coverage mingw-w64-x86-64-python3-pytest
+$ pacman -S git mingw-w64-x86_64-gcc mingw-w64-x86_64-gtk3 \
+mingw-w64-x86_64-pkg-config mingw-w64-x86_64-cairo \
+mingw-w64-x86_64-gobject-introspection mingw-w64-x86_64-python \
+mingw-w64-x86_64-python-gobject mingw-w64-x86_64-python-cairo \
+mingw-w64-x86_64-python-pip
 ```
 
 [Clone the

--- a/win-installer/msys2-install.sh
+++ b/win-installer/msys2-install.sh
@@ -15,11 +15,10 @@ pacman --noconfirm -S --needed \
     mingw-w64-"$MSYS2_ARCH"-pkg-config \
     mingw-w64-"$MSYS2_ARCH"-cairo \
     mingw-w64-"$MSYS2_ARCH"-gobject-introspection \
-    mingw-w64-"$MSYS2_ARCH"-python3 \
-    mingw-w64-"$MSYS2_ARCH"-python3-gobject \
-    mingw-w64-"$MSYS2_ARCH"-python3-cairo \
-    mingw-w64-"$MSYS2_ARCH"-python3-pip \
-    mingw-w64-"$MSYS2_ARCH"-python3-setuptools
+    mingw-w64-"$MSYS2_ARCH"-python \
+    mingw-w64-"$MSYS2_ARCH"-python-gobject \
+    mingw-w64-"$MSYS2_ARCH"-python-cairo \
+    mingw-w64-"$MSYS2_ARCH"-python-pip \
 
 source "$DIR"/../venv
 pip install pyinstaller


### PR DESCRIPTION
MSYS2 made Python 3 the default, so package names no longer need to specify python3.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
