### PR TITLE
Sign using certificate during CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,22 +133,22 @@ jobs:
           certificate: '${{ secrets.BASE64_ENCODED_PFX }}'
           password: '${{ secrets.CERTPASSWORD }}'
           certificatesha1: '${{ secrets.CERTHASH }}'
-          folder: 'win-installer'
+          folder: 'win-installer/output'
       - name: Upload gaphor-${{ steps.meta.outputs.version }}-installer.exe
         uses: actions/upload-artifact@v2
         with:
           name: gaphor-${{ steps.meta.outputs.version }}-installer.exe
-          path: win-installer/gaphor-${{ steps.meta.outputs.version }}-installer.exe
+          path: win-installer/output/gaphor-${{ steps.meta.outputs.version }}-installer.exe
       - name: Upload gaphor-${{ steps.meta.outputs.version }}-portable.exe
         uses: actions/upload-artifact@v2
         with:
           name: gaphor-${{ steps.meta.outputs.version }}-portable.exe
-          path: win-installer/gaphor-${{ steps.meta.outputs.version }}-portable.exe
+          path: win-installer/output/gaphor-${{ steps.meta.outputs.version }}-portable.exe
       - name: Upload Assets
         uses: AButler/upload-release-assets@v2.0
         if: github.event_name == 'release'
         with:
-          files: 'win-installer/*.exe'
+          files: 'win-installer/output/*.exe'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           timestampUrl: 'http://timestamp.digicert.com'
           installer: 'win-installer/output/gaphor-${{ steps.meta.outputs.version }}-installer.exe'
           portable: 'win-installer/output/gaphor-${{ steps.meta.outputs.version }}-portable.exe'
-        run: signtool.exe sign /f 'certificate.pfx' /tr ${timestampUrl} /td sha256 /fd sha256 /p ${password} ${installer} ${portable}
+        run: signtool.exe sign /f 'certificate.pfx' /tr $timestampUrl /td sha256 /fd sha256 /p $password $installer $portable
       - name: Remove certificate
         run: Remove-Item 'certificate.pfx'
       - name: Upload gaphor-${{ steps.meta.outputs.version }}-installer.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,6 @@ jobs:
       MSYS2_ARCH: x86_64
       CHERE_INVOKING: yes
       PY_IGNORE_IMPORTMISMATCH: yes
-      SigningCertificate: SigningCertificate.pfx
     steps:
       - uses: actions/checkout@v2
       - name: Install MSYS2
@@ -129,9 +128,11 @@ jobs:
           $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem"
           C:\tools\msys64\usr\bin\bash -lc "win-installer/build-installer.sh"
       - name: Sign exectables
-        uses: dlemstra/code-sign-action@v1
+        uses: DanaBear/code-sign-action@v4
         with:
           certificate: '${{ secrets.BASE64_ENCODED_PFX }}'
+          password: '${{ secrets.CERTPASSWORD }}'
+          certificatesha1: '${{ secrets.CERTHASH }}'
           folder: 'win-installer'
       - name: Upload gaphor-${{ steps.meta.outputs.version }}-installer.exe
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,11 +128,10 @@ jobs:
           $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem"
           C:\tools\msys64\usr\bin\bash -lc "win-installer/build-installer.sh"
       - name: Sign exectables
-        uses: DanaBear/code-sign-action@v4
+        uses: PazerOP/code-sign-action@v3
         with:
           certificate: '${{ secrets.BASE64_ENCODED_PFX }}'
           password: '${{ secrets.CERTPASSWORD }}'
-          certificatesha1: '${{ secrets.CERTHASH }}'
           folder: 'win-installer/output'
       - name: Upload gaphor-${{ steps.meta.outputs.version }}-installer.exe
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,10 +138,10 @@ jobs:
       - name: Sign executables
         env:
           password: '${{ secrets.CERTPASSWORD }}'
-          timestampUrl: 'http://timestamp.digicert.com'
+          timestampUrl: http://timestamp.digicert.com
           installer: 'win-installer/output/gaphor-${{ steps.meta.outputs.version }}-installer.exe'
           portable: 'win-installer/output/gaphor-${{ steps.meta.outputs.version }}-portable.exe'
-        run: signtool.exe sign /f 'certificate.pfx' /tr $timestampUrl /td sha256 /fd sha256 /p $password $installer $portable
+        run: signtool.exe sign /f 'certificate.pfx' /tr $env:timestampUrl /td sha256 /fd sha256 /p $env:password $env:installer $env:portable
       - name: Remove certificate
         run: Remove-Item 'certificate.pfx'
       - name: Upload gaphor-${{ steps.meta.outputs.version }}-installer.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,12 +127,23 @@ jobs:
         run: |
           $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem"
           C:\tools\msys64\usr\bin\bash -lc "win-installer/build-installer.sh"
-      - name: Sign exectables
-        uses: PazerOP/code-sign-action@v3
-        with:
-          certificate: '${{ secrets.BASE64_ENCODED_PFX }}'
+      - name: Decode the certificate
+        run: |
+          $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
+          $currentDirectory = Get-Location
+          $certificatePath = Join-Path -Path $currentDirectory -ChildPath 'certificate.pfx'
+          [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
+      - name: Add SignTool to Path
+        run: echo "::add-path::C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86"
+      - name: Sign executables
+        env:
           password: '${{ secrets.CERTPASSWORD }}'
-          folder: 'win-installer/output'
+          timestampUrl: 'http://timestamp.digicert.com'
+          installer: 'win-installer/output/gaphor-${{ steps.meta.outputs.version }}-installer.exe'
+          portable: 'win-installer/output/gaphor-${{ steps.meta.outputs.version }}-portable.exe'
+        run: signtool.exe sign /f 'certificate.pfx' /tr ${timestampUrl} /td sha256 /fd sha256 /p ${password} ${installer} ${portable}
+      - name: Remove certificate
+        run: Remove-Item 'certificate.pfx'
       - name: Upload gaphor-${{ steps.meta.outputs.version }}-installer.exe
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
       MSYS2_ARCH: x86_64
       CHERE_INVOKING: yes
       PY_IGNORE_IMPORTMISMATCH: yes
+      SigningCertificate: SigningCertificate.pfx
     steps:
       - uses: actions/checkout@v2
       - name: Install MSYS2
@@ -127,6 +128,11 @@ jobs:
         run: |
           $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem"
           C:\tools\msys64\usr\bin\bash -lc "win-installer/build-installer.sh"
+      - name: Sign exectables
+        uses: dlemstra/code-sign-action@v1
+        with:
+          certificate: '${{ secrets.BASE64_ENCODED_PFX }}'
+          folder: 'win-installer'
       - name: Upload gaphor-${{ steps.meta.outputs.version }}-installer.exe
         uses: actions/upload-artifact@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ pip-wheel-metadata
 win-installer/gaphor-script.py
 win-installer/_build_root
 win-installer/file_version_info.txt
+win-installer/output
 
 # MacOS
 package/gaphor.iconset/

--- a/win-installer/build-installer.sh
+++ b/win-installer/build-installer.sh
@@ -17,6 +17,7 @@ ARCH="x86_64"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${DIR}"
+mkdir -p output
 source ../venv
 
 MISC="${DIR}"/misc
@@ -51,11 +52,11 @@ function build_installer {
     cp "${DIR}"/misc/gaphor.ico "${DIST_LOCATION}"
     (cd "${DIST_LOCATION}" && makensis -NOCD -DVERSION="$VERSION" "${MISC}"/win_installer.nsi)
 
-    mv "${DIST_LOCATION}/gaphor-LATEST.exe" "$DIR/gaphor-$VERSION-installer.exe"
+    mv "${DIST_LOCATION}/gaphor-LATEST.exe" "$DIR/output/gaphor-$VERSION-installer.exe"
 }
 
 function build_portable_installer {
-    local PORTABLE="$DIR/gaphor-$VERSION-portable"
+    local PORTABLE="$DIR/output/gaphor-$VERSION-portable"
 
     rm -rf "$PORTABLE"
     mkdir "$PORTABLE"


### PR DESCRIPTION
Add Windows build signing using a certificate. I used the Microsoft SignTool directly based on the [DevOps for Windows Desktop Apps Using GitHub Actions](https://github.com/microsoft/github-actions-for-desktop-apps) guide. The [code-sign-action GitHub Action](https://github.com/dlemstra/code-sign-action) doesn't allow for passwords on the certificate. There was a few forks of it, but I kept on getting errors.  

![image](https://user-images.githubusercontent.com/10014976/90340881-1a3f5480-dfc9-11ea-82d9-5217f54dc1e5.png)

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #395 

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
