### PR TITLE
Enable Text Wrapping for Requirement Name

### DIFF
--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -45,6 +45,7 @@ class RequirementItem(ClassItem):
                 ),
                 EditableText(
                     text=lambda: self.subject.name or "",
+                    width=lambda: self.width - 4,
                     style={
                         "font-weight": FontWeight.BOLD,
                         "font-style": FontStyle.ITALIC

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -10,6 +10,7 @@ from gaphor.diagram.text import (
     TextAlign,
     TextDecoration,
     VerticalAlign,
+    focus_box_pos,
     text_draw,
     text_draw_focus_box,
     text_point_in_box,
@@ -295,7 +296,6 @@ class Text:
         min_w = max(self.style("min-width"), bounding_box.width)
         min_h = max(self.style("min-height"), bounding_box.height)
         text_align = self.style("text-align")
-        vertical_align = self.style("vertical-align")
         padding = self.style("padding")
 
         text_box = Rectangle(
@@ -309,11 +309,10 @@ class Text:
             cr,
             self.text(),
             self.font(),
-            lambda w, h: text_point_in_box(
-                text_box, (w, h), text_align, vertical_align
-            ),
+            lambda w, h: text_point_in_box(text_box),
             width=text_box.width,
             default_size=(min_w, min_h),
+            text_align=text_align,
         )
         return x, y, w, h
 
@@ -325,6 +324,17 @@ class EditableText(Text):
 
     def draw(self, context, bounding_box):
         x, y, w, h = super().draw(context, bounding_box)
+        cr = context.cairo
+        padding = self.style("padding")
+        text_align = self.style("text-align")
+        vertical_align = self.style("vertical-align")
+        text_box = Rectangle(
+            bounding_box.x + padding[Padding.LEFT],
+            bounding_box.y + padding[Padding.TOP],
+            bounding_box.width - padding[Padding.RIGHT] - padding[Padding.LEFT],
+            bounding_box.height - padding[Padding.TOP] - padding[Padding.BOTTOM],
+        )
+        x, y = focus_box_pos(text_box, self.size(cr), text_align, vertical_align)
         text_draw_focus_box(context, x, y, w, h)
         self.bounding_box = Rectangle(x, y, width=w, height=h)
 

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -1,7 +1,7 @@
 from math import pi
 from typing import List, Optional, Tuple
 
-import cairo
+from gaphas.canvas import Context
 from gaphas.geometry import Rectangle
 from typing_extensions import TypedDict
 
@@ -291,7 +291,7 @@ class Text:
             max(min_h, height + padding[Padding.TOP] + padding[Padding.BOTTOM]),
         )
 
-    def text_box(self, bounding_box: cairo.Context) -> Rectangle:
+    def text_box(self, bounding_box: Rectangle) -> Rectangle:
         """Add padding to a bounding box."""
         padding = self.style("padding")
         return Rectangle(
@@ -302,7 +302,7 @@ class Text:
         )
 
     def draw(
-        self, context: cairo.Context, bounding_box: Rectangle
+        self, context: Context, bounding_box: Rectangle
     ) -> Tuple[int, int, int, int]:
         """Draw the text, return the location and size."""
         cr = context.cairo
@@ -329,11 +329,11 @@ class EditableText(Text):
         self.bounding_box = Rectangle()
 
     def draw(
-        self, context: cairo.Context, bounding_box: Rectangle
+        self, context: Context, bounding_box: Rectangle
     ) -> Tuple[int, int, int, int]:
         """Draw the editable text."""
         x, y, w, h = super().draw(context, bounding_box)
-        text_box = super().text_box(bounding_box)
+        text_box = self.text_box(bounding_box)
         cr = context.cairo
         text_align = self.style("text-align")
         vertical_align = self.style("vertical-align")

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -334,10 +334,10 @@ class EditableText(Text):
         """Draw the editable text."""
         x, y, w, h = super().draw(context, bounding_box)
         text_box = self.text_box(bounding_box)
-        cr = context.cairo
         text_align = self.style("text-align")
         vertical_align = self.style("vertical-align")
-        x, y = focus_box_pos(text_box, self.size(cr), text_align, vertical_align)
+        bounding_size = (bounding_box.width, bounding_box.height)
+        x, y = focus_box_pos(text_box, bounding_size, text_align, vertical_align)
         text_draw_focus_box(context, x, y, w, h)
         self.bounding_box = Rectangle(x, y, width=w, height=h)
         return x, y, w, h

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -292,6 +292,7 @@ class Text:
         )
 
     def text_box(self, bounding_box: cairo.Context) -> Rectangle:
+        """Add padding to a bounding box."""
         padding = self.style("padding")
         return Rectangle(
             bounding_box.x + padding[Padding.LEFT],
@@ -336,10 +337,8 @@ class EditableText(Text):
         cr = context.cairo
         text_align = self.style("text-align")
         vertical_align = self.style("vertical-align")
-        focus_x, focus_y = focus_box_pos(
-            text_box, self.size(cr), text_align, vertical_align
-        )
-        text_draw_focus_box(context, focus_x, focus_y, w, h)
+        x, y = focus_box_pos(text_box, self.size(cr), text_align, vertical_align)
+        text_draw_focus_box(context, x, y, w, h)
         self.bounding_box = Rectangle(x, y, width=w, height=h)
         return x, y, w, h
 

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -73,7 +73,13 @@ def text_size(
 
 
 def text_draw(
-    cr, text, font, calculate_pos, width=-1, default_size=(0, 0), text_align=None
+    cr,
+    text,
+    font,
+    calculate_pos,
+    width=-1,
+    default_size=(0, 0),
+    text_align=TextAlign.CENTER,
 ):
     """
     Draw text relative to (x, y).
@@ -100,7 +106,7 @@ def text_draw(
     return (x, y, w, h)
 
 
-def _text_layout(cr, text, font, width, text_align=None):
+def _text_layout(cr, text, font, width, text_align=TextAlign.CENTER):
     underline = False
     layout = _pango_cairo_create_layout(cr)
 
@@ -133,8 +139,7 @@ def _text_layout(cr, text, font, width, text_align=None):
     else:
         layout.set_text(text, length=-1)
     layout.set_width(int(width * Pango.SCALE))
-    if text_align is TextAlign.CENTER:
-        layout.set_alignment(Pango.Alignment.CENTER)
+    layout.set_alignment(getattr(Pango.Alignment, text_align.name))
     return layout
 
 

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -3,7 +3,7 @@ Support classes for dealing with text.
 """
 
 from enum import Enum
-from typing import Dict, Tuple, TypeVar
+from typing import Dict, Tuple, TypeVar, Union
 
 import cairo
 import gi
@@ -173,7 +173,7 @@ def _pango_cairo_show_layout(cr, layout):
 
 def focus_box_pos(
     bounding_box: Rectangle,
-    text_size: cairo.Context,
+    text_size: Tuple[Union[float, int], Union[float, int]],
     text_align: TextAlign,
     vertical_align: VerticalAlign,
 ) -> Tuple[int, int]:

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -50,7 +50,6 @@ def text_draw_focus_box(context, x, y, w, h):
         cr = context.cairo
         cr.save()
         try:
-            # cr.set_dash(() if context.focused else (2.0, 2.0), 0)
             cr.set_dash((), 0)
             if context.focused:
                 cr.set_source_rgb(0.6, 0.6, 0.6)
@@ -73,7 +72,9 @@ def text_size(
     return layout.get_pixel_size()  # type: ignore[no-any-return] # noqa: F723
 
 
-def text_draw(cr, text, font, calculate_pos, width=-1, default_size=(0, 0)):
+def text_draw(
+    cr, text, font, calculate_pos, width=-1, default_size=(0, 0), text_align=None
+):
     """
     Draw text relative to (x, y).
     text - text to print (utf8)
@@ -83,7 +84,7 @@ def text_draw(cr, text, font, calculate_pos, width=-1, default_size=(0, 0)):
     """
 
     if text:
-        layout = _text_layout(cr, text, font, width)
+        layout = _text_layout(cr, text, font, width, text_align)
         w, h = layout.get_pixel_size()
     else:
         layout = None
@@ -99,7 +100,7 @@ def text_draw(cr, text, font, calculate_pos, width=-1, default_size=(0, 0)):
     return (x, y, w, h)
 
 
-def _text_layout(cr, text, font, width):
+def _text_layout(cr, text, font, width, text_align=None):
     underline = False
     layout = _pango_cairo_create_layout(cr)
 
@@ -132,6 +133,8 @@ def _text_layout(cr, text, font, width):
     else:
         layout.set_text(text, length=-1)
     layout.set_width(int(width * Pango.SCALE))
+    if text_align is TextAlign.CENTER:
+        layout.set_alignment(Pango.Alignment.CENTER)
     return layout
 
 
@@ -162,11 +165,17 @@ def _pango_cairo_show_layout(cr, layout):
         PangoCairo.show_layout(cr, layout)
 
 
-def text_point_in_box(bounding_box, text_size, text_align, vertical_align):
+def text_point_in_box(bounding_box):
+    x, y, width, height = bounding_box
+    return x, y
+
+
+def focus_box_pos(bounding_box, text_size, text_align, vertical_align):
     x, y, width, height = bounding_box
     w, h = text_size
 
     if text_align is TextAlign.CENTER:
+        print("Center")
         x += (width - w) / 2
     elif text_align is TextAlign.RIGHT:
         x += width - w

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -8,6 +8,7 @@ from typing import Dict, Tuple, TypeVar
 import cairo
 import gi
 from gaphas.freehand import FreeHandCairoContext
+from gaphas.geometry import Rectangle
 from gaphas.painter import CairoBoundingBoxContext
 
 # fmt: off
@@ -170,17 +171,17 @@ def _pango_cairo_show_layout(cr, layout):
         PangoCairo.show_layout(cr, layout)
 
 
-def text_point_in_box(bounding_box):
-    x, y, width, height = bounding_box
-    return x, y
-
-
-def focus_box_pos(bounding_box, text_size, text_align, vertical_align):
+def focus_box_pos(
+    bounding_box: Rectangle,
+    text_size: cairo.Context,
+    text_align: TextAlign,
+    vertical_align: VerticalAlign,
+) -> Tuple[int, int]:
+    """Calculate the focus box position based on alignment style."""
     x, y, width, height = bounding_box
     w, h = text_size
 
     if text_align is TextAlign.CENTER:
-        print("Center")
         x += (width - w) / 2
     elif text_align is TextAlign.RIGHT:
         x += width - w


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

<!-- Please add an overview of the PR here -->
Small PR that wraps the requirement name text and centers it.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
Work left to do:
- [x] Center text after on each line of the text box following wrapping
