### PR TITLE
Copy paste with parent items

### DIFF
--- a/gaphor/UML/components/component.py
+++ b/gaphor/UML/components/component.py
@@ -52,6 +52,10 @@ class ComponentItem(ElementPresentation, Classified):
             draw=draw_border
         )
 
+    def postload(self):
+        self.update_shapes()
+        super().postload()
+
 
 def draw_component_icon(box, context, bounding_box):
     bar_width = 12

--- a/gaphor/UML/components/component.py
+++ b/gaphor/UML/components/component.py
@@ -23,6 +23,7 @@ class ComponentItem(ElementPresentation, Classified):
         self.watch("subject.appliedStereotype.slot", self.update_shapes)
         self.watch("subject.appliedStereotype.slot.definingFeature.name")
         self.watch("subject.appliedStereotype.slot.value", self.update_shapes)
+        self.watch("subject[Classifier].useCase", self.update_shapes)
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
 

--- a/gaphor/UML/components/node.py
+++ b/gaphor/UML/components/node.py
@@ -73,6 +73,10 @@ class NodeItem(ElementPresentation, Classified):
             draw=draw_node
         )
 
+    def postload(self):
+        self.update_shapes()
+        super().postload()
+
 
 def draw_node(box, context, bounding_box):
     cr = context.cairo

--- a/gaphor/UML/components/tests/test_grouping.py
+++ b/gaphor/UML/components/tests/test_grouping.py
@@ -111,8 +111,7 @@ class SubsystemUseCaseGroupTestCase(TestCase):
         self.group(s, uc2)
         assert 1 == len(uc2.subject.subject)
 
-        # Classifier.useCase is not navigable to UseCase
-        # self.assertEqual(2, len(s.subject.useCase))
+        self.assertEqual(2, len(s.subject.useCase))
 
     def test_grouping_with_namespace(self):
         """Test adding an use case to a subsystem (with namespace)
@@ -120,14 +119,9 @@ class SubsystemUseCaseGroupTestCase(TestCase):
         s = self.create(ComponentItem, UML.Component)
         uc = self.create(UseCaseItem, UML.UseCase)
 
-        # manipulate namespace
-        c = self.element_factory.create(UML.Class)
-        attribute = self.element_factory.create(UML.Property)
-        c.ownedAttribute = attribute
-
         self.group(s, uc)
         assert 1 == len(uc.subject.subject)
-        assert s.subject.namespace is not uc.subject
+        assert s.subject in uc.subject.subject
 
     def test_ungrouping(self):
         """Test removal of use case from subsystem
@@ -141,10 +135,8 @@ class SubsystemUseCaseGroupTestCase(TestCase):
 
         self.ungroup(s, uc1)
         assert 0 == len(uc1.subject.subject)
-        # Classifier.useCase is not navigable to UseCase
-        # self.assertEqual(1, len(s.subject.useCase))
+        self.assertEqual(1, len(s.subject.useCase))
 
         self.ungroup(s, uc2)
         assert 0 == len(uc2.subject.subject)
-        # Classifier.useCase is not navigable to UseCase
-        # self.assertEqual(0, len(s.subject.useCase))
+        self.assertEqual(0, len(s.subject.useCase))

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -78,6 +78,7 @@ class Classifier(Namespace, Type, RedefinableElement):
     isAbstract: attribute[int]
     ownedUseCase: relation_many[UseCase]
     generalization: relation_many[Generalization]
+    useCase: relation_many[UseCase]
     redefinedClassifier: relation_many[Classifier]
     substitution: relation_many[Substitution]
     attribute: relation_many[Property]
@@ -971,7 +972,8 @@ Slot.owningInstance = association(
 InstanceSpecification.slot = association(
     "slot", Slot, composite=True, opposite="owningInstance"
 )
-UseCase.subject = association("subject", Classifier)
+UseCase.subject = association("subject", Classifier, opposite="useCase")
+Classifier.useCase = association("useCase", UseCase, opposite="subject")
 Property.owningAssociation = association(
     "owningAssociation", Association, upper=1, opposite="ownedEnd"
 )

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -110,6 +110,11 @@ class Diagram(PackageableElement):
         self.model.handle(DiagramItemCreated(self.model, item))
         return item
 
+    def lookup(self, id):
+        for item in self.canvas.get_all_items():
+            if item.id == id:
+                return item
+
     def unlink(self):
         """Unlink all canvas items then unlink this diagram."""
 

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -172,7 +172,6 @@ def paste_presentation(copy_data: PresentationCopy, diagram, lookup):
         for value in deserialize(ser, lookup):
             item.load(name, value)
     item.canvas.update_matrices([item])
-    item.postload()
     return item
 
 
@@ -226,5 +225,8 @@ def _paste_all(copy_data: CopyData, diagram, lookup) -> Set[Presentation]:
         if old_id in new_items:
             continue
         new_items[old_id] = paste(data, diagram, item_lookup)
+
+    for new_item in new_items.values():
+        new_item.postload()
 
     return set(new_items.values())

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -140,6 +140,7 @@ paste.register(NamedElementCopy, paste_named_element)
 class PresentationCopy(NamedTuple):
     cls: Type[Element]
     data: Dict[str, Tuple[str, str]]
+    parent: Optional[str]
 
 
 def copy_presentation(item) -> PresentationCopy:
@@ -149,7 +150,10 @@ def copy_presentation(item) -> PresentationCopy:
         buffer[name] = serialize(value)
 
     item.save(save_func)
-    return PresentationCopy(cls=item.__class__, data=buffer)
+    parent = item.canvas.get_parent(item)
+    return PresentationCopy(
+        cls=item.__class__, data=buffer, parent=parent.id if parent else None
+    )
 
 
 copy.register(Presentation, copy_presentation)  # type: ignore[arg-type]
@@ -158,8 +162,12 @@ copy.register(SimpleItem, copy_presentation)  # type: ignore[arg-type]
 
 @paste.register
 def paste_presentation(copy_data: PresentationCopy, diagram, lookup):
-    cls, data = copy_data
+    cls, data, parent = copy_data
     item = diagram.create(cls)
+    if parent:
+        p = lookup(parent)
+        if p:
+            diagram.canvas.reparent(item, p)
     for name, ser in data.items():
         for value in deserialize(ser, lookup):
             item.load(name, value)
@@ -209,6 +217,9 @@ def _paste_all(copy_data: CopyData, diagram, lookup) -> Set[Presentation]:
         elif ref in copy_data.items:
             new_items[ref] = paste(copy_data.items[ref], diagram, item_lookup)
             return new_items[ref]
+        looked_up = diagram.lookup(ref)
+        if looked_up:
+            return looked_up
         return element_lookup(ref)
 
     for old_id, data in copy_data.items.items():

--- a/gaphor/diagram/tests/test_copypaste_grouping.py
+++ b/gaphor/diagram/tests/test_copypaste_grouping.py
@@ -1,0 +1,59 @@
+import pytest
+
+from gaphor import UML
+from gaphor.diagram.copypaste import copy, paste
+from gaphor.diagram.grouping import Group
+from gaphor.diagram.tests.fixtures import copy_clear_and_paste
+from gaphor.UML.components import ComponentItem, NodeItem
+
+
+@pytest.fixture
+def node_with_component(diagram, element_factory):
+    node = element_factory.create(UML.Node)
+    comp = element_factory.create(UML.Component)
+    node_item = diagram.create(NodeItem, subject=node)
+    comp_item = diagram.create(ComponentItem, subject=comp)
+
+    Group(node_item, comp_item).group()
+    diagram.canvas.reparent(comp_item, parent=node_item)
+
+    assert diagram.canvas.get_parent(comp_item) is node_item
+
+    return node_item, comp_item
+
+
+def test_copy_paste_of_nested_item(diagram, element_factory, node_with_component):
+    node_item, comp_item = node_with_component
+
+    buffer = copy({comp_item})
+
+    (new_comp_item,) = paste(buffer, diagram, element_factory.lookup)
+
+    assert diagram.canvas.get_parent(new_comp_item) is node_item
+
+
+def test_copy_paste_of_item_with_nested_item(
+    diagram, element_factory, node_with_component
+):
+    node_item, comp_item = node_with_component
+
+    buffer = copy(set(node_with_component))
+
+    new_items = paste(buffer, diagram, element_factory.lookup)
+
+    new_node_item = next(i for i in new_items if isinstance(i, NodeItem))
+    new_comp_item = next(i for i in new_items if isinstance(i, ComponentItem))
+
+    assert diagram.canvas.get_parent(new_comp_item) is new_node_item
+
+
+def test_copy_remove_paste_of_item_with_nested_item(
+    diagram, element_factory, node_with_component
+):
+
+    new_items = copy_clear_and_paste(set(node_with_component), diagram, element_factory)
+
+    new_node_item = next(i for i in new_items if isinstance(i, NodeItem))
+    new_comp_item = next(i for i in new_items if isinstance(i, ComponentItem))
+
+    assert diagram.canvas.get_parent(new_comp_item) is new_node_item

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="1.2.0">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="1.3.0">
 <Association id="DCE:12A2B620-4B3C-11D7-B391-02BBFE4396CE">
 <memberEnd>
 <reflist>
@@ -18088,11 +18088,6 @@ BehavioredClassifier.</val>
 <ref refid="DCE:3EEBCC18-6698-11D7-A84E-6C8643AD0CA4"/>
 </reflist>
 </memberEnd>
-<ownedEnd>
-<reflist>
-<ref refid="DCE:3EEBCC18-6698-11D7-A84E-6C8643AD0CA4"/>
-</reflist>
-</ownedEnd>
 <package>
 <ref refid="DCE:5573D924-6690-11D7-A84E-6C8643AD0CA4"/>
 </package>
@@ -18525,6 +18520,7 @@ BehavioredClassifier.</val>
 <ref refid="DCE:BFC7B66E-4B37-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:38A9AE44-4B54-11D7-A5E6-6257AF3C5118"/>
 <ref refid="DCE:E1377E1A-4B34-11D7-B391-02BBFE4396CE"/>
+<ref refid="DCE:3EEBCC18-6698-11D7-A84E-6C8643AD0CA4"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -22444,12 +22440,12 @@ specially for Gaphor</val>
 <association>
 <ref refid="DCE:3EEB934C-6698-11D7-A84E-6C8643AD0CA4"/>
 </association>
+<class_>
+<ref refid="DCE:F10D682A-4A87-11D7-B08B-133D836EF880"/>
+</class_>
 <name>
 <val>useCase</val>
 </name>
-<owningAssociation>
-<ref refid="DCE:3EEB934C-6698-11D7-A84E-6C8643AD0CA4"/>
-</owningAssociation>
 <presentation>
 <reflist/>
 </presentation>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Items, part of a super item, such as Components in a Node, are not copied properly.

Issue Number: #286 

### What is the new behavior?

* When a nested item is copied, it's pasted in the same parent item
* When child and parent item are copied together, a new parent item is created and the child will be part of that

Note that items are still pasted relative to the item position (position to the parent). Gaphor still needs some work so pasted items are always pasted inside the canvas' view port.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


