### PR TITLE
Presentation requires diagram

### DIFF
--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -28,8 +28,8 @@ from gaphor.UML.umlfmt import format_property
 
 @represents(Block)
 class BlockItem(ElementPresentation[Block], Classified):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.watch("show_stereotypes", self.update_shapes).watch(
             "show_parts", self.update_shapes

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -28,8 +28,8 @@ from gaphor.UML.umlfmt import format_property
 
 @represents(Block)
 class BlockItem(ElementPresentation[Block], Classified):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.watch("show_stereotypes", self.update_shapes).watch(
             "show_parts", self.update_shapes

--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -14,8 +14,8 @@ from gaphor.UML.umlfmt import format_property
 
 @represents(UML.Property)
 class PropertyItem(ElementPresentation[UML.Property], Named):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject[Property].name")

--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -14,8 +14,8 @@ from gaphor.UML.umlfmt import format_property
 
 @represents(UML.Property)
 class PropertyItem(ElementPresentation[UML.Property], Named):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject[Property].name")

--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -34,8 +34,8 @@ def text_position(position):
 
 @represents(sysml.ProxyPort)
 class ProxyPortItem(Presentation[sysml.ProxyPort], Named):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
         self._matrix = Matrix()
         self._matrix_i2c = Matrix()
         self._connections = diagram.connections

--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 from gaphas.connector import Handle, LinePort, Position
 from gaphas.geometry import Rectangle, distance_rectangle_point
-from gaphas.matrix import Matrix
 
 from gaphor.core.modeling import Presentation
 from gaphor.diagram.presentation import Named, postload_connect
@@ -36,8 +35,6 @@ def text_position(position):
 class ProxyPortItem(Presentation[sysml.ProxyPort], Named):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
-        self._matrix = Matrix()
-        self._matrix_i2c = Matrix()
         self._connections = diagram.connections
 
         h1 = Handle(connectable=True)
@@ -58,14 +55,6 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], Named):
         self._last_connected_side = None
         self.watch("subject[NamedElement].name")
         self.update_shapes()
-
-    @property
-    def matrix(self) -> Matrix:
-        return self._matrix
-
-    @property
-    def matrix_i2c(self) -> Matrix:
-        return self._matrix_i2c
 
     def handles(self):
         return self._handles

--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -34,11 +34,11 @@ def text_position(position):
 
 @represents(sysml.ProxyPort)
 class ProxyPortItem(Presentation[sysml.ProxyPort], Named):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(id=id, model=model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
         self._matrix = Matrix()
         self._matrix_i2c = Matrix()
-        self._connections = connections
+        self._connections = diagram.connections
 
         h1 = Handle(connectable=True)
         self._handles = [h1]

--- a/gaphor/SysML/blocks/tests/test_proxy_port.py
+++ b/gaphor/SysML/blocks/tests/test_proxy_port.py
@@ -1,16 +1,9 @@
-import pytest
 from gaphas import Item
-from gaphas.connections import Connections
 
 from gaphor.SysML.blocks.proxyport import ProxyPortItem
 
 
-@pytest.fixture
-def connections():
-    return Connections()
-
-
-def test_proxy_port_item_conforms_to_item_protocol(connections):
-    item = ProxyPortItem(connections)
+def test_proxy_port_item_conforms_to_item_protocol(diagram):
+    item = ProxyPortItem(diagram)
 
     assert isinstance(item, Item)

--- a/gaphor/SysML/requirements/relationships.py
+++ b/gaphor/SysML/requirements/relationships.py
@@ -9,8 +9,8 @@ class DirectedRelationshipPropertyPathItem(LinePresentation, Named):
 
     relation_type = ""
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
 
         self.shape_middle = Box(
             Text(

--- a/gaphor/SysML/requirements/relationships.py
+++ b/gaphor/SysML/requirements/relationships.py
@@ -9,8 +9,8 @@ class DirectedRelationshipPropertyPathItem(LinePresentation, Named):
 
     relation_type = ""
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id, style={"dash-style": (7.0, 5.0)})
 
         self.shape_middle = Box(
             Text(

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -29,8 +29,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 
 @represents(Requirement)
 class RequirementItem(ElementPresentation[Requirement], Classified):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.watch("show_stereotypes", self.update_shapes).watch(
             "show_attributes", self.update_shapes

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -29,8 +29,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 
 @represents(Requirement)
 class RequirementItem(ElementPresentation[Requirement], Classified):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.watch("show_stereotypes", self.update_shapes).watch(
             "show_attributes", self.update_shapes

--- a/gaphor/UML/actions/action.py
+++ b/gaphor/UML/actions/action.py
@@ -9,8 +9,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 
 @represents(UML.Action)
 class ActionItem(ElementPresentation, Named):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.shape = Box(
             Text(
@@ -32,8 +32,8 @@ class ActionItem(ElementPresentation, Named):
 
 @represents(UML.SendSignalAction)
 class SendSignalActionItem(ElementPresentation, Named):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.shape = Box(
             Text(
@@ -63,8 +63,8 @@ class SendSignalActionItem(ElementPresentation, Named):
 
 @represents(UML.AcceptEventAction)
 class AcceptEventActionItem(ElementPresentation, Named):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.shape = Box(
             Text(

--- a/gaphor/UML/actions/action.py
+++ b/gaphor/UML/actions/action.py
@@ -9,8 +9,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 
 @represents(UML.Action)
 class ActionItem(ElementPresentation, Named):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.shape = Box(
             Text(
@@ -32,8 +32,8 @@ class ActionItem(ElementPresentation, Named):
 
 @represents(UML.SendSignalAction)
 class SendSignalActionItem(ElementPresentation, Named):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.shape = Box(
             Text(
@@ -63,8 +63,8 @@ class SendSignalActionItem(ElementPresentation, Named):
 
 @represents(UML.AcceptEventAction)
 class AcceptEventActionItem(ElementPresentation, Named):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.shape = Box(
             Text(

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -6,7 +6,6 @@ import math
 from gaphas.constraint import constraint
 from gaphas.geometry import Rectangle, distance_line_point
 from gaphas.item import Handle, LinePort
-from gaphas.matrix import Matrix
 from gaphas.state import observed, reversible_property
 from gaphas.util import path_ellipse
 
@@ -218,8 +217,6 @@ class ForkNodeItem(Presentation[UML.ForkNode], Named):
 
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id=id)
-        self._matrix = Matrix()
-        self._matrix_i2c = Matrix()
 
         h1, h2 = Handle(), Handle()
         self._handles = [h1, h2]
@@ -249,14 +246,6 @@ class ForkNodeItem(Presentation[UML.ForkNode], Named):
         diagram.connections.add_constraint(
             self, constraint(above=(h1.pos, h2.pos), delta=30)
         )
-
-    @property
-    def matrix(self) -> Matrix:
-        return self._matrix
-
-    @property
-    def matrix_i2c(self) -> Matrix:
-        return self._matrix_i2c
 
     def handles(self):
         return self._handles

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -39,8 +39,8 @@ class InitialNodeItem(ElementPresentation, ActivityNodeItem):
     Initial node has name which is put near top-left side of node.
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
         no_movable_handles(self)
 
         self.shape = IconBox(
@@ -77,8 +77,8 @@ class ActivityFinalNodeItem(ElementPresentation, ActivityNodeItem):
     node.
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
         no_movable_handles(self)
 
         self.shape = IconBox(
@@ -126,8 +126,8 @@ class FlowFinalNodeItem(ElementPresentation, ActivityNodeItem):
     node.
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
         no_movable_handles(self)
 
         self.shape = IconBox(
@@ -162,8 +162,8 @@ def draw_flow_final_node(_box, context, _bounding_box):
 class DecisionNodeItem(ElementPresentation, ActivityNodeItem):
     """Representation of decision or merge node."""
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
         no_movable_handles(self)
 
         self._combined = None
@@ -216,11 +216,10 @@ def draw_decision_node(_box, context, _bounding_box):
 class ForkNodeItem(Presentation[UML.ForkNode], Named):
     """Representation of fork and join node."""
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(id=id, model=model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id=id, model=model)
         self._matrix = Matrix()
         self._matrix_i2c = Matrix()
-        self._connections = connections
 
         h1, h2 = Handle(), Handle()
         self._handles = [h1, h2]
@@ -246,8 +245,10 @@ class ForkNodeItem(Presentation[UML.ForkNode], Named):
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[JoinNode].joinSpec")
 
-        connections.add_constraint(self, constraint(vertical=(h1.pos, h2.pos)))
-        connections.add_constraint(self, constraint(above=(h1.pos, h2.pos), delta=30))
+        diagram.connections.add_constraint(self, constraint(vertical=(h1.pos, h2.pos)))
+        diagram.connections.add_constraint(
+            self, constraint(above=(h1.pos, h2.pos), delta=30)
+        )
 
     @property
     def matrix(self) -> Matrix:

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -39,8 +39,8 @@ class InitialNodeItem(ElementPresentation, ActivityNodeItem):
     Initial node has name which is put near top-left side of node.
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
         no_movable_handles(self)
 
         self.shape = IconBox(
@@ -77,8 +77,8 @@ class ActivityFinalNodeItem(ElementPresentation, ActivityNodeItem):
     node.
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
         no_movable_handles(self)
 
         self.shape = IconBox(
@@ -126,8 +126,8 @@ class FlowFinalNodeItem(ElementPresentation, ActivityNodeItem):
     node.
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
         no_movable_handles(self)
 
         self.shape = IconBox(
@@ -162,8 +162,8 @@ def draw_flow_final_node(_box, context, _bounding_box):
 class DecisionNodeItem(ElementPresentation, ActivityNodeItem):
     """Representation of decision or merge node."""
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
         no_movable_handles(self)
 
         self._combined = None
@@ -216,8 +216,8 @@ def draw_decision_node(_box, context, _bounding_box):
 class ForkNodeItem(Presentation[UML.ForkNode], Named):
     """Representation of fork and join node."""
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id=id, model=model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id=id)
         self._matrix = Matrix()
         self._matrix_i2c = Matrix()
 

--- a/gaphor/UML/actions/flow.py
+++ b/gaphor/UML/actions/flow.py
@@ -20,8 +20,8 @@ class FlowItem(LinePresentation, Named):
     activity edge connectors.
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.shape_tail = Box(
             Text(

--- a/gaphor/UML/actions/flow.py
+++ b/gaphor/UML/actions/flow.py
@@ -20,8 +20,8 @@ class FlowItem(LinePresentation, Named):
     activity edge connectors.
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.shape_tail = Box(
             Text(

--- a/gaphor/UML/actions/objectnode.py
+++ b/gaphor/UML/actions/objectnode.py
@@ -21,8 +21,8 @@ class ObjectNodeItem(ElementPresentation, Named):
     Ordering information can be hidden by user.
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self._show_ordering = False
 

--- a/gaphor/UML/actions/objectnode.py
+++ b/gaphor/UML/actions/objectnode.py
@@ -21,8 +21,8 @@ class ObjectNodeItem(ElementPresentation, Named):
     Ordering information can be hidden by user.
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self._show_ordering = False
 

--- a/gaphor/UML/actions/partition.py
+++ b/gaphor/UML/actions/partition.py
@@ -17,8 +17,8 @@ HEADER_HEIGHT: int = 29
 
 @represents(UML.ActivityPartition)
 class PartitionItem(ElementPresentation):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
         self.min_height = 300
 
         self.shape = Box(

--- a/gaphor/UML/actions/partition.py
+++ b/gaphor/UML/actions/partition.py
@@ -17,8 +17,8 @@ HEADER_HEIGHT: int = 29
 
 @represents(UML.ActivityPartition)
 class PartitionItem(ElementPresentation):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
         self.min_height = 300
 
         self.shape = Box(

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -19,7 +19,7 @@ from gaphas.geometry import Rectangle, distance_rectangle_point
 from gaphas.state import reversible_property
 
 from gaphor import UML
-from gaphor.core.modeling import Presentation
+from gaphor.core.modeling.presentation import Presentation, Transient
 from gaphor.core.styling import Style
 from gaphor.diagram.presentation import LinePresentation, Named
 from gaphor.diagram.shapes import (
@@ -47,8 +47,8 @@ class AssociationItem(LinePresentation[UML.Association], Named):
     association).
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         # AssociationEnds are really inseparable from the AssociationItem.
         # We give them the same id as the association item.
@@ -347,7 +347,7 @@ class AssociationEnd(Presentation[UML.Property]):
     """
 
     def __init__(self, owner, end=None):
-        super().__init__(diagram=owner.diagram, id=False)  # Transient object
+        super().__init__(diagram=owner.diagram, id=Transient)
         self._canvas = None
         self._owner = owner
         self._end = end

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -47,8 +47,8 @@ class AssociationItem(LinePresentation[UML.Association], Named):
     association).
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         # AssociationEnds are really inseparable from the AssociationItem.
         # We give them the same id as the association item.
@@ -337,7 +337,7 @@ def draw_tail_navigable(context):
     cr.line_to(15, 6)
 
 
-class AssociationEnd(Presentation):
+class AssociationEnd(Presentation[UML.Property]):
     """An association end represents one end of an association. An association
     has two ends. An association end has two labels: one for the name and one
     for the multiplicity (and maybe one for tagged values in the future).
@@ -347,7 +347,7 @@ class AssociationEnd(Presentation):
     """
 
     def __init__(self, owner, end=None):
-        super().__init__(id=False)  # Transient object
+        super().__init__(diagram=owner.diagram, id=False)  # Transient object
         self._canvas = None
         self._owner = owner
         self._end = end

--- a/gaphor/UML/classes/dependency.py
+++ b/gaphor/UML/classes/dependency.py
@@ -37,8 +37,8 @@ class DependencyItem(LinePresentation, Named):
     drawn as solid line without arrow head.
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id, style={"dash-style": (7.0, 5.0)})
 
         self._dependency_type = UML.Dependency
         # auto_dependency is used by connection logic, not in this class itself

--- a/gaphor/UML/classes/dependency.py
+++ b/gaphor/UML/classes/dependency.py
@@ -37,8 +37,8 @@ class DependencyItem(LinePresentation, Named):
     drawn as solid line without arrow head.
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
 
         self._dependency_type = UML.Dependency
         # auto_dependency is used by connection logic, not in this class itself

--- a/gaphor/UML/classes/generalization.py
+++ b/gaphor/UML/classes/generalization.py
@@ -10,8 +10,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 
 @represents(UML.Generalization)
 class GeneralizationItem(LinePresentation):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.shape_middle = Box(
             Text(

--- a/gaphor/UML/classes/generalization.py
+++ b/gaphor/UML/classes/generalization.py
@@ -10,8 +10,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 
 @represents(UML.Generalization)
 class GeneralizationItem(LinePresentation):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.shape_middle = Box(
             Text(

--- a/gaphor/UML/classes/implementation.py
+++ b/gaphor/UML/classes/implementation.py
@@ -12,8 +12,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 
 @represents(UML.Implementation)
 class ImplementationItem(LinePresentation, Named):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
 
         self.shape_middle = Box(
             Text(

--- a/gaphor/UML/classes/implementation.py
+++ b/gaphor/UML/classes/implementation.py
@@ -12,8 +12,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 
 @represents(UML.Implementation)
 class ImplementationItem(LinePresentation, Named):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id, style={"dash-style": (7.0, 5.0)})
 
         self.shape_middle = Box(
             Text(

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -157,8 +157,8 @@ class InterfaceItem(ElementPresentation, Classified):
     RADIUS_PROVIDED = 10
     RADIUS_REQUIRED = 14
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
         self._folded = Folded.NONE
         self.side = Side.N
 

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -157,8 +157,8 @@ class InterfaceItem(ElementPresentation, Classified):
     RADIUS_PROVIDED = 10
     RADIUS_REQUIRED = 14
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
         self._folded = Folded.NONE
         self.side = Side.N
 

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -37,8 +37,8 @@ class ClassItem(ElementPresentation[UML.Class], Classified):
     for operations.
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id=id, model=model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id=id)
 
         self.watch("show_stereotypes", self.update_shapes).watch(
             "show_attributes", self.update_shapes

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -37,8 +37,8 @@ class ClassItem(ElementPresentation[UML.Class], Classified):
     for operations.
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id=id, model=model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id=id, model=model)
 
         self.watch("show_stereotypes", self.update_shapes).watch(
             "show_attributes", self.update_shapes

--- a/gaphor/UML/classes/package.py
+++ b/gaphor/UML/classes/package.py
@@ -11,8 +11,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 @represents(UML.Package)
 @represents(UML.Profile)
 class PackageItem(ElementPresentation, Named):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.shape = Box(
             Text(

--- a/gaphor/UML/classes/package.py
+++ b/gaphor/UML/classes/package.py
@@ -11,8 +11,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 @represents(UML.Package)
 @represents(UML.Profile)
 class PackageItem(ElementPresentation, Named):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.shape = Box(
             Text(

--- a/gaphor/UML/components/artifact.py
+++ b/gaphor/UML/components/artifact.py
@@ -11,8 +11,8 @@ from gaphor.UML.classes.stereotype import stereotype_compartments
 
 @represents(UML.Artifact)
 class ArtifactItem(ElementPresentation, Classified):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject[NamedElement].name")

--- a/gaphor/UML/components/artifact.py
+++ b/gaphor/UML/components/artifact.py
@@ -11,8 +11,8 @@ from gaphor.UML.classes.stereotype import stereotype_compartments
 
 @represents(UML.Artifact)
 class ArtifactItem(ElementPresentation, Classified):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject[NamedElement].name")

--- a/gaphor/UML/components/component.py
+++ b/gaphor/UML/components/component.py
@@ -11,8 +11,8 @@ from gaphor.UML.classes.stereotype import stereotype_compartments
 
 @represents(UML.Component)
 class ComponentItem(ElementPresentation, Classified):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject[NamedElement].name")

--- a/gaphor/UML/components/component.py
+++ b/gaphor/UML/components/component.py
@@ -11,8 +11,8 @@ from gaphor.UML.classes.stereotype import stereotype_compartments
 
 @represents(UML.Component)
 class ComponentItem(ElementPresentation, Classified):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject[NamedElement].name")

--- a/gaphor/UML/components/connector.py
+++ b/gaphor/UML/components/connector.py
@@ -121,8 +121,8 @@ class ConnectorItem(LinePresentation[UML.Connector], Named):
         ConnectorEnd UML metaclass instance.
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.shape_middle = Box(
             Text(

--- a/gaphor/UML/components/connector.py
+++ b/gaphor/UML/components/connector.py
@@ -121,8 +121,8 @@ class ConnectorItem(LinePresentation[UML.Connector], Named):
         ConnectorEnd UML metaclass instance.
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.shape_middle = Box(
             Text(

--- a/gaphor/UML/components/node.py
+++ b/gaphor/UML/components/node.py
@@ -35,8 +35,8 @@ from gaphor.UML.classes.stereotype import stereotype_compartments
 class NodeItem(ElementPresentation, Classified):
     """Representation of node or device from UML Deployment package."""
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject[NamedElement].name")

--- a/gaphor/UML/components/node.py
+++ b/gaphor/UML/components/node.py
@@ -35,8 +35,8 @@ from gaphor.UML.classes.stereotype import stereotype_compartments
 class NodeItem(ElementPresentation, Classified):
     """Representation of node or device from UML Deployment package."""
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject[NamedElement].name")

--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -41,11 +41,11 @@ from gaphor.diagram.support import represents
 class ExecutionSpecificationItem(Presentation[UML.ExecutionSpecification]):
     """Representation of interaction execution specification."""
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(id=id, model=model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id=id, model=model)
         self._matrix = Matrix()
         self._matrix_i2c = Matrix()
-        self._connections = connections
+        self._connections = diagram.connections
 
         self.bar_width = 12
 
@@ -54,7 +54,7 @@ class ExecutionSpecificationItem(Presentation[UML.ExecutionSpecification]):
 
         self._handles = [ht, hb]
 
-        connections.add_constraint(self, constraint(vertical=(ht.pos, hb.pos)))
+        self._connections.add_constraint(self, constraint(vertical=(ht.pos, hb.pos)))
 
         r = self.bar_width / 2
         nw = Position(-r, 0, strength=WEAK)
@@ -72,7 +72,7 @@ class ExecutionSpecificationItem(Presentation[UML.ExecutionSpecification]):
             constraint(vertical=(sw, hb.pos), delta=-r),
             constraint(vertical=(se, hb.pos), delta=r),
         ):
-            connections.add_constraint(self, c)
+            self._connections.add_constraint(self, c)
 
         self._ports = [LinePort(nw, sw), LinePort(ne, se)]
 

--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -26,7 +26,6 @@ from gaphas import Handle
 from gaphas.connector import LinePort, Position
 from gaphas.constraint import constraint
 from gaphas.geometry import Rectangle, distance_rectangle_point
-from gaphas.matrix import Matrix
 from gaphas.solver import WEAK
 
 from gaphor import UML
@@ -43,8 +42,6 @@ class ExecutionSpecificationItem(Presentation[UML.ExecutionSpecification]):
 
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id=id)
-        self._matrix = Matrix()
-        self._matrix_i2c = Matrix()
         self._connections = diagram.connections
 
         self.bar_width = 12
@@ -79,14 +76,6 @@ class ExecutionSpecificationItem(Presentation[UML.ExecutionSpecification]):
         self.shape = Box(
             style={"background-color": (1.0, 1.0, 1.0, 1.0)}, draw=draw_border
         )
-
-    @property
-    def matrix(self) -> Matrix:
-        return self._matrix
-
-    @property
-    def matrix_i2c(self) -> Matrix:
-        return self._matrix_i2c
 
     def handles(self):
         return self._handles

--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -41,8 +41,8 @@ from gaphor.diagram.support import represents
 class ExecutionSpecificationItem(Presentation[UML.ExecutionSpecification]):
     """Representation of interaction execution specification."""
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id=id, model=model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id=id)
         self._matrix = Matrix()
         self._matrix_i2c = Matrix()
         self._connections = diagram.connections

--- a/gaphor/UML/interactions/interaction.py
+++ b/gaphor/UML/interactions/interaction.py
@@ -10,8 +10,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 
 @represents(UML.Interaction)
 class InteractionItem(ElementPresentation, Named):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.shape = Box(
             Box(

--- a/gaphor/UML/interactions/interaction.py
+++ b/gaphor/UML/interactions/interaction.py
@@ -10,8 +10,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 
 @represents(UML.Interaction)
 class InteractionItem(ElementPresentation, Named):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.shape = Box(
             Box(

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -135,8 +135,8 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
         is_destroyed: Check if delete message is connected.
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.is_destroyed = False
 

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -135,8 +135,8 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
         is_destroyed: Check if delete message is connected.
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.is_destroyed = False
 

--- a/gaphor/UML/interactions/message.py
+++ b/gaphor/UML/interactions/message.py
@@ -74,9 +74,9 @@ class MessageItem(LinePresentation[UML.Message], Named):
     - _arrow_angle: decorating arrow angle
     """
 
-    def __init__(self, connections, id=None, model=None):
+    def __init__(self, diagram, id=None, model=None):
         super().__init__(
-            connections,
+            diagram,
             id,
             model,
             shape_middle=Box(

--- a/gaphor/UML/interactions/message.py
+++ b/gaphor/UML/interactions/message.py
@@ -74,11 +74,10 @@ class MessageItem(LinePresentation[UML.Message], Named):
     - _arrow_angle: decorating arrow angle
     """
 
-    def __init__(self, diagram, id=None, model=None):
+    def __init__(self, diagram, id=None):
         super().__init__(
             diagram,
             id,
-            model,
             shape_middle=Box(
                 Text(
                     text=lambda: stereotypes_str(self.subject),

--- a/gaphor/UML/profiles/extension.py
+++ b/gaphor/UML/profiles/extension.py
@@ -17,8 +17,8 @@ class ExtensionItem(LinePresentation, Named):
     represents a Property (with Property.association == my association).
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.shape_middle = Box(
             Text(

--- a/gaphor/UML/profiles/extension.py
+++ b/gaphor/UML/profiles/extension.py
@@ -17,8 +17,8 @@ class ExtensionItem(LinePresentation, Named):
     represents a Property (with Property.association == my association).
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.shape_middle = Box(
             Text(

--- a/gaphor/UML/profiles/packageimport.py
+++ b/gaphor/UML/profiles/packageimport.py
@@ -11,8 +11,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 class PackageImportItem(LinePresentation):
     """Profile Import dependency relationship."""
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id, style={"dash-style": (7.0, 5.0)})
 
         self.shape_middle = Text(
             text=lambda: stereotypes_str(self.subject, ("import",)),

--- a/gaphor/UML/profiles/packageimport.py
+++ b/gaphor/UML/profiles/packageimport.py
@@ -11,8 +11,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 class PackageImportItem(LinePresentation):
     """Profile Import dependency relationship."""
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
 
         self.shape_middle = Text(
             text=lambda: stereotypes_str(self.subject, ("import",)),

--- a/gaphor/UML/states/finalstate.py
+++ b/gaphor/UML/states/finalstate.py
@@ -12,8 +12,8 @@ from gaphor.UML.states.state import VertexItem
 
 @represents(UML.FinalState)
 class FinalStateItem(ElementPresentation, VertexItem):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
         for h in self.handles():
             h.movable = False
 

--- a/gaphor/UML/states/finalstate.py
+++ b/gaphor/UML/states/finalstate.py
@@ -12,8 +12,8 @@ from gaphor.UML.states.state import VertexItem
 
 @represents(UML.FinalState)
 class FinalStateItem(ElementPresentation, VertexItem):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
         for h in self.handles():
             h.movable = False
 

--- a/gaphor/UML/states/pseudostates.py
+++ b/gaphor/UML/states/pseudostates.py
@@ -15,8 +15,8 @@ from gaphor.UML.states.state import VertexItem
 
 @represents(UML.Pseudostate)
 class PseudostateItem(ElementPresentation, VertexItem):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
         for h in self.handles():
             h.movable = False
 

--- a/gaphor/UML/states/pseudostates.py
+++ b/gaphor/UML/states/pseudostates.py
@@ -15,8 +15,8 @@ from gaphor.UML.states.state import VertexItem
 
 @represents(UML.Pseudostate)
 class PseudostateItem(ElementPresentation, VertexItem):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
         for h in self.handles():
             h.movable = False
 

--- a/gaphor/UML/states/state.py
+++ b/gaphor/UML/states/state.py
@@ -19,8 +19,8 @@ class VertexItem(Named):
 
 @represents(UML.State)
 class StateItem(ElementPresentation[UML.State], VertexItem):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")

--- a/gaphor/UML/states/state.py
+++ b/gaphor/UML/states/state.py
@@ -19,8 +19,8 @@ class VertexItem(Named):
 
 @represents(UML.State)
 class StateItem(ElementPresentation[UML.State], VertexItem):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")

--- a/gaphor/UML/states/transition.py
+++ b/gaphor/UML/states/transition.py
@@ -11,8 +11,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 class TransitionItem(LinePresentation[UML.Transition], Named):
     """Representation of state transition."""
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.shape_tail = Box(
             Text(

--- a/gaphor/UML/states/transition.py
+++ b/gaphor/UML/states/transition.py
@@ -11,8 +11,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 class TransitionItem(LinePresentation[UML.Transition], Named):
     """Representation of state transition."""
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.shape_tail = Box(
             Text(

--- a/gaphor/UML/usecases/actor.py
+++ b/gaphor/UML/usecases/actor.py
@@ -23,8 +23,8 @@ class ActorItem(ElementPresentation, Classified):
     future.
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
 
         self.shape = IconBox(
             Box(

--- a/gaphor/UML/usecases/actor.py
+++ b/gaphor/UML/usecases/actor.py
@@ -23,8 +23,8 @@ class ActorItem(ElementPresentation, Classified):
     future.
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
 
         self.shape = IconBox(
             Box(

--- a/gaphor/UML/usecases/extend.py
+++ b/gaphor/UML/usecases/extend.py
@@ -11,8 +11,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 class ExtendItem(LinePresentation, Named):
     """Use case extension relationship."""
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id, style={"dash-style": (7.0, 5.0)})
 
         self.shape_middle = Box(
             Text(text=lambda: stereotypes_str(self.subject, ("extend",))),

--- a/gaphor/UML/usecases/extend.py
+++ b/gaphor/UML/usecases/extend.py
@@ -11,8 +11,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 class ExtendItem(LinePresentation, Named):
     """Use case extension relationship."""
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
 
         self.shape_middle = Box(
             Text(text=lambda: stereotypes_str(self.subject, ("extend",))),

--- a/gaphor/UML/usecases/include.py
+++ b/gaphor/UML/usecases/include.py
@@ -11,8 +11,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 class IncludeItem(LinePresentation, Named):
     """Use case inclusion relationship."""
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
 
         self.shape_middle = Box(
             Text(text=lambda: stereotypes_str(self.subject, ("include",))),

--- a/gaphor/UML/usecases/include.py
+++ b/gaphor/UML/usecases/include.py
@@ -11,8 +11,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 class IncludeItem(LinePresentation, Named):
     """Use case inclusion relationship."""
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id, style={"dash-style": (7.0, 5.0)})
 
         self.shape_middle = Box(
             Text(text=lambda: stereotypes_str(self.subject, ("include",))),

--- a/gaphor/UML/usecases/usecase.py
+++ b/gaphor/UML/usecases/usecase.py
@@ -14,8 +14,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 class UseCaseItem(ElementPresentation, Classified):
     """Presentation of gaphor.UML.UseCase."""
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
         self.shape = Box(
             Text(
                 text=lambda: stereotypes_str(self.subject),

--- a/gaphor/UML/usecases/usecase.py
+++ b/gaphor/UML/usecases/usecase.py
@@ -14,8 +14,8 @@ from gaphor.UML.modelfactory import stereotypes_str
 class UseCaseItem(ElementPresentation, Classified):
     """Presentation of gaphor.UML.UseCase."""
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
         self.shape = Box(
             Text(
                 text=lambda: stereotypes_str(self.subject),

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -343,7 +343,6 @@ class Diagram(PackageableElement):
 
     def unlink(self):
         """Unlink all canvas items then unlink this diagram."""
-        log.debug("unlinking %s", self)
         for item in self.ownedPresentation:
             self.connections.remove_connections_to_item(item)
         self._watcher.unsubscribe_all()

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -324,11 +324,10 @@ class Diagram(PackageableElement):
             raise TypeError(
                 f"Type {type} can not be added to a diagram as it is not a diagram item"
             )
-        item = type(connections=self._connections, id=id, model=self.model)
+        item = type(diagram=self, id=id, model=self.model)
         assert isinstance(
             item, gaphas.Item
         ), f"Type {type} does not comply with Item protocol"
-        item.diagram = self
         if subject:
             item.subject = subject
         if parent:

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -324,7 +324,7 @@ class Diagram(PackageableElement):
             raise TypeError(
                 f"Type {type} can not be added to a diagram as it is not a diagram item"
             )
-        item = type(diagram=self, id=id, model=self.model)
+        item = type(diagram=self, id=id)
         assert isinstance(
             item, gaphas.Item
         ), f"Type {type} does not comply with Item protocol"

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -20,6 +20,8 @@ S = TypeVar("S", bound=Element)
 
 log = logging.getLogger(__name__)
 
+Transient = False
+
 
 class Presentation(Element, Generic[S]):
     """This presentation is used to link the behaviors of
@@ -32,11 +34,11 @@ class Presentation(Element, Generic[S]):
     DiagramItemDeleted.
     """
 
-    def __init__(self, diagram: Diagram, id=None, model=None):
-        super().__init__(id, model)
-
-        if self.id:
-            # Do not set diagram for transient objects
+    def __init__(self, diagram: Diagram, id=None):
+        if id is Transient:
+            super().__init__(id)
+        else:
+            super().__init__(id, diagram.model)
             self.diagram = diagram
 
         def update(event):

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -32,8 +32,12 @@ class Presentation(Element, Generic[S]):
     DiagramItemDeleted.
     """
 
-    def __init__(self, id=None, model=None):
+    def __init__(self, diagram: Diagram, id=None, model=None):
         super().__init__(id, model)
+
+        if self.id:
+            # Do not set diagram for transient objects
+            self.diagram = diagram
 
         def update(event):
             if self.diagram:

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -3,16 +3,15 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Callable, Generic, List, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from gaphas.item import Matrices
 
 from gaphor.core.modeling import Element
 from gaphor.core.modeling.event import DiagramItemDeleted
 from gaphor.core.modeling.properties import association, relation_many, relation_one
 
 if TYPE_CHECKING:
-    from gaphas.connector import Handle  # noqa
-    from gaphas.matrix import Matrix  # noqa
-
     from gaphor.core.modeling.diagram import Diagram
 
 S = TypeVar("S", bound=Element)
@@ -23,7 +22,7 @@ log = logging.getLogger(__name__)
 Transient = False
 
 
-class Presentation(Element, Generic[S]):
+class Presentation(Matrices, Element, Generic[S]):
     """This presentation is used to link the behaviors of
     `gaphor.core.modeling` and `gaphas.Item`.
 
@@ -36,9 +35,9 @@ class Presentation(Element, Generic[S]):
 
     def __init__(self, diagram: Diagram, id=None):
         if id is Transient:
-            super().__init__(id)
+            super().__init__(id=id)
         else:
-            super().__init__(id, diagram.model)
+            super().__init__(id=id, model=diagram.model)
             self.diagram = diagram
 
         def update(event):
@@ -57,11 +56,6 @@ class Presentation(Element, Generic[S]):
 
     parent: relation_one[Presentation]
     children: relation_many[Presentation]
-
-    handles: Callable[[Presentation], List[Handle]]
-
-    matrix: Matrix
-    matrix_i2c: Matrix
 
     def request_update(self, matrix=True):
         if self.diagram:

--- a/gaphor/core/modeling/tests/test_diagram.py
+++ b/gaphor/core/modeling/tests/test_diagram.py
@@ -8,10 +8,8 @@ from gaphor.UML.modelinglanguage import UMLModelingLanguage
 
 
 class Example(gaphas.Element, Presentation):
-    def __init__(self, diagram, id, model):
-        super().__init__(
-            connections=diagram.connections, diagram=diagram, id=id, model=model
-        )
+    def __init__(self, diagram, id):
+        super().__init__(connections=diagram.connections, diagram=diagram, id=id)
 
     def unlink(self):
         self.test_unlinked = True

--- a/gaphor/core/modeling/tests/test_diagram.py
+++ b/gaphor/core/modeling/tests/test_diagram.py
@@ -8,6 +8,11 @@ from gaphor.UML.modelinglanguage import UMLModelingLanguage
 
 
 class Example(gaphas.Element, Presentation):
+    def __init__(self, diagram, id, model):
+        super().__init__(
+            connections=diagram.connections, diagram=diagram, id=id, model=model
+        )
+
     def unlink(self):
         self.test_unlinked = True
         super().unlink()

--- a/gaphor/core/modeling/tests/test_diagram_style.py
+++ b/gaphor/core/modeling/tests/test_diagram_style.py
@@ -24,18 +24,20 @@ def diagram(element_factory):
 
 
 class DemoItem(gaphas.Element, Presentation):
-    def __init__(self, connections, id, model):
-        super().__init__(connections, id=id, model=model)
+    def __init__(self, diagram, id, model):
+        super().__init__(
+            connections=diagram.connections, diagram=diagram, id=id, model=model
+        )
 
 
-def test_name_does_not_have_item_suffix(diagram):
+def test_name_does_not_have_item_suffix(diagram: Diagram):
     item = diagram.create(DemoItem)
     node = StyledItem(item)
 
     assert node.name() == "demo"
 
 
-def test_diagram_is_parent_of_item(diagram):
+def test_diagram_is_parent_of_item(diagram: Diagram):
     item = diagram.create(DemoItem)
     node = StyledItem(item)
 

--- a/gaphor/core/modeling/tests/test_diagram_style.py
+++ b/gaphor/core/modeling/tests/test_diagram_style.py
@@ -24,10 +24,8 @@ def diagram(element_factory):
 
 
 class DemoItem(gaphas.Element, Presentation):
-    def __init__(self, diagram, id, model):
-        super().__init__(
-            connections=diagram.connections, diagram=diagram, id=id, model=model
-        )
+    def __init__(self, diagram, id):
+        super().__init__(connections=diagram.connections, diagram=diagram, id=id)
 
 
 def test_name_does_not_have_item_suffix(diagram: Diagram):

--- a/gaphor/core/modeling/tests/test_presentation.py
+++ b/gaphor/core/modeling/tests/test_presentation.py
@@ -1,16 +1,77 @@
-import pytest
+from gaphas.constraint import BaseConstraint
 from gaphas.item import Item
+from gaphas.solver import Variable
 
-from gaphor.core.eventmanager import EventManager
-from gaphor.core.modeling.elementfactory import ElementFactory
+from gaphor.core.eventmanager import event_handler
+from gaphor.core.modeling.diagram import Diagram
+from gaphor.core.modeling.event import DiagramItemDeleted
 from gaphor.core.modeling.presentation import Presentation
 
 
-class StubItem(Presentation, Item):
+class Example(Presentation, Item):
     pass
 
 
-@pytest.fixture
-def element_factory():
-    event_manager = EventManager()
-    return ElementFactory(event_manager)
+def test_presentation_implements_item_protocol(diagram):
+    presentation = diagram.create(Example)
+
+    assert isinstance(presentation, Item)
+
+
+def test_presentation_should_have_a_diagram(diagram):
+    presentation = diagram.create(Example)
+
+    assert presentation.diagram is diagram
+
+
+def test_should_emit_event_when_unlinked(diagram, event_manager):
+    presentation = diagram.create(Example)
+    events = []
+
+    @event_handler(DiagramItemDeleted)
+    def handler(event):
+        events.append(event)
+
+    event_manager.subscribe(handler)
+
+    presentation.unlink()
+
+    assert events
+    assert events[0].diagram is diagram
+    assert events[0].element is presentation
+
+
+def test_presentation_should_unlink_when_diagram_changes(diagram):
+    presentation = diagram.create(Example)
+    diagram.connections.add_constraint(presentation, BaseConstraint(Variable()))
+    assert len(list(diagram.connections.get_connections(item=presentation))) == 1
+
+    presentation.diagram = None
+
+    assert not list(diagram.connections.get_connections(item=presentation))
+
+
+def test_presentation_can_not_set_new_diagram(diagram, element_factory):
+    presentation = diagram.create(Example)
+    new_diagram = element_factory.create(Diagram)
+
+    presentation.diagram = new_diagram
+
+    assert presentation.diagram is None
+
+
+def test_should_emit_event_when_diagram_changes(diagram, event_manager):
+    presentation = diagram.create(Example)
+    events = []
+
+    @event_handler(DiagramItemDeleted)
+    def handler(event):
+        events.append(event)
+
+    event_manager.subscribe(handler)
+
+    del presentation.diagram
+
+    assert events
+    assert events[0].diagram is diagram
+    assert events[0].element is presentation

--- a/gaphor/diagram/diagramtools/dropzone.py
+++ b/gaphor/diagram/diagramtools/dropzone.py
@@ -1,5 +1,6 @@
+from typing import Type
+
 from gaphas.aspect.move import Move as MoveAspect
-from gaphas.connections import Connections
 from gaphas.guide import GuidedItemMove
 from gaphas.tool.itemtool import item_at_point
 from gaphas.view import GtkView
@@ -13,13 +14,15 @@ from gaphor.diagram.presentation import (
 )
 
 
-def drop_zone_tool(view, item_class):
+def drop_zone_tool(
+    view: GtkView, item_class: Type[Presentation]
+) -> Gtk.EventController:
     ctrl = Gtk.EventControllerMotion.new(view)
     ctrl.connect("motion", on_motion, item_class)
     return ctrl
 
 
-def on_motion(controller, x, y, item_class):
+def on_motion(controller, x, y, item_class: Type[Presentation]):
     view: GtkView = controller.get_widget()
     model = view.model
 
@@ -29,10 +32,10 @@ def on_motion(controller, x, y, item_class):
         parent = None
 
     if parent:
-        # create dummy adapter
-        connections = Connections()
-        adapter = Group(parent, item_class(connections))
-        if adapter and adapter.can_contain():
+        adapter_type = Group.registry.get_registration(type(parent), item_class)
+        # Do not do in depth check id we can actually connect.
+        # We can do that only when we have and item_class instance.
+        if adapter_type:
             view.selection.dropzone_item = parent
         else:
             view.selection.dropzone_item = None

--- a/gaphor/diagram/diagramtools/dropzone.py
+++ b/gaphor/diagram/diagramtools/dropzone.py
@@ -33,8 +33,8 @@ def on_motion(controller, x, y, item_class: Type[Presentation]):
 
     if parent:
         adapter_type = Group.registry.get_registration(type(parent), item_class)
-        # Do not do in depth check id we can actually connect.
-        # We can do that only when we have and item_class instance.
+        # No in depth check is done to see if we can actually connect,
+        # since we only have the item_class, not an actual item.
         view.selection.dropzone_item = parent if adapter_type else None
         model.request_update(parent, matrix=False)
     else:

--- a/gaphor/diagram/diagramtools/dropzone.py
+++ b/gaphor/diagram/diagramtools/dropzone.py
@@ -35,10 +35,7 @@ def on_motion(controller, x, y, item_class: Type[Presentation]):
         adapter_type = Group.registry.get_registration(type(parent), item_class)
         # Do not do in depth check id we can actually connect.
         # We can do that only when we have and item_class instance.
-        if adapter_type:
-            view.selection.dropzone_item = parent
-        else:
-            view.selection.dropzone_item = None
+        view.selection.dropzone_item = parent if adapter_type else None
         model.request_update(parent, matrix=False)
     else:
         if view.selection.dropzone_item:

--- a/gaphor/diagram/general/comment.py
+++ b/gaphor/diagram/general/comment.py
@@ -12,8 +12,8 @@ from gaphor.diagram.support import represents
 class CommentItem(ElementPresentation):
     EAR = 15
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model)
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model)
         OFFSET = 5
         ear = self.EAR
         self.min_width = ear + 2 * OFFSET

--- a/gaphor/diagram/general/comment.py
+++ b/gaphor/diagram/general/comment.py
@@ -12,8 +12,8 @@ from gaphor.diagram.support import represents
 class CommentItem(ElementPresentation):
     EAR = 15
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model)
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
         OFFSET = 5
         ear = self.EAR
         self.min_width = ear + 2 * OFFSET

--- a/gaphor/diagram/general/commentline.py
+++ b/gaphor/diagram/general/commentline.py
@@ -8,8 +8,8 @@ from gaphor.diagram.presentation import LinePresentation
 
 
 class CommentLineItem(LinePresentation):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id, style={"dash-style": (7.0, 5.0)})
 
     def unlink(self):
         c1 = self._connections.get_connection(self.head)

--- a/gaphor/diagram/general/commentline.py
+++ b/gaphor/diagram/general/commentline.py
@@ -8,8 +8,8 @@ from gaphor.diagram.presentation import LinePresentation
 
 
 class CommentLineItem(LinePresentation):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model, style={"dash-style": (7.0, 5.0)})
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model, style={"dash-style": (7.0, 5.0)})
 
     def unlink(self):
         c1 = self._connections.get_connection(self.head)

--- a/gaphor/diagram/general/simpleitem.py
+++ b/gaphor/diagram/general/simpleitem.py
@@ -12,8 +12,8 @@ from gaphor.diagram.shapes import stroke
 
 
 class Line(_Line, Presentation):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(connections=diagram.connections, diagram=diagram, id=id, model=model)  # type: ignore[call-arg]
+    def __init__(self, diagram, id=None):
+        super().__init__(connections=diagram.connections, diagram=diagram, id=id)  # type: ignore[call-arg]
         self.fuzziness = 2
         self._handles[0].connectable = False
         self._handles[-1].connectable = False
@@ -67,8 +67,8 @@ class Box(Element, Presentation):
     NW +---+ NE SW +---+ SE
     """
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(connections=diagram.connections, diagram=diagram, id=id, model=model)  # type: ignore[call-arg]
+    def __init__(self, diagram, id=None):
+        super().__init__(connections=diagram.connections, diagram=diagram, id=id)  # type: ignore[call-arg]
 
     def save(self, save_func):
         save_func("matrix", tuple(self.matrix))
@@ -102,8 +102,8 @@ class Box(Element, Presentation):
 class Ellipse(Element, Presentation):
     """"""
 
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(connections=diagram.connections, diagram=diagram, id=id, model=model)  # type: ignore[call-arg]
+    def __init__(self, diagram, id=None):
+        super().__init__(connections=diagram.connections, diagram=diagram, id=id)  # type: ignore[call-arg]
 
     def save(self, save_func):
         save_func("matrix", tuple(self.matrix))

--- a/gaphor/diagram/general/simpleitem.py
+++ b/gaphor/diagram/general/simpleitem.py
@@ -12,8 +12,8 @@ from gaphor.diagram.shapes import stroke
 
 
 class Line(_Line, Presentation):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id=id, model=model)  # type: ignore[misc]
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(connections=diagram.connections, diagram=diagram, id=id, model=model)  # type: ignore[call-arg]
         self.fuzziness = 2
         self._handles[0].connectable = False
         self._handles[-1].connectable = False
@@ -67,8 +67,8 @@ class Box(Element, Presentation):
     NW +---+ NE SW +---+ SE
     """
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id=id, model=model)  # type: ignore[misc]
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(connections=diagram.connections, diagram=diagram, id=id, model=model)  # type: ignore[call-arg]
 
     def save(self, save_func):
         save_func("matrix", tuple(self.matrix))
@@ -102,8 +102,8 @@ class Box(Element, Presentation):
 class Ellipse(Element, Presentation):
     """"""
 
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id=id, model=model)  # type: ignore[misc]
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(connections=diagram.connections, diagram=diagram, id=id, model=model)  # type: ignore[call-arg]
 
     def save(self, save_func):
         save_func("matrix", tuple(self.matrix))

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -87,10 +87,8 @@ class ElementPresentation(gaphas.Element, Presentation[S]):
 
     _port_sides = ("top", "right", "bottom", "left")
 
-    def __init__(self, diagram: Diagram, id=None, model=None, shape=None):
-        super().__init__(  # type: ignore[call-arg]
-            connections=diagram.connections, diagram=diagram, id=id, model=model
-        )
+    def __init__(self, diagram: Diagram, id=None, shape=None):
+        super().__init__(connections=diagram.connections, diagram=diagram, id=id)  # type: ignore[call-arg]
         self._shape = shape
 
     def port_side(self, port):
@@ -145,15 +143,12 @@ class LinePresentation(gaphas.Line, Presentation[S]):
         self,
         diagram: Diagram,
         id=None,
-        model=None,
         style: Style = {},
         shape_head=None,
         shape_middle=None,
         shape_tail=None,
     ):
-        super().__init__(  # type: ignore[call-arg]
-            connections=diagram.connections, diagram=diagram, id=id, model=model
-        )
+        super().__init__(connections=diagram.connections, diagram=diagram, id=id)  # type: ignore[call-arg]
 
         self.style = style
         self.shape_head = shape_head

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -10,6 +10,7 @@ from gaphas.connector import Handle
 from gaphas.geometry import Rectangle, distance_rectangle_point
 from gaphas.item import matrix_i2i
 
+from gaphor.core.modeling.diagram import Diagram
 from gaphor.core.modeling.presentation import Presentation, S
 from gaphor.core.styling import Style
 from gaphor.diagram.shapes import combined_style
@@ -86,8 +87,10 @@ class ElementPresentation(gaphas.Element, Presentation[S]):
 
     _port_sides = ("top", "right", "bottom", "left")
 
-    def __init__(self, connections, id=None, model=None, shape=None):
-        super().__init__(connections, id=id, model=model)  # type: ignore[misc]
+    def __init__(self, diagram: Diagram, id=None, model=None, shape=None):
+        super().__init__(  # type: ignore[call-arg]
+            connections=diagram.connections, diagram=diagram, id=id, model=model
+        )
         self._shape = shape
 
     def port_side(self, port):
@@ -140,7 +143,7 @@ class ElementPresentation(gaphas.Element, Presentation[S]):
 class LinePresentation(gaphas.Line, Presentation[S]):
     def __init__(
         self,
-        connections,
+        diagram: Diagram,
         id=None,
         model=None,
         style: Style = {},
@@ -148,7 +151,9 @@ class LinePresentation(gaphas.Line, Presentation[S]):
         shape_middle=None,
         shape_tail=None,
     ):
-        super().__init__(connections, id=id, model=model)  # type: ignore[misc]
+        super().__init__(  # type: ignore[call-arg]
+            connections=diagram.connections, diagram=diagram, id=id, model=model
+        )
 
         self.style = style
         self.shape_head = shape_head

--- a/gaphor/diagram/tests/test_presentation.py
+++ b/gaphor/diagram/tests/test_presentation.py
@@ -11,13 +11,13 @@ class DummyVisualComponent:
 
 
 class StubElement(ElementPresentation):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model, shape=DummyVisualComponent())
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model, shape=DummyVisualComponent())
 
 
 class StubLine(LinePresentation):
-    def __init__(self, connections, id=None, model=None):
-        super().__init__(connections, id, model, shape_middle=DummyVisualComponent())
+    def __init__(self, diagram, id=None, model=None):
+        super().__init__(diagram, id, model, shape_middle=DummyVisualComponent())
 
 
 def test_creation(diagram):

--- a/gaphor/diagram/tests/test_presentation.py
+++ b/gaphor/diagram/tests/test_presentation.py
@@ -11,13 +11,13 @@ class DummyVisualComponent:
 
 
 class StubElement(ElementPresentation):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model, shape=DummyVisualComponent())
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id, shape=DummyVisualComponent())
 
 
 class StubLine(LinePresentation):
-    def __init__(self, diagram, id=None, model=None):
-        super().__init__(diagram, id, model, shape_middle=DummyVisualComponent())
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id, shape_middle=DummyVisualComponent())
 
 
 def test_creation(diagram):

--- a/models/Core.gaphor
+++ b/models/Core.gaphor
@@ -51,6 +51,8 @@
 <ref refid="cf596824-e0b9-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="216581ca-4465-11eb-8946-9bdfa28f7a50"/>
 <ref refid="446a3744-4465-11eb-8946-9bdfa28f7a50"/>
+<ref refid="d6e5886b-478f-11eb-a938-8fcfae32d12c"/>
+<ref refid="f4982c28-478f-11eb-a938-8fcfae32d12c"/>
 </reflist>
 </ownedPresentation>
 <package>
@@ -596,6 +598,46 @@
 <ref refid="446a3746-4465-11eb-8946-9bdfa28f7a50"/>
 </tail-subject>
 </item>
+<item id="d6e5886b-478f-11eb-a938-8fcfae32d12c" type="CommentItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 448.0, 624.0)</val>
+</matrix>
+<width>
+<val>177.0</val>
+</width>
+<height>
+<val>78.0</val>
+</height>
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
+<subject>
+<ref refid="d6e5886a-478f-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="f4982c28-478f-11eb-a938-8fcfae32d12c" type="CommentLineItem">
+<diagram>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</diagram>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 505.0, 557.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(0.0, -4.0), (26.0, 67.0)]</val>
+</points>
+<head-connection>
+<ref refid="216581ca-4465-11eb-8946-9bdfa28f7a50"/>
+</head-connection>
+<tail-connection>
+<ref refid="d6e5886b-478f-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
 </canvas>
 </Diagram>
 <Class id="4cda498e-7a95-11ea-a112-7f953848cf85">
@@ -998,7 +1040,7 @@
 </reflist>
 </annotatedElement>
 <body>
-<val>One instance per model</val>
+<val>One instance per model.</val>
 </body>
 <presentation>
 <reflist>
@@ -1128,6 +1170,11 @@ diagram {
 </upperValue>
 </Property>
 <Association id="216581c9-4465-11eb-8946-9bdfa28f7a50">
+<comment>
+<reflist>
+<ref refid="d6e5886a-478f-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</comment>
 <memberEnd>
 <reflist>
 <ref refid="216581cb-4465-11eb-8946-9bdfa28f7a50"/>
@@ -1263,4 +1310,19 @@ diagram {
 <val>*</val>
 </upperValue>
 </Property>
+<Comment id="d6e5886a-478f-11eb-a938-8fcfae32d12c">
+<annotatedElement>
+<reflist>
+<ref refid="216581c9-4465-11eb-8946-9bdfa28f7a50"/>
+</reflist>
+</annotatedElement>
+<body>
+<val>Presentation is unlinked (destroyed) when diagram changes.</val>
+</body>
+<presentation>
+<reflist>
+<ref refid="d6e5886b-478f-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</Comment>
 </gaphor>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, ~no~ api changes)
- [ ] Documentation content changes

### What is the current behavior?
It's a bit awkward that a `Presentation` takes a Gaphas construct (`Connections`) as one of it's arguments.
A presentation item is tied to a diagram. They have their connections (constraints) centrally managed.
It's not explicit that a `Presentation` is tied to a `Diagram`.

### What is the new behavior?
`Presentation` items take a `Diagram` as their first argument. This way the code is telling us that a `Presentation` item can not exist without a diagram. Also, the presentation is instantly unlinked when the diagram reference changes. This is desired, since we need to clean up constraints and connections made on the diagram (those can not be easily transferred to another diagram).

Because `Presentation` takes a `diagram` argument now, there's no longer need for a `model` to be provided. The `Presentation` class handles the "translation" to normal `Element`s.

`Presentation` also inherits the `gaphas.item.Matrices` mixin. It provides the `matrix` and `matrix_i2c` fields we require anyway.

### Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

### Other information

In the cases where we also inherit from Gaphas' items (`Element`, `Line`) the constructor takes an extra `connections` argument, consumed by the Gaphas item. Any kw-args are passed on to the next (super) class in the MRO sequence.

So in those cases the constructor make look a bit funny:

```python
class ElementPresentation(gaphas.Element, Presentation[S]):
    def __init__(self, diagram: Diagram, id=None, shape=None):
        super().__init__(connections=diagram.connections, diagram=diagram, id=id)  # type: ignore[call-arg]
        ...
```

I think this is acceptable, since we're still able to call super-classes via `super()` and we need to "work around" the different method signatures.
