### PR TITLE
Live editing for inline editors (popovers)

### DIFF
--- a/gaphor/UML/actions/actionseditors.py
+++ b/gaphor/UML/actions/actionseditors.py
@@ -10,14 +10,16 @@ def fork_node_item_inline_editor(item, view, pos=None) -> bool:
     @transactional
     def update_text(text):
         item.subject.joinSpec = text
-        popover.popdown()
         return True
+
+    def done():
+        popover.popdown()
 
     subject = item.subject
     if not subject:
         return False
 
     box = view.get_item_bounding_box(view.hovered_item)
-    entry = popup_entry(subject.joinSpec or "", update_text)
+    entry = popup_entry(subject.joinSpec or "", update_text, done)
     popover = show_popover(entry, view, box)
     return True

--- a/gaphor/UML/actions/actionseditors.py
+++ b/gaphor/UML/actions/actionseditors.py
@@ -12,9 +12,6 @@ def fork_node_item_inline_editor(item, view, pos=None) -> bool:
         item.subject.joinSpec = text
         return True
 
-    def done():
-        popover.popdown()
-
     def escape():
         item.subject.joinSpec = join_spec
 
@@ -24,6 +21,6 @@ def fork_node_item_inline_editor(item, view, pos=None) -> bool:
 
     join_spec = subject.joinSpec or ""
     box = view.get_item_bounding_box(view.hovered_item)
-    entry = popup_entry(join_spec, update_text, done)
-    popover = show_popover(entry, view, box, escape)
+    entry = popup_entry(join_spec, update_text)
+    show_popover(entry, view, box, escape)
     return True

--- a/gaphor/UML/actions/actionseditors.py
+++ b/gaphor/UML/actions/actionseditors.py
@@ -15,11 +15,15 @@ def fork_node_item_inline_editor(item, view, pos=None) -> bool:
     def done():
         popover.popdown()
 
+    def escape():
+        item.subject.joinSpec = join_spec
+
     subject = item.subject
     if not subject:
         return False
 
+    join_spec = subject.joinSpec or ""
     box = view.get_item_bounding_box(view.hovered_item)
-    entry = popup_entry(subject.joinSpec or "", update_text, done)
-    popover = show_popover(entry, view, box)
+    entry = popup_entry(join_spec, update_text, done)
+    popover = show_popover(entry, view, box, escape)
     return True

--- a/gaphor/UML/classes/classeseditors.py
+++ b/gaphor/UML/classes/classeseditors.py
@@ -18,15 +18,16 @@ def association_item_inline_editor(item, view, pos=None) -> bool:
     @transactional
     def update_text(text):
         item.subject.name = text
-        popover.popdown()
         return True
 
     @transactional
     def update_end_text(text):
         assert end_item
         UML.parse(end_item.subject, text)
-        popover.popdown()
         return True
+
+    def done():
+        popover.popdown()
 
     subject = item.subject
     if not subject:
@@ -50,13 +51,13 @@ def association_item_inline_editor(item, view, pos=None) -> bool:
             )
             or ""
         )
-        entry = popup_entry(text, update_end_text)
+        entry = popup_entry(text, update_end_text, done)
         bb = end_item.name_bounds
         x, y = view.get_matrix_i2v(item).transform_point(bb.x, bb.y)
         box = Rectangle(x, y, 10, 10)
     else:
         text = item.subject.name or ""
-        entry = popup_entry(text, update_text)
+        entry = popup_entry(text, update_text, done)
         box = editable_text_box(view, view.hovered_item)
 
     popover = show_popover(entry, view, box)

--- a/gaphor/UML/classes/classeseditors.py
+++ b/gaphor/UML/classes/classeseditors.py
@@ -51,14 +51,23 @@ def association_item_inline_editor(item, view, pos=None) -> bool:
             )
             or ""
         )
+
+        def escape():
+            assert end_item
+            UML.parse(end_item.subject, text)
+
         entry = popup_entry(text, update_end_text, done)
         bb = end_item.name_bounds
         x, y = view.get_matrix_i2v(item).transform_point(bb.x, bb.y)
         box = Rectangle(x, y, 10, 10)
     else:
         text = item.subject.name or ""
+
+        def escape():
+            item.subject.name = text
+
         entry = popup_entry(text, update_text, done)
         box = editable_text_box(view, view.hovered_item)
 
-    popover = show_popover(entry, view, box)
+    popover = show_popover(entry, view, box, escape)
     return True

--- a/gaphor/UML/classes/classeseditors.py
+++ b/gaphor/UML/classes/classeseditors.py
@@ -26,9 +26,6 @@ def association_item_inline_editor(item, view, pos=None) -> bool:
         UML.parse(end_item.subject, text)
         return True
 
-    def done():
-        popover.popdown()
-
     subject = item.subject
     if not subject:
         return False
@@ -56,7 +53,7 @@ def association_item_inline_editor(item, view, pos=None) -> bool:
             assert end_item
             UML.parse(end_item.subject, text)
 
-        entry = popup_entry(text, update_end_text, done)
+        entry = popup_entry(text, update_end_text)
         bb = end_item.name_bounds
         x, y = view.get_matrix_i2v(item).transform_point(bb.x, bb.y)
         box = Rectangle(x, y, 10, 10)
@@ -66,8 +63,8 @@ def association_item_inline_editor(item, view, pos=None) -> bool:
         def escape():
             item.subject.name = text
 
-        entry = popup_entry(text, update_text, done)
+        entry = popup_entry(text, update_text)
         box = editable_text_box(view, view.hovered_item)
 
-    popover = show_popover(entry, view, box, escape)
+    show_popover(entry, view, box, escape)
     return True

--- a/gaphor/diagram/general/generaleditors.py
+++ b/gaphor/diagram/general/generaleditors.py
@@ -1,4 +1,4 @@
-from gi.repository import Gdk, Gtk
+from gi.repository import Gtk
 
 from gaphor.core import transactional
 from gaphor.diagram.general.comment import CommentItem
@@ -14,13 +14,6 @@ def CommentItemInlineEditor(item, view, pos=None) -> bool:
         )
         item.subject.body = text
         return True
-
-    def on_key_press_event(widget, event):
-        if event.keyval == Gdk.KEY_Return and not event.get_state() & (
-            Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK
-        ):
-            popover.popdown()
-            return True
 
     def escape():
         subject.body = body
@@ -39,7 +32,6 @@ def CommentItemInlineEditor(item, view, pos=None) -> bool:
     buffer.connect("changed", lambda _: update_text())
 
     text_view = Gtk.TextView.new_with_buffer(buffer)
-    text_view.connect("key-press-event", on_key_press_event)
     box = view.get_item_bounding_box(view.hovered_item)
 
     frame = Gtk.Frame()
@@ -48,5 +40,5 @@ def CommentItemInlineEditor(item, view, pos=None) -> bool:
     text_view.show()
     frame.show()
 
-    popover = show_popover(frame, view, box, escape)
+    show_popover(frame, view, box, escape)
     return True

--- a/gaphor/diagram/general/generaleditors.py
+++ b/gaphor/diagram/general/generaleditors.py
@@ -13,32 +13,32 @@ def CommentItemInlineEditor(item, view, pos=None) -> bool:
             buffer.get_start_iter(), buffer.get_end_iter(), include_hidden_chars=True
         )
         item.subject.body = text
-        popover.popdown()
         return True
-
-    subject = item.subject
-    if not subject:
-        return False
 
     def on_key_press_event(widget, event):
         if event.keyval == Gdk.KEY_Return and not event.get_state() & (
             Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK
         ):
-            update_text()
-        elif event.keyval == Gdk.KEY_Escape:
-            widget.get_toplevel().destroy()
+            popover.popdown()
+            return True
 
-    def on_focus_out_event(widget, event):
-        update_text()
+    def escape():
+        subject.body = body
+
+    subject = item.subject
+    if not subject:
+        return False
+
+    body = subject.body or ""
 
     buffer = Gtk.TextBuffer()
-    buffer.set_text((subject.body or "") if subject else "", -1)
+    buffer.set_text(body, -1)
     startiter, enditer = buffer.get_bounds()
     buffer.move_mark_by_name("selection_bound", startiter)
     buffer.move_mark_by_name("insert", enditer)
+    buffer.connect("changed", lambda _: update_text())
 
     text_view = Gtk.TextView.new_with_buffer(buffer)
-    text_view.connect("focus-out-event", on_focus_out_event)
     text_view.connect("key-press-event", on_key_press_event)
     box = view.get_item_bounding_box(view.hovered_item)
 
@@ -47,5 +47,6 @@ def CommentItemInlineEditor(item, view, pos=None) -> bool:
 
     text_view.show()
     frame.show()
-    popover = show_popover(frame, view, box)
+
+    popover = show_popover(frame, view, box, escape)
     return True

--- a/gaphor/diagram/inlineeditors.py
+++ b/gaphor/diagram/inlineeditors.py
@@ -31,8 +31,11 @@ def named_item_inline_editor(item, view, pos=None) -> bool:
     @transactional
     def update_text(text):
         item.subject.name = text
-        popover.popdown()
+        # popover.popdown()
         return True
+
+    def done():
+        popover.popdown()
 
     subject = item.subject
     if not subject:
@@ -41,17 +44,18 @@ def named_item_inline_editor(item, view, pos=None) -> bool:
     box = editable_text_box(view, view.hovered_item)
     if not box:
         box = view.get_item_bounding_box(view.hovered_item)
-    entry = popup_entry(subject.name or "", update_text)
+    entry = popup_entry(subject.name or "", update_text, done)
     popover = show_popover(entry, view, box)
     return True
 
 
-def popup_entry(text, update_text):
+def popup_entry(text, update_text, done):
     buffer = Gtk.EntryBuffer()
     buffer.set_text(text, -1)
     entry = Gtk.Entry.new_with_buffer(buffer)
     entry.set_activates_default(True)
-    entry.connect("activate", lambda entry: update_text(entry.get_buffer().get_text()))
+    entry.connect("changed", lambda entry: update_text(entry.get_buffer().get_text()))
+    entry.connect("activate", lambda _: done())
     entry.show()
     return entry
 

--- a/gaphor/diagram/inlineeditors.py
+++ b/gaphor/diagram/inlineeditors.py
@@ -44,8 +44,14 @@ def named_item_inline_editor(item, view, pos=None) -> bool:
     box = editable_text_box(view, view.hovered_item)
     if not box:
         box = view.get_item_bounding_box(view.hovered_item)
-    entry = popup_entry(subject.name or "", update_text, done)
-    popover = show_popover(entry, view, box)
+    name = subject.name or ""
+    entry = popup_entry(name, update_text, done)
+
+    def escape():
+        subject.name = name
+
+    popover = show_popover(entry, view, box, escape)
+
     return True
 
 
@@ -60,7 +66,7 @@ def popup_entry(text, update_text, done):
     return entry
 
 
-def show_popover(widget, view, box):
+def show_popover(widget, view, box, escape):
     popover = Gtk.Popover.new()
     popover.add(widget)
     popover.set_relative_to(view)
@@ -70,6 +76,12 @@ def show_popover(widget, view, box):
     gdk_rect.width = box.width
     gdk_rect.height = box.height
     popover.set_pointing_to(gdk_rect)
+
+    def on_escape(popover, event):
+        if event.keyval == Gdk.KEY_Escape and escape:
+            escape()
+
+    popover.connect("key-press-event", on_escape)
     popover.popup()
     return popover
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

I found it problematic that I had to explicitly "enter" a name in the popover editor. Even more so since the text in the sidebar editor for fields like "name" is instantly applied.

### What is the new behavior?

Text edited in a popover editor is instantly applied. One can hit "ESC" to revert the text to before the change.


### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

### Other information

- [ ] Edit sessions should take place in one (1) transaction
