### PR TITLE
Fix copy paste

### DIFF
--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -35,16 +35,13 @@ class CopyService(Service, ActionProvider):
 
         self.clipboard = Gtk.Clipboard.get_default(Gdk.Display.get_default())
         self.clipboard.connect("owner_change", self.on_clipboard_owner_change)
-        self.clipboard_semaphore = 0
 
     def shutdown(self):
         pass
 
     def on_clipboard_owner_change(self, clipboard, event):
         view = self.diagrams.get_current_view()
-        if self.clipboard_semaphore > 0:
-            self.clipboard_semaphore -= 1
-        elif view and not view.is_focus():
+        if view and not view.is_focus():
             global copy_buffer
             copy_buffer = set()
 
@@ -79,7 +76,6 @@ class CopyService(Service, ActionProvider):
     def copy_action(self):
         view = self.diagrams.get_current_view()
         if view.is_focus():
-            self.clipboard_semaphore += 1
             self.clipboard.set_text("", -1)
             items = view.selected_items
             self.copy(items)
@@ -88,7 +84,6 @@ class CopyService(Service, ActionProvider):
     def cut_action(self):
         view = self.diagrams.get_current_view()
         if view.is_focus():
-            self.clipboard_semaphore += 1
             self.clipboard.set_text("", -1)
             items = view.selected_items
             self.copy(items)

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -41,9 +41,10 @@ class CopyService(Service, ActionProvider):
         pass
 
     def on_clipboard_owner_change(self, clipboard, event):
+        view = self.diagrams.get_current_view()
         if self.clipboard_semaphore > 0:
             self.clipboard_semaphore -= 1
-        else:
+        elif view and not view.is_focus():
             global copy_buffer
             copy_buffer = set()
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Copy/paste breaks on Ubuntu 20.10/Wayland.

### What is the new behavior?

Copy buffer is only cleared if a view has no focus.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

It looks like I get multiple clipboard `OwnerChange` events in Wayland. This broke the logic with semaphores.

Oddly enough it worked fine in VSCode (installed as Snap).