### PR TITLE
Use associations for diagram and parent/child relationships

### DIFF
--- a/gaphor/SysML/blocks/connectors.py
+++ b/gaphor/SysML/blocks/connectors.py
@@ -19,7 +19,7 @@ class BlockProperyProxyPortConnector:
         block: Union[BlockItem, PropertyItem],
         proxy_port: ProxyPortItem,
     ) -> None:
-        assert block.canvas is proxy_port.canvas
+        assert block.diagram is proxy_port.diagram
         self.block = block
         self.proxy_port = proxy_port
 
@@ -70,10 +70,7 @@ class PropertyConnectorConnector(UnaryRelationshipConnect):
         return super().allow(handle, port)
 
     def connect_subject(self, handle):
-        element = self.element
         line = self.line
-
-        assert element.canvas
 
         c1 = self.get_connected(line.head)
         c2 = self.get_connected(line.tail)

--- a/gaphor/SysML/blocks/connectors.py
+++ b/gaphor/SysML/blocks/connectors.py
@@ -38,8 +38,8 @@ class BlockProperyProxyPortConnector:
             proxy_port.subject.encapsulatedClassifier = self.block.subject
 
         # This raises the item in the item hierarchy
-        assert proxy_port.canvas
-        proxy_port.canvas.reparent(proxy_port, self.block)
+        assert proxy_port.diagram
+        proxy_port.diagram.reparent(proxy_port, self.block)
 
         return True
 
@@ -48,7 +48,7 @@ class BlockProperyProxyPortConnector:
         if proxy_port.subject and proxy_port.canvas:
             subject = proxy_port.subject
             del proxy_port.subject
-            proxy_port.canvas.reparent(proxy_port, None)
+            proxy_port.diagram.reparent(proxy_port, None)
             subject.unlink()
 
 

--- a/gaphor/SysML/blocks/connectors.py
+++ b/gaphor/SysML/blocks/connectors.py
@@ -45,7 +45,7 @@ class BlockProperyProxyPortConnector:
 
     def disconnect(self, handle: Handle) -> None:
         proxy_port = self.proxy_port
-        if proxy_port.subject and proxy_port.canvas:
+        if proxy_port.subject and proxy_port.diagram:
             subject = proxy_port.subject
             del proxy_port.subject
             proxy_port.diagram.reparent(proxy_port, None)

--- a/gaphor/SysML/blocks/connectors.py
+++ b/gaphor/SysML/blocks/connectors.py
@@ -39,7 +39,7 @@ class BlockProperyProxyPortConnector:
 
         # This raises the item in the item hierarchy
         assert proxy_port.diagram
-        proxy_port.diagram.reparent(proxy_port, self.block)
+        proxy_port.parent = self.block
 
         return True
 
@@ -48,7 +48,7 @@ class BlockProperyProxyPortConnector:
         if proxy_port.subject and proxy_port.diagram:
             subject = proxy_port.subject
             del proxy_port.subject
-            proxy_port.diagram.reparent(proxy_port, None)
+            proxy_port.parent = None  # type: ignore[assignment]
             subject.unlink()
 
 

--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -32,7 +32,7 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
 
     def alignment(self) -> VerticalAlign:
-        if self.canvas and self.canvas.get_children(self):
+        if self.diagram and self.diagram.get_children(self):
             return VerticalAlign.TOP
         else:
             return VerticalAlign.MIDDLE

--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -32,7 +32,7 @@ class PropertyItem(ElementPresentation[UML.Property], Named):
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
 
     def alignment(self) -> VerticalAlign:
-        if self.diagram and self.diagram.get_children(self):
+        if self.diagram and self.children:
             return VerticalAlign.TOP
         else:
             return VerticalAlign.MIDDLE

--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -95,7 +95,7 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], Named):
     def setup_canvas(self):
         super().setup_canvas()
         self.subscribe_all()
-        # Invoke here, since we do not receive events, unless we're attached to a canvas
+        # Invoke here, since we do not receive events, unless we're attached to a diagram
         self.update_shapes()
 
     def teardown_canvas(self):

--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -93,13 +93,8 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], Named):
         return distance_rectangle_point(self.dimensions(), (x, y))
 
     def setup_canvas(self):
-        super().setup_canvas()
         # Invoke here, since we do not receive events, unless we're attached to a diagram
         self.update_shapes()
-
-    def teardown_canvas(self):
-        self.unsubscribe_all()
-        super().teardown_canvas()
 
     def save(self, save_func):
         save_func("matrix", tuple(self.matrix))

--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -94,7 +94,6 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], Named):
 
     def setup_canvas(self):
         super().setup_canvas()
-        self.subscribe_all()
         # Invoke here, since we do not receive events, unless we're attached to a diagram
         self.update_shapes()
 

--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -57,6 +57,7 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], Named):
 
         self._last_connected_side = None
         self.watch("subject[NamedElement].name")
+        self.update_shapes()
 
     @property
     def matrix(self) -> Matrix:
@@ -91,10 +92,6 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], Named):
 
     def point(self, x, y):
         return distance_rectangle_point(self.dimensions(), (x, y))
-
-    def setup_canvas(self):
-        # Invoke here, since we do not receive events, unless we're attached to a diagram
-        self.update_shapes()
 
     def save(self, save_func):
         save_func("matrix", tuple(self.matrix))

--- a/gaphor/SysML/blocks/tests/test_connectors.py
+++ b/gaphor/SysML/blocks/tests/test_connectors.py
@@ -75,7 +75,7 @@ def test_disconnect_proxy_port_to_block(diagram, block_item, proxy_port_item):
     connector.disconnect(proxy_port_item.handles()[0])
 
     assert proxy_port_item.subject is None
-    assert proxy_port_item.canvas
+    assert proxy_port_item.diagram
 
 
 def test_allow_connector_to_proxy_port(

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -50,7 +50,7 @@ class RequirementPropertyPage(PropertyPageBase):
                 buffer.set_text(event.new_value)
                 buffer.handler_unblock(changed_id)
 
-        self.watcher.watch("text", text_handler).subscribe_all()
+        self.watcher.watch("text", text_handler)
 
         builder.connect_signals(
             {

--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -143,7 +143,7 @@ class FlowPropertyPageAbstract(PropertyPageBase):
 
         def handler(event):
             v = event.new_value
-            guard.set_text(v if v else "")
+            guard.set_text(v or "")
 
         self.watcher.watch("guard", handler)
 

--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -145,7 +145,7 @@ class FlowPropertyPageAbstract(PropertyPageBase):
             v = event.new_value
             guard.set_text(v if v else "")
 
-        self.watcher.watch("guard", handler).subscribe_all()
+        self.watcher.watch("guard", handler)
 
         builder.connect_signals(
             {

--- a/gaphor/UML/actions/partition.py
+++ b/gaphor/UML/actions/partition.py
@@ -53,8 +53,6 @@ class PartitionItem(ElementPresentation):
         The partitions are open on the bottom. We divide the total size
         by the total number of partitions and space them evenly.
         """
-        assert self.canvas
-
         cr = context.cairo
         cr.set_line_width(context.style["line-width"])
         self.draw_outline(bounding_box, cr)

--- a/gaphor/UML/actions/tests/test_activitynodes.py
+++ b/gaphor/UML/actions/tests/test_activitynodes.py
@@ -28,7 +28,7 @@ class ActivityNodesTestCase(TestCase):
         data = self.save()
         self.load(data)
 
-        item = next(self.diagram.canvas.select(DecisionNodeItem))
+        item = next(self.diagram.select(DecisionNodeItem))
         assert item.combined is None, item.combined
 
         merge_node = factory.create(UML.MergeNode)
@@ -36,7 +36,7 @@ class ActivityNodesTestCase(TestCase):
         data = self.save()
         self.load(data)
 
-        item = next(self.diagram.canvas.select(DecisionNodeItem))
+        item = next(self.diagram.select(DecisionNodeItem))
         assert item.combined is not None, item.combined
         assert isinstance(item.combined, UML.MergeNode)
 
@@ -48,7 +48,7 @@ class ActivityNodesTestCase(TestCase):
         data = self.save()
         self.load(data)
 
-        item = next(self.diagram.canvas.select(ForkNodeItem))
+        item = next(self.diagram.select(ForkNodeItem))
         assert item.combined is None, item.combined
 
         merge_node = factory.create(UML.JoinNode)
@@ -56,6 +56,6 @@ class ActivityNodesTestCase(TestCase):
         data = self.save()
         self.load(data)
 
-        item = next(self.diagram.canvas.select(ForkNodeItem))
+        item = next(self.diagram.select(ForkNodeItem))
         assert item.combined is not None, item.combined
         assert isinstance(item.combined, UML.JoinNode)

--- a/gaphor/UML/actions/tests/test_flow.py
+++ b/gaphor/UML/actions/tests/test_flow.py
@@ -46,5 +46,5 @@ class FlowTestCase(TestCase):
             selected=True,
             dropzone=False,
         )
-        self.diagram.canvas.update_now((flow,))
+        self.diagram.update_now((flow,))
         flow.draw(context)

--- a/gaphor/UML/actions/tests/test_grouping.py
+++ b/gaphor/UML/actions/tests/test_grouping.py
@@ -61,11 +61,11 @@ class PartitionGroupTestCase(TestCase):
 
         partition = p.subject
         assert len(partition.node) == 2, partition.node
-        assert len(p.diagram.get_children(p)) == 2, p.diagram.get_children(p)
+        assert len(p.children) == 2, p.diagram.get_children(p)
 
         self.ungroup(p, a1)
         self.ungroup(p, a2)
 
         assert 0 == len(partition.node)
-        assert len(p.diagram.get_children(p)) == 0
+        assert len(p.children) == 0
         assert len(partition.node) == 0

--- a/gaphor/UML/actions/tests/test_grouping.py
+++ b/gaphor/UML/actions/tests/test_grouping.py
@@ -61,7 +61,7 @@ class PartitionGroupTestCase(TestCase):
 
         partition = p.subject
         assert len(partition.node) == 2, partition.node
-        assert len(p.children) == 2, p.diagram.get_children(p)
+        assert len(p.children) == 2, p.children
 
         self.ungroup(p, a1)
         self.ungroup(p, a2)

--- a/gaphor/UML/actions/tests/test_grouping.py
+++ b/gaphor/UML/actions/tests/test_grouping.py
@@ -61,11 +61,11 @@ class PartitionGroupTestCase(TestCase):
 
         partition = p.subject
         assert len(partition.node) == 2, partition.node
-        assert len(p.canvas.get_children(p)) == 2, p.canvas.get_children(p)
+        assert len(p.diagram.get_children(p)) == 2, p.diagram.get_children(p)
 
         self.ungroup(p, a1)
         self.ungroup(p, a2)
 
         assert 0 == len(partition.node)
-        assert len(p.canvas.get_children(p)) == 0
+        assert len(p.diagram.get_children(p)) == 0
         assert len(partition.node) == 0

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -487,7 +487,7 @@ class AssociationEnd(Presentation):
         )
 
     def point(self, x, y):
-        """Given a point (x, y) return the distance to the canvas item."""
+        """Given a point (x, y) return the distance to the diagram item."""
         drp = distance_rectangle_point
         pos = (x, y)
         d1 = drp(self._name_bounds, pos)

--- a/gaphor/UML/classes/classconnect.py
+++ b/gaphor/UML/classes/classconnect.py
@@ -120,7 +120,7 @@ class AssociationConnect(UnaryRelationshipConnect):
         element = self.element
         line = self.line
 
-        assert element.canvas
+        assert element.diagram
 
         c1 = self.get_connected(line.head)
         c2 = self.get_connected(line.tail)

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -131,7 +131,7 @@ class NamedElementPropertyPage(PropertyPageBase):
             if event.element is subject and event.new_value is not None:
                 entry.set_text(event.new_value)
 
-        self.watcher.watch("name", handler).subscribe_all()
+        self.watcher.watch("name", handler)
 
         builder.connect_signals(
             {
@@ -253,7 +253,7 @@ class AttributesPage(PropertyPageBase):
             "ownedAttribute.defaultValue", handler
         ).watch(
             "ownedAttribute.typeValue", handler
-        ).subscribe_all()
+        )
 
         builder.connect_signals(
             {
@@ -325,7 +325,7 @@ class OperationsPage(PropertyPageBase):
             "ownedOperation.formalParameter.typeValue", handler
         ).watch(
             "ownedOperation.formalParameter.defaultValue", handler
-        ).subscribe_all()
+        )
 
         builder.connect_signals(
             {
@@ -375,7 +375,7 @@ class DependencyPropertyPage(PropertyPageBase):
 
         self.update()
 
-        self.watcher.watch("subject", self._on_subject_change).subscribe_all()
+        self.watcher.watch("subject", self._on_subject_change)
 
         self.builder.connect_signals(
             {
@@ -518,7 +518,7 @@ class AssociationPropertyPage(PropertyPageBase):
         ).watch(
             "memberEnd[Property].type",
             restore_nav_handler,
-        ).subscribe_all()
+        )
 
         builder.connect_signals(
             {

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -186,7 +186,7 @@ class InterfacePropertyPage(PropertyPageBase):
         item = self.item
 
         connected_items = [
-            c.item for c in item.canvas.connections.get_connections(connected=item)
+            c.item for c in item.diagram.connections.get_connections(connected=item)
         ]
         disallowed = (ConnectorItem,)
         can_fold = not any(map(lambda i: isinstance(i, disallowed), connected_items))

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -158,8 +158,8 @@ class InterfaceItem(ElementPresentation, Classified):
     RADIUS_REQUIRED = 14
 
     def __init__(self, connections, id=None, model=None):
-        self._folded = Folded.NONE
         super().__init__(connections, id, model)
+        self._folded = Folded.NONE
         self.side = Side.N
 
         handles = self.handles()

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -158,8 +158,8 @@ class InterfaceItem(ElementPresentation, Classified):
     RADIUS_REQUIRED = 14
 
     def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
         self._folded = Folded.NONE
+        super().__init__(connections, id, model)
         self.side = Side.N
 
         handles = self.handles()

--- a/gaphor/UML/classes/tests/test_association.py
+++ b/gaphor/UML/classes/tests/test_association.py
@@ -66,7 +66,7 @@ class AssociationItemTestCase(TestCase):
         assert a.subject.memberEnd[0].name is None
 
         a.subject.memberEnd[0].name = "blah"
-        self.diagram.canvas.update_now((a,))
+        self.diagram.update_now((a,))
 
         assert a.head_end._name == "+ blah", a.head_end.get_name()
 

--- a/gaphor/UML/classes/tests/test_class.py
+++ b/gaphor/UML/classes/tests/test_class.py
@@ -26,7 +26,7 @@ class ClassTestCase(TestCase):
         assert 0 == len(compartments(klass)[0].children)
         assert 0 == len(compartments(klass)[1].children)
 
-        diagram.canvas.update_now((klass,))
+        diagram.update_now((klass,))
 
         assert 54 == float(klass.min_height)  # min_height
         assert 100 == float(klass.min_width)
@@ -35,7 +35,7 @@ class ClassTestCase(TestCase):
         attr.name = 4 * "x"  # about 44 pixels
         klass.subject.ownedAttribute = attr
 
-        diagram.canvas.update_now((klass,))
+        diagram.update_now((klass,))
 
         assert 1 == len(compartments(klass)[0])
         assert compartments(klass)[0].size(context()) > (44.0, 20.0)
@@ -48,7 +48,7 @@ class ClassTestCase(TestCase):
         oper.name = 6 * "x"  # about 66 pixels
         klass.subject.ownedOperation = oper
 
-        diagram.canvas.update_now((klass,))
+        diagram.update_now((klass,))
         assert 2 == len(compartments(klass)[1])
         assert compartments(klass)[1].size(context()) > (63.0, 34.0)
 
@@ -57,7 +57,7 @@ class ClassTestCase(TestCase):
         element_factory = self.element_factory
         diagram = element_factory.create(UML.Diagram)
         klass = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
-        diagram.canvas.update_now((klass,))
+        diagram.update_now((klass,))
 
         attr = element_factory.create(UML.Property)
         attr.name = "blah1"
@@ -83,7 +83,7 @@ class ClassTestCase(TestCase):
         klass = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
         klass.subject.name = "Class1"
 
-        diagram.canvas.update_now((klass,))
+        diagram.update_now((klass,))
 
         attr = element_factory.create(UML.Property)
         attr.name = "blah"
@@ -97,7 +97,7 @@ class ClassTestCase(TestCase):
 
         attr.name = "x" * 25
 
-        diagram.canvas.update_now((klass,))
+        diagram.update_now((klass,))
 
         width = klass.width
         assert width >= 170.0

--- a/gaphor/UML/classes/tests/test_classconnect.py
+++ b/gaphor/UML/classes/tests/test_classconnect.py
@@ -138,7 +138,7 @@ def test_multiple_dependencies(create, element_factory):
     dep2 = diagram2.create(DependencyItem)
 
     connect(dep2, dep2.head, actoritem3)
-    cinfo = diagram2.canvas.connections.get_connection(dep2.head)
+    cinfo = diagram2.connections.get_connection(dep2.head)
     assert cinfo is not None
     assert cinfo.connected is actoritem3
     connect(dep2, dep2.tail, actoritem4)
@@ -224,7 +224,7 @@ def test_generalization_reconnection(create, element_factory):
     gen2 = diagram2.create(GeneralizationItem)
 
     connect(gen2, gen2.head, c3)
-    cinfo = diagram2.canvas.connections.get_connection(gen2.head)
+    cinfo = diagram2.connections.get_connection(gen2.head)
     assert cinfo is not None
     assert cinfo.connected is c3
 

--- a/gaphor/UML/classes/tests/test_interface.py
+++ b/gaphor/UML/classes/tests/test_interface.py
@@ -21,7 +21,7 @@ class InterfaceTestCase(TestCase):
         data = self.save()
         self.load(data)
 
-        interfaces = list(self.diagram.canvas.select(InterfaceItem))
+        interfaces = list(self.diagram.select(InterfaceItem))
         assert len(interfaces) == 1
         # ... gives provided folded mode on load;
         # correct folded mode is determined by connections, which will be

--- a/gaphor/UML/classes/tests/test_interfaceconnect.py
+++ b/gaphor/UML/classes/tests/test_interfaceconnect.py
@@ -21,7 +21,7 @@ class ImplementationTestCase(TestCase):
         impl = self.create(ImplementationItem)
 
         self.connect(impl, impl.head, iface, iface.ports()[0])
-        self.diagram.canvas.update_now((iface, impl))
+        self.diagram.update_now((iface, impl))
 
         assert not impl.style["dash-style"]
 
@@ -54,7 +54,7 @@ class DependencyTestCase(TestCase):
         self.connect(dep, dep.head, iface, iface.ports()[0])
         self.connect(dep, dep.tail, clazz, clazz.ports()[0])
         iface.request_update()
-        iface.canvas.update_now((clazz, iface, dep))
+        self.diagram.update_now((clazz, iface, dep))
 
         assert dep.subject
         assert not dep.style["dash-style"]

--- a/gaphor/UML/components/component.py
+++ b/gaphor/UML/components/component.py
@@ -43,7 +43,7 @@ class ComponentItem(ElementPresentation, Classified):
                 "min-width": 100,
                 "min-height": 50,
                 "vertical-align": VerticalAlign.TOP
-                if self.diagram and self.diagram.get_children(self)
+                if self.diagram and self.children
                 else VerticalAlign.MIDDLE,
             },
             draw=draw_border

--- a/gaphor/UML/components/component.py
+++ b/gaphor/UML/components/component.py
@@ -43,7 +43,7 @@ class ComponentItem(ElementPresentation, Classified):
                 "min-width": 100,
                 "min-height": 50,
                 "vertical-align": VerticalAlign.TOP
-                if self.canvas and self.canvas.get_children(self)
+                if self.diagram and self.diagram.get_children(self)
                 else VerticalAlign.MIDDLE,
             },
             draw=draw_border

--- a/gaphor/UML/components/connectorconnect.py
+++ b/gaphor/UML/components/connectorconnect.py
@@ -51,22 +51,22 @@ class ConnectorConnectBase(BaseConnector):
          both
             If true, then filter out one-side connections.
         """
-        canvas = iface.canvas
-        connected = canvas.connections.get_connections(connected=iface)
+        diagram = iface.diagram
+        connected = diagram.connections.get_connections(connected=iface)
         if both:
             connected = [
                 c
                 for c in connected
-                if canvas.connections.get_connection(c.item.opposite(c.handle))
+                if diagram.connections.get_connection(c.item.opposite(c.handle))
             ]
         return connected
 
     @staticmethod
     def get_component(connector):
         """Get component connected by connector."""
-        canvas = connector.canvas
-        c1 = canvas.connections.get_connection(connector.head)
-        c2 = canvas.connections.get_connection(connector.tail)
+        diagram = connector.diagram
+        c1 = diagram.connections.get_connection(connector.head)
+        c2 = diagram.connections.get_connection(connector.tail)
         component = None
         if c1 and isinstance(c1.connected, ComponentItem):
             component = c1.connected

--- a/gaphor/UML/components/node.py
+++ b/gaphor/UML/components/node.py
@@ -70,7 +70,7 @@ class NodeItem(ElementPresentation, Classified):
                 "min-width": 100,
                 "min-height": 50,
                 "vertical-align": VerticalAlign.TOP
-                if self.diagram and self.diagram.get_children(self)
+                if self.diagram and self.children
                 else VerticalAlign.MIDDLE,
             },
             draw=draw_node

--- a/gaphor/UML/components/node.py
+++ b/gaphor/UML/components/node.py
@@ -70,7 +70,7 @@ class NodeItem(ElementPresentation, Classified):
                 "min-width": 100,
                 "min-height": 50,
                 "vertical-align": VerticalAlign.TOP
-                if self.canvas and self.canvas.get_children(self)
+                if self.diagram and self.diagram.get_children(self)
                 else VerticalAlign.MIDDLE,
             },
             draw=draw_node

--- a/gaphor/UML/components/tests/test_connect.py
+++ b/gaphor/UML/components/tests/test_connect.py
@@ -118,7 +118,7 @@ class InterfaceConnectTestCase(TestCase):
         self.connect(line, line.head, iface, rport)
         self.connect(line, line.tail, comp, pport)
         iface.request_update()
-        iface.canvas.update_now((iface, comp, line))
+        self.diagram.update_now((iface, comp, line))
 
         # interface goes into assembly mode
         assert iface.folded == Folded.PROVIDED

--- a/gaphor/UML/components/tests/test_connector.py
+++ b/gaphor/UML/components/tests/test_connector.py
@@ -25,5 +25,5 @@ class ConnectorItemTestCase(TestCase):
 
         self.load(data)
 
-        assert self.diagram.canvas.select(ConnectorItem)
+        assert self.diagram.select(ConnectorItem)
         assert self.kindof(UML.ConnectorEnd)

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -32,7 +32,7 @@ def order_lifeline_covered_by(lifeline):
 
     def y_and_occurence(connected):
         for conn in diagram.connections.get_connections(connected=connected):
-            m = diagram.get_matrix_i2c(conn.item)
+            m = conn.item.matrix_i2c
             if isinstance(conn.item, ExecutionSpecificationItem):
                 yield (
                     m.transform_point(*conn.handle.pos)[1],

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -14,7 +14,7 @@ from gaphor.UML.interactions.message import MessageItem
 
 def get_connected(item, handle) -> Optional[Presentation[Element]]:
     """Get item connected to a handle."""
-    cinfo = item.canvas.connections.get_connection(handle)
+    cinfo = item.diagram.connections.get_connection(handle)
     if cinfo:
         return cinfo.connected  # type: ignore[no-any-return] # noqa: F723
     return None
@@ -28,11 +28,11 @@ def get_lifeline(item, handle):
 
 
 def order_lifeline_covered_by(lifeline):
-    canvas = lifeline.canvas
+    diagram = lifeline.diagram
 
     def y_and_occurence(connected):
-        for conn in canvas.connections.get_connections(connected=connected):
-            m = canvas.get_matrix_i2c(conn.item)
+        for conn in diagram.connections.get_connections(connected=connected):
+            m = diagram.get_matrix_i2c(conn.item)
             if isinstance(conn.item, ExecutionSpecificationItem):
                 yield (
                     m.transform_point(*conn.handle.pos)[1],
@@ -56,7 +56,7 @@ def order_lifeline_covered_by(lifeline):
 
 
 def owner_for_message(line, lifeline):
-    maybe_interaction = lifeline.canvas.get_parent(lifeline)
+    maybe_interaction = lifeline.diagram.get_parent(lifeline)
     if line.subject.interaction:
         return
     elif isinstance(maybe_interaction, InteractionItem):
@@ -187,7 +187,7 @@ class MessageLifelineConnect(BaseConnector):
 
         disconnect_lifelines(line, send, received)
 
-        if len(list(self.canvas.connections.get_connections(connected=lifeline))) == 1:
+        if len(list(self.diagram.connections.get_connections(connected=lifeline))) == 1:
             # after disconnection count of connected items will be
             # zero, so allow connections to lifeline's lifetime
             lifetime.connectable = True
@@ -247,11 +247,11 @@ class LifelineExecutionSpecificationConnect(BaseConnector):
         if lifeline.interaction:
             exec_spec.enclosingInteraction = lifeline.interaction
 
-        canvas = self.canvas
-        if canvas.get_parent(self.line) is not self.element:
-            canvas.reparent(self.line, self.element)
+        diagram = self.diagram
+        if diagram.get_parent(self.line) is not self.element:
+            diagram.reparent(self.line, self.element)
 
-        for cinfo in canvas.connections.get_connections(connected=self.line):
+        for cinfo in diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).connect(cinfo.handle, cinfo.port)
         return True
 
@@ -261,13 +261,13 @@ class LifelineExecutionSpecificationConnect(BaseConnector):
         if exec_spec:
             exec_spec.unlink()
 
-        canvas = self.canvas
+        diagram = self.diagram
 
-        if canvas.get_parent(self.line) is self.element:
-            new_parent = canvas.get_parent(self.element)
-            canvas.reparent(self.line, new_parent)
+        if diagram.get_parent(self.line) is self.element:
+            new_parent = diagram.get_parent(self.element)
+            diagram.reparent(self.line, new_parent)
 
-        for cinfo in canvas.connections.get_connections(connected=self.line):
+        for cinfo in diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).disconnect(cinfo.handle)
 
 
@@ -289,7 +289,7 @@ class ExecutionSpecificationExecutionSpecificationConnect(BaseConnector):
         assert connected_item
         Connector(connected_item, self.line).connect(handle, None)
 
-        self.canvas.reparent(self.line, self.element)
+        self.diagram.reparent(self.line, self.element)
 
         return True
 
@@ -299,5 +299,5 @@ class ExecutionSpecificationExecutionSpecificationConnect(BaseConnector):
         if exec_spec and not exec_spec.presentation:
             exec_spec.unlink()
 
-        for cinfo in self.canvas.connections.get_connections(connected=self.line):
+        for cinfo in self.diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).disconnect(cinfo.handle)

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -249,7 +249,7 @@ class LifelineExecutionSpecificationConnect(BaseConnector):
 
         diagram = self.diagram
         if diagram.get_parent(self.line) is not self.element:
-            diagram.reparent(self.line, self.element)
+            self.line.parent = self.element
 
         for cinfo in diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).connect(cinfo.handle, cinfo.port)
@@ -265,7 +265,7 @@ class LifelineExecutionSpecificationConnect(BaseConnector):
 
         if diagram.get_parent(self.line) is self.element:
             new_parent = diagram.get_parent(self.element)
-            diagram.reparent(self.line, new_parent)
+            self.line.parent = new_parent  # type: ignore[assignment]
 
         for cinfo in diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).disconnect(cinfo.handle)
@@ -289,7 +289,7 @@ class ExecutionSpecificationExecutionSpecificationConnect(BaseConnector):
         assert connected_item
         Connector(connected_item, self.line).connect(handle, None)
 
-        self.diagram.reparent(self.line, self.element)
+        self.line.parent = self.element
 
         return True
 

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -56,7 +56,7 @@ def order_lifeline_covered_by(lifeline):
 
 
 def owner_for_message(line, lifeline):
-    maybe_interaction = lifeline.diagram.get_parent(lifeline)
+    maybe_interaction = lifeline.parent
     if line.subject.interaction:
         return
     elif isinstance(maybe_interaction, InteractionItem):
@@ -248,7 +248,7 @@ class LifelineExecutionSpecificationConnect(BaseConnector):
             exec_spec.enclosingInteraction = lifeline.interaction
 
         diagram = self.diagram
-        if diagram.get_parent(self.line) is not self.element:
+        if self.line.parent is not self.element:
             self.line.parent = self.element
 
         for cinfo in diagram.connections.get_connections(connected=self.line):
@@ -263,8 +263,8 @@ class LifelineExecutionSpecificationConnect(BaseConnector):
 
         diagram = self.diagram
 
-        if diagram.get_parent(self.line) is self.element:
-            new_parent = diagram.get_parent(self.element)
+        if self.line.parent is self.element:
+            new_parent = self.element.parent
             self.line.parent = new_parent  # type: ignore[assignment]
 
         for cinfo in diagram.connections.get_connections(connected=self.line):

--- a/gaphor/UML/interactions/interactionsgrouping.py
+++ b/gaphor/UML/interactions/interactionsgrouping.py
@@ -9,9 +9,9 @@ class InteractionLifelineGroup(AbstractGroup):
     """Add lifeline to interaction."""
 
     def group(self):
-        assert self.parent.canvas
+        assert self.parent.diagram
         self.parent.subject.lifeline = self.item.subject
-        self.parent.canvas.reparent(self.item, self.parent)
+        self.parent.diagram.reparent(self.item, self.parent)
 
     def ungroup(self):
         """Lifelines are not ungrouped on purpose.
@@ -27,9 +27,9 @@ class InteractionMessageGroup(AbstractGroup):
     def group(self):
         if not self.item.subject:
             return
-        assert self.parent.canvas
+        assert self.parent.diagram
         self.parent.subject.message = self.item.subject
-        self.parent.canvas.reparent(self.item, self.parent)
+        self.parent.diagram.reparent(self.item, self.parent)
 
     def ungroup(self):
         """Messages are not ungrouped on purpose.

--- a/gaphor/UML/interactions/interactionsgrouping.py
+++ b/gaphor/UML/interactions/interactionsgrouping.py
@@ -11,7 +11,7 @@ class InteractionLifelineGroup(AbstractGroup):
     def group(self):
         assert self.parent.diagram
         self.parent.subject.lifeline = self.item.subject
-        self.parent.diagram.reparent(self.item, self.parent)
+        self.item.parent = self.parent
 
     def ungroup(self):
         """Lifelines are not ungrouped on purpose.
@@ -29,7 +29,7 @@ class InteractionMessageGroup(AbstractGroup):
             return
         assert self.parent.diagram
         self.parent.subject.message = self.item.subject
-        self.parent.diagram.reparent(self.item, self.parent)
+        self.item.parent = self.parent
 
     def ungroup(self):
         """Messages are not ungrouped on purpose.

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -165,8 +165,6 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
         self.watch("subject.appliedStereotype.classifier.name")
 
     def setup_canvas(self):
-        assert self.canvas
-
         super().setup_canvas()
 
         top = self.lifetime.top
@@ -191,7 +189,6 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
             self._connections.add_constraint(self, c)
 
     def teardown_canvas(self):
-        assert self.canvas
         super().teardown_canvas()
         for c in self.__constraints:
             self._connections.remove_constraint(self, c)

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -187,12 +187,14 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
         )
         self.__constraints = (c1, c2, c3, self.lifetime._c_min_length)
 
-        list(map(self.canvas.solver.add_constraint, self.__constraints))
+        for c in self.__constraints:
+            self._connections.add_constraint(self, c)
 
     def teardown_canvas(self):
         assert self.canvas
         super().teardown_canvas()
-        list(map(self.canvas.solver.remove_constraint, self.__constraints))
+        for c in self.__constraints:
+            self._connections.remove_constraint(self, c)
 
     def save(self, save_func):
         super().save(save_func)

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -163,10 +163,12 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
 
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
+        self.setup_constraints()
 
     def setup_canvas(self):
         super().setup_canvas()
 
+    def setup_constraints(self):
         top = self.lifetime.top
         bottom = self.lifetime.bottom
 

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -165,9 +165,6 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
         self.watch("subject.appliedStereotype.classifier.name")
         self.setup_constraints()
 
-    def setup_canvas(self):
-        super().setup_canvas()
-
     def setup_constraints(self):
         top = self.lifetime.top
         bottom = self.lifetime.bottom
@@ -185,15 +182,9 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
         self.lifetime._c_min_length = LessThanConstraint(
             top.pos.y, bottom.pos.y, delta=LifetimeItem.MIN_LENGTH
         )
-        self.__constraints = (c1, c2, c3, self.lifetime._c_min_length)
 
-        for c in self.__constraints:
+        for c in [c1, c2, c3, self.lifetime._c_min_length]:
             self._connections.add_constraint(self, c)
-
-    def teardown_canvas(self):
-        super().teardown_canvas()
-        for c in self.__constraints:
-            self._connections.remove_constraint(self, c)
 
     def save(self, save_func):
         super().save(save_func)

--- a/gaphor/UML/interactions/tests/test_executionspecification.py
+++ b/gaphor/UML/interactions/tests/test_executionspecification.py
@@ -78,7 +78,7 @@ def test_disconnect_execution_specification_from_lifeline(diagram, element_facto
 
     assert lifeline.subject
     assert exec_spec.subject is None
-    assert exec_spec.canvas
+    assert exec_spec.diagram
     assert elements_of_kind(UML.ExecutionSpecification) == []
     assert elements_of_kind(UML.ExecutionOccurrenceSpecification) == []
 

--- a/gaphor/UML/interactions/tests/test_executionspecification.py
+++ b/gaphor/UML/interactions/tests/test_executionspecification.py
@@ -197,15 +197,9 @@ def test_disconnect_execution_specification_with_execution_specification_from_li
         child_exec_spec.ports()[0],
     )
 
-    print("parent", parent_exec_spec.subject)
-    print("child", child_exec_spec.subject)
-
     assert child_exec_spec.parent is parent_exec_spec
 
     disconnect(parent_exec_spec, parent_exec_spec.handles()[0])
-
-    print("parent", parent_exec_spec.subject)
-    print("child", child_exec_spec.subject)
 
     assert lifeline.subject
     assert parent_exec_spec.subject is None

--- a/gaphor/UML/interactions/tests/test_executionspecification.py
+++ b/gaphor/UML/interactions/tests/test_executionspecification.py
@@ -212,7 +212,7 @@ def test_save_and_load(diagram, element_factory, saver, loader):
         diagram, element_factory
     )
 
-    diagram.canvas.update_now((lifeline, exec_spec))
+    diagram.update_now((lifeline, exec_spec))
 
     saved_data = saver()
 
@@ -232,6 +232,6 @@ def test_save_and_load(diagram, element_factory, saver, loader):
         )
         == 2
     )
-    assert loaded_exec_spec.canvas.connections.get_connection(
+    assert loaded_exec_spec.diagram.connections.get_connection(
         loaded_exec_spec.handles()[0]
     )

--- a/gaphor/UML/interactions/tests/test_executionspecification.py
+++ b/gaphor/UML/interactions/tests/test_executionspecification.py
@@ -197,7 +197,15 @@ def test_disconnect_execution_specification_with_execution_specification_from_li
         child_exec_spec.ports()[0],
     )
 
+    print("parent", parent_exec_spec.subject)
+    print("child", child_exec_spec.subject)
+
+    assert child_exec_spec.parent is parent_exec_spec
+
     disconnect(parent_exec_spec, parent_exec_spec.handles()[0])
+
+    print("parent", parent_exec_spec.subject)
+    print("child", child_exec_spec.subject)
 
     assert lifeline.subject
     assert parent_exec_spec.subject is None

--- a/gaphor/UML/interactions/tests/test_message.py
+++ b/gaphor/UML/interactions/tests/test_message.py
@@ -12,7 +12,7 @@ def test_message_persistence(diagram, element_factory, saver, loader):
     data = saver()
     loader(data)
     new_diagram = next(element_factory.select(UML.Diagram))
-    item = next(new_diagram.canvas.select(MessageItem))
+    item = next(new_diagram.select(MessageItem))
 
     assert item
 

--- a/gaphor/UML/interactions/tests/test_messageconnect.py
+++ b/gaphor/UML/interactions/tests/test_messageconnect.py
@@ -146,7 +146,7 @@ def test_message_is_owned_by_implicit_interaction_connecting_to_head(
 
     assert msg.subject is not None
     assert msg.subject.interaction is interaction
-    assert diagram.get_parent(msg) is None
+    assert msg.parent is None
 
 
 @pytest.mark.parametrize("end_name", ["head", "tail"])
@@ -165,7 +165,7 @@ def test_message_is_owned_by_interaction_item_connecting_to_one_end(
 
     assert msg.subject is not None
     assert msg.subject.interaction is interaction.subject
-    assert diagram.get_parent(msg) is interaction
+    assert msg.parent is interaction
 
 
 def test_disconnection(diagram):

--- a/gaphor/UML/interactions/tests/test_messageconnect.py
+++ b/gaphor/UML/interactions/tests/test_messageconnect.py
@@ -146,7 +146,7 @@ def test_message_is_owned_by_implicit_interaction_connecting_to_head(
 
     assert msg.subject is not None
     assert msg.subject.interaction is interaction
-    assert msg.canvas.get_parent(msg) is None
+    assert diagram.get_parent(msg) is None
 
 
 @pytest.mark.parametrize("end_name", ["head", "tail"])
@@ -165,7 +165,7 @@ def test_message_is_owned_by_interaction_item_connecting_to_one_end(
 
     assert msg.subject is not None
     assert msg.subject.interaction is interaction.subject
-    assert msg.canvas.get_parent(msg) is interaction
+    assert diagram.get_parent(msg) is interaction
 
 
 def test_disconnection(diagram):

--- a/gaphor/UML/profiles/extensionconnect.py
+++ b/gaphor/UML/profiles/extensionconnect.py
@@ -27,6 +27,7 @@ class ExtensionConnect(RelationshipConnect):
     def connect_subject(self, handle):
         element = self.element
         line = self.line
+        assert element.diagram
 
         c1 = self.get_connected(line.head)
         c2 = self.get_connected(line.tail)
@@ -61,7 +62,7 @@ class ExtensionConnect(RelationshipConnect):
                     # check if this entry is not yet in the diagram
                     # Return if the association is not (yet) on the canvas
                     for item in ext.presentation:
-                        if item.canvas is element.canvas:
+                        if item.diagram is element.diagram:
                             break
                     else:
                         line.subject = ext
@@ -69,7 +70,7 @@ class ExtensionConnect(RelationshipConnect):
             else:
                 # Create a new Extension relationship
                 relation = UML.model.create_extension(head_type, tail_type)
-                relation.package = element.diagram.namespace
+                relation.package = element.diagram.package
                 line.subject = relation
 
     def disconnect_subject(self, handle):

--- a/gaphor/UML/profiles/extensionconnect.py
+++ b/gaphor/UML/profiles/extensionconnect.py
@@ -60,7 +60,7 @@ class ExtensionConnect(RelationshipConnect):
                     end2.type is head_type and end1.type is tail_type
                 ):
                     # check if this entry is not yet in the diagram
-                    # Return if the association is not (yet) on the canvas
+                    # Return if the association is not (yet) on the diagram
                     for item in ext.presentation:
                         if item.diagram is element.diagram:
                             break

--- a/gaphor/UML/profiles/metaclasspropertypage.py
+++ b/gaphor/UML/profiles/metaclasspropertypage.py
@@ -59,7 +59,7 @@ class MetaclassPropertyPage(PropertyPageBase):
             if event.element is self.subject and event.new_value is not None:
                 entry.set_text(event.new_value)
 
-        self.watcher.watch("name", handler).subscribe_all()
+        self.watcher.watch("name", handler)
 
         builder.connect_signals(
             {

--- a/gaphor/UML/profiles/tests/test_classifier_stereotypes.py
+++ b/gaphor/UML/profiles/tests/test_classifier_stereotypes.py
@@ -154,7 +154,7 @@ class StereotypesAttributesTestCase(TestCase):
         data = self.save()
         self.load(data)
 
-        item = next(self.diagram.canvas.select(ComponentItem))
+        item = next(self.diagram.select(ComponentItem))
         assert item.show_stereotypes
         assert len(compartments(c)) == 1
 
@@ -182,7 +182,7 @@ class StereotypesAttributesTestCase(TestCase):
         data = self.save()
         self.load(data)
 
-        item = next(self.diagram.canvas.select(ComponentItem))
+        item = next(self.diagram.select(ComponentItem))
         el = item.subject
         assert len(el.appliedStereotype) == 2
 

--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -55,12 +55,12 @@ class SanitizerService(Service):
         if not (element.canvas and subject):
             return
 
-        for cinfo in element.canvas.connections.get_connections(connected=element):
+        for cinfo in element.diagram.connections.get_connections(connected=element):
             comment_line = cinfo.item
             if not isinstance(comment_line, CommentLineItem):
                 continue
             opposite = comment_line.opposite(cinfo.handle)
-            opposite_cinfo = element.canvas.connections.get_connection(opposite)
+            opposite_cinfo = element.diagram.connections.get_connection(opposite)
             if not opposite_cinfo:
                 continue
             comment_item = opposite_cinfo.connected
@@ -115,6 +115,6 @@ class SanitizerService(Service):
     @event_handler(DerivedSet)
     def _redraw_diagram_on_move(self, event):
         if event.property is Element.owner and isinstance(event.element, Diagram):
-            canvas = event.element.canvas
-            for item in canvas.get_all_items():
-                canvas.request_update(item)
+            diagram = event.element
+            for item in diagram.get_all_items():
+                diagram.request_update(item)

--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -52,7 +52,7 @@ class SanitizerService(Service):
 
         element: Presentation = event.element
         subject = event.new_value
-        if not (element.canvas and subject):
+        if not (element.diagram and subject):
             return
 
         for cinfo in element.diagram.connections.get_connections(connected=element):

--- a/gaphor/UML/states/propertypages.py
+++ b/gaphor/UML/states/propertypages.py
@@ -36,7 +36,7 @@ class TransitionPropertyPage(PropertyPageBase):
             if event.element is subject.guard:
                 guard.set_text(event.new_value or "")
 
-        self.watcher.watch("guard[Constraint].specification", handler).subscribe_all()
+        self.watcher.watch("guard[Constraint].specification", handler)
 
         builder.connect_signals(
             {

--- a/gaphor/UML/states/tests/test_states.py
+++ b/gaphor/UML/states/tests/test_states.py
@@ -25,7 +25,7 @@ class StateTestCase(TestCase):
         data = self.save()
         self.load(data)
 
-        s1 = next(self.diagram.canvas.select(StateItem))
+        s1 = next(self.diagram.select(StateItem))
         assert "test 1 entry" == s1.subject.entry.name
         assert "test 1 exit" == s1.subject.exit.name
         assert "test 1 do" == s1.subject.doActivity.name

--- a/gaphor/UML/states/vertexconnect.py
+++ b/gaphor/UML/states/vertexconnect.py
@@ -69,7 +69,7 @@ class PseudostateTransitionConnect(VertexConnect):
             return super().allow(handle, port)
 
         # Check if no other items are connected
-        connections = self.canvas.connections.get_connections(connected=element)
+        connections = self.diagram.connections.get_connections(connected=element)
         line = self.line
         connected_items = [
             c

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -181,9 +181,9 @@ def test_stereotype_deletion(element_factory):
 def test_diagram_move(element_factory):
     diagram = element_factory.create(UML.Diagram)
     diagram.create(CommentItem, subject=element_factory.create(UML.Comment))
-    diagram.canvas.request_update = Mock()
+    diagram.request_update = Mock()
 
     package = element_factory.create(UML.Package)
     diagram.package = package
 
-    diagram.canvas.request_update.assert_called()
+    diagram.request_update.assert_called()

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -52,13 +52,13 @@ def test_presentation_delete(create_item, element_factory):
     klass = klassitem.subject
 
     assert klassitem.subject.presentation[0] is klassitem
-    assert klassitem.canvas
+    assert klassitem.diagram
 
     # Delete presentation here:
 
     klassitem.unlink()
 
-    assert not klassitem.canvas
+    assert not klassitem.diagram
     assert klass not in element_factory
 
 

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -27,7 +27,7 @@ def create_item(element_factory, diagram):
     return create
 
 
-def test_connect_element_with_comments(create_item):
+def test_connect_element_with_comments(create_item, diagram):
     comment = create_item(CommentItem, UML.Comment)
     line = create_item(CommentLineItem)
     gi = create_item(GeneralizationItem)
@@ -37,7 +37,7 @@ def test_connect_element_with_comments(create_item):
     connect(line, line.head, comment)
     connect(line, line.tail, gi)
 
-    assert line.canvas.connections.get_connection(line.tail).connected is gi
+    assert diagram.connections.get_connection(line.tail).connected is gi
 
     # Now connect generaliztion ends.
     connect(gi, gi.head, clazz1)

--- a/gaphor/core/modeling/coremodel.py
+++ b/gaphor/core/modeling/coremodel.py
@@ -35,16 +35,16 @@ class NamedElement(Element):
     memberNamespace: relation_many[Namespace]
 
 
-# 41: override PackageableElement
+# 39: override PackageableElement
 class PackageableElement(NamedElement):
     owningPackage: relation_one[Package]
 
 
-# 60: override Diagram
+# 67: override Diagram
 # defined in gaphor.core.modeling.diagram
 
 
-# 51: override Presentation
+# 49: override Presentation
 # defined in gaphor.core.modeling.presentation
 
 
@@ -53,23 +53,35 @@ class Comment(Element):
     annotatedElement: relation_many[Element]
 
 
-# 45: override StyleSheet
+# 43: override StyleSheet
 # defined in gaphor.core.modeling.presentation
 
 
 NamedElement.name = attribute("name", str)
 Comment.body = attribute("body", str)
-# 48: override StyleSheet.styleSheet
+# 46: override StyleSheet.styleSheet
 # defined in gaphor.core.modeling.presentation
 
-# 57: override Presentation.subject
+# 58: override Presentation.subject
 # defined in gaphor.core.modeling.presentation
 
-# 54: override Element.presentation
+# 52: override Element.presentation
 # defined in gaphor.core.modeling.presentation
 
 Comment.annotatedElement = association("annotatedElement", Element, opposite="comment")
 Element.comment = association("comment", Comment, opposite="annotatedElement")
+# 70: override Diagram.ownedPresentation
+# defined in gaphor.core.modeling.presentation
+
+# 55: override Presentation.diagram
+# defined in gaphor.core.modeling.presentation
+
+# 61: override Presentation.parent
+# defined in gaphor.core.modeling.presentation
+
+# 64: override Presentation.children
+# defined in gaphor.core.modeling.presentation
+
 # 22: override NamedElement.qualifiedName(NamedElement.namespace): derived[List[str]]
 
 

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -166,7 +166,8 @@ class StyledDiagram:
     def children(self) -> Iterator[StyledItem]:
         return (
             StyledItem(item, self.selection)
-            for item in self.diagram.canvas.get_root_items()
+            for item in self.diagram.get_all_items()
+            if not self.diagram.get_parent(item)
         )
 
     def attribute(self, name: str) -> str:
@@ -187,24 +188,24 @@ class StyledItem:
     def __init__(
         self, item: Presentation, selection: Optional[gaphas.view.Selection] = None
     ):
-        assert item.canvas
+        assert item.diagram
         self.item = item
-        self.canvas = item.canvas
+        self.diagram = item.diagram
         self.selection = selection or gaphas.view.Selection()
 
     def name(self) -> str:
         return removesuffix(type(self.item).__name__, "Item").lower()
 
     def parent(self) -> Union[StyledItem, StyledDiagram]:
-        parent = self.canvas.get_parent(self.item)
+        parent = self.diagram.get_parent(self.item)
         return (
             StyledItem(parent, self.selection)
             if parent
-            else StyledDiagram(self.item.diagram, self.selection)
+            else StyledDiagram(self.diagram, self.selection)
         )
 
     def children(self) -> Iterator[StyledItem]:
-        children = self.canvas.get_children(self.item)
+        children = self.diagram.get_children(self.item)
         selection = self.selection
         return (StyledItem(child, selection) for child in children)
 

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -322,7 +322,7 @@ class DiagramCanvas(gaphas.Canvas):
         for item in self.get_root_items():
             save_func(item)
 
-    def select(self, expression=lambda e: True):
+    def select(self, expression=None):
         """Return a list of all canvas items that match expression."""
         if expression is None:
             yield from self.get_all_items()
@@ -330,8 +330,6 @@ class DiagramCanvas(gaphas.Canvas):
             yield from (e for e in self.get_all_items() if isinstance(e, expression))
         else:
             yield from (e for e in self.get_all_items() if expression(e))
-
-            return list(filter(expression, self.get_all_items()))
 
     def reparent(self, item, parent):
         """A more fancy version of the reparent method."""
@@ -434,6 +432,9 @@ class Diagram(PackageableElement):
 
         super().unlink()
 
+    def select(self, expression=lambda e: True):
+        return self.canvas.select(expression)
+
     @property
     def connections(self) -> gaphas.connections.Connections:
         return self.canvas.connections
@@ -461,7 +462,7 @@ class Diagram(PackageableElement):
     def update_now(
         self,
         dirty_items: Sequence[Presentation],
-        dirty_matrix_items: Sequence[Presentation],
+        dirty_matrix_items: Sequence[Presentation] = (),
     ) -> None:
         self.canvas.update_now(dirty_items, dirty_matrix_items)
 

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -435,6 +435,9 @@ class Diagram(PackageableElement):
     def select(self, expression=lambda e: True):
         return self.canvas.select(expression)
 
+    def reparent(self, item: Presentation, parent: Optional[Presentation]) -> None:
+        self.canvas.reparent(item, parent)
+
     @property
     def connections(self) -> gaphas.connections.Connections:
         return self.canvas.connections

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -157,7 +157,7 @@ class StyledDiagram:
         return (
             StyledItem(item, self.selection)
             for item in self.diagram.get_all_items()
-            if not self.diagram.get_parent(item)
+            if not item.parent
         )
 
     def attribute(self, name: str) -> str:
@@ -187,7 +187,7 @@ class StyledItem:
         return removesuffix(type(self.item).__name__, "Item").lower()
 
     def parent(self) -> Union[StyledItem, StyledDiagram]:
-        parent = self.diagram.get_parent(self.item)
+        parent = self.item.parent
         return (
             StyledItem(parent, self.selection)
             if parent

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -438,6 +438,9 @@ class Diagram(PackageableElement):
     def connections(self) -> gaphas.connections.Connections:
         return self.canvas.connections
 
+    def get_matrix_i2c(self, item: Presentation) -> gaphas.matrix.Matrix:
+        return self.canvas.get_matrix_i2c(item)
+
     def get_all_items(self) -> Iterable[Presentation]:
         return self.canvas.get_all_items()  # type: ignore[no-any-return]
 

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -195,9 +195,8 @@ class StyledItem:
         )
 
     def children(self) -> Iterator[StyledItem]:
-        children = self.diagram.get_children(self.item)
         selection = self.selection
-        return (StyledItem(child, selection) for child in children)
+        return (StyledItem(child, selection) for child in self.item.children)
 
     def attribute(self, name: str) -> str:
         fields = name.split(".")

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -351,8 +351,8 @@ class Diagram(PackageableElement):
         self._watcher.unsubscribe_all()
         super().unlink()
 
-    def select(self, expression=None):
-        """Return a list of all canvas items that match expression."""
+    def select(self, expression=None) -> Iterable[Presentation]:
+        """Return a iterator of all canvas items that match expression."""
         if expression is None:
             yield from self.get_all_items()
         elif isinstance(expression, type):

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -363,7 +363,7 @@ class Diagram(PackageableElement):
         """
 
         super().__init__(id, model)
-        self.canvas = DiagramCanvas(self)
+        self._canvas = DiagramCanvas(self)
 
     @property
     def styleSheet(self) -> Optional[StyleSheet]:
@@ -385,7 +385,7 @@ class Diagram(PackageableElement):
         """Apply the supplied save function to this diagram and the canvas."""
 
         super().save(save_func)
-        save_func("canvas", self.canvas)
+        save_func("canvas", self._canvas)
 
     def postload(self):
         """Handle post-load functionality for the diagram canvas."""
@@ -407,25 +407,25 @@ class Diagram(PackageableElement):
             raise TypeError(
                 f"Type {type} can not be added to a diagram as it is not a diagram item"
             )
-        item = type(connections=self.canvas.connections, id=id, model=self.model)
+        item = type(connections=self._canvas.connections, id=id, model=self.model)
         assert isinstance(
             item, gaphas.Item
         ), f"Type {type} does not comply with Item protocol"
         if subject:
             item.subject = subject
-        self.canvas.add(item, parent)
+        self._canvas.add(item, parent)
         self.model.handle(DiagramItemCreated(self, item))
         return item
 
     def lookup(self, id):
-        for item in self.canvas.get_all_items():
+        for item in self._canvas.get_all_items():
             if item.id == id:
                 return item
 
     def unlink(self):
         """Unlink all canvas items then unlink this diagram."""
 
-        for item in self.canvas.get_all_items():
+        for item in self._canvas.get_all_items():
             try:
                 item.unlink()
             except (AttributeError, KeyError):
@@ -434,44 +434,44 @@ class Diagram(PackageableElement):
         super().unlink()
 
     def select(self, expression=lambda e: True):
-        return self.canvas.select(expression)
+        return self._canvas.select(expression)
 
     def reparent(self, item: Presentation, parent: Optional[Presentation]) -> None:
-        self.canvas.reparent(item, parent)
+        self._canvas.reparent(item, parent)
 
     @property
     def connections(self) -> gaphas.connections.Connections:
-        return self.canvas.connections
+        return self._canvas.connections
 
     def get_matrix_i2c(self, item: Presentation) -> gaphas.matrix.Matrix:
-        return self.canvas.get_matrix_i2c(item)
+        return self._canvas.get_matrix_i2c(item)
 
     def get_all_items(self) -> Iterable[Presentation]:
-        return self.canvas.get_all_items()  # type: ignore[no-any-return]
+        return self._canvas.get_all_items()  # type: ignore[no-any-return]
 
     def get_parent(self, item: Presentation) -> Optional[Presentation]:
-        return self.canvas.get_parent(item)  # type: ignore[no-any-return]
+        return self._canvas.get_parent(item)  # type: ignore[no-any-return]
 
     def get_children(self, item: Presentation) -> Iterable[Presentation]:
-        return self.canvas.get_children(item)  # type: ignore[no-any-return]
+        return self._canvas.get_children(item)  # type: ignore[no-any-return]
 
     def sort(self, items: Sequence[Presentation]) -> Reversible[Presentation]:
-        return self.canvas.sort(items)  # type: ignore[no-any-return]
+        return self._canvas.sort(items)  # type: ignore[no-any-return]
 
     def request_update(
         self, item: gaphas.item.Item, update: bool = True, matrix: bool = True
     ) -> None:
-        self.canvas.request_update(item, update, matrix)
+        self._canvas.request_update(item, update, matrix)
 
     def update_now(
         self,
         dirty_items: Sequence[Presentation],
         dirty_matrix_items: Sequence[Presentation] = (),
     ) -> None:
-        self.canvas.update_now(dirty_items, dirty_matrix_items)
+        self._canvas.update_now(dirty_items, dirty_matrix_items)
 
     def register_view(self, view: gaphas.view.model.View[Presentation]) -> None:
-        self.canvas.register_view(view)
+        self._canvas.register_view(view)
 
     def unregister_view(self, view: gaphas.view.model.View[Presentation]) -> None:
-        self.canvas.unregister_view(view)
+        self._canvas.unregister_view(view)

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -153,8 +153,6 @@ class Element:
         else:
             return DummyEventWatcher()
 
-    # OCL methods: (from SMW by Ivan Porres (http://www.abo.fi/~iporres/smw))
-
     def isKindOf(self, class_: Type[Element]) -> bool:
         """Returns true if the object is an instance of `class_`."""
         return isinstance(self, class_)

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -168,9 +168,6 @@ class DummyEventWatcher:
     def watch(self, path: str, handler: Optional[Handler] = None) -> DummyEventWatcher:
         return self
 
-    def subscribe_all(self) -> None:
-        pass
-
     def unsubscribe_all(self) -> None:
         pass
 
@@ -212,9 +209,6 @@ class EventWatcherProtocol(Protocol):
     def watch(
         self, path: str, handler: Optional[Handler] = None
     ) -> EventWatcherProtocol:
-        ...
-
-    def subscribe_all(self) -> None:
         ...
 
     def unsubscribe_all(self) -> None:

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -130,6 +130,8 @@ class Element:
         if self._unlink_lock:
             return
 
+        log.debug("unlinking %s", self)
+
         try:
             self._unlink_lock += 1
 

--- a/gaphor/core/modeling/elementdispatcher.py
+++ b/gaphor/core/modeling/elementdispatcher.py
@@ -54,9 +54,6 @@ class EventWatcher:
             dispatcher.subscribe(self._watched_paths[path], self.element, path)
         return self
 
-    def subscribe_all(self):
-        pass
-
     def unsubscribe_all(self, *_args):
         """Unregister handlers.
 

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -140,8 +140,8 @@ class ElementFactory(Service):
     def flush(self) -> None:
         """Flush all elements (remove them from the factory).
 
-        Diagram elements are flushed first.  This is so that canvas
-        updates are blocked.  The remaining elements are then flushed.
+        Diagram elements are flushed first. The remaining elements are
+        flushed next.
         """
         with self.block_events():
             for element in self.lselect(Diagram):

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -59,8 +59,6 @@ class Presentation(Element, Generic[S]):
 
     def on_diagram_changed(self, event):
         log.debug("diagram change %s, %s", event.old_value, event.new_value)
-        if event.old_value:
-            self.teardown_canvas()
         if event.new_value:
             self.setup_canvas()
 
@@ -68,13 +66,6 @@ class Presentation(Element, Generic[S]):
         """Called when the diagram is set for the item.
 
         This method can be used to create constraints.
-        """
-        pass
-
-    def teardown_canvas(self):
-        """Called when the diagram is unset for the item.
-
-        This method can be used to dispose constraints.
         """
         pass
 
@@ -101,7 +92,7 @@ class Presentation(Element, Generic[S]):
     def unlink(self):
         """Remove the item from the diagram and set subject to None."""
         diagram = self.diagram
-        self.unsubscribe_all()
+        self._watcher.unsubscribe_all()
         if diagram:
             diagram.connections.remove_connections_to_item(self)
         super().unlink()

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -40,7 +40,6 @@ class Presentation(Element, Generic[S]):
                 self.diagram.request_update(self)
 
         self._watcher = self.watcher(default_handler=update)
-        self.watch("diagram", self.on_diagram_changed)
         self.watch("subject")
 
     subject: relation_one[S] = association(
@@ -56,18 +55,6 @@ class Presentation(Element, Generic[S]):
 
     matrix: Matrix
     matrix_i2c: Matrix
-
-    def on_diagram_changed(self, event):
-        log.debug("diagram change %s, %s", event.old_value, event.new_value)
-        if event.new_value:
-            self.setup_canvas()
-
-    def setup_canvas(self):
-        """Called when the diagram is set for the item.
-
-        This method can be used to create constraints.
-        """
-        pass
 
     def request_update(self, matrix=True):
         if self.diagram:

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     from gaphas.connector import Handle  # noqa
     from gaphas.matrix import Matrix  # noqa
 
+    from gaphor.core.modeling.diagram import Diagram
+
 S = TypeVar("S", bound=Element)
 
 
@@ -81,14 +83,20 @@ class Presentation(Element, Generic[S]):
         """
         pass
 
-    canvas = property(lambda s: s._canvas, _set_canvas)
+    @property
+    def canvas(self) -> Optional[Canvas]:
+        return self._canvas
+
+    @canvas.setter
+    def canvas(self, canvas: Optional[Canvas]) -> None:
+        self._set_canvas(canvas)
 
     def request_update(self, matrix=True):
         if self.canvas:
             self.canvas.request_update(self, matrix=matrix)
 
     @property
-    def diagram(self):
+    def diagram(self) -> Optional[Diagram]:
         canvas = self.canvas
         return canvas.diagram if canvas else None
 

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -8,7 +8,7 @@ from gaphas.state import observed, reversible_method
 
 from gaphor.core.modeling import Element
 from gaphor.core.modeling.event import DiagramItemDeleted
-from gaphor.core.modeling.properties import association, relation_one
+from gaphor.core.modeling.properties import association, relation_many, relation_one
 
 if TYPE_CHECKING:
     from gaphas.canvas import Canvas  # noqa
@@ -47,6 +47,11 @@ class Presentation(Element, Generic[S]):
     subject: relation_one[S] = association(
         "subject", Element, upper=1, opposite="presentation"
     )
+
+    diagram: relation_one[Diagram]
+
+    parent: relation_one[Presentation]
+    children: relation_many[Presentation]
 
     handles: Callable[[Presentation], List[Handle]]
 
@@ -95,11 +100,6 @@ class Presentation(Element, Generic[S]):
         if self.canvas:
             self.canvas.request_update(self, matrix=matrix)
 
-    @property
-    def diagram(self) -> Optional[Diagram]:
-        canvas = self.canvas
-        return canvas.diagram if canvas else None
-
     def watch(self, path, handler=None):
         """Watch a certain path of elements starting with the DiagramItem. The
         handler is optional and will default to a simple self.request_update().
@@ -132,3 +132,7 @@ class Presentation(Element, Generic[S]):
 Element.presentation = association(
     "presentation", Presentation, composite=True, opposite="subject"
 )
+Presentation.parent = association(
+    "parent", Presentation, upper=1, composite=True, opposite="children"
+)
+Presentation.children = association("children", Presentation, opposite="parent")

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -94,10 +94,6 @@ class Presentation(Element, Generic[S]):
         self._watcher.watch(path, handler)
         return self
 
-    def subscribe_all(self):
-        """Subscribe all watched paths, as defined through `watch()`."""
-        self._watcher.subscribe_all()
-
     def unsubscribe_all(self):
         """Unsubscribe all watched paths, as defined through `watch()`."""
         self._watcher.unsubscribe_all()

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -116,7 +116,7 @@ class Presentation(Element, Generic[S]):
 Element.presentation = association(
     "presentation", Presentation, composite=True, opposite="subject"
 )
-Presentation.parent = association(
-    "parent", Presentation, upper=1, composite=True, opposite="children"
+Presentation.parent = association("parent", Presentation, upper=1, opposite="children")
+Presentation.children = association(
+    "children", Presentation, composite=True, opposite="parent"
 )
-Presentation.children = association("children", Presentation, opposite="parent")

--- a/gaphor/core/modeling/tests/test_diagram.py
+++ b/gaphor/core/modeling/tests/test_diagram.py
@@ -45,7 +45,7 @@ def test_canvas_item_is_created(element_factory):
     diagram = element_factory.create(Diagram)
     example = diagram.create(Example)
 
-    assert example in diagram.canvas.get_all_items()
+    assert example in diagram.get_all_items()
 
 
 def test_canvas_is_unlinked(element_factory):

--- a/gaphor/core/modeling/tests/test_diagram.py
+++ b/gaphor/core/modeling/tests/test_diagram.py
@@ -40,6 +40,7 @@ def test_canvas_item_is_created(element_factory):
     example = diagram.create(Example)
 
     assert example in diagram.get_all_items()
+    assert example.diagram is diagram
 
 
 def test_canvas_is_unlinked(element_factory):

--- a/gaphor/core/modeling/tests/test_diagram.py
+++ b/gaphor/core/modeling/tests/test_diagram.py
@@ -21,12 +21,6 @@ def element_factory():
     event_manager.shutdown()
 
 
-def test_canvas_is_set_up():
-    diagram = Diagram("id", None)
-
-    assert diagram.canvas
-
-
 def test_diagram_can_be_used_as_gtkview_model():
     diagram = Diagram("id", None)
 

--- a/gaphor/core/modeling/tests/test_elementdispatcher.py
+++ b/gaphor/core/modeling/tests/test_elementdispatcher.py
@@ -273,18 +273,18 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         )
         p.name = "func"
         dispatcher.subscribe(self._handler, element, "ownedOperation.parameter.name")
-        assert len(dispatcher._handlers) == 3
+        assert len(dispatcher._handlers) == 4
         assert not self.events
 
         element.ownedOperation = self.element_factory.create(UML.Operation)
         assert len(self.events) == 1, self.events
-        assert len(dispatcher._handlers) == 4
+        assert len(dispatcher._handlers) == 5
 
         p.name = "othername"
         assert len(self.events) == 2, self.events
 
         del element.ownedOperation[o]
-        assert len(dispatcher._handlers) == 2
+        assert len(dispatcher._handlers) == 3
 
     def test_association_notification(self):
         """Test notifications with Class object.
@@ -298,12 +298,12 @@ class ElementDispatcherAsServiceTestCase(TestCase):
 
         assert len(element.memberEnd) == 2
         dispatcher.subscribe(self._handler, element, "memberEnd.name")
-        assert len(dispatcher._handlers) == 3, len(dispatcher._handlers)
+        assert len(dispatcher._handlers) == 4, len(dispatcher._handlers)
         assert not self.events
 
         p1.name = "foo"
         assert len(self.events) == 1, (self.events, dispatcher._handlers)
-        assert len(dispatcher._handlers) == 3
+        assert len(dispatcher._handlers) == 4
 
         p1.name = "othername"
         assert len(self.events) == 2, self.events
@@ -334,12 +334,12 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         dispatcher.subscribe(self._handler, element, base + "lowerValue")
         dispatcher.subscribe(self._handler, element, base + "upperValue")
 
-        assert len(dispatcher._handlers) == 11, len(dispatcher._handlers)
+        assert len(dispatcher._handlers) == 12, len(dispatcher._handlers)
         assert not self.events
 
         p1.name = "foo"
         assert len(self.events) == 1, (self.events, dispatcher._handlers)
-        assert len(dispatcher._handlers) == 11
+        assert len(dispatcher._handlers) == 12
 
         p1.name = "othername"
         assert len(self.events) == 2, self.events
@@ -387,7 +387,7 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         a.unlink()
         watcher.unsubscribe_all()
         watcher.unsubscribe_all()
-        assert len(self.dispatcher._handlers) == 0
+        assert len(self.dispatcher._handlers) == 1
 
     def test_braking_big_diamond(self):
         """Test diamond shaped dependencies a -> b -> c -> d, a -> b' -> c' ->
@@ -407,12 +407,12 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         a.one.two[1].one.two = a.one.two[0].one.two[0]
 
         assert len(self.events) == 7
-        assert len(self.dispatcher._handlers) == 6
+        assert len(self.dispatcher._handlers) == 7
 
         del a.one.two[0].one
         watcher.unsubscribe_all()
         watcher.unsubscribe_all()
-        assert len(self.dispatcher._handlers) == 0
+        assert len(self.dispatcher._handlers) == 1
 
     def test_cyclic(self):
         """Test cyclic dependency a -> b -> c -> a."""
@@ -430,4 +430,4 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         assert 4 == len(self.events)
 
         a.unlink()
-        assert 1 == len(self.dispatcher._handlers)
+        assert 2 == len(self.dispatcher._handlers)

--- a/gaphor/core/modeling/tests/test_elementdispatcher.py
+++ b/gaphor/core/modeling/tests/test_elementdispatcher.py
@@ -350,7 +350,6 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         a = A()
         watcher = EventWatcher(a, self.dispatcher, self._handler)
         watcher.watch("one.two.one.two")
-        watcher.subscribe_all()
 
         a.one = A()
         a.one.two = A()
@@ -372,7 +371,6 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         a = A()
         watcher = EventWatcher(a, self.dispatcher, self._handler)
         watcher.watch("one.two.one.two")
-        watcher.subscribe_all()
 
         a.one = A()
         a.one.two = A()
@@ -396,7 +394,6 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         a = A()
         watcher = EventWatcher(a, self.dispatcher, self._handler)
         watcher.watch("one.two.one.two")
-        watcher.subscribe_all()
 
         a.one = A()
         a.one.two = A()
@@ -420,7 +417,6 @@ class ElementDispatcherAsServiceTestCase(TestCase):
         a = A()
         watcher = EventWatcher(a, self.dispatcher, self._handler)
         watcher.watch("one.two.one.two")
-        watcher.subscribe_all()
 
         a.one = A()
         a.one.two = A()

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -65,7 +65,9 @@ class BaseConnector:
         element: Presentation[Element],
         line: Presentation[Element],
     ) -> None:
-        assert element.diagram and element.diagram is line.diagram
+        assert (
+            element.diagram and element.diagram is line.diagram
+        ), f"Connector without diagram ({element}: {element.diagram}, {line}: {line.diagram})"
         self.element = element
         self.line = line
         self.diagram: Diagram = element.diagram

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -153,7 +153,7 @@ def copy_presentation(item: Presentation) -> PresentationCopy:
             buffer[name] = serialize(value)
 
     item.save(save_func)
-    parent = item.diagram.get_parent(item)
+    parent = item.parent
     return PresentationCopy(
         cls=item.__class__,
         data=buffer,

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -168,7 +168,7 @@ def paste_presentation(copy_data: PresentationCopy, diagram, lookup):
     if parent:
         p = lookup(parent)
         if p:
-            diagram.reparent(item, p)
+            item.parent = p
     for name, ser in data.items():
         for value in deserialize(ser, lookup):
             item.load(name, value)

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -144,16 +144,18 @@ class PresentationCopy(NamedTuple):
 
 @copy.register
 def copy_presentation(item: Presentation) -> PresentationCopy:
-    assert item.canvas
+    assert item.diagram
     buffer = {}
 
     def save_func(name, value):
         buffer[name] = serialize(value)
 
     item.save(save_func)
-    parent = item.canvas.get_parent(item)
+    parent = item.diagram.get_parent(item)
     return PresentationCopy(
-        cls=item.__class__, data=buffer, parent=parent.id if parent else None
+        cls=item.__class__,
+        data=buffer,
+        parent=parent.id if parent and isinstance(parent.id, str) else None,
     )
 
 
@@ -164,11 +166,11 @@ def paste_presentation(copy_data: PresentationCopy, diagram, lookup):
     if parent:
         p = lookup(parent)
         if p:
-            diagram.canvas.reparent(item, p)
+            diagram.reparent(item, p)
     for name, ser in data.items():
         for value in deserialize(ser, lookup):
             item.load(name, value)
-    item.canvas.update_now((), [item])
+    diagram.update_now((), [item])
     return item
 
 

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -149,7 +149,7 @@ def copy_presentation(item: Presentation) -> PresentationCopy:
 
     def save_func(name, value):
         # Do not copy diagram, it's set when pasted
-        if name != "diagram":
+        if name not in ("diagram", "parent", "children"):
             buffer[name] = serialize(value)
 
     item.save(save_func)

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -148,7 +148,9 @@ def copy_presentation(item: Presentation) -> PresentationCopy:
     buffer = {}
 
     def save_func(name, value):
-        buffer[name] = serialize(value)
+        # Do not copy diagram, it's set when pasted
+        if name != "diagram":
+            buffer[name] = serialize(value)
 
     item.save(save_func)
     parent = item.diagram.get_parent(item)

--- a/gaphor/diagram/diagramtools/__init__.py
+++ b/gaphor/diagram/diagramtools/__init__.py
@@ -1,7 +1,4 @@
-"""Tools for handling items on the canvas.
-
-TODO: make tools transactional.
-"""
+"""Tools for handling items on a diagram."""
 
 from gaphas.segment import segment_tool
 from gaphas.tool import (

--- a/gaphor/diagram/diagramtools/dropzone.py
+++ b/gaphor/diagram/diagramtools/dropzone.py
@@ -57,7 +57,7 @@ class DropZoneMove(GuidedItemMove):
         view = self.view
         x, y = pos
 
-        current_parent = view.model.get_parent(item)
+        current_parent = item.parent
         over_item = item_at_point(view, (x, y), selected=False)
 
         if not over_item:
@@ -83,8 +83,7 @@ class DropZoneMove(GuidedItemMove):
         super().stop_move(pos)
         item = self.item
         view = self.view
-        model = view.model
-        old_parent = model.get_parent(item)
+        old_parent = item.parent
         new_parent = view.selection.dropzone_item
         try:
 

--- a/gaphor/diagram/diagramtools/dropzone.py
+++ b/gaphor/diagram/diagramtools/dropzone.py
@@ -94,7 +94,7 @@ class DropZoneMove(GuidedItemMove):
                 return
 
             if old_parent:
-                model.reparent(item, None)
+                item.parent = None
 
                 adapter = Group(old_parent, item)
                 if adapter:
@@ -103,7 +103,7 @@ class DropZoneMove(GuidedItemMove):
                 old_parent.request_update()
 
             if new_parent:
-                model.reparent(item, new_parent)
+                item.parent = new_parent
 
                 adapter = Group(new_parent, item)
                 if adapter and adapter.can_contain():

--- a/gaphor/diagram/diagramtools/placement.py
+++ b/gaphor/diagram/diagramtools/placement.py
@@ -79,7 +79,6 @@ def connect_opposite_handle(view, new_item, x, y, handle_index):
     except (KeyError, AttributeError):
         pass
     else:
-        # First make sure all matrices are updated:
         new_item.matrix_i2c.set(*view.model.get_matrix_i2c(new_item))
 
         handle_move = HandleMove(new_item, opposite, view)

--- a/gaphor/diagram/diagramtools/placement.py
+++ b/gaphor/diagram/diagramtools/placement.py
@@ -123,8 +123,7 @@ def new_item_factory(
 
         adapter = Group(parent, item)
         if parent and adapter.can_contain():
-            canvas = diagram.canvas
-            canvas.reparent(item, parent=parent)
+            diagram.reparent(item, parent=parent)
             adapter.group()
 
         if config_func:

--- a/gaphor/diagram/diagramtools/placement.py
+++ b/gaphor/diagram/diagramtools/placement.py
@@ -65,7 +65,7 @@ def on_drag_begin(gesture, start_x, start_y, placement_state):
 def create_item(view, factory, x, y):
     selection = view.selection
     parent = selection.dropzone_item
-    item = factory(view.model.diagram, parent)
+    item = factory(view.model, parent)
     x, y = view.get_matrix_v2i(item).transform_point(x, y)
     item.matrix.translate(x, y)
     selection.unselect_all()

--- a/gaphor/diagram/diagramtools/placement.py
+++ b/gaphor/diagram/diagramtools/placement.py
@@ -122,7 +122,7 @@ def new_item_factory(
 
         adapter = Group(parent, item)
         if parent and adapter.can_contain():
-            diagram.reparent(item, parent=parent)
+            item.parent = parent
             adapter.group()
 
         if config_func:

--- a/gaphor/diagram/diagramtools/shortcut.py
+++ b/gaphor/diagram/diagramtools/shortcut.py
@@ -36,8 +36,8 @@ def delete_selected_items(view: GtkView, event_manager):
             if isinstance(i, Presentation):
                 i.unlink()
             else:
-                if i.canvas:
-                    i.canvas.remove(i)
+                if i.diagram:
+                    i.diagram.remove(i)
 
 
 def on_shortcut(ctrl, keyval, keycode, state, modeling_language):

--- a/gaphor/diagram/diagramtools/tests/conftest.py
+++ b/gaphor/diagram/diagramtools/tests/conftest.py
@@ -9,7 +9,7 @@ from gaphor.diagram.tests.fixtures import diagram, element_factory, event_manage
 
 @pytest.fixture
 def view(diagram):
-    view = GtkView(model=diagram.canvas, selection=Selection())
+    view = GtkView(model=diagram, selection=Selection())
     view._qtree.resize((-100, -100, 400, 400))
     item_painter = ItemPainter(view.selection)
     view.painter = item_painter

--- a/gaphor/diagram/general/generalpropertypages.py
+++ b/gaphor/diagram/general/generalpropertypages.py
@@ -35,7 +35,7 @@ class CommentItemPropertyPage(PropertyPageBase):
                 buffer.set_text(event.new_value)
                 buffer.handler_unblock(changed_id)
 
-        self.watcher.watch("body", handler).subscribe_all()
+        self.watcher.watch("body", handler)
         text_view.connect("destroy", self.watcher.unsubscribe_all)
 
         return builder.get_object("comment-editor")

--- a/gaphor/diagram/general/tests/test_comment.py
+++ b/gaphor/diagram/general/tests/test_comment.py
@@ -41,7 +41,7 @@ def test_commentline_annotated_element(create, diagram):
 
     connect(line, line.head, comment)
     # connected, but no annotated element yet
-    assert diagram.canvas.connections.get_connection(line.head)
+    assert diagram.connections.get_connection(line.head)
     assert not comment.subject.annotatedElement
 
 
@@ -64,7 +64,7 @@ def test_commentline_element_connect(create, diagram):
 
     connect(line, line.head, comment)
     connect(line, line.tail, ac)
-    assert diagram.canvas.connections.get_connection(line.tail).connected is ac
+    assert diagram.connections.get_connection(line.tail).connected is ac
     assert len(comment.subject.annotatedElement) == 1
     assert ac.subject in comment.subject.annotatedElement
 
@@ -85,7 +85,7 @@ def test_commentline_item_with_no_subject_connect(create, diagram):
 
     connect(line, line.head, comment)
     connect(line, line.tail, gi)
-    assert diagram.canvas.connections.get_connection(line.tail).connected is gi
+    assert diagram.connections.get_connection(line.tail).connected is gi
     assert len(comment.subject.annotatedElement) == 0
 
 
@@ -97,14 +97,14 @@ def test_commentline_element_reconnect(create, diagram):
 
     connect(line, line.head, comment)
     connect(line, line.tail, ac)
-    assert diagram.canvas.connections.get_connection(line.tail).connected is ac
+    assert diagram.connections.get_connection(line.tail).connected is ac
     assert 1 == len(comment.subject.annotatedElement)
     assert ac.subject in comment.subject.annotatedElement
 
     ac2 = create(ActorItem, UML.Actor)
     disconnect(line, line.tail)
     connect(line, line.tail, ac2)
-    assert diagram.canvas.connections.get_connection(line.tail).connected is ac2
+    assert diagram.connections.get_connection(line.tail).connected is ac2
     assert len(comment.subject.annotatedElement) == 1
     assert ac2.subject in comment.subject.annotatedElement
 
@@ -118,10 +118,10 @@ def test_commentline_element_disconnect(create, diagram):
     connect(line, line.head, comment)
     connect(line, line.tail, ac)
 
-    assert diagram.canvas.connections.get_connection(line.tail).connected is ac
+    assert diagram.connections.get_connection(line.tail).connected is ac
 
     disconnect(line, line.tail)
-    assert not diagram.canvas.connections.get_connection(line.tail)
+    assert not diagram.connections.get_connection(line.tail)
 
 
 def test_commentline_relationship_disconnect(create):
@@ -164,14 +164,14 @@ def test_commentline_unlink(create):
     assert clazz.subject in comment.subject.annotatedElement
     assert comment.subject in clazz.subject.comment
 
-    assert line.canvas
+    assert line.diagram
 
     # FixMe: This should invoke the disconnect handler of the line's
     #  handles.
 
     line.unlink()
 
-    assert not line.canvas
+    assert not line.diagram
     assert clazz.subject not in comment.subject.annotatedElement
     assert comment.subject not in clazz.subject.comment
     assert len(comment.subject.annotatedElement) == 0, comment.subject.annotatedElement
@@ -189,7 +189,7 @@ def test_commentline_element_unlink(create):
     assert clazz.subject in comment.subject.annotatedElement
     assert comment.subject in clazz.subject.comment
 
-    assert line.canvas
+    assert line.diagram
 
     clazz_subject = clazz.subject
 
@@ -198,8 +198,8 @@ def test_commentline_element_unlink(create):
 
     clazz.unlink()
 
-    assert not clazz.canvas
-    assert line.canvas
+    assert not clazz.diagram
+    assert line.diagram
     assert not comment.subject.annotatedElement
     assert len(clazz_subject.comment) == 0
 

--- a/gaphor/diagram/general/tests/test_comment.py
+++ b/gaphor/diagram/general/tests/test_comment.py
@@ -23,7 +23,7 @@ def create(element_factory, diagram):
         if subject_cls:
             subject = element_factory.create(subject_cls)
         item = diagram.create(item_cls, subject=subject)
-        diagram.canvas.update_now((item,))
+        diagram.update_now((item,), ())
         return item
 
     return create

--- a/gaphor/diagram/general/tests/test_comment.py
+++ b/gaphor/diagram/general/tests/test_comment.py
@@ -178,7 +178,7 @@ def test_commentline_unlink(create):
     assert len(clazz.subject.comment) == 0, clazz.subject.comment
 
 
-def test_commentline_element_unlink(create):
+def test_commentline_element_unlink(create, diagram):
     """Test comment line unlinking using a class item."""
     clazz = create(ClassItem, UML.Class)
     comment = create(CommentItem, Comment)
@@ -193,11 +193,9 @@ def test_commentline_element_unlink(create):
 
     clazz_subject = clazz.subject
 
-    # FixMe: This should invoke the disconnect handler of the line's
-    #  handles.
-
     clazz.unlink()
 
+    assert clazz not in diagram.ownedPresentation
     assert not clazz.diagram
     assert line.diagram
     assert not comment.subject.annotatedElement

--- a/gaphor/diagram/painter.py
+++ b/gaphor/diagram/painter.py
@@ -1,8 +1,8 @@
-"""The painter module provides different painters for parts of the canvas.
+"""The painter module provides different painters for parts of the diagram.
 
 Painters can be swapped in and out.
 
-Each painter takes care of a layer in the canvas (such as grid, items
+Each painter takes care of a layer in the diagram (such as grid, items
 and handles).
 """
 

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -89,7 +89,6 @@ class ElementPresentation(gaphas.Element, Presentation[S]):
     def __init__(self, connections, id=None, model=None, shape=None):
         super().__init__(connections, id=id, model=model)  # type: ignore[misc]
         self._shape = shape
-        self.update_shapes()
 
     def port_side(self, port):
         return self._port_sides[self._ports.index(port)]

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -122,9 +122,6 @@ class ElementPresentation(gaphas.Element, Presentation[S]):
         # Invoke here, since we do not receive events, unless we're attached to a diagram
         self.update_shapes()
 
-    def teardown_canvas(self):
-        self.unsubscribe_all()
-
     def save(self, save_func):
         save_func("matrix", tuple(self.matrix))
         for prop in ("width", "height"):
@@ -219,10 +216,6 @@ class LinePresentation(gaphas.Line, Presentation[S]):
         ):
             if shape:
                 shape.draw(context, rect)
-
-    def teardown_canvas(self):
-        self.unsubscribe_all()
-        super().teardown_canvas()
 
     def save(self, save_func):
         def save_connection(name, handle):

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -65,7 +65,7 @@ def postload_connect(item: gaphas.Item, handle: gaphas.Handle, target: gaphas.It
     This function finds a suitable spot on the `target` item to connect
     the handle to.
     """
-    connector = ConnectorAspect(item, handle, item.canvas.connections)
+    connector = ConnectorAspect(item, handle, item.diagram.connections)
     sink = _get_sink(item, handle, target)
     connector.connect(sink)
 

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -89,6 +89,7 @@ class ElementPresentation(gaphas.Element, Presentation[S]):
     def __init__(self, connections, id=None, model=None, shape=None):
         super().__init__(connections, id=id, model=model)  # type: ignore[misc]
         self._shape = shape
+        self.update_shapes()
 
     def port_side(self, port):
         return self._port_sides[self._ports.index(port)]
@@ -117,10 +118,6 @@ class ElementPresentation(gaphas.Element, Presentation[S]):
             context,
             Rectangle(0, 0, self.width, self.height),
         )
-
-    def setup_canvas(self):
-        # Invoke here, since we do not receive events, unless we're attached to a diagram
-        self.update_shapes()
 
     def save(self, save_func):
         save_func("matrix", tuple(self.matrix))

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -119,7 +119,6 @@ class ElementPresentation(gaphas.Element, Presentation[S]):
         )
 
     def setup_canvas(self):
-        self.subscribe_all()
         # Invoke here, since we do not receive events, unless we're attached to a diagram
         self.update_shapes()
 
@@ -220,10 +219,6 @@ class LinePresentation(gaphas.Line, Presentation[S]):
         ):
             if shape:
                 shape.draw(context, rect)
-
-    def setup_canvas(self):
-        super().setup_canvas()
-        self.subscribe_all()
 
     def teardown_canvas(self):
         self.unsubscribe_all()

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -28,13 +28,13 @@ def from_package_str(item):
     """Display name space info when it is different, then diagram's or parent's
     namespace."""
     subject = item.subject
-    canvas = item.canvas
+    diagram = item.diagram
 
-    if not (subject and canvas):
+    if not (subject and diagram):
         return False
 
     namespace = subject.namespace
-    parent = canvas.get_parent(item)
+    parent = diagram.get_parent(item)
 
     # if there is a parent (i.e. interaction)
     if parent and parent.subject and parent.subject.namespace is not namespace:
@@ -44,7 +44,7 @@ def from_package_str(item):
 
 
 def _get_sink(item, handle, target):
-    assert item.canvas
+    assert item.diagram
 
     hpos = matrix_i2i(item, target).transform_point(*handle.pos)
     port = None
@@ -120,7 +120,7 @@ class ElementPresentation(gaphas.Element, Presentation[S]):
 
     def setup_canvas(self):
         self.subscribe_all()
-        # Invoke here, since we do not receive events, unless we're attached to a canvas
+        # Invoke here, since we do not receive events, unless we're attached to a diagram
         self.update_shapes()
 
     def teardown_canvas(self):
@@ -187,7 +187,7 @@ class LinePresentation(gaphas.Line, Presentation[S]):
         self._shape_tail_rect = shape_bounds(self.shape_tail, TextAlign.RIGHT)
 
     def point(self, x, y):
-        """Given a point (x, y) return the distance to the canvas item."""
+        """Given a point (x, y) return the distance to the diagram item."""
         d0 = super().point(x, y)
         ds = [
             distance_rectangle_point(shape, (x, y))

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -34,7 +34,7 @@ def from_package_str(item):
         return False
 
     namespace = subject.namespace
-    parent = diagram.get_parent(item)
+    parent = item.parent
 
     # if there is a parent (i.e. interaction)
     if parent and parent.subject and parent.subject.namespace is not namespace:

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -302,14 +302,14 @@ class LineStylePage(PropertyPageBase):
     @transactional
     def _on_orthogonal_change(self, button):
         if len(self.item.handles()) < 3:
-            line_segment = Segment(self.item, self.item.canvas)
+            line_segment = Segment(self.item, self.item.diagram)
             line_segment.split_segment(0)
         active = button.get_active()
         self.item.orthogonal = active
-        self.item.canvas.update_now((self.item,))
+        self.item.diagram.update_now((self.item,))
         self.horizontal_button.set_sensitive(active)
 
     @transactional
     def _on_horizontal_change(self, button):
         self.item.horizontal = button.get_active()
-        self.item.canvas.update_now((self.item,))
+        self.item.diagram.update_now((self.item,))

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -99,19 +99,14 @@ class EditableTreeModel(Gtk.ListStore):
 
     Last row is empty and contains no object to edit. It allows to enter
     new values.
-
-    When model is edited, then item is requested to be updated on canvas.
-
-    Attributes:
-    - _item: diagram item owning tree model
     """
 
     def __init__(self, item, cols=None):
         """Create new model.
 
-        Parameters:
-        - _item: diagram item owning tree model
-        - cols: model columns, defaults to [str, object]
+        Args:
+          item (Presentation): diagram item owning tree model
+          cols (tuple): model column types, defaults to [str, object]
         """
 
         if cols is None:

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -32,7 +32,7 @@ def modeling_language():
 
 
 @pytest.fixture
-def diagram(element_factory):
+def diagram(element_factory) -> Diagram:
     diagram = element_factory.create(Diagram)
     yield diagram
     diagram.unlink()

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -80,31 +80,31 @@ def connect(line, handle, item, port=None):
 
     If port is not provided, then first port is used.
     """
-    canvas = line.canvas
+    diagram = line.diagram
 
     if port is None and len(item.ports()) > 0:
         port = item.ports()[0]
 
     sink = ConnectionSink(item, port)
-    connector = ConnectorAspect(line, handle, canvas.connections)
+    connector = ConnectorAspect(line, handle, diagram.connections)
 
     connector.connect(sink)
 
-    cinfo = canvas.connections.get_connection(handle)
+    cinfo = diagram.connections.get_connection(handle)
     assert cinfo.connected is item
     assert cinfo.port is port
 
 
 def disconnect(line, handle):
     """Disconnect line's handle."""
-    canvas = line.canvas
+    diagram = line.diagram
 
-    canvas.connections.disconnect_item(line, handle)
-    assert not canvas.connections.get_connection(handle)
+    diagram.connections.disconnect_item(line, handle)
+    assert not diagram.connections.get_connection(handle)
 
 
 def get_connected(item, handle):
-    cinfo = item.canvas.connections.get_connection(handle)
+    cinfo = item.diagram.connections.get_connection(handle)
     if cinfo:
         return cinfo.connected  # type: ignore[no-any-return] # noqa: F723
     return None
@@ -116,7 +116,7 @@ def clear_model(diagram, element_factory, retain=[]):
         if element is not diagram and element not in retain:
             element.unlink()
 
-    for item in diagram.canvas.get_all_items():
+    for item in diagram.get_all_items():
         item.unlink()
 
 

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -1,4 +1,5 @@
 from gaphor import UML
+from gaphor.core.modeling import Diagram
 from gaphor.diagram.copypaste import copy, paste
 from gaphor.diagram.general.simpleitem import Box, Ellipse, Line
 from gaphor.diagram.tests.fixtures import connect, copy_clear_and_paste
@@ -168,3 +169,16 @@ def test_copy_remove_paste_simple_items(diagram, element_factory):
     new_box = next(item for item in new_items if isinstance(item, Box))
 
     assert new_box
+
+
+def test_copy_to_new_diagram(diagram, element_factory):
+    new_diagram = element_factory.create(Diagram)
+    cls = element_factory.create(UML.Class)
+    cls_item = diagram.create(ClassItem, subject=cls)
+
+    buffer = copy({cls_item})
+
+    paste(buffer, new_diagram, element_factory.lookup)
+
+    assert len(list(new_diagram.get_all_items())) == 1
+    assert next(new_diagram.get_all_items()).diagram is new_diagram

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -13,7 +13,7 @@ def test_copy_item_adds_new_item_to_the_diagram(diagram, element_factory):
 
     paste(buffer, diagram, element_factory.lookup)
 
-    assert len(diagram.canvas.get_root_items()) == 2
+    assert len(list(diagram.get_all_items())) == 2
 
 
 def test_copied_item_references_same_model_element(diagram, element_factory):
@@ -24,8 +24,8 @@ def test_copied_item_references_same_model_element(diagram, element_factory):
 
     paste(buffer, diagram, element_factory.lookup)
 
-    assert len(diagram.canvas.get_root_items()) == 2
-    item1, item2 = diagram.canvas.get_root_items()
+    assert len(list(diagram.get_all_items())) == 2
+    item1, item2 = diagram.get_all_items()
 
     assert item1.subject is item2.subject
 
@@ -39,7 +39,7 @@ def test_copy_multiple_items(diagram, element_factory):
 
     paste(buffer, diagram, element_factory.lookup)
 
-    assert len(diagram.canvas.get_root_items()) == 4
+    assert len(list(diagram.get_all_items())) == 4
     assert len(element_factory.lselect(UML.Class)) == 1
 
 
@@ -53,7 +53,7 @@ def test_copy_item_without_copying_connection(diagram, element_factory):
 
     new_items = paste(buffer, diagram, element_factory.lookup)
 
-    assert len(diagram.canvas.get_root_items()) == 3
+    assert len(list(diagram.get_all_items())) == 3
     assert len(element_factory.lselect(UML.Class)) == 1
     assert type(new_items) is set
     assert len(new_items) == 1
@@ -80,15 +80,15 @@ def test_copy_item_with_connection(diagram, element_factory):
     new_items = paste(buffer, diagram, element_factory.lookup)
     new_gen_item = next(i for i in new_items if isinstance(i, GeneralizationItem))
 
-    new_cls_item1 = new_gen_item.canvas.connections.get_connection(
+    new_cls_item1 = diagram.connections.get_connection(
         new_gen_item.handles()[0]
     ).connected
-    new_cls_item2 = new_gen_item.canvas.connections.get_connection(
+    new_cls_item2 = diagram.connections.get_connection(
         new_gen_item.handles()[1]
     ).connected
 
-    assert new_cls_item1 in diagram.canvas.get_root_items()
-    assert new_cls_item2 in diagram.canvas.get_root_items()
+    assert new_cls_item1 in diagram.get_all_items()
+    assert new_cls_item2 in diagram.get_all_items()
 
     assert len(new_items) == 3
     assert new_cls_item1 in new_items
@@ -111,7 +111,7 @@ def test_copy_item_when_subject_has_been_removed(diagram, element_factory):
     cls_item.unlink()
     cls.unlink()  # normally handled by the sanitizer service
 
-    assert len(list(diagram.canvas.get_all_items())) == 0
+    assert len(list(diagram.get_all_items())) == 0
     assert cls not in element_factory.select()
     assert not element_factory.lookup(orig_cls_id)
 
@@ -119,7 +119,7 @@ def test_copy_item_when_subject_has_been_removed(diagram, element_factory):
 
     paste(buffer, diagram, element_factory.lookup)
     new_cls = element_factory.lselect(UML.Class)[0]
-    assert len(diagram.canvas.get_root_items()) == 1
+    assert len(list(diagram.get_all_items())) == 1
     assert new_cls.package is package
     assert element_factory.lookup(orig_cls_id) is new_cls
 

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -112,6 +112,7 @@ def test_copy_item_when_subject_has_been_removed(diagram, element_factory):
     cls_item.unlink()
     cls.unlink()  # normally handled by the sanitizer service
 
+    assert set(diagram.ownedPresentation) == set(diagram.get_all_items())
     assert len(list(diagram.get_all_items())) == 0
     assert cls not in element_factory.select()
     assert not element_factory.lookup(orig_cls_id)

--- a/gaphor/diagram/tests/test_copypaste_grouping.py
+++ b/gaphor/diagram/tests/test_copypaste_grouping.py
@@ -15,9 +15,9 @@ def node_with_component(diagram, element_factory):
     comp_item = diagram.create(ComponentItem, subject=comp)
 
     Group(node_item, comp_item).group()
-    diagram.canvas.reparent(comp_item, parent=node_item)
+    diagram.reparent(comp_item, parent=node_item)
 
-    assert diagram.canvas.get_parent(comp_item) is node_item
+    assert diagram.get_parent(comp_item) is node_item
 
     return node_item, comp_item
 
@@ -29,7 +29,7 @@ def test_copy_paste_of_nested_item(diagram, element_factory, node_with_component
 
     (new_comp_item,) = paste(buffer, diagram, element_factory.lookup)
 
-    assert diagram.canvas.get_parent(new_comp_item) is node_item
+    assert diagram.get_parent(new_comp_item) is node_item
 
 
 def test_copy_paste_of_item_with_nested_item(
@@ -44,7 +44,7 @@ def test_copy_paste_of_item_with_nested_item(
     new_node_item = next(i for i in new_items if isinstance(i, NodeItem))
     new_comp_item = next(i for i in new_items if isinstance(i, ComponentItem))
 
-    assert diagram.canvas.get_parent(new_comp_item) is new_node_item
+    assert diagram.get_parent(new_comp_item) is new_node_item
 
 
 def test_copy_remove_paste_of_item_with_nested_item(
@@ -56,4 +56,4 @@ def test_copy_remove_paste_of_item_with_nested_item(
     new_node_item = next(i for i in new_items if isinstance(i, NodeItem))
     new_comp_item = next(i for i in new_items if isinstance(i, ComponentItem))
 
-    assert diagram.canvas.get_parent(new_comp_item) is new_node_item
+    assert diagram.get_parent(new_comp_item) is new_node_item

--- a/gaphor/diagram/tests/test_copypaste_grouping.py
+++ b/gaphor/diagram/tests/test_copypaste_grouping.py
@@ -17,7 +17,7 @@ def node_with_component(diagram, element_factory):
     Group(node_item, comp_item).group()
     comp_item.parent = node_item
 
-    assert diagram.get_parent(comp_item) is node_item
+    assert comp_item.parent is node_item
 
     return node_item, comp_item
 
@@ -29,7 +29,7 @@ def test_copy_paste_of_nested_item(diagram, element_factory, node_with_component
 
     (new_comp_item,) = paste(buffer, diagram, element_factory.lookup)
 
-    assert diagram.get_parent(new_comp_item) is node_item
+    assert new_comp_item.parent is node_item
 
 
 def test_copy_paste_of_item_with_nested_item(
@@ -44,7 +44,7 @@ def test_copy_paste_of_item_with_nested_item(
     new_node_item = next(i for i in new_items if isinstance(i, NodeItem))
     new_comp_item = next(i for i in new_items if isinstance(i, ComponentItem))
 
-    assert diagram.get_parent(new_comp_item) is new_node_item
+    assert new_comp_item.parent is new_node_item
 
 
 def test_copy_remove_paste_of_item_with_nested_item(
@@ -56,4 +56,4 @@ def test_copy_remove_paste_of_item_with_nested_item(
     new_node_item = next(i for i in new_items if isinstance(i, NodeItem))
     new_comp_item = next(i for i in new_items if isinstance(i, ComponentItem))
 
-    assert diagram.get_parent(new_comp_item) is new_node_item
+    assert new_comp_item.parent is new_node_item

--- a/gaphor/diagram/tests/test_copypaste_grouping.py
+++ b/gaphor/diagram/tests/test_copypaste_grouping.py
@@ -15,7 +15,7 @@ def node_with_component(diagram, element_factory):
     comp_item = diagram.create(ComponentItem, subject=comp)
 
     Group(node_item, comp_item).group()
-    diagram.reparent(comp_item, parent=node_item)
+    comp_item.parent = node_item
 
     assert diagram.get_parent(comp_item) is node_item
 

--- a/gaphor/diagram/tests/test_diagramtools.py
+++ b/gaphor/diagram/tests/test_diagramtools.py
@@ -50,7 +50,7 @@ class DiagramItemConnectorTestCase(TestCase):
         # The act: perform button press event and button release
         view = self.component_registry.get(UIComponent, "diagrams").get_current_view()
 
-        assert self.diagram.canvas is view.model
+        assert self.diagram is view.model
 
         p = view.get_matrix_i2v(a).transform_point(*a.head.pos)
 

--- a/gaphor/diagram/tests/test_presentation.py
+++ b/gaphor/diagram/tests/test_presentation.py
@@ -53,11 +53,12 @@ def test_element_saving(element_factory, diagram):
 
     p.save(save_func)
 
-    assert len(properties) == 4
+    assert len(properties) == 5
     assert properties["matrix"] == (1.0, 0.0, 0.0, 1.0, 0.0, 0.0)
     assert properties["width"] == 10.0
     assert properties["height"] == 10.0
     assert properties["subject"] is subject
+    assert properties["diagram"] is diagram
 
 
 def test_element_loading(element_factory, diagram):

--- a/gaphor/plugins/diagramexport/__init__.py
+++ b/gaphor/plugins/diagramexport/__init__.py
@@ -54,8 +54,7 @@ class DiagramExport(Service, ActionProvider):
         )
 
     def render(self, diagram, new_surface):
-        canvas = diagram.canvas
-        canvas.update_now(canvas.get_all_items())
+        diagram.update_now(diagram.get_all_items())
 
         painter = new_painter(diagram)
 
@@ -64,7 +63,7 @@ class DiagramExport(Service, ActionProvider):
         tmpsurface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 0, 0)
         tmpcr = cairo.Context(tmpsurface)
         bounding_box = BoundingBoxPainter(painter).bounding_box(
-            canvas.get_all_items(), tmpcr
+            diagram.get_all_items(), tmpcr
         )
         tmpcr.show_page()
         tmpsurface.flush()
@@ -73,7 +72,7 @@ class DiagramExport(Service, ActionProvider):
         surface = new_surface(w, h)
         cr = cairo.Context(surface)
         cr.translate(-bounding_box.x, -bounding_box.y)
-        painter.paint(items=canvas.get_all_items(), cairo=cr)
+        painter.paint(items=diagram.get_all_items(), cairo=cr)
         cr.show_page()
         return surface
 

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -25,7 +25,7 @@ class CopyService(Service, ActionProvider):
     - How much data should be saved? An example use case is to copy a diagram
       item, remove it (the underlying UML element is removed), and then paste
       the copied item. The diagram should act as if we have placed a copy of
-      the removed item on the canvas and make the UML element visible again.
+      the removed item on the diagram and make the UML element visible again.
     """
 
     def __init__(self, event_manager, element_factory, diagrams):

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -60,7 +60,7 @@ class CopyService(Service, ActionProvider):
 
             # move pasted items a bit, so user can see result of his action :)
             for item in new_items:
-                if diagram.get_parent(item) not in new_items:
+                if item.parent not in new_items:
                     item.matrix.translate(10, 10)
 
         return new_items

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -52,8 +52,6 @@ class CopyService(Service, ActionProvider):
 
     def paste(self, diagram):
         """Paste items in the copy-buffer to the diagram."""
-        canvas = diagram.canvas
-
         with Transaction(self.event_manager):
             # Create new id's that have to be used to create the items:
             new_items: Set[Presentation] = paste(
@@ -62,7 +60,7 @@ class CopyService(Service, ActionProvider):
 
             # move pasted items a bit, so user can see result of his action :)
             for item in new_items:
-                if canvas.get_parent(item) not in new_items:
+                if diagram.get_parent(item) not in new_items:
                     item.matrix.translate(10, 10)
 
         return new_items

--- a/gaphor/services/tests/test_copyservice.py
+++ b/gaphor/services/tests/test_copyservice.py
@@ -33,13 +33,11 @@ class CopyServiceTestCase(TestCase):
         ci = diagram.create(CommentItem, subject=ef.create(UML.Comment))
 
         service.copy({ci})
-        assert list(diagram.canvas.get_all_items()) == [ci]
+        assert list(diagram.get_all_items()) == [ci]
 
         service.paste(diagram)
 
-        assert len(list(diagram.canvas.get_all_items())) == 2, list(
-            diagram.canvas.get_all_items()
-        )
+        assert len(list(diagram.get_all_items())) == 2, list(diagram.get_all_items())
 
     def _skip_test_copy_paste_undo(self):
         """Test if copied data is undoable."""

--- a/gaphor/services/tests/test_copyservice.py
+++ b/gaphor/services/tests/test_copyservice.py
@@ -61,7 +61,7 @@ class CopyServiceTestCase(TestCase):
 
         service.paste(self.diagram)
 
-        all_items = list(self.diagram.canvas.get_all_items())
+        all_items = list(self.diagram.get_all_items())
 
         assert len(all_items) == 6
         assert not orphan_references(self.element_factory)
@@ -74,5 +74,5 @@ class CopyServiceTestCase(TestCase):
 
         undo_manager.undo_transaction()
 
-        assert len(self.diagram.canvas.get_all_items()) == 3
+        assert len(list(self.diagram.get_all_items())) == 3
         assert not orphan_references(self.element_factory)

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -12,11 +12,11 @@ import os.path
 import uuid
 from functools import partial
 
-import gaphas
-
 from gaphor import application
-from gaphor.core.modeling import Diagram, Element
 from gaphor.core.modeling.collection import collection
+from gaphor.core.modeling.diagram import Diagram, PseudoCanvas
+from gaphor.core.modeling.element import Element
+from gaphor.core.modeling.presentation import Presentation
 from gaphor.storage import parser
 
 FILE_FORMAT_VERSION = "3.0"
@@ -67,8 +67,7 @@ def save_element(name, value, writer):
 
     A value may be a primitive (string, int), a
     gaphor.core.modeling.collection (which contains a list of references
-    to other UML elements) or a gaphas.Canvas (which contains canvas
-    items).
+    to other UML elements) or a Diagram (which contains canvas items).
     """
 
     def save_reference(name, value):
@@ -112,7 +111,7 @@ def save_element(name, value, writer):
 
         The extra attribute reference can be used to force UML
         """
-        assert isinstance(value, gaphas.Item)
+        assert isinstance(value, Presentation)
         writer.startElement("item", {"id": value.id, "type": value.__class__.__name__})
         value.save(save_canvas_item)
 
@@ -128,16 +127,16 @@ def save_element(name, value, writer):
         """
         if isinstance(value, collection):
             save_collection(name, value)
-        elif isinstance(value, (Element, gaphas.Item)):
+        elif isinstance(value, Element):
             save_reference(name, value)
         else:
             save_value(name, value)
 
-    if isinstance(value, (Element, gaphas.Item)):
+    if isinstance(value, Element):
         save_reference(name, value)
     elif isinstance(value, collection):
         save_collection(name, value)
-    elif isinstance(value, gaphas.Canvas):
+    elif isinstance(value, PseudoCanvas):
         writer.startElement("canvas", {})
         value.save(save_canvas)
         writer.endElement("canvas")
@@ -187,7 +186,7 @@ def _load_elements_and_canvasitems(
     elements, factory, modeling_language, gaphor_version, update_status_queue
 ):
     def create_canvasitems(diagram, canvasitems, parent=None):
-        """Canvas is a read gaphas.Canvas, items is a list of
+        """Diagram is a Core Diagram, items is a list of
         parser.canvasitem's."""
         if version_lower_than(gaphor_version, (1, 1, 0)):
             new_canvasitems = upgrade_message_item_to_1_1_0(canvasitems)

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -67,7 +67,7 @@ def save_element(name, value, writer):
 
     A value may be a primitive (string, int), a
     gaphor.core.modeling.collection (which contains a list of references
-    to other UML elements) or a Diagram (which contains canvas items).
+    to other UML elements) or a Diagram (which contains diagram items).
     """
 
     def save_reference(name, value):
@@ -106,21 +106,21 @@ def save_element(name, value, writer):
             writer.endElement("val")
             writer.endElement(name)
 
-    def save_canvas(value):
+    def save_diagram(value):
         """Save attributes and references in a gaphor.diagram.* object.
 
         The extra attribute reference can be used to force UML
         """
         assert isinstance(value, Presentation)
         writer.startElement("item", {"id": value.id, "type": value.__class__.__name__})
-        value.save(save_canvas_item)
+        value.save(save_diagram_item)
 
         for child in value.children:
-            save_canvas(child)
+            save_diagram(child)
 
         writer.endElement("item")
 
-    def save_canvas_item(name, value):
+    def save_diagram_item(name, value):
         """Save attributes and references in a gaphor.diagram.* object.
 
         The extra attribute reference can be used to force UML
@@ -138,7 +138,7 @@ def save_element(name, value, writer):
         save_collection(name, value)
     elif isinstance(value, PseudoCanvas):
         writer.startElement("canvas", {})
-        value.save(save_canvas)
+        value.save(save_diagram)
         writer.endElement("canvas")
     else:
         save_value(name, value)

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -115,7 +115,7 @@ def save_element(name, value, writer):
         writer.startElement("item", {"id": value.id, "type": value.__class__.__name__})
         value.save(save_canvas_item)
 
-        for child in value.diagram.get_children(value):
+        for child in value.children:
             save_canvas(child)
 
         writer.endElement("item")

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -116,7 +116,7 @@ def save_element(name, value, writer):
         writer.startElement("item", {"id": value.id, "type": value.__class__.__name__})
         value.save(save_canvas_item)
 
-        for child in value.canvas.get_children(value):
+        for child in value.diagram.get_children(value):
             save_canvas(child)
 
         writer.endElement("item")
@@ -175,9 +175,8 @@ def load_elements_generator(elements, factory, modeling_language, gaphor_version
     yield from _load_attributes_and_references(elements, update_status_queue)
 
     for d in factory.lselect(Diagram):
-        canvas = d.canvas
-        for item in canvas.get_all_items():
-            item.matrix_i2c.set(*canvas.get_matrix_i2c(item))
+        for item in d.get_all_items():
+            item.matrix_i2c.set(*d.get_matrix_i2c(item))
 
     for id, elem in list(elements.items()):
         yield from update_status_queue()

--- a/gaphor/storage/tests/test_group.py
+++ b/gaphor/storage/tests/test_group.py
@@ -21,7 +21,7 @@ def test_load_grouped_connected_items(element_factory, loader):
         e for e in diagram.get_all_items() if not diagram.get_parent(e)
     ]
 
-    child_one, child_two = diagram.get_children(node_item)
+    child_one, child_two = node_item.children
 
     assert isinstance(node_item, NodeItem)
     assert isinstance(dep_item, DependencyItem)

--- a/gaphor/storage/tests/test_group.py
+++ b/gaphor/storage/tests/test_group.py
@@ -17,9 +17,10 @@ def test_load_grouped_connected_items(element_factory, loader):
     loader(NODE_EXAMPLE_XML)
 
     diagram = element_factory.lselect()[0]
-    node_item, dep_item = list(
+    node_item, dep_item = [
         e for e in diagram.get_all_items() if not diagram.get_parent(e)
-    )
+    ]
+
     child_one, child_two = diagram.get_children(node_item)
 
     assert isinstance(node_item, NodeItem)

--- a/gaphor/storage/tests/test_group.py
+++ b/gaphor/storage/tests/test_group.py
@@ -17,18 +17,19 @@ def test_load_grouped_connected_items(element_factory, loader):
     loader(NODE_EXAMPLE_XML)
 
     diagram = element_factory.lselect()[0]
-    canvas = diagram.canvas
-    node_item, dep_item = canvas.get_root_items()
-    child_one, child_two = canvas.get_children(node_item)
+    node_item, dep_item = list(
+        e for e in diagram.get_all_items() if not diagram.get_parent(e)
+    )
+    child_one, child_two = diagram.get_children(node_item)
 
     assert isinstance(node_item, NodeItem)
     assert isinstance(dep_item, DependencyItem)
     assert isinstance(child_one, NodeItem)
     assert isinstance(child_two, NodeItem)
 
-    assert canvas.get_parent(child_one) is node_item
+    assert diagram.get_parent(child_one) is node_item
 
-    assert tuple(canvas.get_matrix_i2c(child_one)) == (
+    assert tuple(diagram.get_matrix_i2c(child_one)) == (
         1.0,
         0.0,
         0.0,
@@ -36,7 +37,7 @@ def test_load_grouped_connected_items(element_factory, loader):
         PARENT_X + CHILD_ONE_X,
         PARENT_Y + CHILD_ONE_Y,
     )
-    assert tuple(canvas.get_matrix_i2c(child_two)) == (
+    assert tuple(diagram.get_matrix_i2c(child_two)) == (
         1.0,
         0.0,
         0.0,

--- a/gaphor/storage/tests/test_group.py
+++ b/gaphor/storage/tests/test_group.py
@@ -17,9 +17,7 @@ def test_load_grouped_connected_items(element_factory, loader):
     loader(NODE_EXAMPLE_XML)
 
     diagram = element_factory.lselect()[0]
-    node_item, dep_item = [
-        e for e in diagram.get_all_items() if not diagram.get_parent(e)
-    ]
+    node_item, dep_item = [e for e in diagram.get_all_items() if not e.parent]
 
     child_one, child_two = node_item.children
 
@@ -28,7 +26,7 @@ def test_load_grouped_connected_items(element_factory, loader):
     assert isinstance(child_one, NodeItem)
     assert isinstance(child_two, NodeItem)
 
-    assert diagram.get_parent(child_one) is node_item
+    assert child_one.parent is node_item
 
     assert tuple(diagram.get_matrix_i2c(child_one)) == (
         1.0,

--- a/gaphor/storage/tests/test_storage.py
+++ b/gaphor/storage/tests/test_storage.py
@@ -124,7 +124,7 @@ class StorageTestCase(TestCase):
         assert len(list(d.get_all_items())) == 3
         for item in d.get_all_items():
             assert item.subject, f"No subject for {item}"
-        d1 = next(d.canvas.select(lambda e: isinstance(e, ClassItem)))
+        d1 = next(d.select(lambda e: isinstance(e, ClassItem)))
         assert d1
 
     def test_load_with_whitespace_name(self):
@@ -172,24 +172,22 @@ class StorageTestCase(TestCase):
         assert len(self.element_factory.lselect(UML.Association)) == 0
 
         # Check load/save of other canvas items.
-        assert len(list(d.canvas.get_all_items())) == 3
+        assert len(list(d.get_all_items())) == 3
         aa = next(
-            item
-            for item in d.canvas.get_all_items()
-            if isinstance(item, AssociationItem)
+            item for item in d.get_all_items() if isinstance(item, AssociationItem)
         )
         assert aa
         assert list(map(float, aa.handles()[0].pos)) == [10, 20], aa.handles()[0].pos
         assert list(map(float, aa.handles()[1].pos)) == [50, 60], aa.handles()[1].pos
-        d1 = next(d.canvas.select(lambda e: isinstance(e, ClassItem)))
+        d1 = next(d.select(lambda e: isinstance(e, ClassItem)))
         assert d1
 
     def test_save_and_load_of_association_with_two_connected_classes(self):
         c1 = self.create(ClassItem, UML.Class)
         c2 = self.create(ClassItem, UML.Class)
         c2.matrix.translate(200, 200)
-        self.diagram.canvas.request_update(c2)
-        self.diagram.canvas.update_now((c1, c2))
+        self.diagram.request_update(c2)
+        self.diagram.update_now((c1, c2))
         assert tuple(c2.matrix_i2c) == (1, 0, 0, 1, 200, 200)
 
         a = self.create(AssociationItem)
@@ -197,7 +195,7 @@ class StorageTestCase(TestCase):
         self.connect(a, a.head, c1)
         self.connect(a, a.tail, c2)
 
-        self.diagram.canvas.update_now((c1, c2, a))
+        self.diagram.update_now((c1, c2, a))
 
         assert a.head.pos.y == 0, a.head.pos
         assert a.tail.pos.x == 10, a.tail.pos
@@ -222,12 +220,12 @@ class StorageTestCase(TestCase):
         diagrams = list(self.kindof(UML.Diagram))
         assert len(diagrams) == 1
         d = diagrams[0]
-        a = next(d.canvas.select(lambda e: isinstance(e, AssociationItem)))
+        a = next(d.select(lambda e: isinstance(e, AssociationItem)))
         assert a.subject is not None
         assert old_a_subject_id == a.subject.id
-        cinfo_head = a.canvas.connections.get_connection(a.head)
+        cinfo_head = a.diagram.connections.get_connection(a.head)
         assert cinfo_head.connected is not None
-        cinfo_tail = a.canvas.connections.get_connection(a.tail)
+        cinfo_tail = a.diagram.connections.get_connection(a.tail)
         assert cinfo_tail.connected is not None
         assert cinfo_head.connected is not cinfo_tail.connected
 

--- a/gaphor/storage/tests/test_storage.py
+++ b/gaphor/storage/tests/test_storage.py
@@ -121,8 +121,8 @@ class StorageTestCase(TestCase):
         )
 
         # Check load/save of other canvas items.
-        assert len(list(d.canvas.get_all_items())) == 3
-        for item in d.canvas.get_all_items():
+        assert len(list(d.get_all_items())) == 3
+        for item in d.get_all_items():
             assert item.subject, f"No subject for {item}"
         d1 = next(d.canvas.select(lambda e: isinstance(e, ClassItem)))
         assert d1

--- a/gaphor/storage/tests/test_storage_message_item_upgrade.py
+++ b/gaphor/storage/tests/test_storage_message_item_upgrade.py
@@ -13,7 +13,7 @@ def test_message_item_upgrade(element_factory, modeling_language):
     load_elements(elements, element_factory, modeling_language)
 
     diagram = element_factory.lselect(UML.Diagram)[0]
-    items = diagram.canvas.get_root_items()
+    items = [e for e in diagram.get_all_items() if not diagram.get_parent(e)]
     message_items = [i for i in items if isinstance(i, diagramitems.MessageItem)]
     subjects = [m.subject for m in message_items]
     messages = element_factory.lselect(UML.Message)

--- a/gaphor/storage/tests/test_storage_message_item_upgrade.py
+++ b/gaphor/storage/tests/test_storage_message_item_upgrade.py
@@ -13,7 +13,7 @@ def test_message_item_upgrade(element_factory, modeling_language):
     load_elements(elements, element_factory, modeling_language)
 
     diagram = element_factory.lselect(UML.Diagram)[0]
-    items = [e for e in diagram.get_all_items() if not diagram.get_parent(e)]
+    items = [e for e in diagram.get_all_items() if not e.parent]
     message_items = [i for i in items if isinstance(i, diagramitems.MessageItem)]
     subjects = [m.subject for m in message_items]
     messages = element_factory.lselect(UML.Message)

--- a/gaphor/storage/tests/test_storage_upgrades.py
+++ b/gaphor/storage/tests/test_storage_upgrades.py
@@ -15,7 +15,7 @@ def loader(element_factory, modeling_language):
             **{p.id: p for p in parsed_items},
         }
         load_elements(parsed_data, element_factory, modeling_language)
-        return element_factory.lselect()[0].canvas.get_root_items()[0]
+        return next(element_factory.lselect()[0].get_all_items())
 
     return _loader
 

--- a/gaphor/storage/verify.py
+++ b/gaphor/storage/verify.py
@@ -44,7 +44,7 @@ def orphan_references(factory):
     def verify_canvas(value):
         elements.add(value.id)
         value.save(verify_canvasitem)
-        for child in value.canvas.get_children(value):
+        for child in value.diagram.get_children(value):
             verify_canvas(child)
 
     def verify_canvasitem(name, value):

--- a/gaphor/storage/verify.py
+++ b/gaphor/storage/verify.py
@@ -43,7 +43,7 @@ def orphan_references(factory):
     def verify_canvas(value):
         elements.add(value.id)
         value.save(verify_canvasitem)
-        for child in value.diagram.get_children(value):
+        for child in value.children:
             verify_canvas(child)
 
     def verify_canvasitem(name, value):

--- a/gaphor/storage/verify.py
+++ b/gaphor/storage/verify.py
@@ -1,9 +1,8 @@
 """Verify the content of an element factory before it is saved."""
 
-import gaphas
-
 from gaphor.core.modeling import Element
 from gaphor.core.modeling.collection import collection
+from gaphor.core.modeling.diagram import PseudoCanvas
 
 
 def orphan_references(factory):
@@ -34,11 +33,11 @@ def orphan_references(factory):
 
     def verify_element(name, value):
         """Store the element id."""
-        if isinstance(value, (Element, gaphas.Item)):
+        if isinstance(value, Element):
             verify_reference(name, value)
         elif isinstance(value, collection):
             verify_collection(name, value)
-        elif isinstance(value, gaphas.Canvas):
+        elif isinstance(value, PseudoCanvas):
             value.save(verify_canvas)
 
     def verify_canvas(value):
@@ -54,7 +53,7 @@ def orphan_references(factory):
         """
         if isinstance(value, collection):
             verify_collection(name, value)
-        elif isinstance(value, (Element, gaphas.Item)):
+        elif isinstance(value, Element):
             verify_reference(name, value)
 
     for e in list(factory.values()):

--- a/gaphor/tests/testcase.py
+++ b/gaphor/tests/testcase.py
@@ -70,7 +70,7 @@ class TestCase(unittest.TestCase):
             subject = self.element_factory.create(subject_cls)
         item = self.diagram.create(item_cls, subject=subject)
         item.canvas = self.diagram.canvas
-        self.diagram.canvas.update_now((item,))
+        self.diagram.update_now((item,))
         return item
 
     def allow(self, line, handle, item, port=None):
@@ -89,38 +89,38 @@ class TestCase(unittest.TestCase):
 
         If port is not provided, then first port is used.
         """
-        canvas = line.canvas
-        assert canvas is item.canvas
+        diagram = line.diagram
+        assert diagram is item.diagram
         if port is None and len(item.ports()) > 0:
             port = item.ports()[0]
 
         sink = ConnectionSink(item, port)
-        connector = ConnectorAspect(line, handle, canvas.connections)
+        connector = ConnectorAspect(line, handle, diagram.connections)
 
         connector.connect(sink)
 
-        cinfo = canvas.connections.get_connection(handle)
+        cinfo = diagram.connections.get_connection(handle)
         assert cinfo.connected is item
         assert cinfo.port is port
 
     def disconnect(self, line, handle):
         """Disconnect line's handle."""
-        canvas = self.diagram.canvas
+        diagram = self.diagram
         # disconnection on adapter level is performed due to callback, so
         # no adapter look up here
-        canvas.connections.disconnect_item(line, handle)
-        assert not canvas.connections.get_connection(handle)
+        diagram.connections.disconnect_item(line, handle)
+        assert not diagram.connections.get_connection(handle)
 
     def get_connected(self, handle):
         """Get item connected to line via handle."""
-        cinfo = self.diagram.canvas.connections.get_connection(handle)
+        cinfo = self.diagram.connections.get_connection(handle)
         if cinfo:
             return cinfo.connected
         return None
 
     def get_connection(self, handle):
         """Get connection information."""
-        return self.diagram.canvas.connections.get_connection(handle)
+        return self.diagram.connections.get_connection(handle)
 
     def can_group(self, parent, item):
         """Check if an item can be grouped by parent."""
@@ -129,7 +129,7 @@ class TestCase(unittest.TestCase):
 
     def group(self, parent, item):
         """Group item within a parent."""
-        self.diagram.canvas.reparent(item, parent)
+        self.diagram.reparent(item, parent)
         adapter = Group(parent, item)
         adapter.group()
 
@@ -137,7 +137,7 @@ class TestCase(unittest.TestCase):
         """Remove item from a parent."""
         adapter = Group(parent, item)
         adapter.ungroup()
-        self.diagram.canvas.reparent(item, None)
+        self.diagram.reparent(item, None)
 
     def kindof(self, cls):
         """Find UML metaclass instances using element factory."""

--- a/gaphor/tests/testcase.py
+++ b/gaphor/tests/testcase.py
@@ -128,7 +128,7 @@ class TestCase(unittest.TestCase):
 
     def group(self, parent, item):
         """Group item within a parent."""
-        self.diagram.reparent(item, parent)
+        item.parent = parent
         adapter = Group(parent, item)
         adapter.group()
 
@@ -136,7 +136,7 @@ class TestCase(unittest.TestCase):
         """Remove item from a parent."""
         adapter = Group(parent, item)
         adapter.ungroup()
-        self.diagram.reparent(item, None)
+        item.parent = None
 
     def kindof(self, cls):
         """Find UML metaclass instances using element factory."""

--- a/gaphor/tests/testcase.py
+++ b/gaphor/tests/testcase.py
@@ -50,7 +50,7 @@ class TestCase(unittest.TestCase):
         self.diagram = self.element_factory.create(UML.Diagram)
 
         # We need to hook up a view for now, so updates are done instantly
-        self.view = GtkView(self.diagram.canvas, selection=Selection())
+        self.view = GtkView(self.diagram, selection=Selection())
         self.view.painter = ItemPainter(self.view.selection)
         self.view.bounding_box_painter = BoundingBoxPainter(self.view.painter)
         assert len(list(self.element_factory.select())) == 1, list(

--- a/gaphor/tests/testcase.py
+++ b/gaphor/tests/testcase.py
@@ -69,7 +69,6 @@ class TestCase(unittest.TestCase):
         if subject_cls is not None:
             subject = self.element_factory.create(subject_cls)
         item = self.diagram.create(item_cls, subject=subject)
-        item.canvas = self.diagram.canvas
         self.diagram.update_now((item,))
         return item
 

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -114,7 +114,7 @@ class DiagramPage:
         """
         assert self.diagram
 
-        view = GtkView(model=self.diagram.canvas, selection=Selection())
+        view = GtkView(model=self.diagram, selection=Selection())
         view.drag_dest_set(
             Gtk.DestDefaults.ALL,
             DiagramPage.VIEW_DND_TARGETS,
@@ -192,9 +192,9 @@ class DiagramPage:
         if event.property is StyleSheet.styleSheet:
             self.set_drawing_style()
 
-            canvas = self.diagram.canvas
-            for item in canvas.get_all_items():
-                canvas.request_update(item)
+            diagram = self.diagram
+            for item in diagram.get_all_items():
+                diagram.request_update(item)
 
     def close(self):
         """Tab is destroyed.
@@ -313,7 +313,7 @@ class DiagramPage:
         )
 
     def _on_drag_data_received(self, view, context, x, y, data, info, time):
-        """Handle data dropped on the canvas."""
+        """Handle data dropped on the diagram."""
         if (
             data
             and data.get_format() == 8

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -208,11 +208,11 @@ class FileManager(Service, ActionProvider):
 
         filename = self.filename
 
-        if filename:
-            self.save(filename)
-            return True
-        else:
+        if not filename:
             return self.action_save_as()
+
+        self.save(filename)
+        return True
 
     @action(name="file-save-as", shortcut="<Primary><Shift>s")
     def action_save_as(self):

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -135,6 +135,7 @@ class FileManager(Service, ActionProvider):
         orphans = verify.orphan_references(self.element_factory)
 
         if orphans:
+            log.info("Found orphan references %s", orphans)
             main_window = self.main_window
 
             dialog = QuestionDialog(

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -268,8 +268,9 @@ class Namespace(UIComponent):
     def tree_view_create_diagram(self):
         assert self.view
         element = self.view.get_selected_element()
+        assert element
         while not isinstance(element, UML.Package):
-            element = element.namespace
+            element = element.owner
         diagram = self.element_factory.create(Diagram)
         diagram.package = element
 
@@ -283,6 +284,7 @@ class Namespace(UIComponent):
     def tree_view_create_package(self):
         assert self.view
         element = self.view.get_selected_element()
+        assert isinstance(element, UML.Package)
         package = self.element_factory.create(UML.Package)
         package.package = element
 
@@ -308,7 +310,7 @@ class Namespace(UIComponent):
                 "that are not shown in other diagrams." % (element.name or "<None>"),
             )
             if m.run() == Gtk.ResponseType.YES:
-                for i in reversed(element.canvas.get_all_items()):
+                for i in reversed(list(element.get_all_items())):
                     s = i.subject
                     if s and len(s.presentation) == 1:
                         s.unlink()

--- a/gaphor/ui/namespaceview.py
+++ b/gaphor/ui/namespaceview.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from gi.repository import Gdk, Gtk, Pango
 
 from gaphor import UML
 from gaphor.core import gettext, transactional
 from gaphor.core.format import format, parse
-from gaphor.core.modeling import Diagram
+from gaphor.core.modeling import Diagram, Element
 from gaphor.ui.iconname import get_icon_name
 from gaphor.ui.namespacemodel import RELATIONSHIPS, relationship_iter_parent
 
@@ -67,12 +67,12 @@ class NamespaceView(Gtk.TreeView):
         self.connect("drag-motion", NamespaceView.on_drag_motion)
         self.connect("drag-data-received", NamespaceView.on_drag_data_received)
 
-    def get_selected_element(self):
+    def get_selected_element(self) -> Optional[Element]:
         selection = self.get_selection()
         model, iter = selection.get_selected()
         if not iter:
-            return
-        return model.get_value(iter, 0)
+            return None
+        return model.get_value(iter, 0)  # type: ignore[no-any-return]
 
     def _set_pixbuf(self, column, cell, model, iter, data):
         element = model.get_value(iter, 0)

--- a/gaphor/ui/tests/test_diagrampage.py
+++ b/gaphor/ui/tests/test_diagrampage.py
@@ -14,7 +14,7 @@ def page(diagram, event_manager, element_factory, properties):
     )
     page.construct()
     assert page.diagram == diagram
-    assert page.view.model == diagram.canvas
+    assert page.view.model == diagram
     yield page
     page.close()
 

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -31,7 +31,7 @@ def diagrams(event_manager, element_factory, properties):
 
 @pytest.fixture
 def connections(diagram):
-    return diagram.canvas.connections
+    return diagram.connections
 
 
 @pytest.fixture
@@ -66,8 +66,7 @@ def test_connect(diagram, comment, commentline, connections):
     sink = ConnectionSink(comment, comment.ports()[0])
     aspect = ConnectorAspect(commentline, commentline.handles()[0], connections)
     aspect.connect(sink)
-    canvas = diagram.canvas
-    cinfo = canvas.connections.get_connection(commentline.handles()[0])
+    cinfo = diagram.connections.get_connection(commentline.handles()[0])
     assert cinfo, cinfo
 
 
@@ -91,7 +90,7 @@ def test_iconnect(event_manager, element_factory, diagrams):
 
     actor = diagram.create(ActorItem, subject=element_factory.create(UML.Actor))
     actor.matrix.translate(200, 200)
-    diagram.canvas.update_now((actor,))
+    diagram.update_now((actor,))
 
     line = diagram.create(CommentLineItem)
 
@@ -108,13 +107,13 @@ def test_iconnect(event_manager, element_factory, diagrams):
     assert item is not None
 
     move.connect(handle.pos)
-    cinfo = diagram.canvas.connections.get_connection(handle)
+    cinfo = diagram.connections.get_connection(handle)
     assert cinfo.constraint is not None
     assert cinfo.connected is comment, cinfo.connected
 
-    ConnectorAspect(line, handle, diagram.canvas.connections).disconnect()
+    ConnectorAspect(line, handle, diagram.connections).disconnect()
 
-    cinfo = diagram.canvas.connections.get_connection(handle)
+    cinfo = diagram.connections.get_connection(handle)
 
     assert cinfo is None
 
@@ -139,7 +138,7 @@ def test_connect_comment_and_actor(event_manager, element_factory, diagrams):
     assert sink.item is comment
 
     move.connect(handle.pos)
-    cinfo = diagram.canvas.connections.get_connection(handle)
+    cinfo = diagram.connections.get_connection(handle)
     assert cinfo is not None, None
     assert cinfo.item is line
     assert cinfo.connected is comment

--- a/models/Core.gaphor
+++ b/models/Core.gaphor
@@ -27,6 +27,32 @@
 <name>
 <val>main</val>
 </name>
+<ownedPresentation>
+<reflist>
+<ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="5286c313-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="5cdae47f-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="639b48d1-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="68e63fac-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="8d9bc178-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="928c9ebe-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="04c97773-7a96-11ea-a112-7f953848cf85"/>
+<ref refid="1875194e-7a96-11ea-a112-7f953848cf85"/>
+<ref refid="c9b0922c-7a97-11ea-a112-7f953848cf85"/>
+<ref refid="34cd79d7-7aa6-11ea-a112-7f953848cf85"/>
+<ref refid="4355661c-7aa6-11ea-a112-7f953848cf85"/>
+<ref refid="4a93f8b0-7aa6-11ea-a112-7f953848cf85"/>
+<ref refid="4b561cdd-7cf9-11ea-b719-1f391582df99"/>
+<ref refid="5175e1cd-7cf9-11ea-b719-1f391582df99"/>
+<ref refid="15e4b0b3-9f17-11ea-b537-dfaaecc5bf61"/>
+<ref refid="29de062c-9f17-11ea-b537-dfaaecc5bf61"/>
+<ref refid="9bdd3fed-9f17-11ea-b537-dfaaecc5bf61"/>
+<ref refid="ada170c7-9f17-11ea-b537-dfaaecc5bf61"/>
+<ref refid="cf596824-e0b9-11ea-b7ab-f5b4c130f24e"/>
+<ref refid="216581ca-4465-11eb-8946-9bdfa28f7a50"/>
+<ref refid="446a3744-4465-11eb-8946-9bdfa28f7a50"/>
+</reflist>
+</ownedPresentation>
 <package>
 <ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
 </package>
@@ -41,6 +67,9 @@
 <height>
 <val>84.68594360351562</val>
 </height>
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -58,6 +87,9 @@
 <height>
 <val>57.0</val>
 </height>
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -75,6 +107,9 @@
 <height>
 <val>66.0</val>
 </height>
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -92,6 +127,9 @@
 <height>
 <val>66.0</val>
 </height>
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -100,6 +138,9 @@
 </subject>
 </item>
 <item id="68e63fac-7a95-11ea-a112-7f953848cf85" type="AssociationItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="69c25758-7a95-11ea-a112-7f953848cf85"/>
 </subject>
@@ -132,6 +173,9 @@
 </tail-subject>
 </item>
 <item id="8d9bc178-7a95-11ea-a112-7f953848cf85" type="GeneralizationItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="8f000556-7a95-11ea-a112-7f953848cf85"/>
 </subject>
@@ -155,6 +199,9 @@
 </tail-connection>
 </item>
 <item id="928c9ebe-7a95-11ea-a112-7f953848cf85" type="GeneralizationItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="937b5de2-7a95-11ea-a112-7f953848cf85"/>
 </subject>
@@ -187,6 +234,9 @@
 <height>
 <val>83.0</val>
 </height>
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -195,6 +245,9 @@
 </subject>
 </item>
 <item id="1875194e-7a96-11ea-a112-7f953848cf85" type="GeneralizationItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="0321eb6a-a184-11ea-b537-dfaaecc5bf61"/>
 </subject>
@@ -218,6 +271,9 @@
 </tail-connection>
 </item>
 <item id="c9b0922c-7a97-11ea-a112-7f953848cf85" type="GeneralizationItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="00e85fc8-a184-11ea-b537-dfaaecc5bf61"/>
 </subject>
@@ -250,11 +306,17 @@
 <height>
 <val>61.0</val>
 </height>
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="34cd79d6-7aa6-11ea-a112-7f953848cf85"/>
 </subject>
 </item>
 <item id="4355661c-7aa6-11ea-a112-7f953848cf85" type="CommentLineItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 820.3973693847656, 381.8609619140625)</val>
 </matrix>
@@ -275,6 +337,9 @@
 </tail-connection>
 </item>
 <item id="4a93f8b0-7aa6-11ea-a112-7f953848cf85" type="CommentLineItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 820.3973693847656, 406.763427734375)</val>
 </matrix>
@@ -295,6 +360,9 @@
 </tail-connection>
 </item>
 <item id="4b561cdd-7cf9-11ea-b719-1f391582df99" type="GeneralizationItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="55d98dea-7cf9-11ea-b719-1f391582df99"/>
 </subject>
@@ -327,6 +395,9 @@
 <height>
 <val>66.0</val>
 </height>
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -344,6 +415,9 @@
 <height>
 <val>66.0</val>
 </height>
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -352,6 +426,9 @@
 </subject>
 </item>
 <item id="29de062c-9f17-11ea-b537-dfaaecc5bf61" type="GeneralizationItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="f929580a-a183-11ea-b537-dfaaecc5bf61"/>
 </subject>
@@ -384,11 +461,17 @@
 <height>
 <val>44.0</val>
 </height>
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="9bdd3fec-9f17-11ea-b537-dfaaecc5bf61"/>
 </subject>
 </item>
 <item id="ada170c7-9f17-11ea-b537-dfaaecc5bf61" type="CommentLineItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 432.1161416499558, 523.8687744140625)</val>
 </matrix>
@@ -409,6 +492,9 @@
 </tail-connection>
 </item>
 <item id="cf596824-e0b9-11ea-b7ab-f5b4c130f24e" type="AssociationItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="d092794c-e0b9-11ea-b7ab-f5b4c130f24e"/>
 </subject>
@@ -441,6 +527,9 @@
 </tail-subject>
 </item>
 <item id="216581ca-4465-11eb-8946-9bdfa28f7a50" type="AssociationItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="216581c9-4465-11eb-8946-9bdfa28f7a50"/>
 </subject>
@@ -473,6 +562,9 @@
 </tail-subject>
 </item>
 <item id="446a3744-4465-11eb-8946-9bdfa28f7a50" type="AssociationItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
 <subject>
 <ref refid="446a3743-4465-11eb-8946-9bdfa28f7a50"/>
 </subject>
@@ -1117,9 +1209,6 @@ diagram {
 </presentation>
 </Association>
 <Property id="446a3745-4465-11eb-8946-9bdfa28f7a50">
-<aggregation>
-<val>composite</val>
-</aggregation>
 <association>
 <ref refid="446a3743-4465-11eb-8946-9bdfa28f7a50"/>
 </association>
@@ -1149,6 +1238,9 @@ diagram {
 </upperValue>
 </Property>
 <Property id="446a3746-4465-11eb-8946-9bdfa28f7a50">
+<aggregation>
+<val>composite</val>
+</aggregation>
 <association>
 <ref refid="446a3743-4465-11eb-8946-9bdfa28f7a50"/>
 </association>

--- a/models/Core.gaphor
+++ b/models/Core.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.0.0">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.1.1">
 <Package id="3867dda4-7a95-11ea-a112-7f953848cf85">
 <name>
 <val>Core</val>
@@ -67,13 +67,13 @@
 </item>
 <item id="5cdae47f-7a95-11ea-a112-7f953848cf85" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 599.8694152832031, 523.8687744140625)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 599.8694152832031, 521.4187622070312)</val>
 </matrix>
 <width>
-<val>108.79656982421875</val>
+<val>107.13058471679688</val>
 </width>
 <height>
-<val>66.851806640625</val>
+<val>66.0</val>
 </height>
 <show_operations>
 <val>0</val>
@@ -84,7 +84,7 @@
 </item>
 <item id="639b48d1-7a95-11ea-a112-7f953848cf85" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 174.91839599609347, 521.4187622070312)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 226.9597672172212, 521.4187622070312)</val>
 </matrix>
 <width>
 <val>188.0</val>
@@ -113,7 +113,7 @@
 <val>1</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-430.0612294724194, 0.0), (-430.0612294724194, 467.28001403808594), (-320.6803395798416, 467.28001403808594)]</val>
+<val>[(0.0, 0.0), (-430.0612294724194, 0.0), (-430.0612294724194, 467.28001403808594), (-268.63896835871384, 467.28001403808594)]</val>
 </points>
 <head-connection>
 <ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
@@ -168,7 +168,7 @@
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-0.13115509033207218, 70.74114990234375)]</val>
+<val>[(0.0, 0.0), (-0.9391578674317316, 68.2911376953125)]</val>
 </points>
 <head-connection>
 <ref refid="5286c313-7a95-11ea-a112-7f953848cf85"/>
@@ -231,7 +231,7 @@
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (0.0, 74.77569580078125), (-310.43929390285354, 74.77569580078125), (-310.43929390285354, 400.1944580078125)]</val>
+<val>[(0.0, 0.0), (0.0, 74.77569580078125), (-258.3979226817258, 74.77569580078125), (-258.3979226817258, 400.1944580078125)]</val>
 </points>
 <head-connection>
 <ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
@@ -242,7 +242,7 @@
 </item>
 <item id="34cd79d7-7aa6-11ea-a112-7f953848cf85" type="CommentItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 820.3973693847656, 365.62762451171875)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 400.59873557593505, 392.12762451171875)</val>
 </matrix>
 <width>
 <val>117.0</val>
@@ -265,7 +265,7 @@
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-56.129669189453125, -94.74874877929688)]</val>
+<val>[(-376.3973693847656, 10.26666259765625), (-276.1296691894531, -91.8609619140625)]</val>
 </points>
 <head-connection>
 <ref refid="34cd79d7-7aa6-11ea-a112-7f953848cf85"/>
@@ -285,7 +285,7 @@
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-83.85244146668083, 14.632568359375)]</val>
+<val>[(-302.7986338088306, 16.236572265625), (-253.85244146668083, 16.236572265625)]</val>
 </points>
 <head-connection>
 <ref refid="34cd79d7-7aa6-11ea-a112-7f953848cf85"/>
@@ -336,7 +336,7 @@
 </item>
 <item id="15e4b0b3-9f17-11ea-b537-dfaaecc5bf61" type="ClassItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 405.7207298415308, 523.8687744140625)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 761.7207298415308, 521.4187622070312)</val>
 </matrix>
 <width>
 <val>149.0</val>
@@ -365,7 +365,7 @@
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (0.0, 74.77569580078125), (-98.67207745885685, 74.77569580078125), (-98.67207745885685, 402.64447021484375)]</val>
+<val>[(0.0, 0.0), (0.0, 74.77569580078125), (257.32792254114315, 74.77569580078125), (257.32792254114315, 400.1944580078125)]</val>
 </points>
 <head-connection>
 <ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
@@ -376,7 +376,7 @@
 </item>
 <item id="9bdd3fed-9f17-11ea-b537-dfaaecc5bf61" type="CommentItem">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 320.01983642578125, 434.12652587890625)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 879.1386901855469, 418.12652587890625)</val>
 </matrix>
 <width>
 <val>122.6197509765625</val>
@@ -399,7 +399,7 @@
 <val>0</val>
 </horizontal>
 <points>
-<val>[(0.0, 0.0), (-51.24864897417456, -45.74224853515625)]</val>
+<val>[(452.8838583500442, -2.45001220703125), (507.8702047855911, -61.74224853515625)]</val>
 </points>
 <head-connection>
 <ref refid="15e4b0b3-9f17-11ea-b537-dfaaecc5bf61"/>
@@ -438,6 +438,70 @@
 </head-subject>
 <tail-subject>
 <ref refid="d092794e-e0b9-11ea-b7ab-f5b4c130f24e"/>
+</tail-subject>
+</item>
+<item id="216581ca-4465-11eb-8946-9bdfa28f7a50" type="AssociationItem">
+<subject>
+<ref refid="216581c9-4465-11eb-8946-9bdfa28f7a50"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 451.0, 554.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-36.04023278277879, -1.0), (148.86941528320312, -1.0)]</val>
+</points>
+<head-connection>
+<ref refid="639b48d1-7a95-11ea-a112-7f953848cf85"/>
+</head-connection>
+<tail-connection>
+<ref refid="5cdae47f-7a95-11ea-a112-7f953848cf85"/>
+</tail-connection>
+<show-direction>
+<val>0</val>
+</show-direction>
+<head-subject>
+<ref refid="216581cb-4465-11eb-8946-9bdfa28f7a50"/>
+</head-subject>
+<tail-subject>
+<ref refid="216581cc-4465-11eb-8946-9bdfa28f7a50"/>
+</tail-subject>
+</item>
+<item id="446a3744-4465-11eb-8946-9bdfa28f7a50" type="AssociationItem">
+<subject>
+<ref refid="446a3743-4465-11eb-8946-9bdfa28f7a50"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 416.0, 594.0)</val>
+</matrix>
+<orthogonal>
+<val>1</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-41.0, -6.58123779296875), (-41.0, 93.0), (-118.0, 93.0), (-118.0, -6.58123779296875)]</val>
+</points>
+<head-connection>
+<ref refid="639b48d1-7a95-11ea-a112-7f953848cf85"/>
+</head-connection>
+<tail-connection>
+<ref refid="639b48d1-7a95-11ea-a112-7f953848cf85"/>
+</tail-connection>
+<show-direction>
+<val>0</val>
+</show-direction>
+<head-subject>
+<ref refid="446a3745-4465-11eb-8946-9bdfa28f7a50"/>
+</head-subject>
+<tail-subject>
+<ref refid="446a3746-4465-11eb-8946-9bdfa28f7a50"/>
 </tail-subject>
 </item>
 </canvas>
@@ -499,6 +563,11 @@
 <name>
 <val>Diagram</val>
 </name>
+<ownedAttribute>
+<reflist>
+<ref refid="216581cb-4465-11eb-8946-9bdfa28f7a50"/>
+</reflist>
+</ownedAttribute>
 <package>
 <ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
 </package>
@@ -524,6 +593,9 @@
 <reflist>
 <ref refid="69c25759-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="0b0b00ce-9f17-11ea-b537-dfaaecc5bf61"/>
+<ref refid="446a3745-4465-11eb-8946-9bdfa28f7a50"/>
+<ref refid="446a3746-4465-11eb-8946-9bdfa28f7a50"/>
+<ref refid="216581cc-4465-11eb-8946-9bdfa28f7a50"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -955,6 +1027,142 @@ diagram {
 </presentation>
 <type>
 <ref refid="5175e1cc-7cf9-11ea-b719-1f391582df99"/>
+</type>
+<upperValue>
+<val>*</val>
+</upperValue>
+<upperValue>
+<val>*</val>
+</upperValue>
+</Property>
+<Association id="216581c9-4465-11eb-8946-9bdfa28f7a50">
+<memberEnd>
+<reflist>
+<ref refid="216581cb-4465-11eb-8946-9bdfa28f7a50"/>
+<ref refid="216581cc-4465-11eb-8946-9bdfa28f7a50"/>
+</reflist>
+</memberEnd>
+<presentation>
+<reflist>
+<ref refid="216581ca-4465-11eb-8946-9bdfa28f7a50"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="216581cb-4465-11eb-8946-9bdfa28f7a50">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="216581c9-4465-11eb-8946-9bdfa28f7a50"/>
+</association>
+<class_>
+<ref refid="5cdae47e-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<name>
+<val>ownedPresentation</val>
+</name>
+<presentation>
+<reflist/>
+</presentation>
+<type>
+<ref refid="639b48d0-7a95-11ea-a112-7f953848cf85"/>
+</type>
+<upperValue>
+<val>*</val>
+</upperValue>
+<upperValue>
+<val>*</val>
+</upperValue>
+</Property>
+<Property id="216581cc-4465-11eb-8946-9bdfa28f7a50">
+<association>
+<ref refid="216581c9-4465-11eb-8946-9bdfa28f7a50"/>
+</association>
+<class_>
+<ref refid="639b48d0-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>diagram</val>
+</name>
+<presentation>
+<reflist/>
+</presentation>
+<type>
+<ref refid="5cdae47e-7a95-11ea-a112-7f953848cf85"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<Association id="446a3743-4465-11eb-8946-9bdfa28f7a50">
+<memberEnd>
+<reflist>
+<ref refid="446a3745-4465-11eb-8946-9bdfa28f7a50"/>
+<ref refid="446a3746-4465-11eb-8946-9bdfa28f7a50"/>
+</reflist>
+</memberEnd>
+<presentation>
+<reflist>
+<ref refid="446a3744-4465-11eb-8946-9bdfa28f7a50"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="446a3745-4465-11eb-8946-9bdfa28f7a50">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="446a3743-4465-11eb-8946-9bdfa28f7a50"/>
+</association>
+<class_>
+<ref refid="639b48d0-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>parent</val>
+</name>
+<presentation>
+<reflist/>
+</presentation>
+<type>
+<ref refid="639b48d0-7a95-11ea-a112-7f953848cf85"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<Property id="446a3746-4465-11eb-8946-9bdfa28f7a50">
+<association>
+<ref refid="446a3743-4465-11eb-8946-9bdfa28f7a50"/>
+</association>
+<class_>
+<ref refid="639b48d0-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<name>
+<val>children</val>
+</name>
+<presentation>
+<reflist/>
+</presentation>
+<type>
+<ref refid="639b48d0-7a95-11ea-a112-7f953848cf85"/>
 </type>
 <upperValue>
 <val>*</val>

--- a/models/Core.override
+++ b/models/Core.override
@@ -52,8 +52,20 @@ override Presentation
 override Element.presentation
 # defined in gaphor.core.modeling.presentation
 %%
+override Presentation.diagram
+# defined in gaphor.core.modeling.presentation
+%%
 override Presentation.subject
+# defined in gaphor.core.modeling.presentation
+%%
+override Presentation.parent
+# defined in gaphor.core.modeling.presentation
+%%
+override Presentation.children
 # defined in gaphor.core.modeling.presentation
 %%
 override Diagram
 # defined in gaphor.core.modeling.diagram
+%%
+override Diagram.ownedPresentation
+# defined in gaphor.core.modeling.presentation

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,7 @@ check_untyped_defs = True
 strict_optional = True
 disallow_any_explicit = True
 show_error_codes = True
+ignore_missing_imports=True
 
 [mypy-*.tests.*]
 ignore_errors = True

--- a/test-models/simple-items.gaphor
+++ b/test-models/simple-items.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="1.3.0">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.1.1">
 <Package id="DCE:658E43CC-3A1D-11DC-8B61-000D93868322">
 <name>
 <val>New model</val>
@@ -14,6 +14,13 @@
 <name>
 <val>main</val>
 </name>
+<ownedPresentation>
+<reflist>
+<ref refid="DCE:6719E9C4-3A1D-11DC-8B61-000D93868322"/>
+<ref refid="DCE:680E2142-3A1D-11DC-8B61-000D93868322"/>
+<ref refid="DCE:68ECCFB2-3A1D-11DC-8B61-000D93868322"/>
+</reflist>
+</ownedPresentation>
 <package>
 <ref refid="DCE:658E43CC-3A1D-11DC-8B61-000D93868322"/>
 </package>

--- a/tests/test_action_issue.py
+++ b/tests/test_action_issue.py
@@ -87,5 +87,5 @@ class ActionIssueTestCase(TestCase):
         for a in actions:
             (p,) = a.inPartition
             assert p
-            assert diagram.get_parent(a.presentation[0])
-            assert diagram.get_parent(a.presentation[0]) is p.presentation[0]
+            assert a.presentation[0].parent
+            assert a.presentation[0].parent is p.presentation[0]

--- a/tests/test_action_issue.py
+++ b/tests/test_action_issue.py
@@ -27,13 +27,13 @@ class ActionIssueTestCase(TestCase):
         diagrams = ef.lselect(UML.Diagram)
         assert 1 == len(diagrams)
 
-        canvas = diagrams[0].canvas
-        assert 7 == len(list(canvas.get_all_items()))
+        diagram = diagrams[0]
+        assert 7 == len(list(diagram.get_all_items()))
         # Part, Act, Act, Act, Flow, Flow, Flow
 
         for e in actions + flows:
             assert 1 == len(e.presentation), e
-        for i in canvas.select(lambda e: isinstance(e, (FlowItem, ActionItem))):
+        for i in diagram.select(lambda e: isinstance(e, (FlowItem, ActionItem))):
             assert i.subject, i
 
         # Loaded as:
@@ -48,11 +48,11 @@ class ActionIssueTestCase(TestCase):
         assert actions[2].outgoing[0] is flows[2]
         assert not actions[0].incoming
 
-        (cinfo,) = canvas.connections.get_connections(
+        (cinfo,) = diagram.connections.get_connections(
             handle=flows[0].presentation[0].head
         )
         assert cinfo.connected is actions[0].presentation[0]
-        (cinfo,) = canvas.connections.get_connections(
+        (cinfo,) = diagram.connections.get_connections(
             handle=flows[1].presentation[0].head
         )
         assert cinfo.connected is actions[0].presentation[0]
@@ -61,11 +61,11 @@ class ActionIssueTestCase(TestCase):
         assert actions[2].incoming[0] is flows[1]
         assert actions[2].outgoing[0] is flows[2]
 
-        (cinfo,) = canvas.connections.get_connections(
+        (cinfo,) = diagram.connections.get_connections(
             handle=flows[1].presentation[0].tail
         )
         assert cinfo.connected is actions[2].presentation[0]
-        (cinfo,) = canvas.connections.get_connections(
+        (cinfo,) = diagram.connections.get_connections(
             handle=flows[2].presentation[0].head
         )
         assert cinfo.connected is actions[2].presentation[0]
@@ -74,11 +74,11 @@ class ActionIssueTestCase(TestCase):
         assert actions[1].incoming[0] is flows[0]
         assert actions[1].incoming[1] is flows[2]
 
-        (cinfo,) = canvas.connections.get_connections(
+        (cinfo,) = diagram.connections.get_connections(
             handle=flows[0].presentation[0].tail
         )
         assert cinfo.connected is actions[1].presentation[0]
-        (cinfo,) = canvas.connections.get_connections(
+        (cinfo,) = diagram.connections.get_connections(
             handle=flows[2].presentation[0].tail
         )
         assert cinfo.connected is actions[1].presentation[0]
@@ -87,5 +87,5 @@ class ActionIssueTestCase(TestCase):
         for a in actions:
             (p,) = a.inPartition
             assert p
-            assert canvas.get_parent(a.presentation[0])
-            assert canvas.get_parent(a.presentation[0]) is p.presentation[0]
+            assert diagram.get_parent(a.presentation[0])
+            assert diagram.get_parent(a.presentation[0]) is p.presentation[0]

--- a/tests/test_issue_gaphas.py
+++ b/tests/test_issue_gaphas.py
@@ -15,7 +15,7 @@ class GaphasTest(TestCase):
 
         a = self.create(AssociationItem)
 
-        assert len(list(self.diagram.canvas.get_all_items())) == 3
+        assert len(list(self.diagram.get_all_items())) == 3
 
         self.connect(a, a.head, c1)
         self.connect(a, a.tail, c2)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

We do special things for Presentation relationships. These should be ordinary relationships, as defined in the core model.

Issue Number: #468

### What is the new behavior?

* `Diagram` now owns all presentations (`Diagram.ownedPresentation`).
* `Presentation.diagram` is a normal association. We can watch it. No need for canvas variables anymore.
* Removed `DiagramCanvas`. Functionality is merged with `Diagram`
* `Presentation` elements use a `parent`-`children` relationship. The tree structure is no longer centrally managed by the Canvas.
* Watched paths are directly registered. `EventWatcher.subscribe_all()` has be removed.
* Removed `Presentation.setup_canvas()` and `teardown_canvas()`. We no longer need them.

### Does this PR introduce a breaking change?
- [X] Yes
- [ ] No
