### PR TITLE
Add Vagrant File for Arch Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,11 +34,6 @@ pip-wheel-metadata
 # Editors
 .idea
 
-# Flatpak
-flatpak/build
-flatpak/gaphor-repo
-flatpak/.flatpak-builder
-
 # Windows Install
 win-installer/gaphor-script.py
 win-installer/_build_root
@@ -46,3 +41,6 @@ win-installer/file_version_info.txt
 
 # MacOS
 package/gaphor.iconset/
+
+# Vagrant
+.vagrant

--- a/images/vagrant-arch/Vagrantfile
+++ b/images/vagrant-arch/Vagrantfile
@@ -1,0 +1,20 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "archlinux/archlinux"
+config.vm.provider "virtualbox" do |vb|
+  vb.gui = true
+  vb.memory = "1024"
+end
+config.vm.synced_folder '../..', '/home/vagrant/gaphor'
+
+config.vm.provision "shell", inline: <<-SHELL
+  pacman -Syu --noconfirm
+  pacman -Sy --noconfirm xorg-server xf86-video-vmware xorg-xinit
+  pacman -Sy --noconfirm lxde-gtk3 lxdm-gtk3 
+  systemctl enable lxdm.service
+  pacman -S --noconfirm virtualbox-guest-utils virtualbox-guest-dkms
+  pacman -S --noconfirm cairo pkgconf gobject-introspection git base-devel
+  pacman -S --noconfirm python-pip
+  pip install poetry
+
+SHELL
+end


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

Since we got a bug report with Arch Linux, I thought it might be worthwhile for us to start collecting some image configs so that we can quickly spin up a VM of a non-Ubuntu distro. This PR adds a Vagrantfile for Arch, to make use of it:

```bash
cd images/vagrant-arch
vagrant up
```
Once it installs and configures everything, run:
`vagrant reload`

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
