### PR TITLE
Shorten timeout during build stages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v2
@@ -24,6 +25,7 @@ jobs:
   linux:
     needs: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v2
@@ -81,6 +83,7 @@ jobs:
   windows:
     needs: lint
     runs-on: windows-latest
+    timeout-minutes: 30
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     env:
       MSYSTEM: MINGW64
@@ -161,6 +164,7 @@ jobs:
   macos:
     needs: lint
     runs-on: macos-latest
+    timeout-minutes: 30
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     env:
       LDFLAGS: -L/usr/local/opt/python@3.8/lib


### PR DESCRIPTION
The default timeout of a build stage 360 minutes, and I caught one of builds trying to generate a macOS package for 4 hours. This PR limits the lint stage to 10 minutes, and the other stages to 30 minutes.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
