### PR TITLE
Parts and references

### DIFF
--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -20,9 +20,6 @@ from gaphor.diagram.support import represents
 from gaphor.SysML.sysml import Block
 from gaphor.UML.classes.klass import (
     attribute_watches,
-    attributes_compartment,
-    operation_watches,
-    operations_compartment,
     stereotype_compartments,
     stereotype_watches,
 )
@@ -36,12 +33,8 @@ class BlockItem(ElementPresentation[Block], Classified):
         super().__init__(id, model)
 
         self.watch("show_stereotypes", self.update_shapes).watch(
-            "show_attributes", self.update_shapes
-        ).watch("show_operations", self.update_shapes).watch(
             "show_parts", self.update_shapes
-        ).watch(
-            "show_references", self.update_shapes
-        ).watch(
+        ).watch("show_references", self.update_shapes).watch(
             "subject[NamedElement].name"
         ).watch(
             "subject[NamedElement].namespace.name"
@@ -51,14 +44,9 @@ class BlockItem(ElementPresentation[Block], Classified):
             "subject[Class].ownedAttribute.aggregation", self.update_shapes
         )
         attribute_watches(self, "Block")
-        operation_watches(self, "Block")
         stereotype_watches(self)
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
-
-    show_attributes: attribute[int] = attribute("show_attributes", int, default=False)
-
-    show_operations: attribute[int] = attribute("show_operations", int, default=False)
 
     show_parts: attribute[int] = attribute("show_parts", int, default=False)
 
@@ -86,18 +74,6 @@ class BlockItem(ElementPresentation[Block], Classified):
                     style={"font-size": 10, "min-width": 0, "min-height": 0},
                 ),
                 style={"padding": (12, 4, 12, 4)},
-            ),
-            *(
-                self.show_attributes
-                and self.subject
-                and [attributes_compartment(self.subject)]
-                or []
-            ),
-            *(
-                self.show_operations
-                and self.subject
-                and [operations_compartment(self.subject)]
-                or []
             ),
             *(
                 self.show_parts

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -105,7 +105,7 @@ class BlockItem(ElementPresentation[Block], Classified):
                 and [
                     self.block_compartment(
                         gettext("parts"),
-                        lambda a: a.association and a.aggregation != "none",
+                        lambda a: a.association and a.aggregation == "composite",
                     )
                 ]
                 or []
@@ -116,7 +116,7 @@ class BlockItem(ElementPresentation[Block], Classified):
                 and [
                     self.block_compartment(
                         gettext("references"),
-                        lambda a: a.association and a.aggregation == "none",
+                        lambda a: a.association and a.aggregation != "composite",
                     )
                 ]
                 or []

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -1,9 +1,154 @@
+from gaphor.core import gettext
+from gaphor.core.modeling.properties import attribute
+from gaphor.diagram.presentation import (
+    Classified,
+    ElementPresentation,
+    from_package_str,
+)
+from gaphor.diagram.shapes import (
+    Box,
+    EditableText,
+    FontStyle,
+    FontWeight,
+    Text,
+    TextAlign,
+    VerticalAlign,
+    draw_border,
+    draw_top_separator,
+)
 from gaphor.diagram.support import represents
 from gaphor.SysML.sysml import Block
-from gaphor.UML.classes import ClassItem
+from gaphor.UML.classes.klass import (
+    attribute_watches,
+    attributes_compartment,
+    operation_watches,
+    operations_compartment,
+    stereotype_compartments,
+    stereotype_watches,
+)
+from gaphor.UML.modelfactory import stereotypes_str
+from gaphor.UML.umlfmt import format_attribute
 
 
 @represents(Block)
-class BlockItem(ClassItem):
-    def additional_stereotypes(self):
-        return ["block"]
+class BlockItem(ElementPresentation[Block], Classified):
+    def __init__(self, id=None, model=None):
+        super().__init__(id, model)
+
+        self.watch("show_stereotypes", self.update_shapes).watch(
+            "show_attributes", self.update_shapes
+        ).watch("show_operations", self.update_shapes).watch(
+            "show_parts", self.update_shapes
+        ).watch(
+            "show_references", self.update_shapes
+        ).watch(
+            "subject[NamedElement].name"
+        ).watch(
+            "subject[NamedElement].namespace.name"
+        ).watch(
+            "subject[Classifier].isAbstract", self.update_shapes
+        ).watch(
+            "subject[Class].ownedAttribute.aggregation", self.update_shapes
+        )
+        attribute_watches(self, "Block")
+        operation_watches(self, "Block")
+        stereotype_watches(self)
+
+    show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
+
+    show_attributes: attribute[int] = attribute("show_attributes", int, default=False)
+
+    show_operations: attribute[int] = attribute("show_operations", int, default=False)
+
+    show_parts: attribute[int] = attribute("show_parts", int, default=False)
+
+    show_references: attribute[int] = attribute("show_references", int, default=False)
+
+    def update_shapes(self, event=None):
+        self.shape = Box(
+            Box(
+                Text(
+                    text=lambda: stereotypes_str(self.subject, ["block"]),
+                    style={"min-width": 0, "min-height": 0},
+                ),
+                EditableText(
+                    text=lambda: self.subject.name or "",
+                    width=lambda: self.width - 4,
+                    style={
+                        "font-weight": FontWeight.BOLD,
+                        "font-style": FontStyle.ITALIC
+                        if self.subject and self.subject.isAbstract
+                        else FontStyle.NORMAL,
+                    },
+                ),
+                Text(
+                    text=lambda: from_package_str(self),
+                    style={"font-size": 10, "min-width": 0, "min-height": 0},
+                ),
+                style={"padding": (12, 4, 12, 4)},
+            ),
+            *(
+                self.show_attributes
+                and self.subject
+                and [attributes_compartment(self.subject)]
+                or []
+            ),
+            *(
+                self.show_operations
+                and self.subject
+                and [operations_compartment(self.subject)]
+                or []
+            ),
+            *(
+                self.show_parts
+                and self.subject
+                and [
+                    self.block_compartment(
+                        gettext("parts"),
+                        lambda a: a.association and a.aggregation != "none",
+                    )
+                ]
+                or []
+            ),
+            *(
+                self.show_references
+                and self.subject
+                and [
+                    self.block_compartment(
+                        gettext("references"),
+                        lambda a: a.association and a.aggregation == "none",
+                    )
+                ]
+                or []
+            ),
+            *(self.show_stereotypes and stereotype_compartments(self.subject) or []),
+            style={
+                "min-width": 100,
+                "min-height": 50,
+                "vertical-align": VerticalAlign.TOP,
+            },
+            draw=draw_border,
+        )
+
+    def block_compartment(self, name, predicate):
+        # We need to fix the attribute value, since the for loop changes it.
+        def lazy_format(attribute):
+            return lambda: format_attribute(attribute) or gettext("unnamed")
+
+        return Box(
+            Text(
+                text=name,
+                style={
+                    "padding": (0, 0, 4, 0),
+                    "font-size": 10,
+                    "font-style": FontStyle.ITALIC,
+                },
+            ),
+            *(
+                Text(text=lazy_format(attribute), style={"text-align": TextAlign.LEFT})
+                for attribute in self.subject.ownedAttribute
+                if predicate(attribute)
+            ),
+            style={"padding": (4, 4, 4, 4), "min-height": 8},
+            draw=draw_top_separator,
+        )

--- a/gaphor/SysML/propertypages.glade
+++ b/gaphor/SysML/propertypages.glade
@@ -15,6 +15,58 @@ Edit, from the popup menu, will allow you to add cell
 renderers and such.</property>
     <property name="xalign">0</property>
   </object>
+  <object class="GtkExpander" id="parts-and-references-editor">
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <property name="margin_top">12</property>
+    <property name="expanded">True</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_top">6</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkCheckButton" id="show-parts">
+            <property name="label" translatable="yes">Show parts</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="draw_indicator">True</property>
+            <signal name="toggled" handler="show-parts-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="show-references">
+            <property name="label" translatable="yes">Show references</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="draw_indicator">True</property>
+            <signal name="toggled" handler="show-references-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child type="label">
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Parts and References</property>
+      </object>
+    </child>
+  </object>
   <object class="GtkTextBuffer" id="requirement-text-buffer"/>
   <object class="GtkBox" id="requirement-editor">
     <property name="visible">True</property>

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -5,6 +5,7 @@ from gi.repository import Gtk
 from gaphor.core import transactional
 from gaphor.diagram.propertypages import PropertyPageBase, PropertyPages
 from gaphor.SysML import sysml
+from gaphor.SysML.blocks.block import BlockItem
 from gaphor.SysML.requirements.requirement import RequirementItem
 from gaphor.UML.classes.classespropertypages import AttributesPage, OperationsPage
 
@@ -76,3 +77,49 @@ class RequirementPropertyPage(PropertyPageBase):
 
 PropertyPages.register(RequirementItem)(AttributesPage)
 PropertyPages.register(RequirementItem)(OperationsPage)
+
+
+@PropertyPages.register(BlockItem)
+class PartsAndReferencesPage(PropertyPageBase):
+    """An editor for Block items."""
+
+    order = 30
+
+    def __init__(self, item):
+        super().__init__()
+        self.item = item
+        self.watcher = item.subject and item.subject.watcher()
+
+    def construct(self):
+        if not self.item.subject:
+            return
+
+        builder = new_builder("parts-and-references-editor")
+
+        show_parts = builder.get_object("show-parts")
+        show_parts.set_active(self.item.show_parts)
+
+        show_references = builder.get_object("show-references")
+        show_references.set_active(self.item.show_references)
+
+        builder.connect_signals(
+            {
+                "show-parts-changed": (self._on_show_parts_change,),
+                "show-references-changed": (self._on_show_references_change,),
+            }
+        )
+        return builder.get_object("parts-and-references-editor")
+
+    @transactional
+    def _on_show_parts_change(self, button):
+        self.item.show_parts = button.get_active()
+        self.item.request_update()
+
+    @transactional
+    def _on_show_references_change(self, button):
+        self.item.show_references = button.get_active()
+        self.item.request_update()
+
+
+PropertyPages.register(BlockItem)(AttributesPage)
+PropertyPages.register(BlockItem)(OperationsPage)

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -5,6 +5,8 @@ from gi.repository import Gtk
 from gaphor.core import transactional
 from gaphor.diagram.propertypages import PropertyPageBase, PropertyPages
 from gaphor.SysML import sysml
+from gaphor.SysML.requirements.requirement import RequirementItem
+from gaphor.UML.classes.classespropertypages import AttributesPage, OperationsPage
 
 
 def new_builder(*object_ids):
@@ -70,3 +72,7 @@ class RequirementPropertyPage(PropertyPageBase):
         self.subject.text = buffer.get_text(
             buffer.get_start_iter(), buffer.get_end_iter(), False
         )
+
+
+PropertyPages.register(RequirementItem)(AttributesPage)
+PropertyPages.register(RequirementItem)(OperationsPage)

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -119,7 +119,3 @@ class PartsAndReferencesPage(PropertyPageBase):
     def _on_show_references_change(self, button):
         self.item.show_references = button.get_active()
         self.item.request_update()
-
-
-PropertyPages.register(BlockItem)(AttributesPage)
-PropertyPages.register(BlockItem)(OperationsPage)

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -132,6 +132,8 @@ def attribute_watches(presentation, cast):
     ).watch(
         f"subject[{cast}].ownedAttribute.defaultValue"
     ).watch(
+        f"subject[{cast}].ownedAttribute.type"
+    ).watch(
         f"subject[{cast}].ownedAttribute.typeValue"
     )
 

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -46,20 +46,11 @@ class ClassItem(ElementPresentation[UML.Class], Classified):
         ).watch(
             "subject[NamedElement].namespace.name"
         ).watch(
-            "subject.appliedStereotype", self.update_shapes
-        ).watch(
-            "subject.appliedStereotype.classifier.name"
-        ).watch(
-            "subject.appliedStereotype.slot", self.update_shapes
-        ).watch(
-            "subject.appliedStereotype.slot.definingFeature.name"
-        ).watch(
-            "subject.appliedStereotype.slot.value", self.update_shapes
-        ).watch(
             "subject[Classifier].isAbstract", self.update_shapes
         )
         attribute_watches(self, "Class")
         operation_watches(self, "Class")
+        stereotype_watches(self)
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
 
@@ -168,6 +159,16 @@ def operation_watches(presentation, cast):
         f"subject[{cast}].ownedOperation.formalParameter.typeValue"
     ).watch(
         f"subject[{cast}].ownedOperation.formalParameter.defaultValue"
+    )
+
+
+def stereotype_watches(presentation):
+    presentation.watch("subject.appliedStereotype", presentation.update_shapes).watch(
+        "subject.appliedStereotype.classifier.name"
+    ).watch("subject.appliedStereotype.slot", presentation.update_shapes).watch(
+        "subject.appliedStereotype.slot.definingFeature.name"
+    ).watch(
+        "subject.appliedStereotype.slot.value", presentation.update_shapes
     )
 
 

--- a/gaphor/UML/modelfactory.py
+++ b/gaphor/UML/modelfactory.py
@@ -313,7 +313,7 @@ def set_navigability(assoc, end, nav):
     When an end is non-navigable, then it is just member of an association.
     """
     # remove "navigable" and "unspecified" navigation indicators first
-    if type(end.type) in (Class, Interface):
+    if isinstance(end.type, (Class, Interface)):
         owner = end.opposite.type
         if end in owner.ownedAttribute:
             owner.ownedAttribute.remove(end)
@@ -325,7 +325,7 @@ def set_navigability(assoc, end, nav):
     assert end not in assoc.navigableOwnedEnd
 
     if nav is True:
-        if type(end.type) in (Class, Interface):
+        if isinstance(end.type, (Class, Interface)):
             owner = end.opposite.type
             owner.ownedAttribute = end
         else:

--- a/gaphor/UML/tests/test_modelfactory.py
+++ b/gaphor/UML/tests/test_modelfactory.py
@@ -216,7 +216,7 @@ def test_relationship_navigability(element_factory):
 
     # class/interface navigability, Association.navigableOwnedEnd not
     # involved
-    assert end in assoc.navigableOwnedEnd
+    assert end in n2.ownedAttribute
     assert end not in assoc.ownedEnd
     assert end.navigability is True
 
@@ -239,7 +239,7 @@ def test_relationship_navigability(element_factory):
     assert end.navigability is None
 
     UML.model.set_navigability(assoc, end, True)
-    assert end in assoc.navigableOwnedEnd
+    assert end in n2.ownedAttribute
     assert end not in assoc.ownedEnd
     assert end.navigability is True
 

--- a/gaphor/UML/tests/test_umlfmt.py
+++ b/gaphor/UML/tests/test_umlfmt.py
@@ -79,6 +79,17 @@ def test_association_end(factory, text, name_part, mult_part):
     assert (name_part, mult_part) == format(a)
 
 
+def test_attribute_with_type(factory):
+    """Test simple attribute formatting
+    """
+    a = factory.create(UML.Property)
+    a.type = factory.create(UML.Class)
+    a.name = "attr"
+    a.type.name = "MyClass"
+
+    assert "+ attr: MyClass" == format(a)
+
+
 def test_association_end_with_applied_stereotype(factory):
     a = factory.create(UML.Property)
     a.association = factory.create(UML.Association)

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -82,6 +82,8 @@ def format_attribute(
 
     if type and el.typeValue:
         s.append(f": {el.typeValue}")
+    elif type and el.type and el.type.name:
+        s.append(f": {el.type.name}")
 
     if multiplicity:
         s.append(format_multiplicity(el))


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

No parts and references compartment in Block diagram

Issue Number: #138 

### What is the new behavior?

Parts and references are visible:

![image](https://user-images.githubusercontent.com/96249/83331258-459d8780-a295-11ea-97c0-3c327c82d643.png)


### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

NB. It looks like SysML elements are not visible in the tree view at all (!)