### PR TITLE
Fix is directory error with importlib resources in Python 3.9

### DIFF
--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -4,6 +4,7 @@ and diagram windows."""
 import importlib.resources
 import logging
 import sys
+from pathlib import Path
 from typing import Optional
 
 import gi
@@ -26,8 +27,12 @@ APPLICATION_ID = "org.gaphor.Gaphor"
 
 
 icon_theme = Gtk.IconTheme.get_default()
-with importlib.resources.path("gaphor.ui", "icons") as path:
+if sys.version_info >= (3, 9):
+    path: Path = importlib.resources.files("gaphor") / "ui" / "icons"
     icon_theme.append_search_path(str(path))
+else:
+    with importlib.resources.path("gaphor.ui", "icons") as path:
+        icon_theme.append_search_path(str(path))
 
 LOG_FORMAT = "%(name)s %(levelname)s %(message)s"
 


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

Python 3.9 is right around the corner, with release candidates out now. One of the changes is that importlib.resources now has a `files` method that returns a path and you can feed it directories. Some of the methods that did exist like `importlib.resources.path` were only supposed to be used for resources, which don't include directories. The new method is nice, because it doesn't force using a context manager to get a path to a file or directory.

This PR fixes a IsADirectoryError with Python 3.9 since it no longer allows calling directories with `importlib.resources.path`.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
