### PR TITLE
Fix Windows Packaging Fails for Missing Files

### DIFF
--- a/win-installer/gaphor.spec
+++ b/win-installer/gaphor.spec
@@ -19,7 +19,7 @@ a = Analysis(['gaphor-script.py'],
 		       ('../gaphor/locale/*', 'gaphor/locale')
 		     ]+copy_metadata('gaphor')+copy_metadata('gaphas'),
              hiddenimports=[],
-             hookspath=[],
+             hookspath=['hooks'],
              runtime_hooks=[],
              excludes=['lib2to3', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter'],
              win_no_prefer_redirects=False,

--- a/win-installer/hooks/hook-cssselect2.py
+++ b/win-installer/hooks/hook-cssselect2.py
@@ -1,7 +1,0 @@
-"""This hook can be removed onces integrated in PyInstaller"""
-
-from PyInstaller.utils.hooks import collect_data_files
-
-
-def hook(hook_api):
-    hook_api.add_datas(collect_data_files(hook_api.__name__))

--- a/win-installer/hooks/hook-cssselect2.py
+++ b/win-installer/hooks/hook-cssselect2.py
@@ -1,0 +1,8 @@
+"""This hook can be removed onces integrated in PyInstaller"""
+
+from PyInstaller.utils.hooks import collect_data_files
+
+
+def hook(hook_api):
+    hook_api.add_datas(collect_data_files(hook_api.__name__))
+

--- a/win-installer/hooks/hook-cssselect2.py
+++ b/win-installer/hooks/hook-cssselect2.py
@@ -5,4 +5,3 @@ from PyInstaller.utils.hooks import collect_data_files
 
 def hook(hook_api):
     hook_api.add_datas(collect_data_files(hook_api.__name__))
-

--- a/win-installer/hooks/hook-tinycss2.py
+++ b/win-installer/hooks/hook-tinycss2.py
@@ -1,0 +1,8 @@
+"""This hook can be removed onces integrated in PyInstaller"""
+
+from PyInstaller.utils.hooks import collect_data_files
+
+
+def hook(hook_api):
+    hook_api.add_datas(collect_data_files(hook_api.__name__))
+

--- a/win-installer/hooks/hook-tinycss2.py
+++ b/win-installer/hooks/hook-tinycss2.py
@@ -5,4 +5,3 @@ from PyInstaller.utils.hooks import collect_data_files
 
 def hook(hook_api):
     hook_api.add_datas(collect_data_files(hook_api.__name__))
-


### PR DESCRIPTION
PyInstaller was unable to find the tinycss2/VERSION file.
Adds two PyInstaller hooks to collect the data files. These hooks can be removed once I get them in to a released version of https://github.com/pyinstaller/pyinstaller-hooks-contrib.


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
Gaphor fails to launch after installed in Windows.

Issue Number: N/A

### What is the new behavior?
Gaphor launches again :tada:

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
