### PR TITLE
Fix MSYS2 timeout due to mirror down

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
   windows:
     needs: lint
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     env:
       MSYSTEM: MINGW64

--- a/win-installer/msys2-install.sh
+++ b/win-installer/msys2-install.sh
@@ -25,4 +25,4 @@ pacman --noconfirm -S --needed \
 # shellcheck source=venv
 source "$DIR"/../venv
 pip install pyinstaller==3.6.0
-make translations
+mingw32-make translations

--- a/win-installer/msys2-install.sh
+++ b/win-installer/msys2-install.sh
@@ -5,11 +5,13 @@ set -euo pipefail
 export MSYS2_FC_CACHE_SKIP=1
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+cp /etc/pacman.d/mirrorlist.mingw64 /etc/pacman.d/mirrorlist.backup
+rankmirrors -r mingw64 -n 3 -v /etc/pacman.d/mirrorlist.backup > /etc/pacman.d/mirrorlist.mingw64
+
 pacman --noconfirm -Suy
 
 pacman --noconfirm -S --needed \
-    git \
-    make \
+    mingw-w64-"$MSYS2_ARCH"-make \
     mingw-w64-"$MSYS2_ARCH"-gcc \
     mingw-w64-"$MSYS2_ARCH"-gtk3 \
     mingw-w64-"$MSYS2_ARCH"-pkg-config \


### PR DESCRIPTION
This PR uses the rankmirrors util to look for the fastest MSYS2 repo to prevent issues with long timeouts when the main msys2 repo is down.

We also should also avoid mixing msys2 (POSIX) with mingw64 packages like git and make. For example virtualenv doesn't work when using msys2 git, we should instead be linking to git-for-windows instead which is based off of mingw64. I don't think the CI needs git installed using pacman, but I changed to the mingw64 version of make.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
