### PR TITLE
Show Reference Properties as Dashed

### DIFF
--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -22,9 +22,7 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
         self.watch("subject.appliedStereotype.slot.definingFeature.name")
         self.watch("subject.appliedStereotype.slot.value", self.update_shapes)
         self.watch("subject[Classifier].useCase", self.update_shapes)
-        self.watch(
-            "subject[Association].memberEnd[Property].aggregation", self.update_shapes
-        )
+        self.watch("subject[Property].aggregation", self.update_shapes)
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
 
@@ -49,5 +47,5 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
                 if self.subject and self.subject.aggregation != "composite"
                 else (),
             },
-            draw=draw_border,
+            draw=draw_border
         )

--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -1,5 +1,7 @@
 """Property item."""
 
+from typing import Sequence, Union
+
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.presentation import ElementPresentation, Named
@@ -26,6 +28,18 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
 
+    def get_alignment(self) -> VerticalAlign:
+        if self.canvas and self.canvas.get_children(self):
+            return VerticalAlign.TOP
+        else:
+            return VerticalAlign.MIDDLE
+
+    def get_dash(self) -> Sequence[Union[int, float]]:
+        if self.subject and self.subject.aggregation != "composite":
+            return (7.0, 5.0)
+        else:
+            return ()
+
     def update_shapes(self, event=None):
         self.shape = Box(
             Box(
@@ -40,12 +54,8 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
             style={
                 "min-width": 100,
                 "min-height": 50,
-                "vertical-align": VerticalAlign.TOP
-                if self.canvas and self.canvas.get_children(self)
-                else VerticalAlign.MIDDLE,
-                "dash-style": (7.0, 5.0)
-                if self.subject and self.subject.aggregation != "composite"
-                else (),
+                "vertical-align": self.get_alignment(),
+                "dash-style": self.get_dash(),
             },
             draw=draw_border
         )

--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -22,6 +22,9 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
         self.watch("subject.appliedStereotype.slot.definingFeature.name")
         self.watch("subject.appliedStereotype.slot.value", self.update_shapes)
         self.watch("subject[Classifier].useCase", self.update_shapes)
+        self.watch(
+            "subject[Association].memberEnd[Property].aggregation", self.update_shapes
+        )
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
 
@@ -42,6 +45,9 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
                 "vertical-align": VerticalAlign.TOP
                 if self.canvas and self.canvas.get_children(self)
                 else VerticalAlign.MIDDLE,
+                "dash-style": (7.0, 5.0)
+                if self.subject and self.subject.aggregation != "composite"
+                else (),
             },
-            draw=draw_border
+            draw=draw_border,
         )

--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -23,18 +23,17 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
         self.watch("subject.appliedStereotype.slot", self.update_shapes)
         self.watch("subject.appliedStereotype.slot.definingFeature.name")
         self.watch("subject.appliedStereotype.slot.value", self.update_shapes)
-        self.watch("subject[Classifier].useCase", self.update_shapes)
         self.watch("subject[Property].aggregation", self.update_shapes)
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
 
-    def get_alignment(self) -> VerticalAlign:
+    def alignment(self) -> VerticalAlign:
         if self.canvas and self.canvas.get_children(self):
             return VerticalAlign.TOP
         else:
             return VerticalAlign.MIDDLE
 
-    def get_dash(self) -> Sequence[Union[int, float]]:
+    def dash(self) -> Sequence[Union[int, float]]:
         if self.subject and self.subject.aggregation != "composite":
             return (7.0, 5.0)
         else:
@@ -54,8 +53,8 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
             style={
                 "min-width": 100,
                 "min-height": 50,
-                "vertical-align": self.get_alignment(),
-                "dash-style": self.get_dash(),
+                "vertical-align": self.alignment(),
+                "dash-style": self.dash(),
             },
             draw=draw_border
         )

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -105,9 +105,7 @@ def draw_border(box, context: DrawContext, bounding_box: Rectangle):
     x, y, width, height = bounding_box
 
     cr.move_to(x, d)
-    dash = context.style["dash-style"]
-    if dash:
-        cr.set_dash(dash, 0)
+    cr.set_dash(context.style["dash-style"], 0)
     if d:
         x1 = width + x
         y1 = height + y

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -105,6 +105,9 @@ def draw_border(box, context: DrawContext, bounding_box: Rectangle):
     x, y, width, height = bounding_box
 
     cr.move_to(x, d)
+    dash = context.style["dash-style"]
+    if dash:
+        cr.set_dash(dash, 0)
     if d:
         x1 = width + x
         y1 = height + y


### PR DESCRIPTION
This is part of closing #138 in order to show Reference Properties with dashed borders instead of solid.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
All properties are shown as a rectangle with a solid line.

Issue Number: #138 

### What is the new behavior?
Reference Properties are shown as a rectangle with a dashed line.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


### TODO
- [x] Update shape style when aggregation changes