### PR TITLE
Render property item with type and multiplicity

### DIFF
--- a/gaphor/SysML/blocks/grouping.py
+++ b/gaphor/SysML/blocks/grouping.py
@@ -9,8 +9,16 @@ class PropertyGroup(AbstractGroup):
     Add Property to a Block.
     """
 
+    def can_contain(self) -> bool:
+        return (
+            not self.item.subject.association
+            or self.item.subject.owner is self.parent.subject
+        )
+
     def group(self):
-        self.parent.subject.ownedAttribute = self.item.subject
+        if not self.item.subject.association:
+            self.parent.subject.ownedAttribute = self.item.subject
 
     def ungroup(self):
-        del self.parent.subject.ownedAttribute[self.item.subject]
+        if not self.item.subject.association:
+            del self.parent.subject.ownedAttribute[self.item.subject]

--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -9,6 +9,7 @@ from gaphor.diagram.presentation import ElementPresentation, Named
 from gaphor.diagram.shapes import Box, EditableText, Text, draw_border
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.stereotype import stereotype_compartments
+from gaphor.UML.umlfmt import format_attribute
 
 
 @represents(UML.Property)
@@ -17,7 +18,10 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
         super().__init__(id, model)
 
         self.watch("show_stereotypes", self.update_shapes)
-        self.watch("subject[NamedElement].name")
+        self.watch("subject[Property].name")
+        self.watch("subject[Property].type.name")
+        self.watch("subject[Property].lowerValue")
+        self.watch("subject[Property].upperValue")
         self.watch("subject.appliedStereotype", self.update_shapes)
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject.appliedStereotype.slot", self.update_shapes)
@@ -44,7 +48,10 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
             Box(
                 Text(text=lambda: UML.model.stereotypes_str(self.subject),),
                 EditableText(
-                    text=lambda: self.subject.name or "",
+                    text=lambda: format_attribute(
+                        self.subject, type=True, multiplicity=True
+                    )
+                    or "",
                     style={"font-weight": FontWeight.BOLD},
                 ),
                 style={"padding": (12, 4, 12, 4), "min-height": 44},


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Property item only has its name rendered

Issue Number: #138 

### What is the new behavior?

- Render contents of Property item with type and multiplicity, if applicable.
- Grouping for properties that are created as part of an association, can only group with their owner.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
