### PR TITLE
Ownership for interactions

### DIFF
--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -35,6 +35,7 @@ from gaphor.diagram.support import represents
 
 
 @represents(UML.ExecutionSpecification)
+@represents(UML.BehaviorExecutionSpecification)
 class ExecutionSpecificationItem(Presentation[UML.ExecutionSpecification], Item):
     """Representation of interaction execution specification."""
 

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -57,8 +57,12 @@ def order_lifeline_covered_by(lifeline):
 
 def owner_for_message(line, lifeline):
     maybe_interaction = lifeline.canvas.get_parent(lifeline)
-    if not line.subject.interaction and isinstance(maybe_interaction, InteractionItem):
+    if line.subject.interaction:
+        return
+    elif isinstance(maybe_interaction, InteractionItem):
         Group(maybe_interaction, line).group()
+    elif lifeline.subject and lifeline.subject.interaction:
+        line.subject.interaction = lifeline.subject.interaction
 
 
 def connect_lifelines(line, send, received):

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -5,7 +5,9 @@ from typing import Optional
 from gaphor import UML
 from gaphor.core.modeling import Element, Presentation
 from gaphor.diagram.connectors import BaseConnector, Connector
+from gaphor.diagram.grouping import Group
 from gaphor.UML.interactions.executionspecification import ExecutionSpecificationItem
+from gaphor.UML.interactions.interaction import InteractionItem
 from gaphor.UML.interactions.lifeline import LifelineItem
 from gaphor.UML.interactions.message import MessageItem
 
@@ -53,6 +55,12 @@ def order_lifeline_covered_by(lifeline):
     lifeline.subject.coveredBy.order(keys.get)
 
 
+def owner_for_message(line, lifeline):
+    maybe_interaction = lifeline.canvas.get_parent(lifeline)
+    if not line.subject.interaction and isinstance(maybe_interaction, InteractionItem):
+        Group(maybe_interaction, line).group()
+
+
 def connect_lifelines(line, send, received):
     """Always create a new Message with two EventOccurrence instances."""
 
@@ -70,6 +78,7 @@ def connect_lifelines(line, send, received):
             event.sendMessage = message
             event.covered = send.subject
             order_lifeline_covered_by(send)
+        owner_for_message(line, send)
 
     if received:
         message = get_subject()
@@ -78,6 +87,7 @@ def connect_lifelines(line, send, received):
             event.receiveMessage = message
             event.covered = received.subject
             order_lifeline_covered_by(received)
+        owner_for_message(line, received)
 
 
 def disconnect_lifelines(line, send, received):

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -226,7 +226,7 @@ class LifelineExecutionSpecificationConnect(BaseConnector):
 
     def connect(self, handle, port):
         lifeline = self.element.subject
-        exec_spec: UML.ExecutionSpecification = self.line.subject
+        exec_spec = self.line.subject
         model = self.element.model
         if not exec_spec:
             exec_spec = model.create(UML.BehaviorExecutionSpecification)
@@ -243,6 +243,9 @@ class LifelineExecutionSpecificationConnect(BaseConnector):
             )
             finish_occurence.covered = lifeline
             finish_occurence.execution = exec_spec
+
+        if lifeline.interaction:
+            exec_spec.enclosingInteraction = lifeline.interaction
 
         canvas = self.canvas
         if canvas.get_parent(self.line) is not self.element:

--- a/gaphor/UML/interactions/interactionsgrouping.py
+++ b/gaphor/UML/interactions/interactionsgrouping.py
@@ -14,7 +14,10 @@ class InteractionLifelineGroup(AbstractGroup):
         self.parent.canvas.reparent(self.item, self.parent)
 
     def ungroup(self):
-        del self.parent.subject.lifeline[self.item.subject]
+        """Lifelines are not ungrouped on purpose.
+
+        They would be dangling without an owner.
+        """
 
 
 @Group.register(InteractionItem, MessageItem)
@@ -29,4 +32,7 @@ class InteractionMessageGroup(AbstractGroup):
         self.parent.canvas.reparent(self.item, self.parent)
 
     def ungroup(self):
-        del self.parent.subject.message[self.item.subject]
+        """Messages are not ungrouped on purpose.
+
+        They would be dangling without an owner.
+        """

--- a/gaphor/UML/interactions/interactionsgrouping.py
+++ b/gaphor/UML/interactions/interactionsgrouping.py
@@ -1,6 +1,7 @@
 from gaphor.diagram.grouping import AbstractGroup, Group
 from gaphor.UML.interactions.interaction import InteractionItem
 from gaphor.UML.interactions.lifeline import LifelineItem
+from gaphor.UML.interactions.message import MessageItem
 
 
 @Group.register(InteractionItem, LifelineItem)
@@ -14,3 +15,18 @@ class InteractionLifelineGroup(AbstractGroup):
 
     def ungroup(self):
         del self.parent.subject.lifeline[self.item.subject]
+
+
+@Group.register(InteractionItem, MessageItem)
+class InteractionMessageGroup(AbstractGroup):
+    """Add message to interaction."""
+
+    def group(self):
+        if not self.item.subject:
+            return
+        assert self.parent.canvas
+        self.parent.subject.message = self.item.subject
+        self.parent.canvas.reparent(self.item, self.parent)
+
+    def ungroup(self):
+        del self.parent.subject.message[self.item.subject]

--- a/gaphor/UML/interactions/tests/test_message.py
+++ b/gaphor/UML/interactions/tests/test_message.py
@@ -1,6 +1,8 @@
 """Test messages."""
 
 from gaphor import UML
+from gaphor.diagram.grouping import Group
+from gaphor.UML.interactions.interaction import InteractionItem
 from gaphor.UML.interactions.message import MessageItem
 
 
@@ -13,3 +15,26 @@ def test_message_persistence(diagram, element_factory, saver, loader):
     item = new_diagram.canvas.select(MessageItem)[0]
 
     assert item
+
+
+def test_group_message_item_without_subject(diagram, element_factory):
+    interaction = diagram.create(
+        InteractionItem, subject=element_factory.create(UML.Interaction)
+    )
+    message = diagram.create(MessageItem)
+
+    Group(interaction, message).group()
+
+    assert message.subject is None
+
+
+def test_group_message_item_with_subject(diagram, element_factory):
+    interaction = diagram.create(
+        InteractionItem, subject=element_factory.create(UML.Interaction)
+    )
+    message = diagram.create(MessageItem, subject=element_factory.create(UML.Message))
+
+    Group(interaction, message).group()
+
+    assert message.subject
+    assert message.subject.interaction is interaction.subject

--- a/gaphor/UML/interactions/tests/test_messageconnect.py
+++ b/gaphor/UML/interactions/tests/test_messageconnect.py
@@ -1,8 +1,10 @@
 """Message connection adapter tests."""
 
 from gaphor import UML
+from gaphor.diagram.grouping import Group
 from gaphor.diagram.tests.fixtures import allow, connect, disconnect
 from gaphor.UML.interactions.executionspecification import ExecutionSpecificationItem
+from gaphor.UML.interactions.interaction import InteractionItem
 from gaphor.UML.interactions.lifeline import LifelineItem
 from gaphor.UML.interactions.message import MessageItem
 
@@ -126,6 +128,44 @@ def test_lifetime_connection(diagram):
 
     assert msg.subject is not None
     assert msg.subject.messageKind == "complete"
+
+
+def test_message_is_owned_by_interaction_connecting_to_head(diagram, element_factory):
+    """Test messages' lifetimes connection."""
+    interaction = diagram.create(
+        InteractionItem, subject=element_factory.create(UML.Interaction)
+    )
+    msg = diagram.create(MessageItem)
+    ll1 = diagram.create(LifelineItem, subject=element_factory.create(UML.Lifeline))
+    ll2 = diagram.create(LifelineItem, subject=element_factory.create(UML.Lifeline))
+
+    Group(interaction, ll1).group()
+
+    connect(msg, msg.head, ll1)
+    connect(msg, msg.tail, ll2)
+
+    assert msg.subject is not None
+    assert msg.subject.interaction is interaction.subject
+    assert msg.canvas.get_parent(msg) is interaction
+
+
+def test_message_is_owned_by_interaction_connecting_to_tail(diagram, element_factory):
+    """Test messages' lifetimes connection."""
+    interaction = diagram.create(
+        InteractionItem, subject=element_factory.create(UML.Interaction)
+    )
+    msg = diagram.create(MessageItem)
+    ll1 = diagram.create(LifelineItem, subject=element_factory.create(UML.Lifeline))
+    ll2 = diagram.create(LifelineItem, subject=element_factory.create(UML.Lifeline))
+
+    Group(interaction, ll2).group()
+
+    connect(msg, msg.head, ll1)
+    connect(msg, msg.tail, ll2)
+
+    assert msg.subject is not None
+    assert msg.subject.interaction is interaction.subject
+    assert msg.canvas.get_parent(msg) is interaction
 
 
 def test_disconnection(diagram):

--- a/gaphor/UML/tests/test_interactions.py
+++ b/gaphor/UML/tests/test_interactions.py
@@ -1,0 +1,47 @@
+import pytest
+
+from gaphor import UML
+from gaphor.ui.diagrampage import tooliter
+from gaphor.UML.interactions.interaction import InteractionItem
+from gaphor.UML.toolbox import uml_toolbox_actions
+
+
+@pytest.fixture
+def interaction(diagram, element_factory):
+    return diagram.create(
+        InteractionItem, subject=element_factory.create(UML.Interaction)
+    )
+
+
+@pytest.fixture
+def lifeline_factory():
+    return next(
+        t for t in tooliter(uml_toolbox_actions) if t.id == "toolbox-lifeline"
+    ).item_factory
+
+
+def test_create_lifeline_on_diagram_should_create_an_interaction(
+    diagram, lifeline_factory
+):
+    lifeline = lifeline_factory(diagram)
+
+    assert lifeline.subject.interaction
+
+
+def test_create_lifeline_on_diagram_in_package_should_create_an_interaction(
+    diagram, element_factory, lifeline_factory
+):
+    package = element_factory.create(UML.Package)
+    diagram.package = package
+    lifeline = lifeline_factory(diagram)
+
+    assert lifeline.subject.interaction
+    assert lifeline.subject.interaction.package is package
+
+
+def test_create_lifeline_over_interaction_uses_that_interaction(
+    diagram, interaction, lifeline_factory
+):
+    lifeline = lifeline_factory(diagram, parent=interaction)
+
+    assert lifeline.subject.interaction is interaction.subject

--- a/gaphor/UML/toolbox.py
+++ b/gaphor/UML/toolbox.py
@@ -399,6 +399,18 @@ uml_toolbox_actions: ToolboxDefinition = (
         gettext("Interactions"),
         (
             ToolDef(
+                "toolbox-interaction",
+                gettext("Interaction"),
+                "gaphor-interaction-symbolic",
+                "<Shift>N",
+                item_factory=PlacementTool.new_item_factory(
+                    diagramitems.InteractionItem,
+                    UML.Interaction,
+                    config_func=namespace_config,
+                ),
+                handle_index=SE,
+            ),
+            ToolDef(
                 "toolbox-lifeline",
                 gettext("Lifeline"),
                 "gaphor-lifeline-symbolic",
@@ -411,13 +423,6 @@ uml_toolbox_actions: ToolboxDefinition = (
                 handle_index=SE,
             ),
             ToolDef(
-                "toolbox-message",
-                gettext("Message"),
-                "gaphor-message-symbolic",
-                "M",
-                item_factory=PlacementTool.new_item_factory(diagramitems.MessageItem),
-            ),
-            ToolDef(
                 "toolbox-execution-specification",
                 gettext("Execution Specification"),
                 "gaphor-execution-specification-symbolic",
@@ -428,16 +433,11 @@ uml_toolbox_actions: ToolboxDefinition = (
                 handle_index=0,
             ),
             ToolDef(
-                "toolbox-interaction",
-                gettext("Interaction"),
-                "gaphor-interaction-symbolic",
-                "<Shift>N",
-                item_factory=PlacementTool.new_item_factory(
-                    diagramitems.InteractionItem,
-                    UML.Interaction,
-                    config_func=namespace_config,
-                ),
-                handle_index=SE,
+                "toolbox-message",
+                gettext("Message"),
+                "gaphor-message-symbolic",
+                "M",
+                item_factory=PlacementTool.new_item_factory(diagramitems.MessageItem),
             ),
         ),
     ),

--- a/gaphor/UML/toolbox.py
+++ b/gaphor/UML/toolbox.py
@@ -23,6 +23,29 @@ def namespace_config(new_item):
     subject.name = f"New{type(subject).__name__}"
 
 
+def interaction_config(new_item):
+    subject = new_item.subject
+    subject.name = f"New{type(subject).__name__}"
+    if subject.interaction:
+        return
+
+    diagram = new_item.diagram
+    package = diagram.namespace
+
+    interactions = (
+        [i for i in package.ownedClassifier if isinstance(i, UML.Interaction)]
+        if package
+        else []
+    )
+    if interactions:
+        subject.interaction = interactions[0]
+    else:
+        interaction = subject.model.create(UML.Interaction)
+        interaction.name = "Interaction"
+        interaction.package = package
+        subject.interaction = interaction
+
+
 def initial_pseudostate_config(new_item):
     new_item.subject.kind = "initial"
 
@@ -383,7 +406,7 @@ uml_toolbox_actions: ToolboxDefinition = (
                 item_factory=PlacementTool.new_item_factory(
                     diagramitems.LifelineItem,
                     UML.Lifeline,
-                    config_func=namespace_config,
+                    config_func=interaction_config,
                 ),
                 handle_index=SE,
             ),

--- a/gaphor/diagram/diagramtools.py
+++ b/gaphor/diagram/diagramtools.py
@@ -180,14 +180,15 @@ class PlacementTool(_PlacementTool):
                 subject = None
 
             item = diagram.create(item_class, subject=subject)
-            if config_func:
-                config_func(item)
 
             adapter = Group(parent, item)
             if parent and adapter.can_contain():
                 canvas = diagram.canvas
                 canvas.reparent(item, parent=parent)
                 adapter.group()
+
+            if config_func:
+                config_func(item)
 
             return item
 

--- a/gaphor/ui/icons/Makefile
+++ b/gaphor/ui/icons/Makefile
@@ -39,6 +39,7 @@ ICONS=diagram \
 	send-signal-action \
 	accept-event-action \
 	lifeline \
+	behavior-execution-specification \
 	execution-specification \
 	message \
 	interaction \

--- a/gaphor/ui/icons/hicolor/scalable/actions/gaphor-behavior-execution-specification-symbolic.svg
+++ b/gaphor/ui/icons/hicolor/scalable/actions/gaphor-behavior-execution-specification-symbolic.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="7.9999976"
+   height="15.978738"
+   viewBox="0 0 2.116666 4.2277078"
+   version="1.1"
+   id="svg4268">
+  <defs
+     id="defs4262" />
+  <metadata
+     id="metadata4265">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.370417;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+     d="M 1.0585938 3.0644531 A 0.1852085 0.1852085 0 0 0 0.87304688 3.2480469 L 0.87304688 4.0429688 A 0.1852085 0.1852085 0 0 0 1.0585938 4.2285156 A 0.1852085 0.1852085 0 0 0 1.2441406 4.0429688 L 1.2441406 3.2480469 A 0.1852085 0.1852085 0 0 0 1.0585938 3.0644531 z "
+     id="path24" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.370417;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+     d="M 1.0585938 0 A 0.1852085 0.1852085 0 0 0 0.87304688 0.18554688 L 0.87304688 0.97851562 A 0.1852085 0.1852085 0 0 0 1.0585938 1.1640625 A 0.1852085 0.1852085 0 0 0 1.2441406 0.97851562 L 1.2441406 0.18554688 A 0.1852085 0.1852085 0 0 0 1.0585938 0 z "
+     id="path20" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+     d="M 0.26367188 0.79101562 A 0.26460996 0.26460996 0 0 0 0 1.0566406 L 0 3.1738281 A 0.26460996 0.26460996 0 0 0 0.26367188 3.4375 L 1.8515625 3.4375 A 0.26460996 0.26460996 0 0 0 2.1171875 3.1738281 L 2.1171875 1.0566406 A 0.26460996 0.26460996 0 0 0 1.8515625 0.79101562 L 0.26367188 0.79101562 z M 0.52929688 1.3203125 L 1.5878906 1.3203125 L 1.5878906 2.9082031 L 0.52929688 2.9082031 L 0.52929688 1.3203125 z "
+     id="path16" />
+</svg>

--- a/gaphor/ui/icons/stensil.svg
+++ b/gaphor/ui/icons/stensil.svg
@@ -31,11 +31,11 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.9483843"
-     inkscape:cx="151.10697"
-     inkscape:cy="59.287845"
+     inkscape:zoom="5.894754"
+     inkscape:cx="207.99017"
+     inkscape:cy="5.6119414"
      inkscape:document-units="px"
-     inkscape:current-layer="new-diagram"
+     inkscape:current-layer="behavior-execution-specification"
      showgrid="true"
      units="px"
      inkscape:window-width="1920"
@@ -1826,6 +1826,30 @@
        height="2.116667"
        x="60.854168"
        y="-8.8583422" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="behavior-execution-specification"
+     inkscape:label="behavior-execution-specification"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.370417;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 61.643287,-1.3229167 v 0.79375013"
+       id="path1186"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.370417;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 61.643287,-4.3864573 v 0.7937496"
+       id="path1188"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect1190"
+       width="1.5874989"
+       height="2.116667"
+       x="60.849541"
+       y="-3.5153227" />
   </g>
   <g
      inkscape:groupmode="layer"


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Lifelines and Messages are not _owned_, hence they end up in the root of the tree view

Issue Number: #386 

### What is the new behavior?

Lifelines, Messages, and Execution Specifications are shown in an Interaction. If no Interaction exists in the package the diagram resides in, a new one will be created.

When a lifeline/message/execspec is dragged out of an interaction, it remains part of that interaction hierarchically. This avoid dangling elements. It is placed in a new interaction if it's dragged in to one.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

### Other information

No migration has been written for older models.