### PR TITLE
Cleanup session lifecycle

### DIFF
--- a/gaphor/application.py
+++ b/gaphor/application.py
@@ -80,7 +80,7 @@ class Application(Service, ActionProvider):
     def active_session(self):
         return self._active_session
 
-    def new_session(self, services=None, with_ui=False):
+    def new_session(self, services=None):
         """
         Initialize an application session.
         """

--- a/gaphor/application.py
+++ b/gaphor/application.py
@@ -70,6 +70,12 @@ class Application(Service, ActionProvider):
 
         transaction.subscribers.add(self._transaction_proxy)
 
+    def get_service(self, name):
+        if not self._services_by_name:
+            raise NotInitializedError("Session is no longer alive")
+
+        return self._services_by_name[name]
+
     @property
     def active_session(self):
         return self._active_session

--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -20,8 +20,8 @@ class ServiceInitializedEvent(ServiceEvent):
     """
 
     def __init__(self, name: str, service: Service):
+        super().__init__(service)
         self.name = name
-        self.service = service
 
 
 class ServiceShutdownEvent(ServiceEvent):
@@ -30,8 +30,25 @@ class ServiceShutdownEvent(ServiceEvent):
     """
 
     def __init__(self, name: str, service: Service):
+        super().__init__(service)
         self.name = name
-        self.service = service
+
+
+class ApplicationShutdown(ServiceEvent):
+    """
+    This event is emitted from the application when it has been shut down.
+    """
+
+
+class SessionCreated(ServiceEvent):
+    """
+    The session is emitting this event when it's ready to shut down.
+    """
+
+    def __init__(self, applicaton: Service, session: Service):
+        super().__init__(applicaton)
+        self.application = applicaton
+        self.session = session
 
 
 class ActiveSessionChanged(ServiceEvent):

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -89,8 +89,9 @@ def run(args):
             apply_application_actions(application, gtk_app)
             if macos_init:
                 macos_init(application, gtk_app)
-            application.event_manager.subscribe(on_session_created)
-            application.event_manager.subscribe(on_quit)
+            event_manager = application.get_service("event_manager")
+            event_manager.subscribe(on_session_created)
+            event_manager.subscribe(on_quit)
         except Exception:
             gtk_app.quit()
             raise
@@ -103,14 +104,13 @@ def run(args):
     def app_open(gtk_app, files, n_files, hint):
         # appfilemanager should take care of this:
         assert application
-        session = application.new_session()
-        file_manager = session.get_service("file_manager")
+        app_file_manager = application.get_service("app_file_manager")
         if hint == "__new__":
-            file_manager.new()
+            app_file_manager.new()
         else:
             assert n_files == 1
             for file in files:
-                file_manager.load(file.get_path())
+                app_file_manager.load(file.get_path())
 
     gtk_app = Gtk.Application(
         application_id=APPLICATION_ID, flags=Gio.ApplicationFlags.HANDLES_OPEN

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -99,7 +99,8 @@ def run(args):
     def app_activate(gtk_app):
         assert application
         if not application.has_sessions():
-            application.new_session()
+            app_file_manager = application.get_service("app_file_manager")
+            app_file_manager.new()
 
     def app_open(gtk_app, files, n_files, hint):
         # appfilemanager should take care of this:

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -88,7 +88,7 @@ def run(args):
             application = Application()
             apply_application_actions(application, gtk_app)
             if macos_init:
-                macos_init(application, gtk_app)
+                macos_init(application)
             event_manager = application.get_service("event_manager")
             event_manager.subscribe(on_session_created)
             event_manager.subscribe(on_quit)

--- a/gaphor/ui/appfilemanager.py
+++ b/gaphor/ui/appfilemanager.py
@@ -31,6 +31,10 @@ class AppFileManager(Service, ActionProvider):
         else:
             session = self.application.new_session()
 
+        main_window = session.get_service("main_window")
+        if main_window.window:
+            main_window.window.present()
+
         file_manager = session.get_service("file_manager")
         file_manager.load(filename)
 
@@ -42,6 +46,9 @@ class AppFileManager(Service, ActionProvider):
         If it's a new model, there is no state change (undo & redo)
         and no file name is defined.
         """
+        if not self.application.active_session:
+            return False
+
         undo_manager = self.session.get_service("undo_manager")
         file_manager = self.session.get_service("file_manager")
 

--- a/gaphor/ui/appfilemanager.py
+++ b/gaphor/ui/appfilemanager.py
@@ -1,7 +1,5 @@
 import logging
 
-from gi.repository import Gio
-
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import action, gettext
 from gaphor.ui.filedialog import FileDialog
@@ -20,25 +18,24 @@ class AppFileManager(Service, ActionProvider):
     Handle application level file loading
     """
 
-    def __init__(self, session):
+    def __init__(self, application, session):
+        self.application = application
         self.session = session
 
     def shutdown(self):
         pass
 
-    @property
-    def application(self):
-        return Gio.Application.get_default()
-
     def load(self, filename):
         if self.active_session_is_new():
-            file_manager = self.session.get_service("file_manager")
-            file_manager.load(filename)
+            session = self.session
         else:
-            self.application.open([Gio.File.new_for_path(filename)], "")
+            session = self.application.new_session()
+
+        file_manager = session.get_service("file_manager")
+        file_manager.load(filename)
 
     def new(self):
-        self.application.open([], "__new__")
+        self.application.new_session()
 
     def active_session_is_new(self):
         """

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -6,7 +6,6 @@ import logging
 
 from gi.repository import Gtk
 
-from gaphor import UML
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import action, event_handler, gettext
 from gaphor.event import SessionShutdown, SessionShutdownRequested
@@ -59,18 +58,6 @@ class FileManager(Service, ActionProvider):
 
     filename = property(get_filename, set_filename)
 
-    def new(self):
-        element_factory = self.element_factory
-        element_factory.flush()
-        with element_factory.block_events():
-            model = element_factory.create(UML.Package)
-            model.name = gettext("New model")
-            diagram = element_factory.create(UML.Diagram)
-            diagram.package = model
-            diagram.name = gettext("main")
-        self.filename = None
-        element_factory.model_ready()
-
     def load(self, filename):
         """Load the Gaphor model from the supplied file name.  A status window
         displays the loading progress.  The load generator updates the progress
@@ -106,7 +93,6 @@ class FileManager(Service, ActionProvider):
                 ).format(filename=filename),
                 window=self.main_window.window,
             )
-            self.new()
             raise
         finally:
             status_window.destroy()
@@ -186,7 +172,6 @@ class FileManager(Service, ActionProvider):
                 ),
                 window=self.main_window.window,
             )
-            self.new()
             raise
         finally:
             status_window.destroy()

--- a/gaphor/ui/macosshim.py
+++ b/gaphor/ui/macosshim.py
@@ -5,15 +5,16 @@ try:
 except ValueError:
     macos_init = None
 else:
-    from gi.repository import Gio, GtkosxApplication
+    from gi.repository import GtkosxApplication
 
     macos_app = GtkosxApplication.Application.get()
 
-    def open_file(macos_app, path, gtk_app):
+    def open_file(macos_app, path, application):
         if path == __file__:
             return False
 
-        gtk_app.open([Gio.File.new_for_path(path)], "")
+        app_file_manager = application.get_service("app_file_manager")
+        app_file_manager.load(path)
 
         return True
 
@@ -21,8 +22,8 @@ else:
         quit = application.quit()
         return not quit
 
-    def macos_init(application, gtk_app):
-        macos_app.connect("NSApplicationOpenFile", open_file, gtk_app)
+    def macos_init(application):
+        macos_app.connect("NSApplicationOpenFile", open_file, application)
         macos_app.connect(
             "NSApplicationBlockTermination", block_termination, application
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ gaphor = 'gaphor.ui:main'
 gaphorconvert = 'gaphor.plugins.diagramexport.gaphorconvert:main'
 
 [tool.poetry.plugins."gaphor.appservices"]
+"event_manager" = "gaphor.core.eventmanager:EventManager"
 "session" = "gaphor.services.session:Session"
 "help" = "gaphor.services.helpservice:HelpService"
 "app_file_manager" = "gaphor.ui.appfilemanager:AppFileManager"


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

There was a lot of hopping around the code when dealing with file loading and session creation. This was only possible through the `GtkApplication`. This is inconvenient and not handy, since `GtkApplication` is not out core application: `gaphor.application.Application` is.

Issue Number: N/A

### What is the new behavior?

This PR cleans up the code. Makes sure all file loading takes place through the `app_file_manager` and ensures session lifecycle can be completely handled in our code.

On application level there's also an event manager now, so session creation and application shutdown events can be propagated to the GtkApplication as well. Handlers in GtkApplication ensure that the main window is shown when a new session is created and make sure the Gtk main loop is ended when the Gaphor Application ends.


### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
