### PR TITLE
Update diagram when moved

### DIFF
--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from gaphor import UML
@@ -176,3 +178,14 @@ def test_stereotype_deletion(element_factory):
     stereotype.unlink()
 
     assert [] == list(klass.appliedStereotype)
+
+
+def test_diagram_move(element_factory):
+    diagram = element_factory.create(UML.Diagram)
+    diagram.create(CommentItem, subject=element_factory.create(UML.Comment))
+    diagram.canvas.update = Mock()
+
+    package = element_factory.create(UML.Package)
+    diagram.package = package
+
+    diagram.canvas.update.assert_called()


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

- Bugfix

### What is the current behavior?

When a diagram is moved, "from" lines remain, although they may be invalid.

Issue Number: #373

### What is the new behavior?

Diagram is updated when moved. Relative references are updated, as are "from" messages in classes and packages.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
