### PR TITLE
Add extra model integrity checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ htmlcov
 .eggs/
 gaphor.egg-info/
 tmp.gaphor
+gaphor.prof
 .gpg
 pip-wheel-metadata
 

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -103,6 +103,10 @@ class Diagram(PackageableElement):
         return self.create_as(type, str(uuid.uuid1()), parent, subject)
 
     def create_as(self, type, id, parent=None, subject=None):
+        if not type or not issubclass(type, gaphas.Item):
+            raise TypeError(
+                f"Type {type} can not be added to a diagram as it is not a diagram item"
+            )
         item = type(id, self.model)
         if subject:
             item.subject = subject

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -26,6 +26,7 @@ from gaphor.core.modeling.event import (
     ModelFlushed,
     ModelReady,
 )
+from gaphor.core.modeling.presentation import Presentation
 
 if TYPE_CHECKING:
     from gaphor.core.eventmanager import EventManager  # noqa
@@ -74,26 +75,11 @@ class ElementFactory(Service):
         This method should only be used when loading models, since it does
         not emit an ElementCreated event.
         """
-        assert issubclass(type, Element)
+        if not type or not issubclass(type, Element) or issubclass(type, Presentation):
+            raise TypeError(f"Type {type} is not a valid model element")
         obj = type(id, self)
         self._elements[id] = obj
         return obj
-
-    def bind(self, element: Element) -> None:
-        """
-        Bind an already created element to the element factory.
-        The element may not be bound to another factory already.
-        """
-        if hasattr(element, "_model") and element._model:
-            raise AttributeError("element is already bound")
-        if not isinstance(element.id, str):
-            raise AttributeError(
-                f"Element should contain a string id (found: {element.id}"
-            )
-        if self._elements.get(element.id):
-            raise AttributeError("an element already exists with the same id")
-        element._model = self
-        self._elements[element.id] = element
 
     def size(self) -> int:
         """

--- a/gaphor/core/modeling/tests/test_diagram.py
+++ b/gaphor/core/modeling/tests/test_diagram.py
@@ -49,3 +49,10 @@ def test_canvas_is_unlinked(element_factory):
     diagram.unlink()
 
     assert example.test_unlinked
+
+
+def test_can_only_add_diagram_items(element_factory):
+    diagram = element_factory.create(Diagram)
+
+    with pytest.raises(TypeError):
+        diagram.create(Diagram)

--- a/gaphor/core/modeling/tests/test_elementfactory.py
+++ b/gaphor/core/modeling/tests/test_elementfactory.py
@@ -12,6 +12,7 @@ from gaphor.core.modeling.event import (
     ModelReady,
     ServiceEvent,
 )
+from gaphor.core.modeling.presentation import Presentation
 from gaphor.UML import Parameter
 
 
@@ -24,6 +25,11 @@ def factory():
 def test_create(factory):
     factory.create(Parameter)
     assert len(list(factory.values())) == 1
+
+
+def test_should_not_create_presentation_elements(factory):
+    with pytest.raises(TypeError):
+        factory.create(Presentation)
 
 
 def test_flush(factory):

--- a/gaphor/diagram/tests/test_presentation.py
+++ b/gaphor/diagram/tests/test_presentation.py
@@ -21,8 +21,8 @@ class StubLine(LinePresentation):
         super().__init__(id, model, shape_middle=DummyVisualComponent())
 
 
-def test_creation(element_factory):
-    p = element_factory.create(Presentation)
+def test_creation(diagram):
+    p = diagram.create(StubElement)
 
     assert p
     assert p.model


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

It used to be possible for diagram items to end up in the model. This leads to issues when loading models.

Issue Number: #286, #326

### What is the new behavior?

Extra checks are done for the type sanity for both `Element Factory` (which contains the model) and `Diagram` (where diagram items are added).

This should ensure the model stays clean.

`ElementFatctory.bind()` has been removed since it was not used (nor tested).

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
