### PR TITLE
Edit style sheet

### DIFF
--- a/examples/all-elements.gaphor
+++ b/examples/all-elements.gaphor
@@ -62,7 +62,7 @@
 <val>100.0</val>
 </width>
 <height>
-<val>91.0</val>
+<val>92.0</val>
 </height>
 <show_attributes>
 <val>1</val>
@@ -82,10 +82,10 @@
 <val>(1.0, 0.0, 0.0, 1.0, 95.0, 218.5)</val>
 </matrix>
 <width>
-<val>112.0</val>
+<val>114.0</val>
 </width>
 <height>
-<val>74.0</val>
+<val>75.0</val>
 </height>
 <show_attributes>
 <val>1</val>
@@ -108,7 +108,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 240.0, 90.0)</val>
 </matrix>
 <width>
-<val>118.0</val>
+<val>120.0</val>
 </width>
 <height>
 <val>70.0</val>
@@ -330,7 +330,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 230.0, 531.5)</val>
 </matrix>
 <width>
-<val>94.0</val>
+<val>97.0</val>
 </width>
 <height>
 <val>30.0</val>
@@ -395,7 +395,7 @@
 <ref refid="0c9b68e6-8a25-11e9-94a9-784f435640ba"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 324.0, 544.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 327.0, 544.5)</val>
 </matrix>
 <orthogonal>
 <val>0</val>
@@ -404,7 +404,7 @@
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (31.0, -1.0)]</val>
+<val>[(0.0, 0.0), (28.0, -1.0)]</val>
 </points>
 <head-connection>
 <ref refid="007a1a30-8a25-11e9-94a9-784f435640ba"/>
@@ -460,7 +460,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 428.0, 531.5)</val>
 </matrix>
 <width>
-<val>133.0</val>
+<val>135.0</val>
 </width>
 <height>
 <val>50.0</val>
@@ -488,7 +488,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 255.0, 599.5)</val>
 </matrix>
 <width>
-<val>189.0</val>
+<val>192.0</val>
 </width>
 <height>
 <val>30.0</val>
@@ -502,7 +502,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 440.4522705078125, 599.5)</val>
 </matrix>
 <width>
-<val>197.0</val>
+<val>202.0</val>
 </width>
 <height>
 <val>30.0</val>
@@ -765,7 +765,7 @@
 <val>100.0</val>
 </width>
 <height>
-<val>57.0</val>
+<val>58.0</val>
 </height>
 <show_attributes>
 <val>1</val>
@@ -788,7 +788,7 @@
 <val>129.0</val>
 </width>
 <height>
-<val>74.0</val>
+<val>75.0</val>
 </height>
 <show_attributes>
 <val>1</val>
@@ -929,7 +929,7 @@
 <val>106.5</val>
 </width>
 <height>
-<val>58.0</val>
+<val>59.0</val>
 </height>
 <show_attributes>
 <val>0</val>
@@ -1512,9 +1512,9 @@
 <StyleSheet id="3b6a9420-9fe2-11ea-b537-dfaaecc5bf61">
 <styleSheet>
 <val>* {
-	font-family: DejaVu serif;
-	color: darkblue;
-	text-color: darkblue;
+ font-family: serif;
+ color: darkblue;
+ text-color: darkblue;
 }
 </val>
 </styleSheet>

--- a/gaphor/SysML/propertypages.glade
+++ b/gaphor/SysML/propertypages.glade
@@ -28,13 +28,34 @@ renderers and such.</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkCheckButton" id="show-parts">
-            <property name="label" translatable="yes">Show parts</property>
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="draw_indicator">True</property>
-            <signal name="toggled" handler="show-parts-changed" swapped="no"/>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Show Parts</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="show-parts">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="notify::active" handler="show-parts-changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -43,13 +64,34 @@ renderers and such.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkCheckButton" id="show-references">
-            <property name="label" translatable="yes">Show references</property>
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="draw_indicator">True</property>
-            <signal name="toggled" handler="show-references-changed" swapped="no"/>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Show references</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="show-references">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="notify::active" handler="show-references-changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -64,6 +106,9 @@ renderers and such.</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="label" translatable="yes">Parts and References</property>
+        <attributes>
+          <attribute name="weight" value="bold"/>
+        </attributes>
       </object>
     </child>
   </object>

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -111,11 +111,11 @@ class PartsAndReferencesPage(PropertyPageBase):
         return builder.get_object("parts-and-references-editor")
 
     @transactional
-    def _on_show_parts_change(self, button):
+    def _on_show_parts_change(self, button, gparam):
         self.item.show_parts = button.get_active()
         self.item.request_update()
 
     @transactional
-    def _on_show_references_change(self, button):
+    def _on_show_references_change(self, button, gparam):
         self.item.show_references = button.get_active()
         self.item.request_update()

--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -57,7 +57,7 @@ class ObjectNodePropertyPage(PropertyPageBase):
         self.item.subject.ordering = value
 
     @transactional
-    def _on_ordering_show_change(self, button):
+    def _on_ordering_show_change(self, button, gparam):
         self.item.show_ordering = button.get_active()
 
 
@@ -79,7 +79,7 @@ class ForkNodePropertyPage(PropertyPageBase):
         return builder.get_object("fork-node-editor")
 
     @transactional
-    def _on_horizontal_change(self, button):
+    def _on_horizontal_change(self, button, gparam):
         if button.get_active():
             self.item.matrix.rotate(math.pi / 2)
         else:

--- a/gaphor/UML/actions/partitionpage.py
+++ b/gaphor/UML/actions/partitionpage.py
@@ -30,7 +30,7 @@ class PartitionPropertyPage(PropertyPageBase):
         return builder.get_object("partition-editor")
 
     @transactional
-    def _on_external_change(self, button):
+    def _on_external_change(self, button, gparam):
         item = self.item
         if item.subject:
             item.subject.isExternal = button.get_active()

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -264,7 +264,7 @@ class AttributesPage(PropertyPageBase):
         return page
 
     @transactional
-    def _on_show_attributes_change(self, button):
+    def _on_show_attributes_change(self, button, gparam):
         self.item.show_attributes = button.get_active()
         self.item.request_update()
 
@@ -338,7 +338,7 @@ class OperationsPage(PropertyPageBase):
         return builder.get_object("operations-editor")
 
     @transactional
-    def _on_show_operations_change(self, button):
+    def _on_show_operations_change(self, button, gparam):
         self.item.show_operations = button.get_active()
         self.item.request_update()
 

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -347,7 +347,7 @@ class OperationsPage(PropertyPageBase):
 class DependencyPropertyPage(PropertyPageBase):
     """Dependency item editor."""
 
-    order = 0
+    order = 20
 
     DEPENDENCY_TYPES = (
         (gettext("Dependency"), UML.Dependency),
@@ -410,8 +410,8 @@ class DependencyPropertyPage(PropertyPageBase):
             self.item.request_update()
 
     @transactional
-    def _on_auto_dependency_change(self, button):
-        self.item.auto_dependency = button.get_active()
+    def _on_auto_dependency_change(self, switch, gparam):
+        self.item.auto_dependency = switch.get_active()
         self.update()
 
 

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -167,7 +167,7 @@ class ClassifierPropertyPage(PropertyPageBase):
         return builder.get_object("classifier-editor")
 
     @transactional
-    def _on_abstract_change(self, button):
+    def _on_abstract_change(self, button, gparam):
         self.subject.isAbstract = button.get_active()
 
 
@@ -197,7 +197,7 @@ class InterfacePropertyPage(PropertyPageBase):
         return builder.get_object("interface-editor")
 
     @transactional
-    def _on_fold_change(self, button):
+    def _on_fold_change(self, button, gparam):
         item = self.item
 
         fold = button.get_active()

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -524,7 +524,7 @@ class AssociationPropertyPage(PropertyPageBase):
         return builder.get_object("association-editor")
 
     @transactional
-    def _on_show_direction_change(self, button):
+    def _on_show_direction_change(self, button, gparam):
         self.item.show_direction = button.get_active()
 
     @transactional

--- a/gaphor/UML/components/componentspropertypage.py
+++ b/gaphor/UML/components/componentspropertypage.py
@@ -30,7 +30,7 @@ class ComponentPropertyPage(PropertyPageBase):
         return builder.get_object("component-editor")
 
     @transactional
-    def _on_ii_change(self, button):
+    def _on_ii_change(self, button, gparam):
         """
         Called when user clicks "Indirectly instantiated" check button.
         """

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -54,7 +54,7 @@ class StereotypePage(PropertyPageBase):
         return builder.get_object("stereotypes-editor")
 
     @transactional
-    def _on_show_stereotypes_change(self, button):
+    def _on_show_stereotypes_change(self, button, gparam):
         self.item.show_stereotypes = button.get_active()
 
 

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -18,22 +18,6 @@ if TYPE_CHECKING:
 S = TypeVar("S", bound=Element)
 
 
-def read_style_css():
-    """
-    Intermediate solution to read styling from an external file
-    This allows for testing some styles at least.
-    """
-    from gaphor.services.properties import get_config_dir
-    import os.path
-
-    style_css = os.path.join(get_config_dir(), "style.css")
-    try:
-        with open(style_css) as f:
-            return f.read()
-    except OSError:
-        return ""
-
-
 class StyleSheet(Element):
     def __init__(self, id=None, model=None):
         super().__init__(id, model)
@@ -42,7 +26,6 @@ class StyleSheet(Element):
         self._watcher.subscribe_all()
 
         self._style = {}
-        self.styleSheet = read_style_css()
 
     styleSheet: attribute[str] = attribute("styleSheet", str)
 

--- a/gaphor/core/styling.py
+++ b/gaphor/core/styling.py
@@ -45,7 +45,9 @@ def parse_stylesheet(
     None,
     None,
 ]:
-    rules = tinycss2.parse_stylesheet(css, skip_comments=True, skip_whitespace=True)
+    rules = tinycss2.parse_stylesheet(
+        css or "", skip_comments=True, skip_whitespace=True
+    )
     for rule in rules:
         if rule.type == "error":
             yield ("error", rule)

--- a/gaphor/diagram/propertypages.glade
+++ b/gaphor/diagram/propertypages.glade
@@ -592,6 +592,42 @@ Use -/= to move items up or down.</property>
       </packing>
     </child>
     <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Automatic</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="automatic">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <signal name="notify::active" handler="automatic-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
       <object class="GtkComboBox" id="dependency-combo">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
@@ -602,21 +638,6 @@ Use -/= to move items up or down.</property>
             <attribute name="text">0</attribute>
           </attributes>
         </child>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkCheckButton" id="automatic">
-        <property name="label" translatable="yes">Automatic</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="draw_indicator">True</property>
-        <signal name="toggled" handler="automatic-changed" swapped="no"/>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/gaphor/diagram/propertypages.glade
+++ b/gaphor/diagram/propertypages.glade
@@ -607,13 +607,34 @@ Use -/= to move items up or down.</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
     <child>
-      <object class="GtkCheckButton" id="indirectly-instantiated">
-        <property name="label" translatable="yes">Indirectly instantiated</property>
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="draw_indicator">True</property>
-        <signal name="toggled" handler="indirectly-instantiated-changed" swapped="no"/>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Indirectly Instantiated</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="indirectly-instantiated">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <signal name="notify::active" handler="indirectly-instantiated-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -706,13 +727,34 @@ Use -/= to move items up or down.</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
     <child>
-      <object class="GtkCheckButton" id="horizontal">
-        <property name="label" translatable="yes">Horizontal</property>
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="draw_indicator">True</property>
-        <signal name="toggled" handler="horizontal-changed" swapped="no"/>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Horizontal</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="horizontal">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <signal name="notify::active" handler="horizontal-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -1010,13 +1052,34 @@ Use -/= to move items up or down.</property>
       </packing>
     </child>
     <child>
-      <object class="GtkCheckButton" id="show-ordering">
-        <property name="label" translatable="yes">Show Ordering</property>
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="draw_indicator">True</property>
-        <signal name="toggled" handler="show-ordering-changed" swapped="no"/>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Show Ordering</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-ordering">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <signal name="notify::active" handler="show-ordering-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -1080,7 +1143,7 @@ Use -/= to move items up or down.</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">True</property>
+                <property name="fill">False</property>
                 <property name="pack_type">end</property>
                 <property name="position">1</property>
               </packing>
@@ -1197,13 +1260,34 @@ Use -/= to move items up or down.</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
     <child>
-      <object class="GtkCheckButton" id="external">
-        <property name="label" translatable="yes">External</property>
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="draw_indicator">True</property>
-        <signal name="toggled" handler="external-changed" swapped="no"/>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">External</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="external">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <signal name="notify::active" handler="external-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/gaphor/diagram/propertypages.glade
+++ b/gaphor/diagram/propertypages.glade
@@ -480,13 +480,34 @@ Use -/= to move items up or down.</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
     <child>
-      <object class="GtkCheckButton" id="abstract">
-        <property name="label" translatable="yes">Abstract</property>
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="draw_indicator">True</property>
-        <signal name="toggled" handler="abstract-changed" swapped="no"/>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Abstract</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="abstract">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <signal name="notify::active" handler="abstract-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -674,13 +695,34 @@ Use -/= to move items up or down.</property>
     <property name="margin_top">6</property>
     <property name="orientation">vertical</property>
     <child>
-      <object class="GtkCheckButton" id="folded">
-        <property name="label" translatable="yes">Folded</property>
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="draw_indicator">True</property>
-        <signal name="toggled" handler="folded-changed" swapped="no"/>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Folded</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="folded">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <signal name="notify::active" handler="folded-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/gaphor/diagram/propertypages.glade
+++ b/gaphor/diagram/propertypages.glade
@@ -30,7 +30,7 @@ renderers and such.</property>
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Show direction</property>
+            <property name="label" translatable="yes">Show Direction</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -383,15 +383,35 @@ renderers and such.</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkCheckButton" id="show-attributes">
-            <property name="label" translatable="yes">Show Attributes</property>
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="valign">start</property>
-            <property name="draw_indicator">True</property>
-            <signal name="destroy" handler="tree-view-destroy" swapped="no"/>
-            <signal name="toggled" handler="show-attributes-changed" swapped="no"/>
+            <property name="can_focus">False</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Show Attributes</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="show-attributes">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="notify::active" handler="show-attributes-changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -1036,14 +1056,35 @@ Use -/= to move items up or down.</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkCheckButton" id="show-operations">
-            <property name="label" translatable="yes">Show Operations</property>
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="valign">start</property>
-            <property name="draw_indicator">True</property>
-            <signal name="toggled" handler="show-operations-changed" swapped="no"/>
+            <property name="can_focus">False</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Show Operations</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="show-operations">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="notify::active" handler="show-operations-changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -1284,18 +1325,40 @@ Use -/= to move items up or down.</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkCheckButton" id="show-stereotypes">
-            <property name="label" translatable="yes">Show stereotype attributes</property>
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="draw_indicator">True</property>
-            <signal name="toggled" handler="show-stereotypes-changed" swapped="no"/>
+            <property name="can_focus">False</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Show Stereotypes</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="show-stereotypes">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="notify::active" handler="show-stereotypes-changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -1354,7 +1417,7 @@ Use -/= to move items up or down.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/gaphor/diagram/propertypages.glade
+++ b/gaphor/diagram/propertypages.glade
@@ -18,7 +18,6 @@ renderers and such.</property>
   <object class="GtkBox" id="association-editor">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="margin_top">6</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
     <signal name="destroy" handler="association-editor-destroy" swapped="no"/>
@@ -28,18 +27,29 @@ renderers and such.</property>
         <property name="can_focus">False</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkCheckButton" id="show-direction">
-            <property name="label" translatable="yes">Show direction</property>
+          <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="draw_indicator">True</property>
-            <signal name="toggled" handler="show-direction-changed" swapped="no"/>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Show direction</property>
           </object>
           <packing>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-direction">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="valign">center</property>
+            <signal name="notify::active" handler="show-direction-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -47,6 +57,8 @@ renderers and such.</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Invert direction</property>
+            <property name="relief">none</property>
             <signal name="clicked" handler="invert-direction-changed" swapped="no"/>
             <child>
               <object class="GtkImage">
@@ -58,8 +70,9 @@ renderers and such.</property>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>
@@ -73,7 +86,6 @@ renderers and such.</property>
       <object class="GtkExpander">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
-        <property name="margin_top">6</property>
         <property name="expanded">True</property>
         <child>
           <object class="GtkBox">
@@ -503,7 +515,7 @@ Use -/= to move items up or down.</property>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">1</property>
           </packing>
@@ -636,7 +648,7 @@ Use -/= to move items up or down.</property>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">1</property>
           </packing>
@@ -718,7 +730,7 @@ Use -/= to move items up or down.</property>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">1</property>
           </packing>

--- a/gaphor/diagram/style.py
+++ b/gaphor/diagram/style.py
@@ -87,7 +87,10 @@ def _clip_color(c):
     "background-color", "color", "highlight-color", "text-color"
 )
 def parse_color(prop, value):
-    color = tinycss2.color3.parse_color(value)
+    try:
+        color = tinycss2.color3.parse_color(value)
+    except AttributeError:
+        return None
     return tuple(_clip_color(v) for v in color) if color else None
 
 

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -236,12 +236,14 @@ class DiagramPage:
     )
     def select_all(self):
         assert self.view
-        self.view.select_all()
+        if self.view.has_focus():
+            self.view.select_all()
 
     @action(name="diagram.unselect-all", shortcut="<Primary><Shift>a")
     def unselect_all(self):
         assert self.view
-        self.view.unselect_all()
+        if self.view.has_focus():
+            self.view.unselect_all()
 
     @action(name="diagram.delete")
     @transactional

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -282,9 +282,10 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                       <object class="GtkBox" id="editors">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">2</property>
-                        <property name="margin_right">2</property>
-                        <property name="margin_bottom">2</property>
+                        <property name="margin_left">6</property>
+                        <property name="margin_right">6</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <placeholder/>
@@ -303,10 +304,10 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">2</property>
-                <property name="margin_right">2</property>
-                <property name="margin_top">6</property>
-                <property name="margin_bottom">2</property>
+                <property name="margin_left">6</property>
+                <property name="margin_right">6</property>
+                <property name="margin_top">12</property>
+                <property name="margin_bottom">6</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
@@ -326,13 +327,34 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCheckButton" id="enable-style-sheet">
-                    <property name="label" translatable="yes">Enable style sheet</property>
+                  <object class="GtkBox">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="action_name">win.enable-style-sheet</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Enable style sheet</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="enable-style-sheet">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="action_name">win.enable-style-sheet</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -346,7 +346,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                     <property name="can_focus">True</property>
                     <property name="shadow_type">in</property>
                     <child>
-                      <object class="GtkTextView">
+                      <object class="GtkTextView" id="style-sheet-view">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="buffer">style-sheet-buffer</property>

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -24,14 +24,36 @@
       </packing>
     </child>
     <child>
-      <object class="GtkCheckButton" id="show-tips">
-        <property name="label" translatable="yes">Show tips</property>
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="margin_top">12</property>
-        <property name="active">True</property>
-        <property name="draw_indicator">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_top">6</property>
+        <property name="margin_bottom">6</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Show Tips</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-tips">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -2,6 +2,73 @@
 <!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkBox" id="no-item-selected">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_top">18</property>
+        <property name="margin_bottom">12</property>
+        <property name="label" translatable="yes">No item selected</property>
+        <attributes>
+          <attribute name="weight" value="bold"/>
+        </attributes>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="show-tips">
+        <property name="label" translatable="yes">Show tips</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="margin_top">12</property>
+        <property name="active">True</property>
+        <property name="draw_indicator">True</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="tips">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="no_show_all">True</property>
+        <property name="margin_left">4</property>
+        <property name="margin_right">4</property>
+        <property name="margin_top">12</property>
+        <property name="label" translatable="yes">Add a model element from the tool box to the diagram. Here you will see it's properties appear.
+
+This pane can be hidden by clicking the pensil icon in the header.
+
+&lt;b&gt;Tip:&lt;/b&gt; Most elements in the toolbox have a keyboard shortcut (e.g. "c" for Class).
+Tool selection only works from the diagram. If a tool does not get selected, click on the diagram once (so it's focused) and then hit the shortcut key.
+
+&lt;b&gt;Tip:&lt;/b&gt; To search for an element in the tree view, select an element in the tree view and start typing. A search box will automaticaly appear.
+</property>
+        <property name="use_markup">True</property>
+        <property name="wrap">True</property>
+        <property name="max_width_chars">20</property>
+        <property name="xalign">0</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+  </object>
+  <object class="GtkTextBuffer" id="style-sheet-buffer"/>
   <object class="GtkRevealer" id="elementeditor">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -154,6 +221,26 @@
                 <property name="position">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkToggleButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="action_name">win.show-settings</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">preferences-other</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -177,28 +264,107 @@
           </packing>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkStack" id="editor-stack">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="hscrollbar_policy">never</property>
+            <property name="can_focus">False</property>
             <child>
-              <object class="GtkViewport">
+              <object class="GtkScrolledWindow">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="shadow_type">none</property>
+                <property name="can_focus">True</property>
+                <property name="hscrollbar_policy">never</property>
                 <child>
-                  <object class="GtkBox" id="editors">
+                  <object class="GtkViewport">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">2</property>
-                    <property name="margin_right">2</property>
-                    <property name="orientation">vertical</property>
+                    <property name="shadow_type">none</property>
                     <child>
-                      <placeholder/>
+                      <object class="GtkBox" id="editors">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">2</property>
+                        <property name="margin_right">2</property>
+                        <property name="margin_bottom">2</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
                     </child>
                   </object>
                 </child>
               </object>
+              <packing>
+                <property name="name">editors</property>
+                <property name="title" translatable="yes">Editors</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">2</property>
+                <property name="margin_right">2</property>
+                <property name="margin_top">6</property>
+                <property name="margin_bottom">2</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Style sheet</property>
+                    <property name="xalign">0</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="enable-style-sheet">
+                    <property name="label" translatable="yes">Enable style sheet</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="action_name">win.enable-style-sheet</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">in</property>
+                    <child>
+                      <object class="GtkTextView">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="buffer">style-sheet-buffer</property>
+                        <property name="monospace">True</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">settings</property>
+                <property name="title" translatable="yes">Settings</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
           <packing>
@@ -208,72 +374,6 @@
           </packing>
         </child>
       </object>
-    </child>
-  </object>
-  <object class="GtkBox" id="no-item-selected">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="orientation">vertical</property>
-    <child>
-      <object class="GtkLabel">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_top">18</property>
-        <property name="margin_bottom">12</property>
-        <property name="label" translatable="yes">No item selected</property>
-        <attributes>
-          <attribute name="weight" value="bold"/>
-        </attributes>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkCheckButton" id="show-tips">
-        <property name="label" translatable="yes">Show tips</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="margin_top">12</property>
-        <property name="active">True</property>
-        <property name="draw_indicator">True</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="tips">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="no_show_all">True</property>
-        <property name="margin_left">4</property>
-        <property name="margin_right">4</property>
-        <property name="margin_top">12</property>
-        <property name="label" translatable="yes">Add a model element from the tool box to the diagram. Here you will see it's properties appear.
-
-This pane can be hidden by clicking the pensil icon in the header.
-
-&lt;b&gt;Tip:&lt;/b&gt; Most elements in the toolbox have a keyboard shortcut (e.g. "c" for Class).
-Tool selection only works from the diagram. If a tool does not get selected, click on the diagram once (so it's focused) and then hit the shortcut key.
-
-&lt;b&gt;Tip:&lt;/b&gt; To search for an element in the tree view, select an element in the tree view and start typing. A search box will automaticaly appear.
-</property>
-        <property name="use_markup">True</property>
-        <property name="wrap">True</property>
-        <property name="max_width_chars">20</property>
-        <property name="xalign">0</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -267,6 +267,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
           <object class="GtkStack" id="editor-stack">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="transition_type">slide-left-right</property>
             <child>
               <object class="GtkScrolledWindow">
                 <property name="visible">True</property>

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -246,14 +246,15 @@ class EditorStack:
 
         tips = builder.get_object("tips")
 
-        def on_show_tips_changed(checkbox):
+        def on_show_tips_changed(checkbox, gparam):
             active = checkbox.get_active()
             tips.show() if active else tips.hide()
             self.properties.set("show-tips", active)
 
         show_tips = builder.get_object("show-tips")
-        show_tips.connect("toggled", on_show_tips_changed)
+        show_tips.connect("notify::active", on_show_tips_changed)
         show_tips.set_active(self.properties.get("show-tips", True))
+        on_show_tips_changed(show_tips, None)
 
     @event_handler(AssociationUpdated)
     def _element_changed(self, event: AssociationUpdated):

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -9,8 +9,8 @@ from gi.repository import Gtk
 
 from gaphor.abc import ActionProvider
 from gaphor.core import action, event_handler, gettext
-from gaphor.core.modeling import Presentation
-from gaphor.core.modeling.event import AssociationUpdated
+from gaphor.core.modeling import Presentation, StyleSheet
+from gaphor.core.modeling.event import AssociationUpdated, AttributeUpdated, ModelReady
 from gaphor.diagram.propertypages import PropertyPages
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.event import DiagramSelectionChanged
@@ -45,26 +45,31 @@ class ElementEditor(UIComponent, ActionProvider):
         self.vbox: Optional[Gtk.Box] = None
         self._current_item = None
         self._expanded_pages = {gettext("Properties"): True}
+        self._on_style_sheet_changed_id = -1
 
     def open(self):
         """Display the ElementEditor pane."""
-        builder = new_builder("elementeditor")
+        builder = new_builder("elementeditor", "style-sheet-buffer")
 
         self.revealer = builder.get_object("elementeditor")
+        self.editor_stack = builder.get_object("editor-stack")
         self.vbox = builder.get_object("editors")
 
         current_view = self.diagrams.get_current_view()
         self._selection_change(focused_item=current_view and current_view.focused_item)
 
-        # Make sure we receive
         self.event_manager.subscribe(self._selection_change)
         self.event_manager.subscribe(self._element_changed)
 
-        return self.revealer
+        self.enable_style_sheet = builder.get_object("enable-style-sheet")
+        self.style_sheet_buffer = builder.get_object("style-sheet-buffer")
 
-    @action(name="win.show-editors", shortcut="<Primary>e", state=True)
-    def toggle_editor_visibility(self, active):
-        self.revealer.set_reveal_child(active)
+        self.event_manager.subscribe(self._model_ready)
+        self._on_style_sheet_changed_id = self.style_sheet_buffer.connect(
+            "changed", self.on_style_sheet_changed
+        )
+
+        return self.revealer
 
     def close(self, widget=None):
         """Hide the element editor window and deactivate the toolbar button.
@@ -73,9 +78,16 @@ class ElementEditor(UIComponent, ActionProvider):
 
         self.event_manager.unsubscribe(self._selection_change)
         self.event_manager.unsubscribe(self._element_changed)
+        self.event_manager.unsubscribe(self._model_ready)
         self.vbox = None
         self._current_item = None
         return True
+
+    @action(name="show-editors", shortcut="<Primary>e", state=True)
+    def toggle_editor_visibility(self, active):
+        self.revealer.set_reveal_child(active)
+
+    ## Diagram item editor
 
     def _get_adapters(self, item):
         """
@@ -161,9 +173,49 @@ class ElementEditor(UIComponent, ActionProvider):
             show_tips.set_active(self.properties.get("show-tips", True))
 
     @event_handler(AssociationUpdated)
-    def _element_changed(self, event):
+    def _element_changed(self, event: AssociationUpdated):
         if event.property is Presentation.subject:  # type: ignore[misc] # noqa: F821
             element = event.element
             if element is self._current_item:
                 self.clear_pages()
                 self.create_pages(self._current_item)
+
+    ## Settings stack
+
+    @action(name="show-settings", state=False)
+    def toggle_editor_settings(self, active):
+        self.editor_stack.set_visible_child_name("settings" if active else "editors")
+
+    @action(name="enable-style-sheet", state=False)
+    def toggle_enable_style_sheet(self, active):
+        style_sheets = self.element_factory.lselect(StyleSheet)
+        if active and not style_sheets:
+            style_sheet = self.element_factory.create(StyleSheet)
+            style_sheet.style_sheet = "* { }"
+        elif not active and style_sheets:
+            for style_sheet in style_sheets:
+                # Trigger style update on diagrams:
+                style_sheet.styleSheet = ""
+                style_sheet.unlink()
+
+    def on_style_sheet_changed(self, buffer):
+        style_sheets = self.element_factory.lselect(StyleSheet)
+        if style_sheets:
+            text = buffer.get_text(
+                buffer.get_start_iter(), buffer.get_end_iter(), False
+            )
+            style_sheet = style_sheets[0]
+            if style_sheet.styleSheet != text:
+                style_sheet.styleSheet = text
+
+    @event_handler(ModelReady)
+    def _model_ready(self, event):
+        style_sheets = self.element_factory.lselect(StyleSheet)
+
+        self.enable_style_sheet.set_active(bool(style_sheets))
+
+        self.style_sheet_buffer.handler_block(self._on_style_sheet_changed_id)
+        self.style_sheet_buffer.set_text(
+            style_sheets[0].styleSheet if style_sheets else ""
+        )
+        self.style_sheet_buffer.handler_unblock(self._on_style_sheet_changed_id)

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -347,4 +347,5 @@ class SettingsStack:
 
     @event_handler(ElementCreated, ElementDeleted)
     def _style_sheet_created_or_deleted(self, event: ElementDeleted):
-        self.enable_style_sheet.set_active(bool(self.style_sheet))
+        if isinstance(event.element, StyleSheet):
+            self.enable_style_sheet.set_active(bool(self.style_sheet))

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -281,6 +281,7 @@ class SettingsStack:
 
         self._style_sheet_update = DelayedFunction(800, tx_update_style_sheet)
         self._in_update = 0
+        self.css = DEFAULT_STYLE_SHEET
 
     def open(self, builder):
         self.enable_style_sheet = builder.get_object("enable-style-sheet")
@@ -307,10 +308,11 @@ class SettingsStack:
         if active and not style_sheet:
             with Transaction(self.event_manager):
                 style_sheet = self.element_factory.create(StyleSheet)
-                style_sheet.styleSheet = DEFAULT_STYLE_SHEET
+                style_sheet.styleSheet = self.css
         elif not active and style_sheet:
             with Transaction(self.event_manager):
                 for style_sheet in self.element_factory.lselect(StyleSheet):
+                    self.css = style_sheet.styleSheet
                     # Resetting the style sheet will trigger an update on diagrams
                     style_sheet.styleSheet = ""
                     style_sheet.unlink()

--- a/gaphor/ui/tests/test_elementeditor.py
+++ b/gaphor/ui/tests/test_elementeditor.py
@@ -13,8 +13,14 @@ def diagrams():
     return DiagramsStub()
 
 
+class DummyProperties(dict):
+    def set(self, key, val):
+        self[key] = val
+
+
 def test_reopen_of_window(event_manager, element_factory, diagrams):
-    editor = ElementEditor(event_manager, element_factory, diagrams, properties={})
+    properties = DummyProperties()
+    editor = ElementEditor(event_manager, element_factory, diagrams, properties)
 
     editor.open()
     editor.close()


### PR DESCRIPTION
Follow-up on #346 

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Style sheet can only be edited from a separate editor and placed in a special place to be picked up by Gaphor. Enabling stylesheet requires tinkering in the Console editor.

Issue Number: N/A

### What is the new behavior?

An editor is available in the Element editor

![image](https://user-images.githubusercontent.com/96249/83980422-ff3fcc80-a915-11ea-990e-fde5ee859329.png)

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


### Other information

I'm thinking about moving the other Preferences here too.


### To do

- [X] Fix (de)select-all in stylesheet editor: should not select all elements in diagram as well
- [x] Show _[edited]_ in header when stylesheet has been edited (make undo-able)
- [x] Add instructions to "empty" style sheet
- [ ] Use Gtk.Switch to enable/disable these preferences. 
- [ ] Add Preferences to this pane as well. Remove Preferences window.