### PR TITLE
Use a global copy buffer

### DIFF
--- a/gaphor/services/tests/test_copyservice.py
+++ b/gaphor/services/tests/test_copyservice.py
@@ -10,6 +10,7 @@ class CopyServiceTestCase(TestCase):
 
     services = TestCase.services + [
         "main_window",
+        "diagrams",
         "properties",
         "undo_manager",
         "export_menu",
@@ -21,7 +22,7 @@ class CopyServiceTestCase(TestCase):
         self.service = CopyService(
             self.get_service("event_manager"),
             self.get_service("element_factory"),
-            self.get_service("main_window"),
+            self.get_service("diagrams"),
         )
 
     def test_copy(self):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

When you copy some items in a diagram, you can only paste them in the same model.

Issue Number: #463 

### What is the new behavior?

You can copy, and then paste the items in a different diagram. The diagram items are backed by their model elements.


### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

The current implementation (a global variable) is not really nice. But it proves the application can handle this copy/paste behavior. The actual behavior should work via an `gaphor.appservice`. However, there's no way to inject an app service in a session. And I'm not sure if we want to.
