### PR TITLE
Show element editor by default

### DIFF
--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -12,13 +12,13 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_right">2</property>
         <property name="margin_top">2</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_right">2</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkBox">
@@ -164,6 +164,7 @@
           <object class="GtkSeparator">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_right">2</property>
             <property name="margin_top">2</property>
             <property name="margin_bottom">2</property>
           </object>
@@ -174,16 +175,31 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="editors">
+          <object class="GtkScrolledWindow">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
+            <property name="can_focus">True</property>
+            <property name="hscrollbar_policy">never</property>
             <child>
-              <placeholder/>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkBox" id="editors">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_right">2</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                </child>
+              </object>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">2</property>
           </packing>

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkRevealer" id="elementeditor">
@@ -7,6 +7,7 @@
     <property name="can_focus">False</property>
     <property name="transition_type">slide-left</property>
     <property name="transition_duration">200</property>
+    <property name="reveal_child">True</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -210,4 +210,70 @@
       </object>
     </child>
   </object>
+  <object class="GtkBox" id="no-item-selected">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_top">18</property>
+        <property name="margin_bottom">12</property>
+        <property name="label" translatable="yes">No item selected</property>
+        <attributes>
+          <attribute name="weight" value="bold"/>
+        </attributes>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="show-tips">
+        <property name="label" translatable="yes">Show tips</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="margin_top">12</property>
+        <property name="active">True</property>
+        <property name="draw_indicator">True</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="tips">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="no_show_all">True</property>
+        <property name="margin_left">4</property>
+        <property name="margin_right">4</property>
+        <property name="margin_top">12</property>
+        <property name="label" translatable="yes">Add a model element from the tool box to the diagram. Here you will see it's properties appear.
+
+This pane can be hidden by clicking the pensil icon in the header.
+
+&lt;b&gt;Tip:&lt;/b&gt; Most elements in the toolbox have a keyboard shortcut (e.g. "c" for Class).
+Tool selection only works from the diagram. If a tool does not get selected, click on the diagram once (so it's focused) and then hit the shortcut key.
+
+&lt;b&gt;Tip:&lt;/b&gt; To search for an element in the tree view, select an element in the tree view and start typing. A search box will automaticaly appear.
+</property>
+        <property name="use_markup">True</property>
+        <property name="wrap">True</property>
+        <property name="max_width_chars">20</property>
+        <property name="xalign">0</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+  </object>
 </interface>

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -18,6 +18,7 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_left">2</property>
             <property name="margin_right">2</property>
             <property name="spacing">6</property>
             <child>
@@ -164,6 +165,7 @@
           <object class="GtkSeparator">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_left">2</property>
             <property name="margin_right">2</property>
             <property name="margin_top">2</property>
             <property name="margin_bottom">2</property>
@@ -188,6 +190,7 @@
                   <object class="GtkBox" id="editors">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="margin_left">2</property>
                     <property name="margin_right">2</property>
                     <property name="orientation">vertical</property>
                     <child>

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -18,27 +18,11 @@ from gaphor.ui.event import DiagramSelectionChanged
 log = logging.getLogger(__name__)
 
 
-NO_ITEM_SELECTED = gettext(
-    """\
-    <b>No item selected</b>
-
-    Add a model element from the tool box to the diagram. Here you will see it's properties appear.
-
-    This pane can be hidden by clicking the pensil icon in the header.
-
-    <b>Tip:</b> Most elements in the toolbox have a keyboard shortcut (e.g. "c" for Class).
-    Tool selection only works from the diagram. If a tool does not get selected, click on the diagram once (so it's focused) and then hit the shortcut key.
-
-    <b>Tip:</b> To search for an element in the tree view, select an element in the tree view and start typing. A search box will automaticaly appear.
-    """
-)
-
-
-def new_builder():
+def new_builder(*object_ids):
     builder = Gtk.Builder()
     builder.set_translation_domain("gaphor")
     with importlib.resources.path("gaphor.ui", "elementeditor.glade") as glade_file:
-        builder.add_from_file(str(glade_file))
+        builder.add_objects_from_file(str(glade_file), object_ids)
     return builder
 
 
@@ -50,20 +34,21 @@ class ElementEditor(UIComponent, ActionProvider):
     title = gettext("Element Editor")
     size = (275, -1)
 
-    def __init__(self, event_manager, element_factory, diagrams):
+    def __init__(self, event_manager, element_factory, diagrams, properties):
         """Constructor. Build the action group for the element editor window.
         This will place a button for opening the window in the toolbar.
         The widget attribute is a PropertyEditor."""
         self.event_manager = event_manager
         self.element_factory = element_factory
         self.diagrams = diagrams
+        self.properties = properties
         self.vbox: Optional[Gtk.Box] = None
         self._current_item = None
         self._expanded_pages = {gettext("Properties"): True}
 
     def open(self):
         """Display the ElementEditor pane."""
-        builder = new_builder()
+        builder = new_builder("elementeditor")
 
         self.revealer = builder.get_object("elementeditor")
         self.vbox = builder.get_object("editors")
@@ -74,8 +59,6 @@ class ElementEditor(UIComponent, ActionProvider):
         # Make sure we receive
         self.event_manager.subscribe(self._selection_change)
         self.event_manager.subscribe(self._element_changed)
-
-        self.revealer.show_all()
 
         return self.revealer
 
@@ -123,7 +106,6 @@ class ElementEditor(UIComponent, ActionProvider):
                     page.set_expanded(self._expanded_pages.get(name, True))
                     page.connect_after("activate", self.on_expand, name)
                 self.vbox.pack_start(page, False, True, 0)
-                page.show_all()
             except Exception:
                 log.error(
                     "Could not construct property page for " + name, exc_info=True
@@ -155,16 +137,28 @@ class ElementEditor(UIComponent, ActionProvider):
         self._current_item = item
         self.clear_pages()
 
-        if item is None:
-            label = Gtk.Label()
-            label.set_markup(textwrap.dedent(NO_ITEM_SELECTED))
-            label.set_name("no-item-selected")
-            label.props.wrap = True
-            label.props.max_width_chars = 20
-            self.vbox.pack_start(child=label, expand=False, fill=True, padding=10)
-            label.show()
-            return
-        self.create_pages(item)
+        if item:
+            self.create_pages(item)
+        else:
+            builder = new_builder("no-item-selected")
+
+            self.vbox.pack_start(
+                child=builder.get_object("no-item-selected"),
+                expand=False,
+                fill=True,
+                padding=0,
+            )
+
+            tips = builder.get_object("tips")
+
+            def on_show_tips_changed(checkbox):
+                active = checkbox.get_active()
+                tips.show() if active else tips.hide()
+                self.properties.set("show-tips", active)
+
+            show_tips = builder.get_object("show-tips")
+            show_tips.connect("toggled", on_show_tips_changed)
+            show_tips.set_active(self.properties.get("show-tips", True))
 
     @event_handler(AssociationUpdated)
     def _element_changed(self, event):

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -62,7 +62,7 @@ class ElementEditor(UIComponent, ActionProvider):
 
         return self.revealer
 
-    @action(name="win.show-editors", shortcut="<Primary>e", state=False)
+    @action(name="win.show-editors", shortcut="<Primary>e", state=True)
     def toggle_editor_visibility(self, active):
         self.revealer.set_reveal_child(active)
 

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -150,6 +150,11 @@ class ElementEditor(UIComponent, ActionProvider):
             Add a model element from the tool box to the diagram. Here you will see it's properties appear.
 
             This pane can be hidden by clicking the pensil icon in the header.
+
+            <b>Tip:</b> Most elements in the toolbox have a keyboard shortcut (e.g. "c" for Class).
+            Tool selection only works from the diagram. If a tool does not get selected, click on the diagram once (so it's focused) and then hit the shortcut key.
+
+            <b>Tip:</b> To search for an element in the tree view, select an element in the tree view and start typing. A search box will automaticaly appear.
             """
                     )
                 )

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -18,6 +18,22 @@ from gaphor.ui.event import DiagramSelectionChanged
 log = logging.getLogger(__name__)
 
 
+NO_ITEM_SELECTED = gettext(
+    """\
+    <b>No item selected</b>
+
+    Add a model element from the tool box to the diagram. Here you will see it's properties appear.
+
+    This pane can be hidden by clicking the pensil icon in the header.
+
+    <b>Tip:</b> Most elements in the toolbox have a keyboard shortcut (e.g. "c" for Class).
+    Tool selection only works from the diagram. If a tool does not get selected, click on the diagram once (so it's focused) and then hit the shortcut key.
+
+    <b>Tip:</b> To search for an element in the tree view, select an element in the tree view and start typing. A search box will automaticaly appear.
+    """
+)
+
+
 def new_builder():
     builder = Gtk.Builder()
     builder.set_translation_domain("gaphor")
@@ -141,24 +157,7 @@ class ElementEditor(UIComponent, ActionProvider):
 
         if item is None:
             label = Gtk.Label()
-            label.set_markup(
-                textwrap.dedent(
-                    gettext(
-                        """
-            <b>No item selected</b>
-
-            Add a model element from the tool box to the diagram. Here you will see it's properties appear.
-
-            This pane can be hidden by clicking the pensil icon in the header.
-
-            <b>Tip:</b> Most elements in the toolbox have a keyboard shortcut (e.g. "c" for Class).
-            Tool selection only works from the diagram. If a tool does not get selected, click on the diagram once (so it's focused) and then hit the shortcut key.
-
-            <b>Tip:</b> To search for an element in the tree view, select an element in the tree view and start typing. A search box will automaticaly appear.
-            """
-                    )
-                )
-            )
+            label.set_markup(textwrap.dedent(NO_ITEM_SELECTED))
             label.set_name("no-item-selected")
             label.props.wrap = True
             label.props.max_width_chars = 20

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -2,6 +2,7 @@
 
 import importlib.resources
 import logging
+import textwrap
 from typing import Optional
 
 from gi.repository import Gtk
@@ -140,8 +141,22 @@ class ElementEditor(UIComponent, ActionProvider):
 
         if item is None:
             label = Gtk.Label()
-            label.set_markup("<b>No item selected</b>")
+            label.set_markup(
+                textwrap.dedent(
+                    gettext(
+                        """
+            <b>No item selected</b>
+
+            Add a model element from the tool box to the diagram. Here you will see it's properties appear.
+
+            This pane can be hidden by clicking the pensil icon in the header.
+            """
+                    )
+                )
+            )
             label.set_name("no-item-selected")
+            label.props.wrap = True
+            label.props.max_width_chars = 20
             self.vbox.pack_start(child=label, expand=False, fill=True, padding=10)
             label.show()
             return

--- a/gaphor/ui/layout.css
+++ b/gaphor/ui/layout.css
@@ -14,7 +14,7 @@ toolitemgroup:first-child > button {
 }
 
 #no-item-selected {
-    padding: 12px;
+    padding: 4px;
 }
 
 #diagrams {

--- a/gaphor/ui/layout.py
+++ b/gaphor/ui/layout.py
@@ -51,7 +51,7 @@ def add(widget, index, parent_widget, resize=False, shrink=False):
         elif index == 1:
             parent_widget.pack2(child=widget, resize=resize, shrink=shrink)
     elif isinstance(parent_widget, Gtk.Box):
-        parent_widget.pack_start(widget, resize, resize, 2)
+        parent_widget.pack_start(widget, resize, resize, 0)
     else:
         parent_widget.add(widget)
 

--- a/gaphor/ui/tests/test_elementeditor.py
+++ b/gaphor/ui/tests/test_elementeditor.py
@@ -14,7 +14,7 @@ def diagrams():
 
 
 def test_reopen_of_window(event_manager, element_factory, diagrams):
-    editor = ElementEditor(event_manager, element_factory, diagrams)
+    editor = ElementEditor(event_manager, element_factory, diagrams, properties={})
 
     editor.open()
     editor.close()


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?


Issue Number: #339 

### What is the new behavior?

* Element editor is shown by default
* Extra text is shown with some usage tips
* The editor section is now a scrolled window
* Remove unused space on right side of window when element editor is collapsed
* Fixed box spacing for boxes created via the layout class

 
![image](https://user-images.githubusercontent.com/96249/83682882-d00f1f80-a5e4-11ea-95d8-b2e5cee881f2.png)

![image](https://user-images.githubusercontent.com/96249/83682920-dbfae180-a5e4-11ea-8815-b5d3d5477c2c.png)

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No