### PR TITLE
Fix UML composite and shared association

### DIFF
--- a/gaphor/SysML/toolbox.py
+++ b/gaphor/SysML/toolbox.py
@@ -1,7 +1,5 @@
 """The action definition for the SysML toolbox."""
 
-from enum import Enum
-
 from gaphas.item import SE
 
 from gaphor import UML, diagram
@@ -11,48 +9,13 @@ from gaphor.diagram.diagramtools import PlacementTool
 from gaphor.SysML import diagramitems as sysml_items
 from gaphor.SysML import sysml
 from gaphor.UML import diagramitems as uml_items
-from gaphor.UML.toolbox import namespace_config
-
-
-class AssociationType(Enum):
-    COMPOSITE = "composite"
-    SHARED = "shared"
-
-
-def initial_pseudostate_config(new_item):
-    new_item.subject.kind = "initial"
-
-
-def history_pseudostate_config(new_item):
-    new_item.subject.kind = "shallowHistory"
-
-
-def metaclass_config(new_item):
-    namespace_config(new_item)
-    new_item.subject.name = "Class"
-
-
-def create_association(
-    assoc_item: uml_items.AssociationItem, association_type: AssociationType
-) -> None:
-    assoc = assoc_item.subject
-    assoc.memberEnd.append(assoc_item.model.create(UML.Property))
-    assoc.memberEnd.append(assoc_item.model.create(UML.Property))
-
-    assoc_item.head_end.subject = assoc.memberEnd[0]
-    assoc_item.tail_end.subject = assoc.memberEnd[1]
-
-    UML.model.set_navigability(assoc, assoc_item.head_end.subject, True)
-    assoc_item.head_end.subject.aggregation = association_type.value
-
-
-def composite_association_config(assoc_item: uml_items.AssociationItem) -> None:
-    create_association(assoc_item, AssociationType.COMPOSITE)
-
-
-def shared_association_config(assoc_item: uml_items.AssociationItem) -> None:
-    create_association(assoc_item, AssociationType.SHARED)
-
+from gaphor.UML.toolbox import (
+    composite_association_config,
+    history_pseudostate_config,
+    initial_pseudostate_config,
+    namespace_config,
+    shared_association_config,
+)
 
 # Actions: ((section (name, label, icon_name, shortcut)), ...)
 sysml_toolbox_actions: ToolboxDefinition = (


### PR DESCRIPTION
Using the UML Composite and Share Association tools was only creating a normal association. To resolve this, I copied the SysML implementation, and refactored some of the functions in to the UML toolbox module to prevent duplication.

Signed-off-by: Dan Yeaw <dan@yeaw.me>


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributer guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
UML composite and shared association tools create a normal association.

Issue Number: closes #396 

### What is the new behavior?
This issue is resolved, the composite and share associations are created properly.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
