### PR TITLE
Fix issue where copy/paste + delete of original association causes association ends to be removed

### DIFF
--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -91,6 +91,8 @@ class AssociationItem(LinePresentation[UML.Association], Named):
         ).watch(
             f"{base}.appliedStereotype.classifier", self.on_association_end_value
         ).watch(
+            "subject[Association].memberEnd"
+        ).watch(
             "subject[Association].ownedEnd"
         ).watch(
             "subject[Association].navigableOwnedEnd"
@@ -386,6 +388,16 @@ class AssociationEnd(Presentation):
         self._inline_style: Style = {"font-size": 10}
 
     name_bounds = property(lambda s: s._name_bounds)
+
+    @property
+    def owner(self):
+        """ Override Element.owner. """
+        return self._owner
+
+    @property
+    def owner_handle(self):
+        # handle(event) is the event handler method
+        return self._owner.head if self is self._owner.head_end else self._owner.tail
 
     def request_update(self):
         self._owner.request_update()

--- a/gaphor/UML/classes/classconnect.py
+++ b/gaphor/UML/classes/classconnect.py
@@ -167,7 +167,9 @@ class AssociationConnect(UnaryRelationshipConnect):
         connect to. On disconnect, we remove this relation.
         """
         association = self.line.subject
-        if len(association.presentation) <= 1:
+        if association and len(association.presentation) <= 1:
+            for e in list(association.memberEnd):
+                UML.model.set_navigability(association, e, None)
             for e in list(association.memberEnd):
                 e.type = None
 

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -493,17 +493,24 @@ class AssociationPropertyPage(PropertyPageBase):
         head_signal_handlers = self.construct_end(builder, "head", head)
         tail_signal_handlers = self.construct_end(builder, "tail", tail)
 
-        def handler(event):
+        def name_handler(event):
             end_name = "head" if event.element is head.subject else "tail"
             self.update_end_name(builder, end_name, event.element)
 
+        def restore_nav_handler(event):
+            prop = event.element
+            if prop.type and prop.opposite and prop.opposite.type:
+                for end_name, end in (("head", head), ("tail", tail)):
+                    combo = builder.get_object(f"{end_name}-navigation")
+                    self._on_end_navigability_change(combo, end)
+
         # Watch on association end:
-        self.watcher.watch("memberEnd[Property].name", handler).watch(
-            "memberEnd[Property].aggregation", handler
-        ).watch("memberEnd[Property].visibility", handler).watch(
-            "memberEnd[Property].lowerValue", handler
+        self.watcher.watch("memberEnd[Property].name", name_handler).watch(
+            "memberEnd[Property].visibility", name_handler
+        ).watch("memberEnd[Property].lowerValue", name_handler).watch(
+            "memberEnd[Property].upperValue", name_handler
         ).watch(
-            "memberEnd[Property].upperValue", handler
+            "memberEnd[Property].type", restore_nav_handler,
         ).subscribe_all()
 
         builder.connect_signals(

--- a/gaphor/UML/classes/tests/test_association.py
+++ b/gaphor/UML/classes/tests/test_association.py
@@ -30,19 +30,24 @@ class AssociationItemTestCase(TestCase):
         self.assoc.show_direction = True
         assert self.assoc.show_direction
 
-    def test_invert_direction(self):
+    def test_direction(self):
         """Test association direction inverting
         """
         self.connect(self.assoc, self.assoc.head, self.class1)
         self.connect(self.assoc, self.assoc.tail, self.class2)
 
-        head_subject = self.assoc.subject.memberEnd[0]
-        tail_subject = self.assoc.subject.memberEnd[1]
+        assert self.assoc.head_end.subject is self.assoc.subject.memberEnd[0]
+        assert self.assoc.tail_end.subject is self.assoc.subject.memberEnd[1]
+
+    def test_invert_direction(self):
+        self.connect(self.assoc, self.assoc.head, self.class1)
+        self.connect(self.assoc, self.assoc.tail, self.class2)
 
         self.assoc.invert_direction()
 
-        assert head_subject is self.assoc.subject.memberEnd[1]
-        assert tail_subject is self.assoc.subject.memberEnd[0]
+        assert self.assoc.subject.memberEnd
+        assert self.assoc.head_end.subject is self.assoc.subject.memberEnd[1]
+        assert self.assoc.tail_end.subject is self.assoc.subject.memberEnd[0]
 
     def test_association_end_updates(self):
         """Test association end navigability connected to a class"""
@@ -89,3 +94,7 @@ class AssociationItemTestCase(TestCase):
             pass  # Expected, hanve only 2 handles, need 3 or more
         else:
             assert False, "Can not set line to orthogonal with less than 3 handles"
+
+    def test_association_end_owner_handles(self):
+        assert self.assoc.head_end.owner_handle is self.assoc.head
+        assert self.assoc.tail_end.owner_handle is self.assoc.tail

--- a/gaphor/UML/classes/tests/test_associationconnect.py
+++ b/gaphor/UML/classes/tests/test_associationconnect.py
@@ -115,7 +115,24 @@ def test_disconnect_of_second_association(connected_association, clone):
     assert new.subject is asc.subject
 
 
-# test allow connect on 1st association item, where one association is already connected (reconnect)
+def test_disconnect_of_navigable_end(connected_association):
+    asc, c1, c2 = connected_association
+
+    UML.model.set_navigability(asc.subject, asc.head_end.subject, True)
+
+    assert asc.head_end.subject in c2.subject.ownedAttribute
+
+    disconnect(asc, asc.head)
+
+    assert asc.subject
+    assert len(asc.subject.memberEnd) == 2
+    assert asc.subject.memberEnd[0].type is None
+    assert asc.head_end.subject not in c2.subject.ownedAttribute
+    assert asc.tail_end.subject not in c1.subject.ownedAttribute
+    assert asc.head_end.subject.type is None
+    assert asc.tail_end.subject.type is None
+
+
 def test_allow_reconnect(connected_association, create):
     asc, c1, c2 = connected_association
     c3 = create(ClassItem, UML.Class)
@@ -161,15 +178,21 @@ def test_disallow_reconnect_if_multiple_connected_presentations(
     asc, c1, c2 = connected_association
     new = clone(asc)
     connect(new, new.head, c1)
-    connect(new, new.head, c1)
 
     c3 = create(ClassItem, UML.Class)
 
     assert not allow(asc, asc.head, c3)
 
 
-# test with both ends connected to the same class
+def test_allow_both_ends_connected_to_the_same_class(create, clone):
+    asc = create(AssociationItem)
+    c1 = create(ClassItem, UML.Class)
+    connect(asc, asc.head, c1)
+    connect(asc, asc.tail, c1)
 
-# test with navigable association ends
-# test with non-navigable association ends
-# Test with "inverted" direction (head_end.subject == memberEnd[1])
+    new = clone(asc)
+    c2 = create(ClassItem, UML.Class)
+    assert allow(new, new.head, c1)
+    assert allow(new, new.tail, c1)
+    assert not allow(new, new.head, c2)
+    assert not allow(new, new.tail, c2)

--- a/gaphor/UML/classes/tests/test_associationconnect.py
+++ b/gaphor/UML/classes/tests/test_associationconnect.py
@@ -90,7 +90,7 @@ def test_association_item_reconnect(connected_association, create):
     assert asc.tail_end.subject.navigability is True
 
 
-def test_disconnect(connected_association):
+def test_disconnect_should_disconnect_model(connected_association):
     asc, c1, c2 = connected_association
 
     disconnect(asc, asc.head)
@@ -104,8 +104,9 @@ def test_disconnect(connected_association):
     assert asc.subject.memberEnd[1].type is None
 
 
-# test disconnect with 2 associations -> model should trmain in tact
-def test_disconnect_of_second_association(connected_association, clone):
+def test_disconnect_of_second_association_should_leave_model_in_tact(
+    connected_association, clone
+):
     asc, c1, c2 = connected_association
     new = clone(asc)
 
@@ -115,7 +116,9 @@ def test_disconnect_of_second_association(connected_association, clone):
     assert new.subject is asc.subject
 
 
-def test_disconnect_of_navigable_end(connected_association):
+def test_disconnect_of_navigable_end_should_remove_owner_relationship(
+    connected_association,
+):
     asc, c1, c2 = connected_association
 
     UML.model.set_navigability(asc.subject, asc.head_end.subject, True)
@@ -133,7 +136,7 @@ def test_disconnect_of_navigable_end(connected_association):
     assert asc.tail_end.subject.type is None
 
 
-def test_allow_reconnect(connected_association, create):
+def test_allow_reconnect_for_single_presentation(connected_association, create):
     asc, c1, c2 = connected_association
     c3 = create(ClassItem, UML.Class)
 

--- a/gaphor/UML/classes/tests/test_associationconnect.py
+++ b/gaphor/UML/classes/tests/test_associationconnect.py
@@ -1,0 +1,99 @@
+import pytest
+
+from gaphor import UML
+from gaphor.diagram.tests.fixtures import allow, connect, disconnect
+from gaphor.UML.classes.association import AssociationItem
+from gaphor.UML.classes.klass import ClassItem
+
+
+@pytest.fixture
+def create(diagram, element_factory):
+    def _create(item_class, element_class=None):
+        return diagram.create(
+            item_class,
+            subject=(element_factory.create(element_class) if element_class else None),
+        )
+
+    return _create
+
+
+def get_connected(item, handle):
+    """
+    Get item connected to a handle.
+    """
+    cinfo = item.canvas.get_connection(handle)
+    if cinfo:
+        return cinfo.connected  # type: ignore[no-any-return] # noqa: F723
+    return None
+
+
+def test_glue_to_class(create):
+    asc = create(AssociationItem)
+    c1 = create(ClassItem, UML.Class)
+    c2 = create(ClassItem, UML.Class)
+
+    glued = allow(asc, asc.head, c1)
+    assert glued
+
+    connect(asc, asc.head, c1)
+
+    glued = allow(asc, asc.tail, c2)
+    assert glued
+
+
+def test_association_item_connect(create, element_factory):
+    asc = create(AssociationItem)
+    c1 = create(ClassItem, UML.Class)
+    c2 = create(ClassItem, UML.Class)
+
+    connect(asc, asc.head, c1)
+    assert asc.subject is None  # no UML metaclass yet
+
+    connect(asc, asc.tail, c2)
+    assert asc.subject is not None
+
+    # Diagram, Class *2, Property *2, Association, StyleSheet
+    assert len(element_factory.lselect()) == 7
+    assert asc.head_end.subject is not None
+    assert asc.tail_end.subject is not None
+
+
+def test_association_item_reconnect(create):
+    asc = create(AssociationItem)
+    c1 = create(ClassItem, UML.Class)
+    c2 = create(ClassItem, UML.Class)
+    c3 = create(ClassItem, UML.Class)
+
+    connect(asc, asc.head, c1)
+    connect(asc, asc.tail, c2)
+    UML.model.set_navigability(asc.subject, asc.tail_end.subject, True)
+
+    a = asc.subject
+
+    connect(asc, asc.tail, c3)
+
+    assert a is asc.subject
+    ends = [p.type for p in asc.subject.memberEnd]
+    assert c1.subject in ends
+    assert c3.subject in ends
+    assert c2.subject not in ends
+    assert asc.tail_end.subject.navigability
+
+
+def test_disconnect(create):
+    """Test association item disconnection
+    """
+    asc = create(AssociationItem)
+    c1 = create(ClassItem, UML.Class)
+    c2 = create(ClassItem, UML.Class)
+
+    connect(asc, asc.head, c1)
+    assert asc.subject is None  # no UML metaclass yet
+
+    connect(asc, asc.tail, c2)
+    assert asc.subject is not None
+
+    disconnect(asc, asc.head)
+    disconnect(asc, asc.tail)
+    assert c1 is not get_connected(asc, asc.head)
+    assert c2 is not get_connected(asc, asc.tail)

--- a/gaphor/UML/classes/tests/test_classconnect.py
+++ b/gaphor/UML/classes/tests/test_classconnect.py
@@ -4,7 +4,6 @@ Classes related adapter connection tests.
 
 from gaphor import UML
 from gaphor.tests import TestCase
-from gaphor.UML.classes.association import AssociationItem
 from gaphor.UML.classes.dependency import DependencyItem
 from gaphor.UML.classes.generalization import GeneralizationItem
 from gaphor.UML.classes.interface import InterfaceItem
@@ -271,83 +270,3 @@ class GeneralizationTestCase(TestCase):
         assert c1.subject is gen.subject.general
         assert c3.subject is gen.subject.specific
         assert c2.subject is not gen.subject.specific
-
-
-class AssociationConnectorTestCase(TestCase):
-    """
-    Association item connection adapters tests.
-    """
-
-    def test_glue(self):
-        """Test association item glue
-        """
-        asc = self.create(AssociationItem)
-        c1 = self.create(ClassItem, UML.Class)
-        c2 = self.create(ClassItem, UML.Class)
-
-        glued = self.allow(asc, asc.head, c1)
-        assert glued
-
-        self.connect(asc, asc.head, c1)
-
-        glued = self.allow(asc, asc.tail, c2)
-        assert glued
-
-    def test_connect(self):
-        """Test association item connection
-        """
-        asc = self.create(AssociationItem)
-        c1 = self.create(ClassItem, UML.Class)
-        c2 = self.create(ClassItem, UML.Class)
-
-        self.connect(asc, asc.head, c1)
-        assert asc.subject is None  # no UML metaclass yet
-
-        self.connect(asc, asc.tail, c2)
-        assert asc.subject is not None
-
-        # Diagram, Class *2, Property *2, Association, StyleSheet
-        self.assertEqual(7, len(list(self.element_factory.select())))
-        assert asc.head_end.subject is not None
-        assert asc.tail_end.subject is not None
-
-    def test_reconnect(self):
-        """Test association item reconnection
-        """
-        asc = self.create(AssociationItem)
-        c1 = self.create(ClassItem, UML.Class)
-        c2 = self.create(ClassItem, UML.Class)
-        c3 = self.create(ClassItem, UML.Class)
-
-        self.connect(asc, asc.head, c1)
-        self.connect(asc, asc.tail, c2)
-        UML.model.set_navigability(asc.subject, asc.tail_end.subject, True)
-
-        a = asc.subject
-
-        self.connect(asc, asc.tail, c3)
-
-        assert a is asc.subject
-        ends = [p.type for p in asc.subject.memberEnd]
-        assert c1.subject in ends
-        assert c3.subject in ends
-        assert c2.subject not in ends
-        assert asc.tail_end.subject.navigability
-
-    def test_disconnect(self):
-        """Test association item disconnection
-        """
-        asc = self.create(AssociationItem)
-        c1 = self.create(ClassItem, UML.Class)
-        c2 = self.create(ClassItem, UML.Class)
-
-        self.connect(asc, asc.head, c1)
-        assert asc.subject is None  # no UML metaclass yet
-
-        self.connect(asc, asc.tail, c2)
-        assert asc.subject is not None
-
-        self.disconnect(asc, asc.head)
-        self.disconnect(asc, asc.tail)
-        assert c1 is not self.get_connected(asc.head)
-        assert c2 is not self.get_connected(asc.tail)

--- a/tests/test_multiple_associations.py
+++ b/tests/test_multiple_associations.py
@@ -1,0 +1,115 @@
+"""
+Test issues where associations are copied and pasted, deleted, etc.
+
+Scenario's:
+* Class and association are pasted in a new diagramg
+* Class and association are pasted in a new diagram and original association is deleted
+* Class and association are pasted in a new diagram and new association is deleted
+* Association is pasted in a new diagram and reconnected to the class (same subject as original)
+* Association is pasted and directly deleted
+* Class and association are pasted in a new diagram and one end is connected to a different class
+
+"""
+
+import pytest
+
+from gaphor import UML
+from gaphor.application import Session
+from gaphor.diagram.tests.fixtures import connect
+from gaphor.UML import diagramitems
+from gaphor.UML.modelfactory import set_navigability
+
+
+@pytest.fixture
+def session():
+    session = Session()
+    yield session
+    session.shutdown()
+
+
+@pytest.fixture
+def element_factory(session):
+    return session.get_service("element_factory")
+
+
+@pytest.fixture
+def copy(session):
+    return session.get_service("copy")
+
+
+@pytest.fixture
+def diagram(element_factory):
+    return element_factory.create(UML.Diagram)
+
+
+@pytest.fixture
+def class_and_association_with_copy(diagram, element_factory, copy):
+    c = diagram.create(
+        diagramitems.ClassItem, subject=element_factory.create(UML.Class)
+    )
+
+    a = diagram.create(diagramitems.AssociationItem)
+    connect(a, a.handles()[0], c)
+    connect(a, a.handles()[1], c)
+
+    set_navigability(a.subject, a.subject.memberEnd[0], True)
+
+    copy.copy({a, c})
+    new_diagram = element_factory.create(UML.Diagram)
+    pasted_items = copy.paste(new_diagram)
+
+    aa = pasted_items.pop()
+    if not isinstance(aa, diagramitems.AssociationItem):
+        aa = pasted_items.pop()
+
+    return c, a, aa
+
+
+def test_delete_copied_associations(class_and_association_with_copy):
+
+    c, a, aa = class_and_association_with_copy
+
+    assert a.subject.memberEnd[0].type
+    assert a.subject.memberEnd[1].type
+    assert a.subject.memberEnd[0].type is c.subject
+    assert a.subject.memberEnd[1].type is c.subject
+    assert a.subject.memberEnd[0] is a.head_end.subject
+    assert a.subject.memberEnd[1] is a.tail_end.subject
+    assert a.subject.memberEnd[0] in a.subject.memberEnd[1].type.ownedAttribute
+
+    # Delete the copy and all is fine
+
+    aa.unlink()
+
+    assert a.subject.memberEnd[0].type
+    assert a.subject.memberEnd[1].type
+    assert a.subject.memberEnd[0].type is c.subject
+    assert a.subject.memberEnd[1].type is c.subject
+    assert a.subject.memberEnd[0] is a.head_end.subject
+    assert a.subject.memberEnd[1] is a.tail_end.subject
+    assert a.subject.memberEnd[0] in a.subject.memberEnd[1].type.ownedAttribute
+
+
+def test_delete_original_association(class_and_association_with_copy):
+
+    c, a, aa = class_and_association_with_copy
+
+    assert aa.subject.memberEnd[0].type
+    assert aa.subject.memberEnd[1].type
+    assert aa.subject.memberEnd[0].type is c.subject
+    assert aa.subject.memberEnd[1].type is c.subject
+    assert aa.subject.memberEnd[0] is aa.head_end.subject
+    assert aa.subject.memberEnd[1] is aa.tail_end.subject
+    assert aa.subject.memberEnd[0] in aa.subject.memberEnd[1].type.ownedAttribute
+
+    # Now, when the original is deleted, the model is changed and made invalid
+
+    a.unlink()
+
+    assert aa.subject.memberEnd[0].type
+    assert aa.subject.memberEnd[1].type
+    assert aa.subject.memberEnd[0].type is c.subject
+    assert aa.subject.memberEnd[1].type is c.subject
+    assert aa.subject.memberEnd[0] is aa.head_end.subject
+    assert aa.subject.memberEnd[1] is aa.tail_end.subject
+    assert aa.subject.memberEnd[0] in aa.subject.memberEnd[1].type.ownedAttribute

--- a/tests/test_multiple_associations.py
+++ b/tests/test_multiple_associations.py
@@ -2,13 +2,17 @@
 Test issues where associations are copied and pasted, deleted, etc.
 
 Scenario's:
-* Class and association are pasted in a new diagramg
+* Class and association are pasted in a new diagram
 * Class and association are pasted in a new diagram and original association is deleted
 * Class and association are pasted in a new diagram and new association is deleted
 * Association is pasted in a new diagram and reconnected to the class (same subject as original)
 * Association is pasted and directly deleted
 * Class and association are pasted in a new diagram and one end is connected to a different class
 
+What's the behavior we're looking for?
+
+* If an association has >1 presentations, it can only connect to those same types ()
+* If an association has ==1 presentation, it can reconnect to another type, association is updated
 """
 
 import pytest


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Create a class, connect both ends of an association to it. Copy + paste the association and remove the original.

See `tests/test_multiple_associations.py` for a failing scenario.

### What is the new behavior?

I hope it will work as expected: association ends remain in tact as well as the navigability.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

### Notes

This is also applicable for Connectors!

Scenario's I can think of:

* Class and association are pasted in a new diagram
* Class and association are pasted in a new diagram and original association is deleted
* Class and association are pasted in a new diagram and new association is deleted
* Association is pasted in a new diagram and reconnected to the class (same subject as original)
* Association is pasted and directly deleted
* Class and association are pasted in a new diagram and one end is connected to a different class

What's the behavior we're looking for?

* If an association has >1 presentations, it can only connect to those same types ()
* If an association has ==1 presentations, it can reconnect to another type, association is updated
