### PR TITLE
Slowly move towards event controllers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,8 @@ jobs:
         run: >
           sudo apt-get update -q && sudo apt-get install
           --no-install-recommends -y xvfb python3-dev python3-gi
-          python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev
+          python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev &&
+          sudo apt upgrade -y libgtk-3-0
       - name: Install Poetry
         run: pip install poetry==$POETRY_VERSION
       - name: Collect Project Data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,7 @@ jobs:
         run: >
           sudo apt-get update -q && sudo apt-get install
           --no-install-recommends -y xvfb python3-dev python3-gi
-          python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev &&
-          sudo apt upgrade -y libgtk-3-0
+          python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev
       - name: Install Poetry
         run: pip install poetry==$POETRY_VERSION
       - name: Collect Project Data

--- a/gaphor/diagram/diagramtools/__init__.py
+++ b/gaphor/diagram/diagramtools/__init__.py
@@ -4,7 +4,14 @@ TODO: make tools transactional.
 """
 
 from gaphas.segment import segment_tool
-from gaphas.tool import hover_tool, item_tool, rubberband_tool, scroll_tool, zoom_tool
+from gaphas.tool import (
+    hover_tool,
+    item_tool,
+    rubberband_tool,
+    scroll_tool,
+    view_focus_tool,
+    zoom_tool,
+)
 
 from gaphor.diagram.diagramtools.dropzone import drop_zone_tool
 from gaphor.diagram.diagramtools.placement import new_item_factory, placement_tool
@@ -26,6 +33,7 @@ def apply_default_tool_set(view, modeling_language, event_manager, rubberband_st
     view.add_controller(rubberband_tool(view, rubberband_state))
     view.add_controller(scroll_tool(view))
     view.add_controller(zoom_tool(view))
+    view.add_controller(view_focus_tool(view))
     view.add_controller(shortcut_tool(view, modeling_language, event_manager))
 
 
@@ -40,3 +48,4 @@ def apply_placement_tool_set(view, item_factory, event_manager, handle_index):
     view.add_controller(drop_zone_tool(view, item_factory.item_class))
     view.add_controller(scroll_tool(view))
     view.add_controller(zoom_tool(view))
+    view.add_controller(view_focus_tool(view))

--- a/gaphor/diagram/diagramtools/__init__.py
+++ b/gaphor/diagram/diagramtools/__init__.py
@@ -8,11 +8,12 @@ from gaphas.tool import hover_tool, item_tool, rubberband_tool, scroll_tool, zoo
 
 from gaphor.diagram.diagramtools.dropzone import drop_zone_tool
 from gaphor.diagram.diagramtools.placement import new_item_factory, placement_tool
+from gaphor.diagram.diagramtools.shortcut import shortcut_tool
 from gaphor.diagram.diagramtools.textedit import text_edit_tools
 from gaphor.diagram.diagramtools.txtool import transactional_tool
 
 
-def apply_default_tool_set(view, event_manager, rubberband_state):
+def apply_default_tool_set(view, modeling_language, event_manager, rubberband_state):
     """The default tool set."""
     view.remove_all_controllers()
     view.add_controller(hover_tool(view))
@@ -25,6 +26,7 @@ def apply_default_tool_set(view, event_manager, rubberband_state):
     view.add_controller(rubberband_tool(view, rubberband_state))
     view.add_controller(scroll_tool(view))
     view.add_controller(zoom_tool(view))
+    view.add_controller(shortcut_tool(view, modeling_language, event_manager))
 
 
 def apply_placement_tool_set(view, item_factory, event_manager, handle_index):

--- a/gaphor/diagram/diagramtools/shortcut.py
+++ b/gaphor/diagram/diagramtools/shortcut.py
@@ -21,10 +21,8 @@ def on_delete(ctrl, keyval, keycode, state, event_manager):
     otherwise this key will confuse the text edit stuff.
     """
     view: GtkView = ctrl.get_widget()
-    if (
-        view.is_focus()
-        and keyval in (Gdk.KEY_Delete, Gdk.KEY_BackSpace)
-        and (state == 0 or state & Gdk.ModifierType.MOD2_MASK)
+    if keyval in (Gdk.KEY_Delete, Gdk.KEY_BackSpace) and (
+        state == 0 or state & Gdk.ModifierType.MOD2_MASK
     ):
         delete_selected_items(view, event_manager)
         return True

--- a/gaphor/diagram/diagramtools/shortcut.py
+++ b/gaphor/diagram/diagramtools/shortcut.py
@@ -1,0 +1,68 @@
+import functools
+
+from gaphas.view import GtkView
+from gi.repository import Gdk, GLib, Gtk
+
+from gaphor.core import Transaction
+from gaphor.core.modeling import Presentation
+
+
+def shortcut_tool(view, modeling_language, event_manager):
+    ctrl = Gtk.EventControllerKey.new(view)
+    ctrl.connect("key-pressed", on_delete, event_manager)
+    ctrl.connect("key-pressed", on_shortcut, modeling_language)
+    return ctrl
+
+
+def on_delete(ctrl, keyval, keycode, state, event_manager):
+    """Handle the 'Delete' key.
+
+    This can not be handled directly (through GTK's accelerators),
+    otherwise this key will confuse the text edit stuff.
+    """
+    view: GtkView = ctrl.get_widget()
+    if (
+        view.is_focus()
+        and keyval in (Gdk.KEY_Delete, Gdk.KEY_BackSpace)
+        and (state == 0 or state & Gdk.ModifierType.MOD2_MASK)
+    ):
+        delete_selected_items(view, event_manager)
+        return True
+    return False
+
+
+def delete_selected_items(view: GtkView, event_manager):
+    with Transaction(event_manager):
+        items = view.selection.selected_items
+        for i in list(items):
+            if isinstance(i, Presentation):
+                i.unlink()
+            else:
+                if i.canvas:
+                    i.canvas.remove(i)
+
+
+def on_shortcut(ctrl, keyval, keycode, state, modeling_language):
+    # accelerator keys are lower case. Since we handle them in a key-press event
+    # handler, we'll need the upper-case versions as well in case Shift is pressed.
+    view: GtkView = ctrl.get_widget()
+    for _title, items in modeling_language.toolbox_definition:
+        for action_name, _label, _icon_name, shortcut, *rest in items:
+            if not shortcut:
+                continue
+            keys, mod = parse_shortcut(shortcut)
+            if state == mod and keyval in keys:
+                view.get_toplevel().get_action_group("diagram").lookup_action(
+                    "select-tool"
+                ).change_state(GLib.Variant.new_string(action_name))
+                return True
+    return False
+
+
+_upper_offset = ord("A") - ord("a")
+
+
+@functools.lru_cache(maxsize=None)
+def parse_shortcut(shortcut):
+    key, mod = Gtk.accelerator_parse(shortcut)
+    return (key, key + _upper_offset), mod

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -1,7 +1,7 @@
 import functools
 import importlib
 import logging
-from typing import Dict, Optional, Sequence, Set, Tuple
+from typing import Dict, Optional, Sequence, Tuple
 
 from gaphas.guide import GuidePainter
 from gaphas.painter import (
@@ -16,8 +16,8 @@ from gaphas.view import GtkView
 from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
 
 from gaphor import UML
-from gaphor.core import action, event_handler, gettext, transactional
-from gaphor.core.modeling import Presentation, StyleSheet
+from gaphor.core import action, event_handler, gettext
+from gaphor.core.modeling import StyleSheet
 from gaphor.core.modeling.diagram import StyledDiagram
 from gaphor.core.modeling.event import AttributeUpdated, ElementDeleted
 from gaphor.diagram.diagramtoolbox import ToolDef
@@ -49,15 +49,6 @@ def placement_icon_base():
 GtkView.set_css_name("diagramview")
 
 _placement_pixbuf_map: Dict[str, GdkPixbuf.Pixbuf] = {}
-
-
-_upper_offset = ord("A") - ord("a")
-
-
-@functools.lru_cache(maxsize=None)
-def parse_shortcut(shortcut):
-    key, mod = Gtk.accelerator_parse(shortcut)
-    return (key, key + _upper_offset), mod
 
 
 def get_placement_cursor(display, icon_name):
@@ -101,7 +92,6 @@ class DiagramPage:
         self.view: Optional[GtkView] = None
         self.widget: Optional[Gtk.Widget] = None
         self.diagram_css: Optional[Gtk.CssProvider] = None
-        self.ctrl: Set[Gtk.EventController] = set()
 
         self.rubberband_state = RubberbandState()
 
@@ -145,14 +135,6 @@ class DiagramPage:
         view.selection.add_handler(self._on_view_selection_changed)
         view.connect("drag-data-received", self._on_drag_data_received)
 
-        ctrl = Gtk.EventControllerKey.new(view)
-        ctrl.connect("key-pressed", self._on_delete_action)
-        self.ctrl.add(ctrl)
-
-        ctrl = Gtk.EventControllerKey.new(view)
-        ctrl.connect("key-pressed", self._on_shortcut_action)
-        self.ctrl.add(ctrl)
-
         self.view = view
 
         self.widget.action_group = create_action_group(self, "diagram")
@@ -174,7 +156,10 @@ class DiagramPage:
         """Return a tool associated with an id (action name)."""
         if tool_name == "toolbox-pointer":
             return apply_default_tool_set(
-                self.view, self.event_manager, self.rubberband_state
+                self.view,
+                self.modeling_language,
+                self.event_manager,
+                self.rubberband_state,
             )
 
         tool_def = self.get_tool_def(tool_name)
@@ -216,7 +201,6 @@ class DiagramPage:
         Do the same thing that would be done if Close was pressed.
         """
         assert self.widget
-        self.ctrl.clear()
         self.widget.destroy()
         self.event_manager.unsubscribe(self._on_element_delete)
         self.event_manager.unsubscribe(self._on_style_sheet_updated)
@@ -262,18 +246,6 @@ class DiagramPage:
         assert self.view
         if self.view.has_focus():
             self.view.selection.unselect_all()
-
-    @action(name="diagram.delete")
-    @transactional
-    def delete_selected_items(self):
-        assert self.view
-        items = self.view.selection.selected_items
-        for i in list(items):
-            if isinstance(i, Presentation):
-                i.unlink()
-            else:
-                if i.canvas:
-                    i.canvas.remove(i)
 
     @action(name="diagram.select-tool", state="toolbox-pointer")
     def select_tool(self, tool_name: str):
@@ -328,39 +300,6 @@ class DiagramPage:
         view.bounding_box_painter = BoundingBoxPainter(item_painter)
 
         view.queue_redraw()
-
-    def _on_delete_action(self, ctrl, keyval, keycode, state):
-        """Handle the 'Delete' key.
-
-        This can not be handled directly (through GTK's accelerators),
-        otherwise this key will confuse the text edit stuff.
-        """
-        assert self.view
-        if (
-            self.view.is_focus()
-            and keyval in (Gdk.KEY_Delete, Gdk.KEY_BackSpace)
-            and (state == 0 or state & Gdk.ModifierType.MOD2_MASK)
-        ):
-            self.delete_selected_items()
-            return True
-        return False
-
-    def _on_shortcut_action(self, ctrl, keyval, keycode, state):
-        # accelerator keys are lower case. Since we handle them in a key-press event
-        # handler, we'll need the upper-case versions as well in case Shift is pressed.
-        for _title, items in self.modeling_language.toolbox_definition:
-            for action_name, _label, _icon_name, shortcut, *rest in items:
-                if not shortcut:
-                    continue
-                keys, mod = parse_shortcut(shortcut)
-                if state == mod and keyval in keys:
-                    ctrl.get_widget().get_toplevel().get_action_group(
-                        "diagram"
-                    ).lookup_action("select-tool").change_state(
-                        GLib.Variant.new_string(action_name)
-                    )
-                    return True
-        return False
 
     def _on_view_selection_changed(self):
         view = self.view

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -122,10 +122,14 @@ class Namespace(UIComponent):
         scrolled_window.insert_action_group(
             "tree-view", create_action_group(self, "tree-view")[0]
         )
-        view.connect_after("event-after", self._on_view_event)
         view.connect("row-activated", self._on_view_row_activated)
         view.connect_after("cursor-changed", self._on_view_cursor_changed)
         view.connect("destroy", self._on_view_destroyed)
+
+        ctrl = Gtk.GestureMultiPress.new(view)
+        ctrl.set_button(Gdk.BUTTON_SECONDARY)
+        ctrl.connect("pressed", self._on_show_popup)
+        self.popup_ctrl = ctrl
 
         ctrl = Gtk.EventControllerKey.new(view)
         ctrl.connect("key-pressed", self._on_edit_pressed)
@@ -159,15 +163,12 @@ class Namespace(UIComponent):
         if isinstance(focused_item, Presentation) and focused_item.subject:
             self.select_element(focused_item.subject)
 
-    def _on_view_event(self, view, event):
-        """Show a popup menu if button3 was pressed on the TreeView."""
-        if event.type == Gdk.EventType.BUTTON_PRESS and event.button.button == 3:
-            menu = Gtk.Menu.new_from_model(popup_model(self.view))
-            menu.attach_to_widget(view, None)
-            menu.popup_at_pointer(event)
+    def _on_show_popup(self, ctrl, n_press, x, y):
+        menu = Gtk.Menu.new_from_model(popup_model(self.view))
+        menu.attach_to_widget(self.view, None)
+        menu.popup_at_pointer(None)
 
     def _on_edit_pressed(self, ctrl, keyval, keycode, state):
-        print("key press", keyval, keycode)
         if keyval == Gdk.KEY_F2:
             self.tree_view_rename_selected()
             return True

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -126,6 +126,11 @@ class Namespace(UIComponent):
         view.connect("row-activated", self._on_view_row_activated)
         view.connect_after("cursor-changed", self._on_view_cursor_changed)
         view.connect("destroy", self._on_view_destroyed)
+
+        ctrl = Gtk.EventControllerKey.new(view)
+        ctrl.connect("key-pressed", self._on_edit_pressed)
+        self.edit_ctrl = ctrl
+
         self.view = view
         self.model.refresh()
 
@@ -160,8 +165,13 @@ class Namespace(UIComponent):
             menu = Gtk.Menu.new_from_model(popup_model(self.view))
             menu.attach_to_widget(view, None)
             menu.popup_at_pointer(event)
-        elif event.type == Gdk.EventType.KEY_PRESS and event.key.keyval == Gdk.KEY_F2:
+
+    def _on_edit_pressed(self, ctrl, keyval, keycode, state):
+        print("key press", keyval, keycode)
+        if keyval == Gdk.KEY_F2:
             self.tree_view_rename_selected()
+            return True
+        return False
 
     def _on_view_row_activated(self, view, path, column):
         """Double click on an element in the tree view."""

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -8,7 +8,7 @@ classifiers are shown here.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Set
 
 from gi.repository import Gdk, Gio, GLib, Gtk
 
@@ -80,6 +80,7 @@ class Namespace(UIComponent):
 
         self.model: Optional[NamespaceModel] = None
         self.view: Optional[NamespaceView] = None
+        self.ctrl: Set[Gtk.EventController] = set()
 
     def open(self):
         self.model = NamespaceModel(self.event_manager, self.element_factory)
@@ -129,11 +130,11 @@ class Namespace(UIComponent):
         ctrl = Gtk.GestureMultiPress.new(view)
         ctrl.set_button(Gdk.BUTTON_SECONDARY)
         ctrl.connect("pressed", self._on_show_popup)
-        self.popup_ctrl = ctrl
+        self.ctrl.add(ctrl)
 
         ctrl = Gtk.EventControllerKey.new(view)
         ctrl.connect("key-pressed", self._on_edit_pressed)
-        self.edit_ctrl = ctrl
+        self.ctrl.add(ctrl)
 
         self.view = view
         self.model.refresh()
@@ -141,6 +142,7 @@ class Namespace(UIComponent):
         return scrolled_window
 
     def close(self):
+        self.ctrl.clear()
         if self.view:
             self.view.destroy()
             self.view = None
@@ -242,8 +244,8 @@ class Namespace(UIComponent):
             log.debug(f"No action defined for element {type(element).__name__}")
 
     @action(name="tree-view.show-in-diagram")
-    def tree_view_show_in_diagram(self, diagam_id: str):
-        element = self.element_factory.lookup(diagam_id)
+    def tree_view_show_in_diagram(self, diagram_id: str):
+        element = self.element_factory.lookup(diagram_id)
         self.event_manager.handle(DiagramOpened(element))
 
     @action(name="tree-view.rename", shortcut="F2")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,70 +1,71 @@
 [[package]]
-name = "alabaster"
-version = "0.7.12"
+category = "dev"
 description = "A configurable sidebar-enabled Sphinx theme"
-category = "dev"
+name = "alabaster"
 optional = false
 python-versions = "*"
+version = "0.7.12"
 
 [[package]]
-name = "appdirs"
-version = "1.4.4"
+category = "dev"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+name = "appdirs"
 optional = false
 python-versions = "*"
+version = "1.4.4"
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.0"
+category = "dev"
 description = "Atomic file writes."
-category = "dev"
+marker = "sys_platform == \"win32\""
+name = "atomicwrites"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.4.0"
 
 [[package]]
-name = "attrs"
-version = "20.3.0"
-description = "Classes Without Boilerplate"
 category = "dev"
+description = "Classes Without Boilerplate"
+name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "20.3.0"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
-name = "babel"
-version = "2.9.0"
-description = "Internationalization utilities"
 category = "dev"
+description = "Internationalization utilities"
+name = "babel"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.9.0"
 
 [package.dependencies]
 pytz = ">=2015.7"
 
 [[package]]
-name = "babelgladeextractor"
-version = "0.7.0"
-description = "Babel l10n support for Glade, GtkBuilder, and .desktop files"
 category = "dev"
+description = "Babel l10n support for Glade, GtkBuilder, and .desktop files"
+name = "babelgladeextractor"
 optional = false
 python-versions = "*"
+version = "0.7.0"
 
 [package.dependencies]
 Babel = "*"
 
 [[package]]
-name = "black"
-version = "20.8b1"
-description = "The uncompromising code formatter."
 category = "dev"
+description = "The uncompromising code formatter."
+name = "black"
 optional = false
 python-versions = ">=3.6"
+version = "20.8b1"
 
 [package.dependencies]
 appdirs = "*"
@@ -81,160 +82,164 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
-name = "certifi"
-version = "2020.12.5"
-description = "Python package for providing Mozilla's CA Bundle."
 category = "dev"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
 optional = false
 python-versions = "*"
+version = "2020.12.5"
 
 [[package]]
-name = "cfgv"
-version = "3.2.0"
-description = "Validate configuration and produce human readable error messages."
 category = "dev"
+description = "Validate configuration and produce human readable error messages."
+name = "cfgv"
 optional = false
 python-versions = ">=3.6.1"
+version = "3.2.0"
 
 [[package]]
-name = "chardet"
-version = "4.0.0"
+category = "dev"
 description = "Universal encoding detector for Python 2 and 3"
-category = "dev"
+name = "chardet"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "4.0.0"
 
 [[package]]
-name = "click"
-version = "7.1.2"
+category = "dev"
 description = "Composable command line interface toolkit"
-category = "dev"
+name = "click"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.2"
 
 [[package]]
-name = "colorama"
-version = "0.4.4"
+category = "dev"
 description = "Cross-platform colored terminal text."
-category = "dev"
+marker = "sys_platform == \"win32\""
+name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.4"
 
 [[package]]
-name = "commonmark"
-version = "0.9.1"
-description = "Python parser for the CommonMark Markdown spec"
 category = "dev"
+description = "Python parser for the CommonMark Markdown spec"
+name = "commonmark"
 optional = false
 python-versions = "*"
+version = "0.9.1"
 
 [package.extras]
-test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
+test = ["flake8 (3.7.8)", "hypothesis (3.55.3)"]
 
 [[package]]
-name = "coverage"
-version = "5.3"
-description = "Code coverage measurement for Python"
 category = "dev"
+description = "Code coverage measurement for Python"
+name = "coverage"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.3"
 
 [package.extras]
 toml = ["toml"]
 
 [[package]]
-name = "distlib"
-version = "0.3.1"
-description = "Distribution utilities"
 category = "dev"
+description = "Distribution utilities"
+name = "distlib"
 optional = false
 python-versions = "*"
+version = "0.3.1"
 
 [[package]]
-name = "docutils"
-version = "0.16"
-description = "Docutils -- Python Documentation Utilities"
 category = "dev"
+description = "Docutils -- Python Documentation Utilities"
+name = "docutils"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.16"
 
 [[package]]
-name = "filelock"
-version = "3.0.12"
-description = "A platform independent file lock."
 category = "dev"
+description = "A platform independent file lock."
+name = "filelock"
 optional = false
 python-versions = "*"
+version = "3.0.12"
 
 [[package]]
-name = "flake8"
-version = "3.8.4"
-description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
+description = "the modular source code checker: pep8 pyflakes and co"
+name = "flake8"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "3.8.4"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
 
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
+
 [[package]]
-name = "gaphas"
-version = "3.0.0b0"
-description = "Gaphas is a GTK+ based diagramming widget"
 category = "main"
+description = "Gaphas is a GTK+ based diagramming widget"
+name = "gaphas"
 optional = false
 python-versions = ">=3.7,<4.0"
+version = "3.0.0b2"
 
 [package.dependencies]
-pycairo = ">=1.13.0,<2.0.0"
 PyGObject = ">=3.20.0,<4.0.0"
+pycairo = ">=1.13.0,<2.0.0"
 typing-extensions = ">=3.7.4,<4.0.0"
 
 [[package]]
-name = "generic"
-version = "1.0.0"
-description = "Generic programming library for Python"
 category = "main"
+description = "Generic programming library for Python"
+name = "generic"
 optional = false
 python-versions = ">=3.7,<4.0"
+version = "1.0.0"
 
 [[package]]
-name = "identify"
-version = "1.5.10"
-description = "File identification library for Python"
 category = "dev"
+description = "File identification library for Python"
+name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "1.5.10"
 
 [package.extras]
 license = ["editdistance"]
 
 [[package]]
-name = "idna"
-version = "2.10"
+category = "dev"
 description = "Internationalized Domain Names in Applications (IDNA)"
-category = "dev"
+name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.10"
 
 [[package]]
-name = "imagesize"
-version = "1.2.0"
+category = "dev"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
-category = "dev"
+name = "imagesize"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.2.0"
 
 [[package]]
-name = "importlib-metadata"
-version = "1.7.0"
-description = "Read metadata from Python packages"
 category = "main"
+description = "Read metadata from Python packages"
+name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.7.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -244,33 +249,33 @@ docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
-name = "iniconfig"
-version = "1.1.1"
-description = "iniconfig: brain-dead simple config-ini parsing"
 category = "dev"
+description = "iniconfig: brain-dead simple config-ini parsing"
+name = "iniconfig"
 optional = false
 python-versions = "*"
+version = "1.1.1"
 
 [[package]]
-name = "isort"
-version = "5.6.4"
-description = "A Python utility / library to sort Python imports."
 category = "dev"
+description = "A Python utility / library to sort Python imports."
+name = "isort"
 optional = false
 python-versions = ">=3.6,<4.0"
+version = "5.6.4"
 
 [package.extras]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
 pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
 
 [[package]]
-name = "jinja2"
-version = "2.11.2"
-description = "A very fast and expressive template engine."
 category = "dev"
+description = "A very fast and expressive template engine."
+name = "jinja2"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.11.2"
 
 [package.dependencies]
 MarkupSafe = ">=0.23"
@@ -279,28 +284,28 @@ MarkupSafe = ">=0.23"
 i18n = ["Babel (>=0.8)"]
 
 [[package]]
-name = "markupsafe"
-version = "1.1.1"
-description = "Safely add untrusted strings to HTML/XML markup."
 category = "dev"
+description = "Safely add untrusted strings to HTML/XML markup."
+name = "markupsafe"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "1.1.1"
 
 [[package]]
-name = "mccabe"
-version = "0.6.1"
-description = "McCabe checker, plugin for flake8"
 category = "dev"
+description = "McCabe checker, plugin for flake8"
+name = "mccabe"
 optional = false
 python-versions = "*"
+version = "0.6.1"
 
 [[package]]
-name = "mypy"
-version = "0.790"
-description = "Optional static typing for Python"
 category = "dev"
+description = "Optional static typing for Python"
+name = "mypy"
 optional = false
 python-versions = ">=3.5"
+version = "0.790"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
@@ -311,202 +316,210 @@ typing-extensions = ">=3.7.4"
 dmypy = ["psutil (>=4.0)"]
 
 [[package]]
-name = "mypy-extensions"
-version = "0.4.3"
+category = "dev"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
-category = "dev"
+name = "mypy-extensions"
 optional = false
 python-versions = "*"
+version = "0.4.3"
 
 [[package]]
-name = "nodeenv"
-version = "1.5.0"
+category = "dev"
 description = "Node.js virtual environment builder"
-category = "dev"
+name = "nodeenv"
 optional = false
 python-versions = "*"
+version = "1.5.0"
 
 [[package]]
-name = "packaging"
-version = "20.8"
-description = "Core utilities for Python packages"
 category = "dev"
+description = "Core utilities for Python packages"
+name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "20.8"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
 
 [[package]]
-name = "pathspec"
-version = "0.8.1"
-description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.8.1"
 
 [[package]]
-name = "pluggy"
-version = "0.13.1"
-description = "plugin and hook calling mechanisms for python"
 category = "dev"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.13.1"
 
 [package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-name = "pre-commit"
-version = "2.9.3"
-description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+name = "pre-commit"
 optional = false
 python-versions = ">=3.6.1"
+version = "2.9.3"
 
 [package.dependencies]
 cfgv = ">=2.0.0"
 identify = ">=1.0.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 toml = "*"
 virtualenv = ">=20.0.8"
 
-[[package]]
-name = "py"
-version = "1.10.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
 
 [[package]]
-name = "pycairo"
-version = "1.20.0"
-description = "Python interface for cairo"
+category = "dev"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+name = "py"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.10.0"
+
+[[package]]
 category = "main"
+description = "Python interface for cairo"
+name = "pycairo"
 optional = false
 python-versions = ">=3.6, <4"
+version = "1.20.0"
 
 [[package]]
-name = "pycodestyle"
-version = "2.6.0"
+category = "dev"
 description = "Python style guide checker"
-category = "dev"
+name = "pycodestyle"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.6.0"
 
 [[package]]
-name = "pyflakes"
-version = "2.2.0"
+category = "dev"
 description = "passive checker of Python programs"
-category = "dev"
+name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.2.0"
 
 [[package]]
-name = "pygments"
-version = "2.7.3"
-description = "Pygments is a syntax highlighting package written in Python."
 category = "dev"
+description = "Pygments is a syntax highlighting package written in Python."
+name = "pygments"
 optional = false
 python-versions = ">=3.5"
+version = "2.7.3"
 
 [[package]]
-name = "pygobject"
-version = "3.38.0"
-description = "Python bindings for GObject Introspection"
 category = "main"
+description = "Python bindings for GObject Introspection"
+name = "pygobject"
 optional = false
 python-versions = ">=3.5, <4"
+version = "3.38.0"
 
 [package.dependencies]
 pycairo = ">=1.11.1"
 
 [[package]]
-name = "pyparsing"
-version = "2.4.7"
-description = "Python parsing module"
 category = "dev"
+description = "Python parsing module"
+name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.4.7"
 
 [[package]]
-name = "pytest"
-version = "6.2.1"
-description = "pytest: simple powerful testing with Python"
 category = "dev"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
 optional = false
 python-versions = ">=3.6"
+version = "6.2.1"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+atomicwrites = ">=1.0"
 attrs = ">=19.2.0"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+colorama = "*"
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<1.0.0a1"
 py = ">=1.8.2"
 toml = "*"
 
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-name = "pytest-cov"
-version = "2.10.1"
-description = "Pytest plugin for measuring coverage."
 category = "dev"
+description = "Pytest plugin for measuring coverage."
+name = "pytest-cov"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.10.1"
 
 [package.dependencies]
 coverage = ">=4.4"
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
-name = "pytest-runner"
-version = "5.2"
-description = "Invoke py.test as distutils command with dependency resolution"
 category = "dev"
+description = "Invoke py.test as distutils command with dependency resolution"
+name = "pytest-runner"
 optional = false
 python-versions = ">=2.7"
+version = "5.2"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs", "pytest-flake8", "pytest-black-multipy", "pytest-cov", "pytest-virtualenv"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs", "pytest-flake8", "pytest-black-multipy", "pytest-cov", "pytest-virtualenv"]
 
 [[package]]
-name = "pytz"
-version = "2020.4"
-description = "World timezone definitions, modern and historical"
 category = "dev"
+description = "World timezone definitions, modern and historical"
+name = "pytz"
 optional = false
 python-versions = "*"
+version = "2020.4"
 
 [[package]]
-name = "pyyaml"
-version = "5.3.1"
-description = "YAML parser and emitter for Python"
 category = "dev"
+description = "YAML parser and emitter for Python"
+name = "pyyaml"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "5.3.1"
 
 [[package]]
-name = "recommonmark"
-version = "0.7.1"
-description = "A docutils-compatibility bridge to CommonMark, enabling you to write CommonMark inside of Docutils & Sphinx projects."
 category = "dev"
+description = "A docutils-compatibility bridge to CommonMark, enabling you to write CommonMark inside of Docutils & Sphinx projects."
+name = "recommonmark"
 optional = false
 python-versions = "*"
+version = "0.7.1"
 
 [package.dependencies]
 commonmark = ">=0.8.1"
@@ -514,20 +527,20 @@ docutils = ">=0.11"
 sphinx = ">=1.3.1"
 
 [[package]]
-name = "regex"
-version = "2020.11.13"
-description = "Alternative regular expression module, to replace re."
 category = "dev"
+description = "Alternative regular expression module, to replace re."
+name = "regex"
 optional = false
 python-versions = "*"
+version = "2020.11.13"
 
 [[package]]
-name = "requests"
-version = "2.25.1"
-description = "Python HTTP for Humans."
 category = "dev"
+description = "Python HTTP for Humans."
+name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.25.1"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -537,42 +550,43 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
-name = "six"
-version = "1.15.0"
-description = "Python 2 and 3 compatibility utilities"
 category = "dev"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.15.0"
 
 [[package]]
-name = "snowballstemmer"
-version = "2.0.0"
-description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
 category = "dev"
+description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
+name = "snowballstemmer"
 optional = false
 python-versions = "*"
+version = "2.0.0"
 
 [[package]]
-name = "sphinx"
-version = "3.3.1"
-description = "Python documentation generator"
 category = "dev"
+description = "Python documentation generator"
+name = "sphinx"
 optional = false
 python-versions = ">=3.5"
+version = "3.3.1"
 
 [package.dependencies]
+Jinja2 = ">=2.3"
+Pygments = ">=2.0"
 alabaster = ">=0.7,<0.8"
 babel = ">=1.3"
-colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
+colorama = ">=0.3.5"
 docutils = ">=0.12"
 imagesize = "*"
-Jinja2 = ">=2.3"
 packaging = "*"
-Pygments = ">=2.0"
 requests = ">=2.5.0"
+setuptools = "*"
 snowballstemmer = ">=1.1"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
@@ -587,12 +601,12 @@ lint = ["flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.790)", "docutils-s
 test = ["pytest", "pytest-cov", "html5lib", "typed-ast", "cython"]
 
 [[package]]
-name = "sphinx-rtd-theme"
-version = "0.5.0"
-description = "Read the Docs theme for Sphinx"
 category = "dev"
+description = "Read the Docs theme for Sphinx"
+name = "sphinx-rtd-theme"
 optional = false
 python-versions = "*"
+version = "0.5.0"
 
 [package.dependencies]
 sphinx = "*"
@@ -601,83 +615,83 @@ sphinx = "*"
 dev = ["transifex-client", "sphinxcontrib-httpdomain", "bump2version"]
 
 [[package]]
-name = "sphinxcontrib-applehelp"
-version = "1.0.2"
+category = "dev"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
-category = "dev"
+name = "sphinxcontrib-applehelp"
 optional = false
 python-versions = ">=3.5"
-
-[package.extras]
-lint = ["flake8", "mypy", "docutils-stubs"]
-test = ["pytest"]
-
-[[package]]
-name = "sphinxcontrib-devhelp"
 version = "1.0.2"
-description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
-category = "dev"
-optional = false
-python-versions = ">=3.5"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-name = "sphinxcontrib-htmlhelp"
-version = "1.0.3"
-description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "dev"
+description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
+name = "sphinxcontrib-devhelp"
 optional = false
 python-versions = ">=3.5"
+version = "1.0.2"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
+name = "sphinxcontrib-htmlhelp"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.3"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest", "html5lib"]
 
 [[package]]
-name = "sphinxcontrib-jsmath"
-version = "1.0.1"
-description = "A sphinx extension which renders display math in HTML via JavaScript"
 category = "dev"
+description = "A sphinx extension which renders display math in HTML via JavaScript"
+name = "sphinxcontrib-jsmath"
 optional = false
 python-versions = ">=3.5"
+version = "1.0.1"
 
 [package.extras]
 test = ["pytest", "flake8", "mypy"]
 
 [[package]]
-name = "sphinxcontrib-qthelp"
-version = "1.0.3"
+category = "dev"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
-category = "dev"
+name = "sphinxcontrib-qthelp"
 optional = false
 python-versions = ">=3.5"
+version = "1.0.3"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-name = "sphinxcontrib-serializinghtml"
-version = "1.1.4"
+category = "dev"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
-category = "dev"
+name = "sphinxcontrib-serializinghtml"
 optional = false
 python-versions = ">=3.5"
+version = "1.1.4"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-name = "tinycss2"
-version = "1.1.0"
-description = "tinycss2"
 category = "main"
+description = "tinycss2"
+name = "tinycss2"
 optional = false
 python-versions = ">=3.6"
+version = "1.1.0"
 
 [package.dependencies]
 webencodings = ">=0.4"
@@ -687,93 +701,96 @@ doc = ["sphinx", "sphinx-rtd-theme"]
 test = ["pytest", "pytest-cov", "pytest-flake8", "pytest-isort", "coverage"]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.10.2"
 
 [[package]]
-name = "tomlkit"
-version = "0.7.0"
-description = "Style preserving TOML library"
 category = "dev"
+description = "Style preserving TOML library"
+name = "tomlkit"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.7.0"
 
 [[package]]
-name = "typed-ast"
-version = "1.4.1"
+category = "dev"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "dev"
+name = "typed-ast"
 optional = false
 python-versions = "*"
+version = "1.4.1"
 
 [[package]]
-name = "typing-extensions"
-version = "3.7.4.3"
-description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+name = "typing-extensions"
 optional = false
 python-versions = "*"
+version = "3.7.4.3"
 
 [[package]]
-name = "urllib3"
-version = "1.26.2"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "dev"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.26.2"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
-name = "virtualenv"
-version = "20.2.2"
-description = "Virtual Python Environment builder"
 category = "dev"
+description = "Virtual Python Environment builder"
+name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "20.2.2"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 six = ">=1.9.0,<2"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-xdist (>=1.31.0)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
 
 [[package]]
-name = "webencodings"
-version = "0.5.1"
-description = "Character encoding aliases for legacy web content"
 category = "main"
+description = "Character encoding aliases for legacy web content"
+name = "webencodings"
 optional = false
 python-versions = "*"
+version = "0.5.1"
 
 [[package]]
-name = "zipp"
-version = "3.4.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+name = "zipp"
 optional = false
 python-versions = ">=3.6"
+version = "3.4.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-lock-version = "1.1"
-python-versions = "^3.7"
 content-hash = "282d8ceea958000e412ed575562ff7b21ff540f5aaf1b991ed7bc0dcc5f4de0b"
+lock-version = "1.0"
+python-versions = "^3.7"
 
 [metadata.files]
 alabaster = [
@@ -879,8 +896,8 @@ flake8 = [
     {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
 ]
 gaphas = [
-    {file = "gaphas-3.0.0b0-py3-none-any.whl", hash = "sha256:d63e59d7ee355fc3b1d65fd0efb48198644dcea41f586592d589642f395a273b"},
-    {file = "gaphas-3.0.0b0.tar.gz", hash = "sha256:c04b9cb521253e8f6b859ec3b065c7127e3cfb019f5c164a21317f099aa305b6"},
+    {file = "gaphas-3.0.0b2-py3-none-any.whl", hash = "sha256:05ebb230d1cd5f7f5f10019b12d3c26fbe5b1ded77ac71ec58dcbe4c67dccd17"},
+    {file = "gaphas-3.0.0b2.tar.gz", hash = "sha256:4f789fa64c9a5e57fb6484ed6d53a70a2c5d42e3ecee74f2fc584291d251186f"},
 ]
 generic = [
     {file = "generic-1.0.0-py3-none-any.whl", hash = "sha256:a8dbb3133929223149272fcc70a95967cf3b24e3fa12601f91c67fb61efe29d4"},
@@ -942,6 +959,11 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 mccabe = [
@@ -1049,6 +1071,8 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 recommonmark = [
@@ -1162,19 +1186,28 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
     {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
     {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d"},
     {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win32.whl", hash = "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
 ]
 typing-extensions = [


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

In GTK 4 there are no mouse/keyboard events on the widgets directly. Instead we have to define [EventControllers](https://lazka.github.io/pgi-docs/index.html#Gtk-3.0/classes/EventController.html). Event controllers offer more options (e.g. for multi-touch gestures).

Issue Number: N/A

### What is the new behavior?

I changed the old events to the new EventController style. Just to see how it works. 

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

I updated https://github.com/gaphor/gaphas/issues/72 with some findings and ideas.

NB. _EventControllers_ were added in GTK+ 3.14. `EventControllerKey` was only added in GTK+ 3.24.
If this PR is accepted, the minimal GTK+ version is **3.24**. It's available in Ubuntu 20.04, not in _latest_ (18.04). Therefore I upgraded the build image.

NB2. This PR also fixes focus handling of the view.
