### PR TITLE
Copy/paste items in the same model

### DIFF
--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -177,7 +177,7 @@ class DecisionNodeItem(ElementPresentation, ActivityNodeItem):
 
     def save(self, save_func):
         if self._combined:
-            save_func("combined", self._combined, reference=True)
+            save_func("combined", self._combined)
         super().save(save_func)
 
     def load(self, name, value):
@@ -252,7 +252,7 @@ class ForkNodeItem(Presentation[UML.ForkNode], Item):
         save_func("matrix", tuple(self.matrix))
         save_func("height", float(self._handles[1].pos.y))
         if self._combined:
-            save_func("combined", self._combined, reference=True)
+            save_func("combined", self._combined)
         super().save(save_func)
 
     def load(self, name, value):

--- a/gaphor/UML/classes/__init__.py
+++ b/gaphor/UML/classes/__init__.py
@@ -11,6 +11,7 @@ from gaphor.UML.classes import (
     interfaceconnect,
     classeseditors,
     classespropertypages,
+    copypaste,
 )
 
 __all__ = [

--- a/gaphor/UML/classes/copypaste.py
+++ b/gaphor/UML/classes/copypaste.py
@@ -1,0 +1,29 @@
+from typing import Dict, List, NamedTuple
+
+from gaphor.diagram.copypaste import (
+    ElementCopy,
+    copy,
+    copy_element,
+    paste,
+    paste_element,
+)
+from gaphor.UML import Association
+
+
+class AssociationCopy(NamedTuple):
+    element_copy: ElementCopy
+    member_ends: List[ElementCopy]
+
+
+@copy.register
+def copy_association(element: Association):
+    element_copy = copy_element(element)
+    member_ends = [copy_element(end) for end in element.memberEnd]
+    return AssociationCopy(element_copy=element_copy, member_ends=member_ends)
+
+
+@paste.register
+def paste_association(copy_data: AssociationCopy, diagram, lookup):
+    for member_end in copy_data.member_ends:
+        paste_element(member_end, diagram, lookup)
+    return paste_element(copy_data.element_copy, diagram, lookup)

--- a/gaphor/UML/classes/copypaste.py
+++ b/gaphor/UML/classes/copypaste.py
@@ -31,8 +31,8 @@ def copy_class(element):
         owned_parameters=[
             copy_element(oper)
             for oper in itertools.chain(
-                element.ownedOperation[:].formalParameter,  # type: ignore[attr-defined]
-                element.ownedOperation[:].returnResult,  # type: ignore[attr-defined]
+                element.ownedOperation[:].formalParameter,
+                element.ownedOperation[:].returnResult,
             )
         ],
         owned_operations=[copy_element(oper) for oper in element.ownedOperation],

--- a/gaphor/UML/classes/copypaste.py
+++ b/gaphor/UML/classes/copypaste.py
@@ -8,7 +8,7 @@ from gaphor.diagram.copypaste import (
     paste,
     paste_element,
 )
-from gaphor.UML import Association, Class
+from gaphor.UML import Association, Class, Interface
 
 
 class ClassCopy(NamedTuple):
@@ -18,8 +18,9 @@ class ClassCopy(NamedTuple):
     owned_operations: List[ElementCopy]
 
 
-@copy.register
-def copy_class(element: Class):
+@copy.register(Class)
+@copy.register(Interface)
+def copy_class(element):
     return ClassCopy(
         element_copy=copy_element(element),
         owned_attributes=[

--- a/gaphor/UML/classes/copypaste.py
+++ b/gaphor/UML/classes/copypaste.py
@@ -3,16 +3,19 @@ from typing import Dict, List, NamedTuple
 
 from gaphor.diagram.copypaste import (
     ElementCopy,
+    NamedElementCopy,
     copy,
     copy_element,
+    copy_named_element,
     paste,
     paste_element,
+    paste_named_element,
 )
 from gaphor.UML import Association, Class, Interface
 
 
 class ClassCopy(NamedTuple):
-    element_copy: ElementCopy
+    element_copy: NamedElementCopy
     owned_attributes: List[ElementCopy]
     owned_parameters: List[ElementCopy]
     owned_operations: List[ElementCopy]
@@ -22,7 +25,7 @@ class ClassCopy(NamedTuple):
 @copy.register(Interface)
 def copy_class(element):
     return ClassCopy(
-        element_copy=copy_element(element),
+        element_copy=copy_named_element(element),
         owned_attributes=[
             copy_element(attr)
             for attr in element.ownedAttribute
@@ -47,18 +50,18 @@ def paste_class(copy_data: ClassCopy, diagram, lookup):
         copy_data.owned_operations,
     ):
         paste_element(attr, diagram, lookup)
-    return paste_element(copy_data.element_copy, diagram, lookup)
+    return paste_named_element(copy_data.element_copy, diagram, lookup)
 
 
 class AssociationCopy(NamedTuple):
-    element_copy: ElementCopy
+    element_copy: NamedElementCopy
     member_ends: List[ElementCopy]
 
 
 @copy.register
 def copy_association(element: Association):
     return AssociationCopy(
-        element_copy=copy_element(element),
+        element_copy=copy_named_element(element),
         member_ends=[copy_element(end) for end in element.memberEnd],
     )
 
@@ -67,4 +70,4 @@ def copy_association(element: Association):
 def paste_association(copy_data: AssociationCopy, diagram, lookup):
     for member_end in copy_data.member_ends:
         paste_element(member_end, diagram, lookup)
-    return paste_element(copy_data.element_copy, diagram, lookup)
+    return paste_named_element(copy_data.element_copy, diagram, lookup)

--- a/gaphor/UML/classes/tests/conftest.py
+++ b/gaphor/UML/classes/tests/conftest.py
@@ -1,0 +1,1 @@
+from gaphor.diagram.tests.fixtures import diagram, element_factory, event_manager

--- a/gaphor/UML/classes/tests/test_copypaste.py
+++ b/gaphor/UML/classes/tests/test_copypaste.py
@@ -4,6 +4,53 @@ from gaphor.diagram.tests.fixtures import clear_model, connect
 from gaphor.UML.classes import AssociationItem, ClassItem
 
 
+def test_class_with_attributes(diagram, element_factory):
+    cls = element_factory.create(UML.Class)
+    attr = element_factory.create(UML.Property)
+    UML.parse(attr, "- attr: str")
+    cls.ownedAttribute = attr
+
+    cls_item = diagram.create(ClassItem, subject=cls)
+
+    buffer = copy({cls_item})
+
+    clear_model(diagram, element_factory)
+
+    print(buffer)
+
+    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_cls_item = new_items.pop()
+
+    assert isinstance(new_cls_item, ClassItem)
+    assert UML.format(new_cls_item.subject.ownedAttribute[0]) == "- attr: str"
+
+
+def test_class_with_operation(diagram, element_factory):
+    cls = element_factory.create(UML.Class)
+    oper = element_factory.create(UML.Operation)
+    UML.parse(oper, "- oper(inout param: str): str")
+    cls.ownedOperation = oper
+
+    cls_item = diagram.create(ClassItem, subject=cls)
+
+    buffer = copy({cls_item})
+
+    clear_model(diagram, element_factory)
+
+    print(buffer)
+
+    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_cls_item = new_items.pop()
+
+    assert isinstance(new_cls_item, ClassItem)
+    print("param: ", new_cls_item.subject.ownedOperation[0].formalParameter)
+    print(element_factory.lselect())
+    assert (
+        UML.format(new_cls_item.subject.ownedOperation[0])
+        == "- oper(inout param: str): str"
+    )
+
+
 def two_classes_and_an_association(diagram, element_factory):
     gen_cls = element_factory.create(UML.Class)
     spc_cls = element_factory.create(UML.Class)

--- a/gaphor/UML/classes/tests/test_copypaste.py
+++ b/gaphor/UML/classes/tests/test_copypaste.py
@@ -1,0 +1,38 @@
+from gaphor import UML
+from gaphor.diagram.copypaste import copy, paste
+from gaphor.diagram.tests.fixtures import clear_model, connect
+from gaphor.UML.classes import AssociationItem, ClassItem
+
+
+def two_classes_and_an_association(diagram, element_factory):
+    gen_cls = element_factory.create(UML.Class)
+    spc_cls = element_factory.create(UML.Class)
+    gen_cls_item = diagram.create(ClassItem, subject=gen_cls)
+    spc_cls_item = diagram.create(ClassItem, subject=spc_cls)
+    assoc_item = diagram.create(AssociationItem)
+    connect(assoc_item, assoc_item.handles()[0], gen_cls_item)
+    connect(assoc_item, assoc_item.handles()[1], spc_cls_item)
+
+    return gen_cls_item, spc_cls_item, assoc_item
+
+
+def test_copy_remove_paste_items_with_connections(diagram, element_factory):
+    gen_cls_item, spc_cls_item, assoc_item = two_classes_and_an_association(
+        diagram, element_factory
+    )
+
+    buffer = copy({gen_cls_item, assoc_item, spc_cls_item})
+
+    clear_model(diagram, element_factory)
+
+    print(buffer)
+
+    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_cls1, new_cls2 = element_factory.lselect(lambda e: isinstance(e, UML.Class))
+    new_assoc = element_factory.lselect(lambda e: isinstance(e, UML.Association))[0]
+
+    assert new_assoc.memberEnd[0].type in {new_cls1, new_cls2}
+    assert new_assoc.memberEnd[1].type in {new_cls1, new_cls2}
+    assert new_cls1.presentation[0] in new_items
+    assert new_cls2.presentation[0] in new_items
+    assert new_assoc.presentation[0] in new_items

--- a/gaphor/UML/classes/tests/test_copypaste.py
+++ b/gaphor/UML/classes/tests/test_copypaste.py
@@ -1,7 +1,7 @@
 from gaphor import UML
 from gaphor.diagram.copypaste import copy, paste
 from gaphor.diagram.tests.fixtures import clear_model, connect
-from gaphor.UML.classes import AssociationItem, ClassItem
+from gaphor.UML.classes import AssociationItem, ClassItem, InterfaceItem
 
 
 def test_class_with_attributes(diagram, element_factory):
@@ -43,10 +43,38 @@ def test_class_with_operation(diagram, element_factory):
     new_cls_item = new_items.pop()
 
     assert isinstance(new_cls_item, ClassItem)
-    print("param: ", new_cls_item.subject.ownedOperation[0].formalParameter)
-    print(element_factory.lselect())
     assert (
         UML.format(new_cls_item.subject.ownedOperation[0])
+        == "- oper(inout param: str): str"
+    )
+
+
+def test_interface_with_attributes_and_operation(diagram, element_factory):
+    iface = element_factory.create(UML.Interface)
+
+    attr = element_factory.create(UML.Property)
+    UML.parse(attr, "- attr: str")
+    iface.ownedAttribute = attr
+
+    oper = element_factory.create(UML.Operation)
+    UML.parse(oper, "- oper(inout param: str): str")
+    iface.ownedOperation = oper
+
+    iface_item = diagram.create(InterfaceItem, subject=iface)
+
+    buffer = copy({iface_item})
+
+    clear_model(diagram, element_factory)
+
+    print(buffer)
+
+    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_iface_item = new_items.pop()
+
+    assert isinstance(new_iface_item, InterfaceItem)
+    assert UML.format(new_iface_item.subject.ownedAttribute[0]) == "- attr: str"
+    assert (
+        UML.format(new_iface_item.subject.ownedOperation[0])
         == "- oper(inout param: str): str"
     )
 

--- a/gaphor/UML/classes/tests/test_copypaste.py
+++ b/gaphor/UML/classes/tests/test_copypaste.py
@@ -10,8 +10,12 @@ def two_classes_and_an_association(diagram, element_factory):
     gen_cls_item = diagram.create(ClassItem, subject=gen_cls)
     spc_cls_item = diagram.create(ClassItem, subject=spc_cls)
     assoc_item = diagram.create(AssociationItem)
+
     connect(assoc_item, assoc_item.handles()[0], gen_cls_item)
     connect(assoc_item, assoc_item.handles()[1], spc_cls_item)
+    UML.model.set_navigability(
+        assoc_item.subject, assoc_item.subject.memberEnd[0], True
+    )
 
     return gen_cls_item, spc_cls_item, assoc_item
 
@@ -33,6 +37,7 @@ def test_copy_remove_paste_items_with_connections(diagram, element_factory):
 
     assert new_assoc.memberEnd[0].type in {new_cls1, new_cls2}
     assert new_assoc.memberEnd[1].type in {new_cls1, new_cls2}
+    assert new_assoc.memberEnd[0] in new_assoc.memberEnd[1].type.ownedAttribute
     assert new_cls1.presentation[0] in new_items
     assert new_cls2.presentation[0] in new_items
     assert new_assoc.presentation[0] in new_items

--- a/gaphor/UML/classes/tests/test_copypaste.py
+++ b/gaphor/UML/classes/tests/test_copypaste.py
@@ -1,6 +1,5 @@
 from gaphor import UML
-from gaphor.diagram.copypaste import copy, paste
-from gaphor.diagram.tests.fixtures import clear_model, connect
+from gaphor.diagram.tests.fixtures import clear_model, connect, copy_clear_and_paste
 from gaphor.UML.classes import AssociationItem, ClassItem, InterfaceItem
 
 
@@ -12,13 +11,7 @@ def test_class_with_attributes(diagram, element_factory):
 
     cls_item = diagram.create(ClassItem, subject=cls)
 
-    buffer = copy({cls_item})
-
-    clear_model(diagram, element_factory)
-
-    print(buffer)
-
-    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_items = copy_clear_and_paste({cls_item}, diagram, element_factory)
     new_cls_item = new_items.pop()
 
     assert isinstance(new_cls_item, ClassItem)
@@ -33,13 +26,7 @@ def test_class_with_operation(diagram, element_factory):
 
     cls_item = diagram.create(ClassItem, subject=cls)
 
-    buffer = copy({cls_item})
-
-    clear_model(diagram, element_factory)
-
-    print(buffer)
-
-    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_items = copy_clear_and_paste({cls_item}, diagram, element_factory)
     new_cls_item = new_items.pop()
 
     assert isinstance(new_cls_item, ClassItem)
@@ -62,13 +49,7 @@ def test_interface_with_attributes_and_operation(diagram, element_factory):
 
     iface_item = diagram.create(InterfaceItem, subject=iface)
 
-    buffer = copy({iface_item})
-
-    clear_model(diagram, element_factory)
-
-    print(buffer)
-
-    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_items = copy_clear_and_paste({iface_item}, diagram, element_factory)
     new_iface_item = new_items.pop()
 
     assert isinstance(new_iface_item, InterfaceItem)
@@ -100,13 +81,9 @@ def test_copy_remove_paste_items_with_connections(diagram, element_factory):
         diagram, element_factory
     )
 
-    buffer = copy({gen_cls_item, assoc_item, spc_cls_item})
-
-    clear_model(diagram, element_factory)
-
-    print(buffer)
-
-    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_items = copy_clear_and_paste(
+        {gen_cls_item, assoc_item, spc_cls_item}, diagram, element_factory
+    )
     new_cls1, new_cls2 = element_factory.lselect(lambda e: isinstance(e, UML.Class))
     new_assoc = element_factory.lselect(lambda e: isinstance(e, UML.Association))[0]
 

--- a/gaphor/UML/components/__init__.py
+++ b/gaphor/UML/components/__init__.py
@@ -7,6 +7,7 @@ from gaphor.UML.components import (
     componentsgrouping,
     connectorconnect,
     componentspropertypage,
+    copypaste,
 )
 
 __all__ = ["ArtifactItem", "ComponentItem", "ConnectorItem", "NodeItem"]

--- a/gaphor/UML/components/connectorconnect.py
+++ b/gaphor/UML/components/connectorconnect.py
@@ -107,9 +107,10 @@ class ConnectorConnectBase(BaseConnector):
          component
             Component item.
         """
-        p = component.subject.ownedPort[0]
-        p.unlink()
-        connector.subject = None
+        if component and component.subject:
+            p = component.subject.ownedPort[0]
+            p.unlink()
+            connector.subject = None
 
     def allow(self, handle, port):
         iface = self.element

--- a/gaphor/UML/components/connectorconnect.py
+++ b/gaphor/UML/components/connectorconnect.py
@@ -150,6 +150,14 @@ class ConnectorConnectBase(BaseConnector):
                     assert assembly.kind == "assembly"
                     break
 
+            if line.subject:
+                assert isinstance(line.subject, UML.Connector)
+                assembly = line.subject
+                assert assembly.end
+                assert assembly.end[:].partWithPort
+                assert iface in assembly.end[:].role
+                return
+
             if assembly is None:
                 assembly = self.element.model.create(UML.Connector)
                 assembly.kind = "assembly"

--- a/gaphor/UML/components/copypaste.py
+++ b/gaphor/UML/components/copypaste.py
@@ -22,7 +22,7 @@ def copy_connector(element: Connector):
     return ConnectorCopy(
         element_copy=copy_element(element),
         ends=[copy_element(end) for end in element.end],
-        ports=[copy_element(port) for port in element.end[:].partWithPort],  # type: ignore[attr-defined]
+        ports=[copy_element(port) for port in element.end[:].partWithPort],
     )
 
 

--- a/gaphor/UML/components/copypaste.py
+++ b/gaphor/UML/components/copypaste.py
@@ -1,0 +1,33 @@
+import itertools
+from typing import List, NamedTuple
+
+from gaphor.diagram.copypaste import (
+    ElementCopy,
+    copy,
+    copy_element,
+    paste,
+    paste_element,
+)
+from gaphor.UML import Connector
+
+
+class ConnectorCopy(NamedTuple):
+    element_copy: ElementCopy
+    ends: List[ElementCopy]
+    ports: List[ElementCopy]
+
+
+@copy.register
+def copy_connector(element: Connector):
+    return ConnectorCopy(
+        element_copy=copy_element(element),
+        ends=[copy_element(end) for end in element.end],
+        ports=[copy_element(port) for port in element.end[:].partWithPort],  # type: ignore[attr-defined]
+    )
+
+
+@paste.register
+def paste_connector(copy_data: ConnectorCopy, diagram, lookup):
+    for data in itertools.chain(copy_data.ports, copy_data.ends):
+        paste_element(data, diagram, lookup)
+    return paste_element(copy_data.element_copy, diagram, lookup)

--- a/gaphor/UML/components/tests/conftest.py
+++ b/gaphor/UML/components/tests/conftest.py
@@ -1,0 +1,1 @@
+from gaphor.diagram.tests.fixtures import diagram, element_factory, event_manager

--- a/gaphor/UML/components/tests/test_copypaste.py
+++ b/gaphor/UML/components/tests/test_copypaste.py
@@ -23,5 +23,6 @@ def test_connector(diagram, element_factory):
 
     assert isinstance(new_conn.presentation[0], ConnectorItem)
     assert new_conn.kind == "assembly"
+    assert len(new_conn.end) == 1
     assert new_conn.end[0].role is new_iface
     assert new_conn.end[0].partWithPort in new_comp.ownedPort

--- a/gaphor/UML/components/tests/test_copypaste.py
+++ b/gaphor/UML/components/tests/test_copypaste.py
@@ -1,0 +1,27 @@
+from gaphor import UML
+from gaphor.diagram.tests.fixtures import clear_model, connect, copy_clear_and_paste
+from gaphor.UML.classes import InterfaceItem
+from gaphor.UML.components import ComponentItem, ConnectorItem
+
+
+def test_connector(diagram, element_factory):
+    comp = element_factory.create(UML.Component)
+    iface = element_factory.create(UML.Interface)
+
+    comp_item = diagram.create(ComponentItem, subject=comp)
+    iface_item = diagram.create(InterfaceItem, subject=iface)
+    conn_item = diagram.create(ConnectorItem)
+
+    connect(conn_item, conn_item.handles()[0], comp_item)
+    connect(conn_item, conn_item.handles()[1], iface_item)
+
+    copy_clear_and_paste({comp_item, iface_item, conn_item}, diagram, element_factory)
+
+    new_conn = element_factory.lselect(lambda e: isinstance(e, UML.Connector))[0]
+    new_comp = element_factory.lselect(lambda e: isinstance(e, UML.Component))[0]
+    new_iface = element_factory.lselect(lambda e: isinstance(e, UML.Interface))[0]
+
+    assert isinstance(new_conn.presentation[0], ConnectorItem)
+    assert new_conn.kind == "assembly"
+    assert new_conn.end[0].role is new_iface
+    assert new_conn.end[0].partWithPort in new_comp.ownedPort

--- a/gaphor/UML/interactions/__init__.py
+++ b/gaphor/UML/interactions/__init__.py
@@ -7,6 +7,7 @@ from gaphor.UML.interactions import (
     interactionsconnect,
     interactionsgrouping,
     interactionspropertypages,
+    copypaste,
 )
 
 __all__ = [

--- a/gaphor/UML/interactions/copypaste.py
+++ b/gaphor/UML/interactions/copypaste.py
@@ -1,0 +1,62 @@
+import itertools
+from typing import List, NamedTuple, Optional
+
+from gaphor.diagram.copypaste import (
+    ElementCopy,
+    copy,
+    copy_element,
+    paste,
+    paste_element,
+)
+from gaphor.UML import ExecutionSpecification, Message
+
+
+class MessageCopy(NamedTuple):
+    element_copy: ElementCopy
+    send_event: Optional[ElementCopy]
+    receive_event: Optional[ElementCopy]
+
+
+@copy.register
+def copy_message(element: Message):
+    return MessageCopy(
+        element_copy=copy_element(element),
+        send_event=copy_element(element.sendEvent) if element.sendEvent else None,
+        receive_event=copy_element(element.receiveEvent)
+        if element.receiveEvent
+        else None,
+    )
+
+
+@paste.register
+def paste_message(copy_data: MessageCopy, diagram, lookup):
+    if copy_data.send_event:
+        paste_element(copy_data.send_event, diagram, lookup)
+    if copy_data.receive_event:
+        paste_element(copy_data.receive_event, diagram, lookup)
+    return paste_element(copy_data.element_copy, diagram, lookup)
+
+
+class ExecutionSpecificationCopy(NamedTuple):
+    element_copy: ElementCopy
+    occurrences: List[ElementCopy]
+
+
+@copy.register
+def copy_execution_specification(element: ExecutionSpecification):
+    return ExecutionSpecificationCopy(
+        element_copy=copy_element(element),
+        occurrences=[
+            copy_element(occurrence)
+            for occurrence in element.executionOccurrenceSpecification
+        ],
+    )
+
+
+@paste.register
+def paste_execution_specification(
+    copy_data: ExecutionSpecificationCopy, diagram, lookup
+):
+    for occurrence in copy_data.occurrences:
+        paste_element(occurrence, diagram, lookup)
+    return paste_element(copy_data.element_copy, diagram, lookup)

--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -94,7 +94,7 @@ class ExecutionSpecificationItem(Presentation[UML.ExecutionSpecification], Item)
             assert self.canvas
             c = self.canvas.get_connection(handle)
             if c:
-                save_func(name, c.connected, reference=True)
+                save_func(name, c.connected)
 
         points = [tuple(map(float, h.pos)) for h in self.handles()]
 

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -41,7 +41,7 @@ def get_lifeline(item, handle):
     connected_item = get_connected(item, handle)
     if connected_item is None or isinstance(connected_item, LifelineItem):
         return connected_item
-    return get_lifeline(connected_item, connected_item.handles()[0])  # type: ignore[attr-defined]
+    return get_lifeline(connected_item, connected_item.handles()[0])
 
 
 def order_lifeline_covered_by(lifeline):

--- a/gaphor/UML/interactions/tests/test_copypaste.py
+++ b/gaphor/UML/interactions/tests/test_copypaste.py
@@ -1,0 +1,53 @@
+from gaphor import UML
+from gaphor.diagram.tests.fixtures import clear_model, connect, copy_clear_and_paste
+from gaphor.UML.interactions import LifelineItem, MessageItem
+from gaphor.UML.interactions.tests.test_executionspecification import (
+    create_lifeline_with_execution_specification,
+)
+
+
+def test_message(diagram, element_factory):
+    lifeline1 = element_factory.create(UML.Lifeline)
+    lifeline2 = element_factory.create(UML.Lifeline)
+
+    lifeline1_item = diagram.create(LifelineItem, subject=lifeline1)
+    lifeline2_item = diagram.create(LifelineItem, subject=lifeline2)
+    message_item = diagram.create(MessageItem)
+
+    connect(message_item, message_item.handles()[0], lifeline1_item)
+    connect(message_item, message_item.handles()[1], lifeline2_item)
+
+    copy_clear_and_paste(
+        {lifeline1_item, lifeline2_item, message_item}, diagram, element_factory
+    )
+
+    new_message: UML.Message = element_factory.lselect(
+        lambda e: isinstance(e, UML.Message)
+    )[0]
+    new_lifelines = element_factory.lselect(lambda e: isinstance(e, UML.Lifeline))
+
+    assert new_message.sendEvent.covered in new_lifelines
+    assert new_message.receiveEvent.covered in new_lifelines
+    assert new_message.sendEvent.covered is not new_message.receiveEvent.covered
+
+
+def test_execution_specification(diagram, element_factory):
+    lifeline_item, exec_spec_item = create_lifeline_with_execution_specification(
+        diagram, element_factory
+    )
+
+    copy_clear_and_paste({lifeline_item, exec_spec_item}, diagram, element_factory)
+
+    new_exec_spec: UML.ExecutionSpecification = element_factory.lselect(
+        lambda e: isinstance(e, UML.ExecutionSpecification)
+    )[0]
+    new_lifeline: UML.Lifeline = element_factory.lselect(
+        lambda e: isinstance(e, UML.Lifeline)
+    )[0]
+
+    assert (
+        new_lifeline.coveredBy[0] is new_exec_spec.executionOccurrenceSpecification[0]
+    )
+    assert (
+        new_lifeline.coveredBy[1] is new_exec_spec.executionOccurrenceSpecification[1]
+    )

--- a/gaphor/UML/interactions/tests/test_executionspecification.py
+++ b/gaphor/UML/interactions/tests/test_executionspecification.py
@@ -7,6 +7,18 @@ from gaphor.UML.interactions.executionspecification import ExecutionSpecificatio
 from gaphor.UML.interactions.lifeline import LifelineItem
 
 
+def create_lifeline_with_execution_specification(diagram, element_factory):
+    lifeline = diagram.create(
+        LifelineItem, subject=element_factory.create(UML.Lifeline)
+    )
+    lifeline.lifetime.visible = True
+    exec_spec = diagram.create(ExecutionSpecificationItem)
+
+    connect(exec_spec, exec_spec.handles()[0], lifeline, lifeline.lifetime.port)
+
+    return lifeline, exec_spec
+
+
 def test_draw_on_canvas():
     canvas = Canvas()
     exec_spec = ExecutionSpecificationItem()
@@ -26,13 +38,9 @@ def test_allow_execution_specification_to_lifeline(diagram):
 
 
 def test_connect_execution_specification_to_lifeline(diagram, element_factory):
-    lifeline = diagram.create(
-        LifelineItem, subject=element_factory.create(UML.Lifeline)
+    lifeline, exec_spec = create_lifeline_with_execution_specification(
+        diagram, element_factory
     )
-    lifeline.lifetime.visible = True
-    exec_spec = diagram.create(ExecutionSpecificationItem)
-
-    connect(exec_spec, exec_spec.handles()[0], lifeline, lifeline.lifetime.port)
 
     assert exec_spec.subject
     assert lifeline.subject
@@ -47,12 +55,9 @@ def test_disconnect_execution_specification_from_lifeline(diagram, element_facto
     def elements_of_kind(type):
         return element_factory.lselect(lambda e: e.isKindOf(type))
 
-    lifeline = diagram.create(
-        LifelineItem, subject=element_factory.create(UML.Lifeline)
+    lifeline, exec_spec = create_lifeline_with_execution_specification(
+        diagram, element_factory
     )
-    lifeline.lifetime.visible = True
-    exec_spec = diagram.create(ExecutionSpecificationItem)
-    connect(exec_spec, exec_spec.handles()[0], lifeline, lifeline.lifetime.port)
 
     disconnect(exec_spec, exec_spec.handles()[0])
 
@@ -97,18 +102,11 @@ def test_connect_execution_specification_to_execution_specification(
 def test_connect_execution_specification_to_execution_specification_with_lifeline(
     diagram, element_factory
 ):
-    lifeline = diagram.create(
-        LifelineItem, subject=element_factory.create(UML.Lifeline)
+    lifeline, parent_exec_spec = create_lifeline_with_execution_specification(
+        diagram, element_factory
     )
-    lifeline.lifetime.visible = True
-    parent_exec_spec = diagram.create(ExecutionSpecificationItem)
+
     child_exec_spec = diagram.create(ExecutionSpecificationItem)
-    connect(
-        parent_exec_spec,
-        parent_exec_spec.handles()[0],
-        lifeline,
-        lifeline.lifetime.port,
-    )
 
     connect(
         child_exec_spec,
@@ -166,19 +164,11 @@ def test_disconnect_execution_specification_with_execution_specification_from_li
     def elements_of_kind(type):
         return element_factory.lselect(lambda e: e.isKindOf(type))
 
-    lifeline = diagram.create(
-        LifelineItem, subject=element_factory.create(UML.Lifeline)
+    lifeline, parent_exec_spec = create_lifeline_with_execution_specification(
+        diagram, element_factory
     )
-    lifeline.lifetime.visible = True
-    parent_exec_spec = diagram.create(ExecutionSpecificationItem)
     child_exec_spec = diagram.create(ExecutionSpecificationItem)
     grand_child_exec_spec = diagram.create(ExecutionSpecificationItem)
-    connect(
-        parent_exec_spec,
-        parent_exec_spec.handles()[0],
-        lifeline,
-        lifeline.lifetime.port,
-    )
     connect(
         child_exec_spec,
         child_exec_spec.handles()[0],
@@ -203,13 +193,9 @@ def test_disconnect_execution_specification_with_execution_specification_from_li
 
 
 def test_save_and_load(diagram, element_factory, saver, loader):
-    lifeline = diagram.create(
-        LifelineItem, subject=element_factory.create(UML.Lifeline)
+    lifeline, exec_spec = create_lifeline_with_execution_specification(
+        diagram, element_factory
     )
-    lifeline.lifetime.visible = True
-    exec_spec = diagram.create(ExecutionSpecificationItem)
-
-    connect(exec_spec, exec_spec.handles()[0], lifeline, lifeline.lifetime.port)
 
     diagram.canvas.update_now()
 

--- a/gaphor/UML/states/__init__.py
+++ b/gaphor/UML/states/__init__.py
@@ -27,7 +27,7 @@ from gaphor.UML.states.pseudostates import (
 from gaphor.UML.states.state import StateItem
 from gaphor.UML.states.transition import TransitionItem
 
-from gaphor.UML.states import propertypages, vertexconnect
+from gaphor.UML.states import propertypages, vertexconnect, copypaste
 
 __all__ = [
     "FinalStateItem",

--- a/gaphor/UML/states/copypaste.py
+++ b/gaphor/UML/states/copypaste.py
@@ -1,0 +1,38 @@
+from typing import NamedTuple, Optional
+
+from gaphor.diagram.copypaste import (
+    ElementCopy,
+    copy,
+    copy_element,
+    paste,
+    paste_element,
+)
+from gaphor.UML import Behavior, State
+
+
+class StateCopy(NamedTuple):
+    element_copy: ElementCopy
+    entry: Optional[ElementCopy]
+    exit: Optional[ElementCopy]
+    do_activity: Optional[ElementCopy]
+
+
+@copy.register
+def copy_state(element: State):
+    return StateCopy(
+        element_copy=copy_element(element),
+        entry=copy_element(element.entry) if element.entry else None,
+        exit=copy_element(element.exit) if element.exit else None,
+        do_activity=copy_element(element.doActivity) if element.doActivity else None,
+    )
+
+
+@paste.register
+def paste_state(copy_data: StateCopy, diagram, lookup):
+    if copy_data.entry:
+        paste_element(copy_data.entry, diagram, lookup)
+    if copy_data.exit:
+        paste_element(copy_data.exit, diagram, lookup)
+    if copy_data.do_activity:
+        paste_element(copy_data.do_activity, diagram, lookup)
+    return paste_element(copy_data.element_copy, diagram, lookup)

--- a/gaphor/UML/states/tests/conftest.py
+++ b/gaphor/UML/states/tests/conftest.py
@@ -1,0 +1,1 @@
+from gaphor.diagram.tests.fixtures import diagram, element_factory, event_manager

--- a/gaphor/UML/states/tests/test_copypaste.py
+++ b/gaphor/UML/states/tests/test_copypaste.py
@@ -1,0 +1,23 @@
+from gaphor import UML
+from gaphor.diagram.tests.fixtures import clear_model, connect, copy_clear_and_paste
+from gaphor.UML.states import StateItem
+
+
+def test_state_with_behaviors(diagram, element_factory):
+    state: UML.State = element_factory.create(UML.State)
+    state.entry = element_factory.create(UML.Behavior)
+    state.entry.name = "hi"
+    state.exit = element_factory.create(UML.Behavior)
+    state.exit.name = "bye"
+    state.doActivity = element_factory.create(UML.Behavior)
+    state.doActivity.name = "act"
+
+    state_item = diagram.create(StateItem, subject=state)
+
+    new_items = copy_clear_and_paste({state_item}, diagram, element_factory)
+    new_state_item = new_items.pop()
+
+    assert isinstance(new_state_item, StateItem)
+    assert new_state_item.subject.entry.name == "hi"
+    assert new_state_item.subject.exit.name == "bye"
+    assert new_state_item.subject.doActivity.name == "act"

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -17,7 +17,6 @@ from gaphor.core.modeling import (
     NamedElement,
     PackageableElement,
 )
-from gaphor.core.modeling.collection import collection
 from gaphor.core.modeling.properties import (
     association,
     attribute,
@@ -634,6 +633,7 @@ class FinalState(State):
 class Port(Property):
     isBehavior: attribute[int]
     isService: attribute[int]
+    encapsulatedClassifier: relation_many[EncapsulatedClassifer]
 
 
 class Deployment(Dependency):
@@ -1178,7 +1178,12 @@ StateMachine.extendedStateMachine = association(
     "extendedStateMachine", StateMachine, upper=1
 )
 ConnectorEnd.partWithPort = association("partWithPort", Property, upper=1)
-EncapsulatedClassifer.ownedPort = association("ownedPort", Port, composite=True)
+Port.encapsulatedClassifier = association(
+    "encapsulatedClassifier", EncapsulatedClassifer, opposite="ownedPort"
+)
+EncapsulatedClassifer.ownedPort = association(
+    "ownedPort", Port, composite=True, opposite="encapsulatedClassifier"
+)
 Element.appliedStereotype = association(
     "appliedStereotype", InstanceSpecification, opposite="extended"
 )
@@ -1336,6 +1341,7 @@ RedefinableElement.redefinitionContext = derivedunion(
     Operation.class_,
     Property.classifier,
     Operation.datatype,
+    Port.encapsulatedClassifier,
 )
 NamedElement.namespace = derivedunion(
     NamedElement,

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -207,7 +207,7 @@ def format_slot(el):
 
 
 @format.register(UML.NamedElement)
-def format_namedelement(el):
+def format_namedelement(el, **kwargs):
     """
     Format named element.
     """

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -160,7 +160,6 @@ def parse_attribute(el: uml.Property, s: str) -> None:
             el.defaultValue = None
     else:
         g = m.group
-        el.model.create
         _set_visibility(el, g("vis"))
         el.isDerived = g("derived") and True or False
         el.name = g("name")

--- a/gaphor/codegen/autocoder.py
+++ b/gaphor/codegen/autocoder.py
@@ -24,8 +24,6 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING, Callable, List, Optional
 
-from gaphor.core.modeling.collection import collection
-from gaphor.core.modeling.element import Element
 from gaphor.core.modeling.properties import (
     association,
     attribute,

--- a/gaphor/codegen/tests/test_autocoder.py
+++ b/gaphor/codegen/tests/test_autocoder.py
@@ -32,8 +32,6 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING, Callable, List, Optional
 
-from gaphor.core.modeling.collection import collection
-from gaphor.core.modeling.element import Element
 from gaphor.core.modeling.properties import (
     association,
     attribute,

--- a/gaphor/core/modeling/collection.py
+++ b/gaphor/core/modeling/collection.py
@@ -74,10 +74,10 @@ class collection(Generic[T]):
         ...
 
     @overload  # Literal[slice(None, None, None)]
-    def __getitem__(self, key: slice) -> recurseproxy[T]:  # noqa: F811
+    def __getitem__(self, key: slice) -> recurseproxy[T]:
         ...
 
-    def __getitem__(self, key: Union[int, slice]):  # noqa: F811
+    def __getitem__(self, key: Union[int, slice]):
         return self.items.__getitem__(key)
 
     def __contains__(self, obj) -> bool:

--- a/gaphor/core/modeling/collection.py
+++ b/gaphor/core/modeling/collection.py
@@ -6,12 +6,12 @@ import inspect
 from typing import Generic, List, Type, TypeVar, Union, overload
 
 from gaphor.core.modeling.event import AssociationUpdated
-from gaphor.core.modeling.listmixins import querymixin, recursemixin
+from gaphor.core.modeling.listmixins import querymixin, recursemixin, recurseproxy
 
 T = TypeVar("T")
 
 
-class collectionlist(recursemixin, querymixin, List[T]):
+class collectionlist(recursemixin, querymixin, List[T]):  # type: ignore[misc]
     """
     >>> c = collectionlist()
     >>> c.append('a')
@@ -73,8 +73,8 @@ class collection(Generic[T]):
     def __getitem__(self, key: int) -> T:
         ...
 
-    @overload
-    def __getitem__(self, key: slice) -> List[T]:  # noqa: F811
+    @overload  # Literal[slice(None, None, None)]
+    def __getitem__(self, key: slice) -> recurseproxy[T]:  # noqa: F811
         ...
 
     def __getitem__(self, key: Union[int, slice]):  # noqa: F811

--- a/gaphor/core/modeling/coremodel.py
+++ b/gaphor/core/modeling/coremodel.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING, Callable, List, Optional
 
-from gaphor.core.modeling.collection import collection
 from gaphor.core.modeling.element import Element
 from gaphor.core.modeling.properties import (
     association,

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -58,7 +58,7 @@ class DiagramCanvas(gaphas.Canvas):
         """Apply the supplied save function to all root diagram items."""
 
         for item in self.get_root_items():
-            save_func(None, item)
+            save_func(item)
 
     def postload(self):
         """Called after the diagram canvas has loaded.  Currently does nothing.

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -134,27 +134,15 @@ class ElementFactory(Service):
         """
         return list(self.select(expression))
 
-    def keys(self) -> List[str]:
+    def keys(self) -> Iterator[str]:
         """
         Return a list with all id's in the factory.
         """
-        return list(self._elements.keys())
-
-    def iterkeys(self) -> Iterator[str]:
-        """
-        Return a iterator with all id's in the factory.
-        """
         return iter(self._elements.keys())
 
-    def values(self) -> List[Element]:
+    def values(self) -> Iterator[Element]:
         """
         Return a list with all elements in the factory.
-        """
-        return list(self._elements.values())
-
-    def itervalues(self) -> Iterator[Element]:
-        """
-        Return a iterator with all elements in the factory.
         """
         return iter(self._elements.values())
 

--- a/gaphor/core/modeling/listmixins.py
+++ b/gaphor/core/modeling/listmixins.py
@@ -10,9 +10,12 @@ See the documentation on the mixins.
 
 """
 
+from __future__ import annotations
+
+from typing import Callable, Generic, Iterable, List, Sequence, TypeVar, overload
+
 __all__ = ["querymixin", "recursemixin"]
 
-from typing import Callable, List, TypeVar
 
 T = TypeVar("T")
 
@@ -124,7 +127,7 @@ def issafeiterable(obj):
     return False
 
 
-class recurseproxy:
+class recurseproxy(Generic[T]):
     """
     Proxy object (helper) for the recusemixin.
 
@@ -134,10 +137,10 @@ class recurseproxy:
     getitem operations act as if they're executed on the original list.
     """
 
-    def __init__(self, sequence):
+    def __init__(self, sequence: Sequence[T]):
         self.__sequence = sequence
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: int) -> T:
         return self.__sequence.__getitem__(key)
 
     def __iter__(self):
@@ -147,7 +150,7 @@ class recurseproxy:
         """
         return iter(self.__sequence)
 
-    def __getattr__(self, key):
+    def __getattr__(self, key) -> recurseproxy[T]:
         """
         Create a new proxy for the attribute.
         """
@@ -163,11 +166,11 @@ class recurseproxy:
                 except AttributeError:
                     pass
 
-        # Create a copy of the proxy type, inclusing a copy of the sequence type
-        return type(self)(type(self.__sequence)(mygetattr()))
+        # Create a copy of the proxy type, including a copy of the sequence type
+        return type(self)(type(self.__sequence)(mygetattr()))  # type: ignore[call-arg]
 
 
-class recursemixin:
+class recursemixin(Generic[T]):
     """
     Mixin class for lists, sets, etc. If data is requested using ``[:]``,
     a ``recurseproxy`` instance is created.
@@ -247,7 +250,15 @@ class recursemixin:
     def proxy_class(self):
         return recurseproxy
 
-    def __getitem__(self, key):
+    @overload
+    def __getitem__(self, key: int) -> T:
+        ...
+
+    @overload
+    def __getitem__(self, key: slice) -> recurseproxy[T]:  # noqa: F811
+        ...
+
+    def __getitem__(self, key):  # noqa: F811
         if key == self._recursemixin_trigger:
             return self.proxy_class()(self)
         else:

--- a/gaphor/core/modeling/listmixins.py
+++ b/gaphor/core/modeling/listmixins.py
@@ -255,10 +255,10 @@ class recursemixin(Generic[T]):
         ...
 
     @overload
-    def __getitem__(self, key: slice) -> recurseproxy[T]:  # noqa: F811
+    def __getitem__(self, key: slice) -> recurseproxy[T]:
         ...
 
-    def __getitem__(self, key):  # noqa: F811
+    def __getitem__(self, key):
         if key == self._recursemixin_trigger:
             return self.proxy_class()(self)
         else:

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -10,6 +10,7 @@ from typing import (
     Callable,
     Generic,
     Iterable,
+    List,
     Optional,
     TypeVar,
     Union,
@@ -20,6 +21,7 @@ from gaphor.core.modeling.properties import association, relation_one
 
 if TYPE_CHECKING:
     from gaphas.canvas import Canvas  # noqa
+    from gaphas.connector import Handle  # noqa
     from gaphas.matrix import Matrix  # noqa
 
 S = TypeVar("S", bound=Element)
@@ -44,6 +46,7 @@ class Presentation(Element, Generic[S]):
         "subject", Element, upper=1, opposite="presentation"
     )
 
+    handles: Callable[[Presentation], List[Handle]]
     request_update: Callable[[Presentation], None]
 
     canvas: Optional[Canvas]

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -335,7 +335,7 @@ class association(umlproperty):
                 "Value for %s should be of type %s (%s)"
                 % (self.name, self.type.__name__, type(value).__name__)
             )
-        self._set(obj, value, do_notify=False)
+        self._set(obj, value)
 
     def __str__(self):
         if self.lower == self.upper:

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -329,6 +329,12 @@ class association(umlproperty):
         self.opposite = opposite
         self.stub: Optional[associationstub] = None
 
+    def save(self, obj, save_func: Callable[[str, object], None]):
+        if hasattr(obj, self._name):
+            v = self._get(obj)
+            if v:
+                save_func(self.name, v)
+
     def load(self, obj, value):
         if not isinstance(value, self.type):
             raise AttributeError(

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -77,7 +77,7 @@ class relation_one(Protocol[E]):
         ...
 
     @overload
-    def __get__(self, obj, class_=None) -> E:  # noqa: F811
+    def __get__(self, obj, class_=None) -> E:
         ...
 
     def __set__(self, obj, value: E) -> None:
@@ -96,7 +96,7 @@ class relation_many(Protocol[E]):
         ...
 
     @overload
-    def __get__(self, obj, class_=None) -> collection[E]:  # noqa: F811
+    def __get__(self, obj, class_=None) -> collection[E]:
         ...
 
     def __set__(self, obj, value: E) -> None:

--- a/gaphor/core/modeling/tests/test_properties.py
+++ b/gaphor/core/modeling/tests/test_properties.py
@@ -508,8 +508,8 @@ def test_derivedunion_listmixins():
     a.a[1].name = "bar"
     a.b[0].name = "baz"
 
-    assert list(a.a[:].name) == ["foo", "bar"]  # type: ignore[attr-defined]
-    assert sorted(list(a.u[:].name)) == ["bar", "baz", "foo"]  # type: ignore[attr-defined]
+    assert list(a.a[:].name) == ["foo", "bar"]
+    assert sorted(list(a.u[:].name)) == ["bar", "baz", "foo"]
 
 
 def test_composite():

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -6,24 +6,38 @@ values or reference id's.
 
 The `paste()` function will resolve those values. Based on the elements
 that are already in the model,
+
+The copy() function returns only data that has to be part of the copy buffer.
+the `paste()` function will load this data in a model.
 """
 
 from functools import singledispatch
-from typing import Callable, Dict, NamedTuple, Tuple, Type
+from typing import Callable, Dict, List, NamedTuple, Tuple, Type, TypeVar
 
 import gaphas
 
-from gaphor.core.modeling import Element, Presentation
+from gaphor.core.modeling import Diagram, Element, Presentation
 from gaphor.core.modeling.collection import collection
+
+T = TypeVar("T")
 
 
 @singledispatch
-def copy(obj):
+def copy(obj: Element) -> T:
+    """
+    Create a copy of an element (or list of elements).
+    The returned type should be distinct, so the `paste()`
+    function can properly dispatch.
+    """
     raise ValueError(f"No copier for {obj}")
 
 
 @singledispatch
-def paste(diagram, copy_data, lookup: Callable[[str], Element]):
+def paste(copy_data: T, diagram: Diagram, lookup: Callable[[str], Element]):
+    """
+    Paste previously copied data. Based on the data type created in the
+    `copy()` function, try to duplicate the copied elements.
+    """
     raise ValueError(f"No paster for {copy_data}")
 
 
@@ -32,8 +46,8 @@ class PresentationCopy(NamedTuple):
     data: Dict[str, Tuple[str, str]]
 
 
-@copy.register(Presentation)
-def _copy_presentation(item):
+@copy.register
+def _copy_presentation(item: Presentation) -> PresentationCopy:
     buffer = {}
 
     def save_func(name, value):
@@ -49,14 +63,45 @@ def _copy_presentation(item):
     return PresentationCopy(cls=item.__class__, data=buffer)
 
 
-@paste.register(PresentationCopy)
+@paste.register
 def _paste_presentation(copy_data: PresentationCopy, diagram, lookup):
     cls, data = copy_data
     item = diagram.create(cls)
     for key, (vtype, value) in data.items():
         if vtype == "r":
             other = lookup(value)
-            item.load(key, other)
+            if other:
+                item.load(key, other)
         elif vtype == "v":
             item.load(key, value)
+    item.canvas.update_matrices([item])
     item.postload()
+    return item
+
+
+class ListOfData(NamedTuple):
+    data: Dict[str, object]
+
+
+@copy.register
+def _copy_all(items: set) -> ListOfData:
+    return ListOfData(data={item.id: copy(item) for item in items})
+
+
+@paste.register
+def _paste_all(copy_data: ListOfData, diagram, lookup):
+    new_data: Dict[str, Element] = {}
+
+    def _lookup(ref: str):
+        if ref in new_data:
+            return new_data[ref]
+        elif ref in copy_data.data:
+            new_data[ref] = paste(copy_data.data[ref], diagram, _lookup)
+            return new_data[ref]
+        else:
+            return lookup(ref)
+
+    for old_id, data in copy_data.data.items():
+        new_data[old_id] = paste(data, diagram, _lookup)
+
+    return set(new_data.values())

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -84,7 +84,6 @@ class ElementCopy(NamedTuple):
     data: Dict[str, Tuple[str, str]]
 
 
-@copy.register
 def copy_element(item: Element) -> ElementCopy:
     buffer = {}
 
@@ -97,15 +96,20 @@ def copy_element(item: Element) -> ElementCopy:
     return ElementCopy(cls=item.__class__, id=item.id, data=buffer)
 
 
-@paste.register
+copy.register(Element, copy_element)  # type: ignore[arg-type]
+
+
 def paste_element(copy_data: ElementCopy, diagram, lookup):
     cls, id, data = copy_data
-    item = diagram.model.create_as(cls, id)
+    element = diagram.model.create_as(cls, id)
     for name, ser in data.items():
         for value in deserialize(ser, lookup):
-            item.load(name, value)
-    item.postload()
-    return item
+            element.load(name, value)
+    element.postload()
+    return element
+
+
+paste.register(ElementCopy, paste_element)
 
 
 class PresentationCopy(NamedTuple):

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -30,6 +30,7 @@ import gaphas
 
 from gaphor.core.modeling import Diagram, Element, Presentation
 from gaphor.core.modeling.collection import collection
+from gaphor.diagram.general.simpleitem import SimpleItem
 
 T = TypeVar("T")
 
@@ -117,8 +118,7 @@ class PresentationCopy(NamedTuple):
     data: Dict[str, Tuple[str, str]]
 
 
-@copy.register
-def _copy_presentation(item: Presentation) -> PresentationCopy:
+def copy_presentation(item) -> PresentationCopy:
     buffer = {}
 
     def save_func(name, value):
@@ -128,8 +128,12 @@ def _copy_presentation(item: Presentation) -> PresentationCopy:
     return PresentationCopy(cls=item.__class__, data=buffer)
 
 
+copy.register(Presentation, copy_presentation)  # type: ignore[arg-type]
+copy.register(SimpleItem, copy_presentation)  # type: ignore[arg-type]
+
+
 @paste.register
-def _paste_presentation(copy_data: PresentationCopy, diagram, lookup):
+def paste_presentation(copy_data: PresentationCopy, diagram, lookup):
     cls, data = copy_data
     item = diagram.create(cls)
     for name, ser in data.items():

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -1,0 +1,62 @@
+"""
+Copy and paste data based on an element's `save()` and `load()` methods.
+
+The `copy()` function will return all values serialized, either as string
+values or reference id's.
+
+The `paste()` function will resolve those values. Based on the elements
+that are already in the model,
+"""
+
+from functools import singledispatch
+from typing import Callable, Dict, NamedTuple, Tuple, Type
+
+import gaphas
+
+from gaphor.core.modeling import Element, Presentation
+from gaphor.core.modeling.collection import collection
+
+
+@singledispatch
+def copy(obj):
+    raise ValueError(f"No copier for {obj}")
+
+
+@singledispatch
+def paste(diagram, copy_data, lookup: Callable[[str], Element]):
+    raise ValueError(f"No paster for {copy_data}")
+
+
+class PresentationCopy(NamedTuple):
+    cls: Type[Element]
+    data: Dict[str, Tuple[str, str]]
+
+
+@copy.register(Presentation)
+def _copy_presentation(item):
+    buffer = {}
+
+    def save_func(name, value):
+        if isinstance(value, (Element, gaphas.Item)):
+            buffer[name] = ("r", value.id)
+        else:
+            assert not isinstance(value, collection)
+            if isinstance(value, bool):
+                value = int(value)
+            buffer[name] = ("v", str(value))
+
+    item.save(save_func)
+    return PresentationCopy(cls=item.__class__, data=buffer)
+
+
+@paste.register(PresentationCopy)
+def _paste_presentation(copy_data: PresentationCopy, diagram, lookup):
+    cls, data = copy_data
+    item = diagram.create(cls)
+    for key, (vtype, value) in data.items():
+        if vtype == "r":
+            other = lookup(value)
+            item.load(key, other)
+        elif vtype == "v":
+            item.load(key, value)
+    item.postload()

--- a/gaphor/diagram/general/simpleitem.py
+++ b/gaphor/diagram/general/simpleitem.py
@@ -3,13 +3,39 @@ Trivial drawing aids (box, line, ellipse).
 """
 
 import ast
+from typing import Optional
 
+from gaphas.canvas import Canvas
 from gaphas.item import NW, Element
 from gaphas.item import Line as _Line
 from gaphas.util import path_ellipse
 
 
-class Line(_Line):
+class SimpleItem:
+    """
+    Marker for simple (non-Presentation) diagram items.
+    """
+
+    canvas: Optional[Canvas]
+
+    def save(self, save_func):
+        ...
+
+    def load(self, name, value):
+        ...
+
+    def postload(self):
+        ...
+
+    def unlink(self):
+        """
+        Remove the item from the canvas.
+        """
+        if self.canvas:
+            self.canvas.remove(self)
+
+
+class Line(_Line, SimpleItem):
     def __init__(self, id=None, model=None):
         super().__init__()
         self.style = {"line-width": 2, "color": (0, 0, 0, 1)}.__getitem__
@@ -56,7 +82,7 @@ class Line(_Line):
         super().draw(context)
 
 
-class Box(Element):
+class Box(Element, SimpleItem):
     """
     A Box has 4 handles (for a start)::
 
@@ -99,7 +125,7 @@ class Box(Element):
         cr.stroke()
 
 
-class Ellipse(Element):
+class Ellipse(Element, SimpleItem):
     """
     """
 

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -235,7 +235,7 @@ class LinePresentation(Presentation[S], gaphas.Line):
             assert self.canvas
             c = self.canvas.get_connection(handle)
             if c:
-                save_func(name, c.connected, reference=True)
+                save_func(name, c.connected)
 
         super().save(save_func)
         save_func("matrix", tuple(self.matrix))

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -110,20 +110,20 @@ def disconnect(line, handle):
     assert not canvas.get_connection(handle)
 
 
-def clear_model(diagram, element_factory):
+def clear_model(diagram, element_factory, retain=[]):
     """
     Clear the model and diagram, leaving only an empty diagram.
     """
     for element in list(element_factory.values()):
-        if element is not diagram:
+        if element is not diagram and element not in retain:
             element.unlink()
 
     for item in diagram.canvas.get_all_items():
         item.unlink()
 
 
-def copy_clear_and_paste(items, diagram, element_factory):
+def copy_clear_and_paste(items, diagram, element_factory, retain=[]):
     buffer = copy(items)
-    clear_model(diagram, element_factory)
+    clear_model(diagram, element_factory, retain)
     print(buffer)
     return paste(buffer, diagram, element_factory.lookup)

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -8,6 +8,7 @@ from gaphor.core.eventmanager import EventManager
 from gaphor.core.modeling import Diagram, ElementFactory
 from gaphor.core.modeling.elementdispatcher import ElementDispatcher
 from gaphor.diagram.connectors import Connector
+from gaphor.diagram.copypaste import copy, paste
 from gaphor.storage import storage
 from gaphor.storage.xmlwriter import XMLWriter
 from gaphor.UML.modelinglanguage import UMLModelingLanguage
@@ -119,3 +120,10 @@ def clear_model(diagram, element_factory):
 
     for item in diagram.canvas.get_all_items():
         item.unlink()
+
+
+def copy_clear_and_paste(items, diagram, element_factory):
+    buffer = copy(items)
+    clear_model(diagram, element_factory)
+    print(buffer)
+    return paste(buffer, diagram, element_factory.lookup)

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -107,3 +107,15 @@ def disconnect(line, handle):
 
     canvas.disconnect_item(line, handle)
     assert not canvas.get_connection(handle)
+
+
+def clear_model(diagram, element_factory):
+    """
+    Clear the model and diagram, leaving only an empty diagram.
+    """
+    for element in list(element_factory.values()):
+        if element is not diagram:
+            element.unlink()
+
+    for item in diagram.canvas.get_all_items():
+        item.unlink()

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -2,7 +2,7 @@ import pytest
 
 from gaphor import UML
 from gaphor.diagram.copypaste import copy, paste
-from gaphor.diagram.tests.fixtures import clear_model, connect
+from gaphor.diagram.tests.fixtures import clear_model, connect, copy_clear_and_paste
 from gaphor.UML.classes import ClassItem, GeneralizationItem
 
 
@@ -132,13 +132,9 @@ def test_copy_remove_paste_items_with_connections(diagram, element_factory):
         diagram, element_factory
     )
 
-    buffer = copy({gen_cls_item, gen_item, spc_cls_item})
-
-    clear_model(diagram, element_factory)
-
-    print(buffer)
-
-    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_items = copy_clear_and_paste(
+        {gen_cls_item, gen_item, spc_cls_item}, diagram, element_factory
+    )
     new_cls1, new_cls2 = element_factory.lselect(lambda e: isinstance(e, UML.Class))
     new_gen = element_factory.lselect(lambda e: isinstance(e, UML.Generalization))[0]
 

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -2,7 +2,8 @@ import pytest
 
 from gaphor import UML
 from gaphor.diagram.copypaste import copy, paste
-from gaphor.UML.classes import ClassItem
+from gaphor.diagram.tests.fixtures import connect
+from gaphor.UML.classes import ClassItem, GeneralizationItem
 
 
 def test_copy_item_adds_new_item_to_the_diagram(diagram, element_factory):
@@ -28,3 +29,32 @@ def test_copied_item_references_same_model_element(diagram, element_factory):
     item1, item2 = diagram.canvas.get_root_items()
 
     assert item1.subject is item2.subject
+
+
+def test_copy_multiple_items(diagram, element_factory):
+    cls = element_factory.create(UML.Class)
+    cls_item1 = diagram.create(ClassItem, subject=cls)
+    cls_item2 = diagram.create(ClassItem, subject=cls)
+
+    buffer = copy({cls_item1, cls_item2})
+
+    paste(buffer, diagram, element_factory.lookup)
+
+    assert len(diagram.canvas.get_root_items()) == 4
+    assert len(element_factory.lselect(lambda e: isinstance(e, UML.Class))) == 1
+
+
+def test_copy_item_without_copying_connection(diagram, element_factory):
+    cls = element_factory.create(UML.Class)
+    cls_item = diagram.create(ClassItem, subject=cls)
+    gen_item = diagram.create(GeneralizationItem)
+    connect(gen_item, gen_item.handles()[0], cls_item)
+
+    buffer = copy({cls_item})
+
+    new_items = paste(buffer, diagram, element_factory.lookup)
+
+    assert len(diagram.canvas.get_root_items()) == 3
+    assert len(element_factory.lselect(lambda e: isinstance(e, UML.Class))) == 1
+    assert type(new_items) is set
+    assert len(new_items) == 1

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -146,6 +146,22 @@ def test_copy_remove_paste_items_with_connections(diagram, element_factory):
     assert new_gen.presentation[0] in new_items
 
 
+def test_copy_remove_paste_items_when_namespace_is_removed(diagram, element_factory):
+    package = element_factory.create(UML.Package)
+    cls = element_factory.create(UML.Class)
+    cls.package = package
+    cls_item = diagram.create(ClassItem, subject=cls)
+
+    diagram_package = element_factory.create(UML.Package)
+    diagram.package = diagram_package
+
+    copy_clear_and_paste({cls_item}, diagram, element_factory, retain=[diagram_package])
+
+    new_cls = element_factory.lselect(lambda e: isinstance(e, UML.Class))[0]
+
+    assert new_cls.namespace is diagram_package
+
+
 def test_copy_remove_paste_simple_items(diagram, element_factory):
     box = diagram.create(Box)
     ellipse = diagram.create(Ellipse)

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -120,7 +120,7 @@ def test_copy_item_when_subject_has_been_removed(diagram, element_factory):
 
     print(buffer)
 
-    new_items = paste(buffer, diagram, element_factory.lookup)
+    paste(buffer, diagram, element_factory.lookup)
     new_cls = element_factory.lselect(lambda e: isinstance(e, UML.Class))[0]
     assert len(diagram.canvas.get_root_items()) == 1
     assert new_cls.package is package

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -2,7 +2,7 @@ import pytest
 
 from gaphor import UML
 from gaphor.diagram.copypaste import copy, paste
-from gaphor.diagram.tests.fixtures import connect
+from gaphor.diagram.tests.fixtures import clear_model, connect
 from gaphor.UML.classes import ClassItem, GeneralizationItem
 
 
@@ -70,15 +70,6 @@ def two_classes_and_a_generalization(diagram, element_factory):
     connect(gen_item, gen_item.handles()[1], spc_cls_item)
 
     return gen_cls_item, spc_cls_item, gen_item
-
-
-def clear_model(diagram, element_factory):
-    for element in list(element_factory.values()):
-        if element is not diagram:
-            element.unlink()
-
-    for item in diagram.canvas.get_all_items():
-        item.unlink()
 
 
 def test_copy_item_with_connection(diagram, element_factory):

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -60,8 +60,61 @@ def test_copy_item_without_copying_connection(diagram, element_factory):
     assert len(new_items) == 1
 
 
+def two_classes_and_a_generalization(diagram, element_factory):
+    gen_cls = element_factory.create(UML.Class)
+    spc_cls = element_factory.create(UML.Class)
+    gen_cls_item = diagram.create(ClassItem, subject=gen_cls)
+    spc_cls_item = diagram.create(ClassItem, subject=spc_cls)
+    gen_item = diagram.create(GeneralizationItem)
+    connect(gen_item, gen_item.handles()[0], gen_cls_item)
+    connect(gen_item, gen_item.handles()[1], spc_cls_item)
+
+    return gen_cls_item, spc_cls_item, gen_item
+
+
+def clear_model(diagram, element_factory):
+    for element in list(element_factory.values()):
+        if element is not diagram:
+            element.unlink()
+
+    for item in diagram.canvas.get_all_items():
+        item.unlink()
+
+
+def test_copy_item_with_connection(diagram, element_factory):
+    gen_cls_item, spc_cls_item, gen_item = two_classes_and_a_generalization(
+        diagram, element_factory
+    )
+    buffer = copy({gen_cls_item, gen_item, spc_cls_item})
+
+    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_gen_item = next(i for i in new_items if isinstance(i, GeneralizationItem))
+
+    new_cls_item1 = new_gen_item.canvas.get_connection(
+        new_gen_item.handles()[0]
+    ).connected
+    new_cls_item2 = new_gen_item.canvas.get_connection(
+        new_gen_item.handles()[1]
+    ).connected
+
+    assert new_cls_item1 in diagram.canvas.get_root_items()
+    assert new_cls_item2 in diagram.canvas.get_root_items()
+
+    assert len(new_items) == 3
+    assert new_cls_item1 in new_items
+    assert new_cls_item2 in new_items
+
+    # Model elements are not copied
+    assert len(element_factory.lselect(lambda e: isinstance(e, UML.Class))) == 2
+    assert (
+        len(element_factory.lselect(lambda e: isinstance(e, UML.Generalization))) == 1
+    )
+
+
 def test_copy_item_when_subject_has_been_removed(diagram, element_factory):
+    package = element_factory.create(UML.Package)
     cls = element_factory.create(UML.Class)
+    cls.package = package
     orig_cls_id = cls.id
     cls_item = diagram.create(ClassItem, subject=cls)
 
@@ -71,19 +124,38 @@ def test_copy_item_when_subject_has_been_removed(diagram, element_factory):
     cls.unlink()  # normally handled by the sanitizer service
 
     assert len(diagram.canvas.get_all_items()) == 0
-    assert len(element_factory.lselect()) == 1
+    assert len(element_factory.lselect()) == 2
     assert not element_factory.lookup(orig_cls_id)
 
-    try:
-        new_items = paste(buffer, diagram, element_factory.lookup)
-    except:
-        import pprint
+    print(buffer)
 
-        pprint.pprint(buffer)
-        raise
+    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_cls = element_factory.lselect(lambda e: isinstance(e, UML.Class))[0]
     assert len(diagram.canvas.get_root_items()) == 1
-    assert len(element_factory.lselect(lambda e: isinstance(e, UML.Class))) == 1
-    assert element_factory.lookup(orig_cls_id)
+    assert new_cls.package is package
+    assert element_factory.lookup(orig_cls_id) is new_cls
+
+
+def test_copy_remove_paste_items_with_connections(diagram, element_factory):
+    gen_cls_item, spc_cls_item, gen_item = two_classes_and_a_generalization(
+        diagram, element_factory
+    )
+
+    buffer = copy({gen_cls_item, gen_item, spc_cls_item})
+
+    clear_model(diagram, element_factory)
+
+    print(buffer)
+
+    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_cls1, new_cls2 = element_factory.lselect(lambda e: isinstance(e, UML.Class))
+    new_gen = element_factory.lselect(lambda e: isinstance(e, UML.Generalization))[0]
+
+    assert new_gen.general in {new_cls1, new_cls2}
+    assert new_gen.specific in {new_cls1, new_cls2}
+    assert new_cls1.presentation[0] in new_items
+    assert new_cls2.presentation[0] in new_items
+    assert new_gen.presentation[0] in new_items
 
 
 # copy/paste non-presentation element

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -58,3 +58,32 @@ def test_copy_item_without_copying_connection(diagram, element_factory):
     assert len(element_factory.lselect(lambda e: isinstance(e, UML.Class))) == 1
     assert type(new_items) is set
     assert len(new_items) == 1
+
+
+def test_copy_item_when_subject_has_been_removed(diagram, element_factory):
+    cls = element_factory.create(UML.Class)
+    orig_cls_id = cls.id
+    cls_item = diagram.create(ClassItem, subject=cls)
+
+    buffer = copy({cls_item})
+
+    cls_item.unlink()
+    cls.unlink()  # normally handled by the sanitizer service
+
+    assert len(diagram.canvas.get_all_items()) == 0
+    assert len(element_factory.lselect()) == 1
+    assert not element_factory.lookup(orig_cls_id)
+
+    try:
+        new_items = paste(buffer, diagram, element_factory.lookup)
+    except:
+        import pprint
+
+        pprint.pprint(buffer)
+        raise
+    assert len(diagram.canvas.get_root_items()) == 1
+    assert len(element_factory.lselect(lambda e: isinstance(e, UML.Class))) == 1
+    assert element_factory.lookup(orig_cls_id)
+
+
+# copy/paste non-presentation element

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -1,0 +1,30 @@
+import pytest
+
+from gaphor import UML
+from gaphor.diagram.copypaste import copy, paste
+from gaphor.UML.classes import ClassItem
+
+
+def test_copy_item_adds_new_item_to_the_diagram(diagram, element_factory):
+    cls = element_factory.create(UML.Class)
+    cls_item = diagram.create(ClassItem, subject=cls)
+
+    buffer = copy(cls_item)
+
+    paste(buffer, diagram, element_factory.lookup)
+
+    assert len(diagram.canvas.get_root_items()) == 2
+
+
+def test_copied_item_references_same_model_element(diagram, element_factory):
+    cls = element_factory.create(UML.Class)
+    cls_item = diagram.create(ClassItem, subject=cls)
+
+    buffer = copy(cls_item)
+
+    paste(buffer, diagram, element_factory.lookup)
+
+    assert len(diagram.canvas.get_root_items()) == 2
+    item1, item2 = diagram.canvas.get_root_items()
+
+    assert item1.subject is item2.subject

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -2,6 +2,7 @@ import pytest
 
 from gaphor import UML
 from gaphor.diagram.copypaste import copy, paste
+from gaphor.diagram.general.simpleitem import Box, Ellipse, Line
 from gaphor.diagram.tests.fixtures import clear_model, connect, copy_clear_and_paste
 from gaphor.UML.classes import ClassItem, GeneralizationItem
 
@@ -145,4 +146,13 @@ def test_copy_remove_paste_items_with_connections(diagram, element_factory):
     assert new_gen.presentation[0] in new_items
 
 
-# copy/paste non-presentation element
+def test_copy_remove_paste_simple_items(diagram, element_factory):
+    box = diagram.create(Box)
+    ellipse = diagram.create(Ellipse)
+    line = diagram.create(Line)
+
+    new_items = copy_clear_and_paste({box, ellipse, line}, diagram, element_factory)
+
+    new_box = next(item for item in new_items if isinstance(item, Box))
+
+    assert new_box

--- a/gaphor/diagram/tests/test_presentation.py
+++ b/gaphor/diagram/tests/test_presentation.py
@@ -105,14 +105,16 @@ def test_line_saving_without_subject(diagram):
 
 
 def test_line_loading(element_factory, diagram):
-    subject = element_factory.create(UML.Dependency)
-    p = diagram.create(StubLine)
 
-    p.load("matrix", "(2.0, 0.0, 0.0, 2.0, 0.0, 0.0)")
-    p.load("orthogonal", "0")
-    p.load("horizontal", "1")
-    p.load("points", "[(1.0, 2.0), (3.0, 4.0)]")
-    p.load("subject", subject)
+    with element_factory.block_events():
+        subject = element_factory.create(UML.Dependency)
+        p = diagram.create(StubLine)
+
+        p.load("matrix", "(2.0, 0.0, 0.0, 2.0, 0.0, 0.0)")
+        p.load("orthogonal", "0")
+        p.load("horizontal", "1")
+        p.load("points", "[(1.0, 2.0), (3.0, 4.0)]")
+        p.load("subject", subject)
 
     assert tuple(p.matrix) == (2.0, 0.0, 0.0, 2.0, 0.0, 0.0)
     assert not p.orthogonal

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -7,9 +7,10 @@ from typing import Dict, Set
 import gaphas
 
 from gaphor.abc import ActionProvider, Service
-from gaphor.core import action, event_handler, gettext, transactional
+from gaphor.core import Transaction, action, event_handler, gettext
 from gaphor.core.modeling import Element, Presentation
 from gaphor.core.modeling.collection import collection
+from gaphor.diagram.copypaste import copy, paste
 from gaphor.ui.event import DiagramSelectionChanged
 
 
@@ -33,7 +34,7 @@ class CopyService(Service, ActionProvider):
         self.event_manager = event_manager
         self.element_factory = element_factory
         self.diagrams = diagrams
-        self.copy_buffer: Set[gaphas.Item] = set()
+        self.copy_buffer: object = None
 
         event_manager.subscribe(self._update)
 
@@ -52,74 +53,25 @@ class CopyService(Service, ActionProvider):
 
     def copy(self, items):
         if items:
-            self.copy_buffer = set(items)
+            self.copy_buffer = copy(items)
 
-    @transactional
     def paste(self, diagram):
         """
         Paste items in the copy-buffer to the diagram
         """
         canvas = diagram.canvas
-        if not canvas:
-            return
 
-        copy_items = [c for c in self.copy_buffer if c.canvas]
+        with Transaction(self.event_manager):
+            # Create new id's that have to be used to create the items:
+            new_items: Set[Presentation] = paste(
+                self.copy_buffer, diagram, self.element_factory.lookup
+            )
 
-        # Create new id's that have to be used to create the items:
-        new_items: Dict[str, Presentation] = {
-            ci.id: diagram.create(type(ci)) for ci in copy_items
-        }
+            # move pasted items a bit, so user can see result of his action :)
+            for item in new_items:
+                item.matrix.translate(10, 10)
 
-        def copy_func(copy):
-            def _copy_func(name, value, reference=False):
-                """
-                Copy an element, preferably from the list of new items,
-                otherwise from the element factory.
-                If it does not exist there, do not copy it!
-                """
-
-                def load_element():
-                    item = new_items.get(value.id)
-                    if item:
-                        copy.load(name, item)
-                    else:
-                        item = self.element_factory.lookup(value.id)
-                        if item:
-                            copy.load(name, item)
-
-                if reference or isinstance(value, Element):
-                    setattr(copy, name, value)
-                elif isinstance(value, collection):
-                    values = value
-                    for value in values:
-                        setattr(copy, name, value)
-                elif isinstance(value, gaphas.Item):
-                    load_element()
-                else:
-                    # Plain attribute
-                    copy.load(name, str(value))
-
-            return _copy_func
-
-        # Copy attributes and references. References should be
-        #  1. in the ElementFactory (hence they are model elements)
-        #  2. referred to in new_items
-        #  3. canvas property is overridden
-        for ci in copy_items:
-            ci.save(copy_func(new_items[ci.id]))
-            # new_items[ci.id].subject = ci.subject
-
-        # move pasted items a bit, so user can see result of his action :)
-        # update items' matrix immediately
-        for item in new_items.values():
-            item.matrix.translate(10, 10)
-            canvas.update_matrices([item])
-
-        # solve internal constraints of items immediately as item.postload
-        # reconnects items and all handles have to be in place
-        canvas.solver.solve()
-        for item in new_items.values():
-            item.postload()
+            canvas.update_matrices(new_items)
 
         return new_items
 
@@ -151,16 +103,9 @@ class CopyService(Service, ActionProvider):
 
         new_items = self.paste(diagram)
 
-        focused_item = view.focused_item
         view.unselect_all()
 
-        for item in new_items.values():
+        for item in new_items:
             view.select_item(item)
 
-        new_focused_item = (
-            new_items[focused_item.id] if focused_item else new_items.pop()
-        )
-
-        self.event_manager.handle(
-            DiagramSelectionChanged(view, new_focused_item, new_items)
-        )
+        self.event_manager.handle(DiagramSelectionChanged(view, None, new_items))

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -101,6 +101,9 @@ class CopyService(Service, ActionProvider):
         if not view:
             return
 
+        if not self.copy_buffer:
+            return
+
         new_items = self.paste(diagram)
 
         view.unselect_all()

--- a/gaphor/services/tests/test_copyservice.py
+++ b/gaphor/services/tests/test_copyservice.py
@@ -31,7 +31,7 @@ class CopyServiceTestCase(TestCase):
         diagram = ef.create(UML.Diagram)
         ci = diagram.create(CommentItem, subject=ef.create(UML.Comment))
 
-        service.copy([ci])
+        service.copy({ci})
         assert diagram.canvas.get_all_items() == [ci]
 
         service.paste(diagram)

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -97,34 +97,33 @@ def save_generator(writer, factory):  # noqa: C901
             save_collection(name, value)
         elif isinstance(value, gaphas.Canvas):
             writer.startElement("canvas", {})
-            value.save(save_canvasitem)
+            value.save(save_canvas)
             writer.endElement("canvas")
         else:
             save_value(name, value)
 
-    def save_canvasitem(name, value, reference=False):
+    def save_canvas(value):
         """
         Save attributes and references in a gaphor.diagram.* object.
         The extra attribute reference can be used to force UML
         """
-        if isinstance(value, collection) or (
-            isinstance(value, (list, tuple)) and reference is True
-        ):
+        assert isinstance(value, gaphas.Item)
+        writer.startElement("item", {"id": value.id, "type": value.__class__.__name__})
+        value.save(save_canvas_item)
+
+        for child in value.canvas.get_children(value):
+            save_canvas(child)
+
+        writer.endElement("item")
+
+    def save_canvas_item(name, value):
+        """
+        Save attributes and references in a gaphor.diagram.* object.
+        The extra attribute reference can be used to force UML
+        """
+        if isinstance(value, collection):
             save_collection(name, value)
-        elif reference:
-            save_reference(name, value)
-        elif isinstance(value, gaphas.Item):
-            writer.startElement(
-                "item", {"id": value.id, "type": value.__class__.__name__}
-            )
-            value.save(save_canvasitem)
-
-            for child in value.canvas.get_children(value):
-                save_canvasitem(None, child)
-
-            writer.endElement("item")
-
-        elif isinstance(value, Element):
+        elif isinstance(value, (Element, gaphas.Item)):
             save_reference(name, value)
         else:
             save_value(name, value)

--- a/gaphor/storage/verify.py
+++ b/gaphor/storage/verify.py
@@ -50,28 +50,22 @@ def orphan_references(factory):
         elif isinstance(value, collection):
             verify_collection(name, value)
         elif isinstance(value, gaphas.Canvas):
-            value.save(verify_canvasitem)
+            value.save(verify_canvas)
 
-    def verify_canvasitem(name, value, reference=False):
+    def verify_canvas(value):
+        elements.add(value.id)
+        value.save(verify_canvasitem)
+        for child in value.canvas.get_children(value):
+            verify_canvas(child)
+
+    def verify_canvasitem(name, value):
         """
         Verify attributes and references in a gaphor.diagram.* object.
         The extra attribute referenced can be used to force UML.
         """
-        if isinstance(value, collection) or (
-            isinstance(value, (list, tuple)) and reference is True
-        ):
+        if isinstance(value, collection):
             verify_collection(name, value)
-        elif reference:
-            verify_reference(name, value)
-        elif isinstance(value, gaphas.Item):
-            elements.add(value.id)
-            value.save(verify_canvasitem)
-
-            # save subitems
-            for child in value.canvas.get_children(value):
-                verify_canvasitem(None, child)
-
-        elif isinstance(value, Element):
+        elif isinstance(value, (Element, gaphas.Item)):
             verify_reference(name, value)
 
     for e in list(factory.values()):

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -319,7 +319,7 @@ class DiagramPage:
     def _on_key_press_event(self, view, event):
         """
         Handle the 'Delete' key. This can not be handled directly (through
-        GTK's accelerators) since otherwise this key will confuse the text
+        GTK's accelerators), otherwise this key will confuse the text
         edit stuff.
         """
         if (

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -31652,13 +31652,13 @@ some elements to have a stereotype</val>
 <canvas>
 <item id="DCE:0BDA9AB4-5FE5-11D9-A512-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 760.0, 213.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 711.6838345489954, 205.0)</val>
 </matrix>
 <width>
-<val>472.0</val>
+<val>469.3161654510046</val>
 </width>
 <height>
-<val>76.0</val>
+<val>124.0</val>
 </height>
 <show_attributes>
 <val>1</val>
@@ -31675,7 +31675,7 @@ some elements to have a stereotype</val>
 </item>
 <item id="DCE:D44C8456-5FE5-11D9-A512-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 330.0, 78.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 311.5, 76.0)</val>
 </matrix>
 <width>
 <val>167.0</val>
@@ -31698,7 +31698,7 @@ some elements to have a stereotype</val>
 </item>
 <item id="DCE:EFB33A50-5FE5-11D9-A512-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 743.0, 93.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 822.0, 87.5)</val>
 </matrix>
 <width>
 <val>175.0</val>
@@ -31721,7 +31721,7 @@ some elements to have a stereotype</val>
 </item>
 <item id="DCE:F8EB803E-5FE5-11D9-A512-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 731.0, 354.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 818.0, 393.5)</val>
 </matrix>
 <width>
 <val>190.0</val>
@@ -31747,7 +31747,7 @@ some elements to have a stereotype</val>
 <ref refid="DCE:06EA7796-5FE6-11D9-A512-000D936B094A"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 823.0, 165.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 902.0, 159.5)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -31756,7 +31756,7 @@ some elements to have a stereotype</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (129.14159292035401, 48.0)]</val>
+<val>[(0.0, 0.0), (0.732893051174301, 45.5)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:EFB33A50-5FE5-11D9-A512-000D936B094A"/>
@@ -31770,7 +31770,7 @@ some elements to have a stereotype</val>
 <ref refid="DCE:0BAE4600-5FE6-11D9-A512-000D936B094A"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 964.6725663716816, 289.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 915.1926142578383, 329.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -31779,7 +31779,7 @@ some elements to have a stereotype</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-137.67256637168134, 65.0)]</val>
+<val>[(0.0, 0.0), (-1.192614257838045, 64.5)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:0BDA9AB4-5FE5-11D9-A512-000D936B094A"/>
@@ -31825,7 +31825,7 @@ some elements to have a stereotype</val>
 <ref refid="DCE:35002014-5FE6-11D9-A512-000D936B094A"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 411.6022727272727, 132.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 393.1022727272727, 130.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -31834,7 +31834,7 @@ some elements to have a stereotype</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-18.545934699103668, 69.0)]</val>
+<val>[(0.0, 0.0), (-0.04593469910366821, 71.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:D44C8456-5FE5-11D9-A512-000D936B094A"/>
@@ -31857,7 +31857,7 @@ some elements to have a stereotype</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-2.2977867203219375, 58.0)]</val>
+<val>[(0.0, 0.0), (0.7022132796780625, 94.5)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:27670A8E-5FE6-11D9-A512-000D936B094A"/>
@@ -31889,7 +31889,7 @@ some elements to have a stereotype</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (283.0, -0.7566718995290387)]</val>
+<val>[(0.0, 0.0), (234.68383454899538, -0.39246467817895336)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:27670A8E-5FE6-11D9-A512-000D936B094A"/>
@@ -31909,7 +31909,7 @@ some elements to have a stereotype</val>
 </item>
 <item id="DCE:30082516-1FCF-11DA-A6C3-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1053.0246305418718, 213.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1323.0246305418718, 209.0)</val>
 </matrix>
 <width>
 <val>161.0</val>
@@ -31935,7 +31935,7 @@ some elements to have a stereotype</val>
 <ref refid="DCE:72AC4FE6-1FCF-11DA-A6C3-000D936B094A"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1232.0, 231.48648648648648)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 1181.0, 235.16216216216216)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -31944,7 +31944,7 @@ some elements to have a stereotype</val>
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-178.97536945812817, 6.436590436590478)]</val>
+<val>[(0.0, 0.0), (142.02463054187183, -1.239085239085199)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:0BDA9AB4-5FE5-11D9-A512-000D936B094A"/>
@@ -32088,7 +32088,7 @@ some elements to have a stereotype</val>
 </item>
 <item id="DCE:AC5CE71C-3507-11DA-842A-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 345.0, 333.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 348.0, 369.5)</val>
 </matrix>
 <width>
 <val>100.0</val>
@@ -37757,7 +37757,7 @@ some elements to have a stereotype</val>
 <canvas>
 <item id="DCE:70DEC86A-8352-11DD-8EDA-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 34.0, 42.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 222.5, 34.0)</val>
 </matrix>
 <width>
 <val>172.0</val>
@@ -37780,7 +37780,7 @@ some elements to have a stereotype</val>
 </item>
 <item id="DCE:8BD522E0-8352-11DD-8EDA-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 32.0, 150.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 217.5, 261.5)</val>
 </matrix>
 <width>
 <val>188.0</val>
@@ -37806,7 +37806,7 @@ some elements to have a stereotype</val>
 <ref refid="DCE:9B1D8EF6-8352-11DD-8EDA-000D936B094A"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 112.29850746268656, 96.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 300.79850746268653, 88.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -37815,7 +37815,7 @@ some elements to have a stereotype</val>
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (3.2570480928689847, 54.0)]</val>
+<val>[(0.0, 0.0), (0.2570480928690131, 173.5)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:70DEC86A-8352-11DD-8EDA-000D936B094A"/>
@@ -37826,7 +37826,7 @@ some elements to have a stereotype</val>
 </item>
 <item id="DCE:A51B9220-8352-11DD-8EDA-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 44.0, 239.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 30.0, 34.0)</val>
 </matrix>
 <width>
 <val>154.0</val>
@@ -37849,7 +37849,7 @@ some elements to have a stereotype</val>
 </item>
 <item id="DCE:CA82A210-8352-11DD-8EDA-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 49.0, 343.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 53.0, 176.84999999999997)</val>
 </matrix>
 <width>
 <val>108.0</val>
@@ -37875,7 +37875,7 @@ some elements to have a stereotype</val>
 <ref refid="DCE:F8852E08-8352-11DD-8EDA-000D936B094A"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 122.28333333333333, 293.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 108.28333333333333, 88.0)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -37884,7 +37884,7 @@ some elements to have a stereotype</val>
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-16.28333333333333, 50.0)]</val>
+<val>[(0.0, 0.0), (1.7166666666666686, 88.84999999999997)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:A51B9220-8352-11DD-8EDA-000D936B094A"/>
@@ -37904,7 +37904,7 @@ some elements to have a stereotype</val>
 </item>
 <item id="DCE:3A818718-8353-11DD-8EDA-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 520.0, 40.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 657.5, 55.5)</val>
 </matrix>
 <width>
 <val>103.0</val>
@@ -37927,13 +37927,13 @@ some elements to have a stereotype</val>
 </item>
 <item id="DCE:3C5DB88E-8353-11DD-8EDA-000D936B094A" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 504.0, 118.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 594.5, 139.5)</val>
 </matrix>
 <width>
-<val>471.0</val>
+<val>228.50000000000006</val>
 </width>
 <height>
-<val>85.0</val>
+<val>83.0</val>
 </height>
 <show_attributes>
 <val>1</val>
@@ -37953,7 +37953,7 @@ some elements to have a stereotype</val>
 <ref refid="DCE:4961D970-8353-11DD-8EDA-000D936B094A"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 569.0, 94.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 706.5, 109.5)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -37962,7 +37962,7 @@ some elements to have a stereotype</val>
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (165.7900000000002, 24.0)]</val>
+<val>[(0.0, 0.0), (-0.03499999999985448, 30.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:3A818718-8353-11DD-8EDA-000D936B094A"/>
@@ -37976,16 +37976,16 @@ some elements to have a stereotype</val>
 <ref refid="DCE:89DBA954-8353-11DD-8EDA-000D936B094A"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 220.0, 164.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 343.328125, 261.5)</val>
 </matrix>
 <orthogonal>
-<val>0</val>
+<val>1</val>
 </orthogonal>
 <horizontal>
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (63.0, -17.0), (284.0, -7.750000000000028)]</val>
+<val>[(0.0, 0.0), (0.0, -84.65000000000003), (251.171875, -84.65000000000003)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:8BD522E0-8352-11DD-8EDA-000D936B094A"/>
@@ -38131,6 +38131,7 @@ some elements to have a stereotype</val>
 <reflist>
 <ref refid="DCE:57FBE1E2-8353-11DD-8EDA-000D936B094A"/>
 <ref refid="DCE:685FF302-8353-11DD-8EDA-000D936B094A"/>
+<ref refid="DCE:89DDAC40-8353-11DD-8EDA-000D936B094A"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -38202,24 +38203,24 @@ some elements to have a stereotype</val>
 <association>
 <ref refid="DCE:89DBA954-8353-11DD-8EDA-000D936B094A"/>
 </association>
+<class_>
+<ref refid="DCE:3C5BB4C6-8353-11DD-8EDA-000D936B094A"/>
+</class_>
 <lowerValue>
 <val>0</val>
 </lowerValue>
 <lowerValue>
 <val>0</val>
 </lowerValue>
+<name>
+<val>encapsulatedClassifier</val>
+</name>
 <presentation>
 <reflist/>
 </presentation>
 <type>
 <ref refid="DCE:8BD30E4E-8352-11DD-8EDA-000D936B094A"/>
 </type>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
-</upperValue>
 </Property>
 <Property id="DCE:89E367C0-8353-11DD-8EDA-000D936B094A">
 <aggregation>

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,7 +32,7 @@ marker = "sys_platform == \"win32\""
 name = "atomicwrites"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.3.0"
+version = "1.4.0"
 
 [[package]]
 category = "dev"
@@ -122,7 +122,7 @@ marker = "python_version >= \"3.6\" and python_version < \"4.0\""
 name = "click"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "7.1.1"
+version = "7.1.2"
 
 [[package]]
 category = "dev"
@@ -150,7 +150,7 @@ description = "Code coverage measurement for Python"
 name = "coverage"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.0.4"
+version = "5.1"
 
 [package.extras]
 toml = ["toml"]
@@ -173,14 +173,6 @@ version = "0.16"
 
 [[package]]
 category = "dev"
-description = "Discover and load entry points from installed packages."
-name = "entrypoints"
-optional = false
-python-versions = ">=2.7"
-version = "0.3"
-
-[[package]]
-category = "dev"
 description = "A platform independent file lock."
 name = "filelock"
 optional = false
@@ -189,17 +181,20 @@ version = "3.0.12"
 
 [[package]]
 category = "dev"
-description = "the modular source code checker: pep8, pyflakes and co"
+description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.7.9"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "3.8.0a2"
 
 [package.dependencies]
-entrypoints = ">=0.3.0,<0.4.0"
 mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.5.0,<2.6.0"
-pyflakes = ">=2.1.0,<2.2.0"
+pycodestyle = ">=2.6.0a1,<2.7.0"
+pyflakes = ">=2.2.0,<2.3.0"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
 
 [[package]]
 category = "main"
@@ -228,7 +223,7 @@ description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.4.14"
+version = "1.4.15"
 
 [package.extras]
 license = ["editdistance"]
@@ -284,7 +279,7 @@ description = "A very fast and expressive template engine."
 name = "jinja2"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.11.1"
+version = "2.11.2"
 
 [package.dependencies]
 MarkupSafe = ">=0.23"
@@ -429,7 +424,7 @@ description = "Python style guide checker"
 name = "pycodestyle"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.5.0"
+version = "2.6.0a1"
 
 [[package]]
 category = "dev"
@@ -437,7 +432,7 @@ description = "passive checker of Python programs"
 name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.1.1"
+version = "2.2.0"
 
 [[package]]
 category = "dev"
@@ -525,7 +520,7 @@ description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
 python-versions = "*"
-version = "2019.3"
+version = "2020.1"
 
 [[package]]
 category = "dev"
@@ -742,11 +737,11 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.8"
+version = "1.25.9"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
@@ -755,7 +750,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.17"
+version = "20.0.19"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
@@ -768,8 +763,8 @@ python = "<3.8"
 version = ">=0.12,<2"
 
 [package.extras]
-docs = ["sphinx (>=2.0.0,<3)", "sphinx-argparse (>=0.2.5,<1)", "sphinx-rtd-theme (>=0.4.3,<1)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2,<1)"]
-testing = ["pytest (>=4.0.0,<6)", "coverage (>=4.5.1,<6)", "pytest-mock (>=2.0.0,<3)", "pytest-env (>=0.6.2,<1)", "pytest-timeout (>=1.3.4,<2)", "packaging (>=20.0)", "xonsh (>=0.9.16,<1)"]
+docs = ["sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2)"]
+testing = ["pytest (>=4)", "coverage (>=5)", "coverage-enable-subprocess (>=1)", "pytest-xdist (>=1.31.0)", "pytest-mock (>=2)", "pytest-env (>=0.6.2)", "pytest-randomly (>=1)", "pytest-timeout", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
 
 [[package]]
 category = "dev"
@@ -792,7 +787,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "bd17c6e735475b01195a3fd4feeb2b6d22a1d19fcadc4853a36db4819f67ddf3"
+content-hash = "81f44850c72e93f9a9f482851b4422743bb854174d3697f0acd672decdde9903"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -809,8 +804,8 @@ appdirs = [
     {file = "aspy.yaml-1.3.0.tar.gz", hash = "sha256:e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45"},
 ]
 atomicwrites = [
-    {file = "atomicwrites-1.3.0-py2.py3-none-any.whl", hash = "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4"},
-    {file = "atomicwrites-1.3.0.tar.gz", hash = "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"},
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
     {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
@@ -840,8 +835,8 @@ chardet = [
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
 click = [
-    {file = "click-7.1.1-py2.py3-none-any.whl", hash = "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"},
-    {file = "click-7.1.1.tar.gz", hash = "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc"},
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
@@ -852,37 +847,37 @@ commonmark = [
     {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
 coverage = [
-    {file = "coverage-5.0.4-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:8a620767b8209f3446197c0e29ba895d75a1e272a36af0786ec70fe7834e4307"},
-    {file = "coverage-5.0.4-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:73aa6e86034dad9f00f4bbf5a666a889d17d79db73bc5af04abd6c20a014d9c8"},
-    {file = "coverage-5.0.4-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:408ce64078398b2ee2ec08199ea3fcf382828d2f8a19c5a5ba2946fe5ddc6c31"},
-    {file = "coverage-5.0.4-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:cda33311cb9fb9323958a69499a667bd728a39a7aa4718d7622597a44c4f1441"},
-    {file = "coverage-5.0.4-cp27-cp27m-win32.whl", hash = "sha256:5f587dfd83cb669933186661a351ad6fc7166273bc3e3a1531ec5c783d997aac"},
-    {file = "coverage-5.0.4-cp27-cp27m-win_amd64.whl", hash = "sha256:9fad78c13e71546a76c2f8789623eec8e499f8d2d799f4b4547162ce0a4df435"},
-    {file = "coverage-5.0.4-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:2e08c32cbede4a29e2a701822291ae2bc9b5220a971bba9d1e7615312efd3037"},
-    {file = "coverage-5.0.4-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:922fb9ef2c67c3ab20e22948dcfd783397e4c043a5c5fa5ff5e9df5529074b0a"},
-    {file = "coverage-5.0.4-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:c3fc325ce4cbf902d05a80daa47b645d07e796a80682c1c5800d6ac5045193e5"},
-    {file = "coverage-5.0.4-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:046a1a742e66d065d16fb564a26c2a15867f17695e7f3d358d7b1ad8a61bca30"},
-    {file = "coverage-5.0.4-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6ad6ca45e9e92c05295f638e78cd42bfaaf8ee07878c9ed73e93190b26c125f7"},
-    {file = "coverage-5.0.4-cp35-cp35m-win32.whl", hash = "sha256:eda55e6e9ea258f5e4add23bcf33dc53b2c319e70806e180aecbff8d90ea24de"},
-    {file = "coverage-5.0.4-cp35-cp35m-win_amd64.whl", hash = "sha256:4a8a259bf990044351baf69d3b23e575699dd60b18460c71e81dc565f5819ac1"},
-    {file = "coverage-5.0.4-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:f372cdbb240e09ee855735b9d85e7f50730dcfb6296b74b95a3e5dea0615c4c1"},
-    {file = "coverage-5.0.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a37c6233b28e5bc340054cf6170e7090a4e85069513320275a4dc929144dccf0"},
-    {file = "coverage-5.0.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:443be7602c790960b9514567917af538cac7807a7c0c0727c4d2bbd4014920fd"},
-    {file = "coverage-5.0.4-cp36-cp36m-win32.whl", hash = "sha256:165a48268bfb5a77e2d9dbb80de7ea917332a79c7adb747bd005b3a07ff8caf0"},
-    {file = "coverage-5.0.4-cp36-cp36m-win_amd64.whl", hash = "sha256:0a907199566269e1cfa304325cc3b45c72ae341fbb3253ddde19fa820ded7a8b"},
-    {file = "coverage-5.0.4-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:513e6526e0082c59a984448f4104c9bf346c2da9961779ede1fc458e8e8a1f78"},
-    {file = "coverage-5.0.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3844c3dab800ca8536f75ae89f3cf566848a3eb2af4d9f7b1103b4f4f7a5dad6"},
-    {file = "coverage-5.0.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:641e329e7f2c01531c45c687efcec8aeca2a78a4ff26d49184dce3d53fc35014"},
-    {file = "coverage-5.0.4-cp37-cp37m-win32.whl", hash = "sha256:db1d4e38c9b15be1521722e946ee24f6db95b189d1447fa9ff18dd16ba89f732"},
-    {file = "coverage-5.0.4-cp37-cp37m-win_amd64.whl", hash = "sha256:62061e87071497951155cbccee487980524d7abea647a1b2a6eb6b9647df9006"},
-    {file = "coverage-5.0.4-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:65a7e00c00472cd0f59ae09d2fb8a8aaae7f4a0cf54b2b74f3138d9f9ceb9cb2"},
-    {file = "coverage-5.0.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1f66cf263ec77af5b8fe14ef14c5e46e2eb4a795ac495ad7c03adc72ae43fafe"},
-    {file = "coverage-5.0.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:85596aa5d9aac1bf39fe39d9fa1051b0f00823982a1de5766e35d495b4a36ca9"},
-    {file = "coverage-5.0.4-cp38-cp38-win32.whl", hash = "sha256:86a0ea78fd851b313b2e712266f663e13b6bc78c2fb260b079e8b67d970474b1"},
-    {file = "coverage-5.0.4-cp38-cp38-win_amd64.whl", hash = "sha256:03f630aba2b9b0d69871c2e8d23a69b7fe94a1e2f5f10df5049c0df99db639a0"},
-    {file = "coverage-5.0.4-cp39-cp39-win32.whl", hash = "sha256:7c9762f80a25d8d0e4ab3cb1af5d9dffbddb3ee5d21c43e3474c84bf5ff941f7"},
-    {file = "coverage-5.0.4-cp39-cp39-win_amd64.whl", hash = "sha256:4482f69e0701139d0f2c44f3c395d1d1d37abd81bfafbf9b6efbe2542679d892"},
-    {file = "coverage-5.0.4.tar.gz", hash = "sha256:1b60a95fc995649464e0cd48cecc8288bac5f4198f21d04b8229dc4097d76823"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6"},
+    {file = "coverage-5.1-cp27-cp27m-win32.whl", hash = "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796"},
+    {file = "coverage-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a"},
+    {file = "coverage-5.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768"},
+    {file = "coverage-5.1-cp35-cp35m-win32.whl", hash = "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2"},
+    {file = "coverage-5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7"},
+    {file = "coverage-5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c"},
+    {file = "coverage-5.1-cp36-cp36m-win32.whl", hash = "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1"},
+    {file = "coverage-5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7"},
+    {file = "coverage-5.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd"},
+    {file = "coverage-5.1-cp37-cp37m-win32.whl", hash = "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e"},
+    {file = "coverage-5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a"},
+    {file = "coverage-5.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef"},
+    {file = "coverage-5.1-cp38-cp38-win32.whl", hash = "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24"},
+    {file = "coverage-5.1-cp38-cp38-win_amd64.whl", hash = "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0"},
+    {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
+    {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
+    {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
 ]
 distlib = [
     {file = "distlib-0.3.0.zip", hash = "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"},
@@ -891,17 +886,13 @@ docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
-entrypoints = [
-    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
-    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
-]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
     {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
 ]
 flake8 = [
-    {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
-    {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
+    {file = "flake8-3.8.0a2-py2.py3-none-any.whl", hash = "sha256:c09e7e4ea0d91fa36f7b8439ca158e592be56524f0b67c39ab0ea2b85ed8f9a4"},
+    {file = "flake8-3.8.0a2.tar.gz", hash = "sha256:f33c5320eaa459cdee6367016a4bf4ba2a9b81499ce56e6a32abbf0b8d3a2eb4"},
 ]
 gaphas = [
     {file = "gaphas-2.0.1-py3-none-any.whl", hash = "sha256:36ca8b6fbad7e200101f6f585699206b2f8e8f042116b67df77d2b487e33c884"},
@@ -912,8 +903,8 @@ generic = [
     {file = "generic-1.0.0.tar.gz", hash = "sha256:c7651fb460feae762065b4a29afbfe2a346b2b18dccd4a8495a7e978498f66bc"},
 ]
 identify = [
-    {file = "identify-1.4.14-py2.py3-none-any.whl", hash = "sha256:2bb8760d97d8df4408f4e805883dad26a2d076f04be92a10a3e43f09c6060742"},
-    {file = "identify-1.4.14.tar.gz", hash = "sha256:faffea0fd8ec86bb146ac538ac350ed0c73908326426d387eded0bcc9d077522"},
+    {file = "identify-1.4.15-py2.py3-none-any.whl", hash = "sha256:88ed90632023e52a6495749c6732e61e08ec9f4f04e95484a5c37b9caf40283c"},
+    {file = "identify-1.4.15.tar.gz", hash = "sha256:23c18d97bb50e05be1a54917ee45cc61d57cb96aedc06aabb2b02331edf0dbf0"},
 ]
 idna = [
     {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
@@ -932,8 +923,8 @@ isort = [
     {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
 ]
 jinja2 = [
-    {file = "Jinja2-2.11.1-py2.py3-none-any.whl", hash = "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"},
-    {file = "Jinja2-2.11.1.tar.gz", hash = "sha256:93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250"},
+    {file = "Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"},
+    {file = "Jinja2-2.11.2.tar.gz", hash = "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
@@ -1025,12 +1016,12 @@ pycairo = [
     {file = "pycairo-1.19.1.tar.gz", hash = "sha256:2c143183280feb67f5beb4e543fd49990c28e7df427301ede04fc550d3562e84"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
-    {file = "pycodestyle-2.5.0.tar.gz", hash = "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"},
+    {file = "pycodestyle-2.6.0a1-py2.py3-none-any.whl", hash = "sha256:933bfe8d45355fbb35f9017d81fc51df8cb7ce58b82aca2568b870bf7bea1611"},
+    {file = "pycodestyle-2.6.0a1.tar.gz", hash = "sha256:c1362bf675a7c0171fa5f795917c570c2e405a97e5dc473b51f3656075d73acc"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.1.1-py2.py3-none-any.whl", hash = "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0"},
-    {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
+    {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
+    {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
 ]
 pygments = [
     {file = "Pygments-2.6.1-py3-none-any.whl", hash = "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"},
@@ -1056,8 +1047,8 @@ pytest-runner = [
     {file = "pytest_runner-4.5.1-py2.py3-none-any.whl", hash = "sha256:175d3d9271332b54df0190bec59c3614676f6895ad1056aa391ed034e03f95f6"},
 ]
 pytz = [
-    {file = "pytz-2019.3-py2.py3-none-any.whl", hash = "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d"},
-    {file = "pytz-2019.3.tar.gz", hash = "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"},
+    {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},
+    {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
 ]
 pyyaml = [
     {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
@@ -1181,12 +1172,12 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.8-py2.py3-none-any.whl", hash = "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc"},
-    {file = "urllib3-1.25.8.tar.gz", hash = "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"},
+    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
+    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.17-py2.py3-none-any.whl", hash = "sha256:00cfe8605fb97f5a59d52baab78e6070e72c12ca64f51151695407cc0eb8a431"},
-    {file = "virtualenv-20.0.17.tar.gz", hash = "sha256:c8364ec469084046c779c9a11ae6340094e8a0bf1d844330fc55c1cefe67c172"},
+    {file = "virtualenv-20.0.19-py2.py3-none-any.whl", hash = "sha256:b86480fc1fe3908a85d7377eee8dc9644a58090b9d3a3701b347c69c308f3e72"},
+    {file = "virtualenv-20.0.19.tar.gz", hash = "sha256:8bb59b586fea2eb3bb5600f7ef53d11fd4a64806cdf1a7217b29e7d943dbd8dc"},
 ]
 wcwidth = [
     {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ recommonmark = "^0.6.0"
 sphinx-rtd-theme = "^0.4.3"
 babel = "^2.7.0"
 babelgladeextractor = "^0.6.0"
-flake8 = "^3.7.9"
+flake8 = "^3.8.0a2"
 isort = "^4.3.21"
 
 [tool.poetry.scripts]

--- a/win-installer/misc/depcheck.py
+++ b/win-installer/misc/depcheck.py
@@ -133,9 +133,9 @@ def main(argv):
 
     if "--delete" in argv[1:]:
         while libs:
-            for l in libs:
-                print("DELETE:", l)
-                os.unlink(l)
+            for lib in libs:
+                print("DELETE:", lib)
+                os.unlink(lib)
             libs = get_things_to_delete(sys.prefix)
 
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Copy/paste is buggy. It references elements, rather than copying them. Copies can only be made in the same model. Connections are no (re)established.

Issue Number: #274 

### What is the new behavior?

Better behavior for copying elements. Elements are copied (saved) on copy. Copy behavior can be tweaked per item/element.

This PR fixes issues wrt copy and paste. It should work as a user would expect.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

To Do:

- [x] Copy a single element
- [x] Copy an element with a connected element
- [x] Copy two elements connected by a relation (association/generalization)
- [x] Copy elements, remove elements and paste them again. See if model is remade.
   * Special cases for Class, Association, Interface, Extension, Stereotype (like Class), State (entry/exit/do), Connector, Message, ExecutionSpecification.
- [x] Named items (Class, Package, etc.) should end up in diagram namespace if model elements have to be remade.

Other changes:

- [x] Add a "Cut" action, now copy/cut/paste trio is complete
- [x] Add type annotations to `recursemixin`
- [x] Box, Ellipse and Line now extend `SimpleItem`.
- [x] Upgrade Flake8 to 3.8.0a2. This saves some `noqa` comments
- [x] Added relation Port.encapsulatedClassifier -> EncapsulatedClassifier, to make connector pasting work.

This PR will not:
- Prepare images to be pasted in other applications (using `Gtk.Clipboard`)
- Copy from one model to another: copy service needs to be at application level, will be done in another PR. It should be simple, though, once this is in place.
