### PR TITLE
Fix #408 where undo on diagram items breaks the model

### DIFF
--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -342,7 +342,7 @@ class Diagram(PackageableElement):
         if subject:
             item.subject = subject
         self.canvas.add(item, parent)
-        self.model.handle(DiagramItemCreated(self.model, item))
+        self.model.handle(DiagramItemCreated(self, item))
         return item
 
     def lookup(self, id):

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -195,17 +195,12 @@ class ElementFactory(Service):
         Handle events coming from elements.
         """
         if isinstance(event, UnlinkEvent):
-            self._unlink_element(event.element)
+            element = event.element
+            assert isinstance(element.id, str)
+            try:
+                del self._elements[element.id]
+            except KeyError:
+                return
             event = ElementDeleted(self, event.element)
         if self.event_manager and not self._block_events:
             self.event_manager.handle(event)
-
-    def _unlink_element(self, element: Element) -> None:
-        """
-        NOTE: Invoked from Element.unlink() to perform an element unlink.
-        """
-        try:
-            assert isinstance(element.id, str)
-            del self._elements[element.id]
-        except KeyError:
-            pass

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -157,14 +157,6 @@ class ElementCreated(ServiceEvent):
         self.element = element
 
 
-class DiagramItemCreated(ElementCreated):
-    """A diagram item has been created."""
-
-    def __init__(self, service, element):
-        """Constructor.  The element parameter is the element being created."""
-        super().__init__(service, element)
-
-
 class ElementDeleted(ServiceEvent):
     """An element has been deleted."""
 
@@ -173,6 +165,22 @@ class ElementDeleted(ServiceEvent):
         deleting the element.  The element parameter is the element being
         deleted."""
         super().__init__(service)
+        self.element = element
+
+
+class DiagramItemCreated:
+    """A diagram item has been created."""
+
+    def __init__(self, diagram, element):
+        self.diagram = diagram
+        self.element = element
+
+
+class DiagramItemDeleted:
+    """A diagram item has been deleted."""
+
+    def __init__(self, diagram, element):
+        self.diagram = diagram
         self.element = element
 
 

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, Generic, List, Optional, TypeVar
 
 from gaphor.core.modeling import Element
+from gaphor.core.modeling.event import DiagramItemDeleted
 from gaphor.core.modeling.properties import association, relation_one
 
 if TYPE_CHECKING:
@@ -20,6 +21,11 @@ S = TypeVar("S", bound=Element)
 class Presentation(Element, Generic[S]):
     """
     This presentation is used to link the behaviors of `gaphor.core.modeling` and `gaphas.Item`.
+
+    Note that Presentations are not managed by the Element Factory. Instead, Presentation
+    objects are owned by Diagram.
+    As a result they do not emit ElementCreated and ElementDeleted events. Presentations have their own
+    create and delete events: DiagramItemCreated and DiagramItemDeleted.
     """
 
     def __init__(self, id=None, model=None):
@@ -79,8 +85,10 @@ class Presentation(Element, Generic[S]):
         Remove the item from the canvas and set subject to None.
         """
         if self.canvas:
+            diagram = self.diagram
             self.canvas.remove(self)
-        super().unlink()
+            super().unlink()
+            self.handle(DiagramItemDeleted(diagram, self))
 
 
 Element.presentation = association(

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -146,7 +146,6 @@ class UndoManager(Service, ActionProvider):
         assert self._current_transaction
 
         if self._current_transaction.can_execute():
-            # Here:
             self.clear_redo_stack()
             self._undo_stack.append(self._current_transaction)
             while len(self._undo_stack) > self._stack_depth:
@@ -291,9 +290,6 @@ class UndoManager(Service, ActionProvider):
     @event_handler(ElementCreated)
     def undo_create_event(self, event):
         factory = event.service
-        # A factory is not always present, e.g. for DiagramItems
-        if not factory:
-            return
         element = event.element
 
         def _undo_create_event():
@@ -308,11 +304,7 @@ class UndoManager(Service, ActionProvider):
     @event_handler(ElementDeleted)
     def undo_delete_event(self, event):
         factory = event.service
-        # A factory is not always present, e.g. for DiagramItems
-        if not factory:
-            return
         element = event.element
-        assert factory, f"No factory defined for {element} ({factory})"
 
         def _undo_delete_event():
             factory._elements[element.id] = element


### PR DESCRIPTION
diagram items end up in the ElementFactory, because they emited
ElementCreated and ElementDeleted events.

<!-- Please add an overview of the PR here -->

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

Undo does no longer break the model. Instead `DiagramItemCreated` events are no longer inherited from `ElementCreated` events. This ensures both code paths do not intervene. 

I added `DiagramItemDeleted` events, to match with the `DiagramItemCreated` events.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
