### PR TITLE
Presentation instantly updates `matrix_i2c`

### DIFF
--- a/gaphor/core/modeling/tests/test_presentation.py
+++ b/gaphor/core/modeling/tests/test_presentation.py
@@ -75,3 +75,55 @@ def test_should_emit_event_when_diagram_changes(diagram, event_manager):
     assert events
     assert events[0].diagram is diagram
     assert events[0].element is presentation
+
+
+def test_matrix_i2c_updates_when_matrix_changes(diagram):
+    presentation = diagram.create(Example)
+
+    presentation.matrix.translate(1, 1)
+
+    assert tuple(presentation.matrix_i2c) == (1, 0, 0, 1, 1, 1)
+
+
+def test_parent_matrix_updates(diagram):
+    parent = diagram.create(Example)
+    presentation = diagram.create(Example)
+
+    presentation.parent = parent
+    parent.matrix.scale(2, 2)
+
+    assert tuple(presentation.matrix_i2c) == (2, 0, 0, 2, 0, 0)
+
+
+def test_set_parent_updates_matrix_i2c(diagram):
+    parent = diagram.create(Example)
+    presentation = diagram.create(Example)
+
+    parent.matrix.scale(2, 2)
+    presentation.parent = parent
+
+    assert tuple(presentation.matrix_i2c) == (1, 0, 0, 1, 0, 0)
+
+
+def test_unset_parent_updates_matrix_i2c(diagram):
+    parent = diagram.create(Example)
+    presentation = diagram.create(Example)
+
+    parent.matrix.scale(2, 2)
+    presentation.parent = parent
+    presentation.parent = None
+
+    assert tuple(presentation.matrix_i2c) == (1, 0, 0, 1, 0, 0)
+
+
+def test_change_parent_updates_matrix_i2c_and_keeps_coordinates(diagram):
+    parent = diagram.create(Example)
+    new_parent = diagram.create(Example)
+    presentation = diagram.create(Example)
+
+    parent.matrix.scale(2, 2)
+    new_parent.matrix.translate(2, 2)
+    presentation.parent = parent
+    presentation.parent = new_parent
+
+    assert tuple(presentation.matrix_i2c) == (1, 0, 0, 1, 0, 0)

--- a/gaphor/diagram/diagramtools/placement.py
+++ b/gaphor/diagram/diagramtools/placement.py
@@ -79,8 +79,6 @@ def connect_opposite_handle(view, new_item, x, y, handle_index):
     except (KeyError, AttributeError):
         pass
     else:
-        new_item.matrix_i2c.set(*view.model.get_matrix_i2c(new_item))
-
         handle_move = HandleMove(new_item, opposite, view)
         vpos = (x, y)
 

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -173,10 +173,6 @@ def load_elements_generator(elements, factory, modeling_language, gaphor_version
     )
     yield from _load_attributes_and_references(elements, update_status_queue)
 
-    for d in factory.lselect(Diagram):
-        for item in d.get_all_items():
-            item.matrix_i2c.set(*d.get_matrix_i2c(item))
-
     for id, elem in list(elements.items()):
         yield from update_status_queue()
         elem.element.postload()

--- a/gaphor/storage/tests/test_group.py
+++ b/gaphor/storage/tests/test_group.py
@@ -28,7 +28,7 @@ def test_load_grouped_connected_items(element_factory, loader):
 
     assert child_one.parent is node_item
 
-    assert tuple(diagram.get_matrix_i2c(child_one)) == (
+    assert tuple(child_one.matrix_i2c) == (
         1.0,
         0.0,
         0.0,
@@ -36,7 +36,7 @@ def test_load_grouped_connected_items(element_factory, loader):
         PARENT_X + CHILD_ONE_X,
         PARENT_Y + CHILD_ONE_Y,
     )
-    assert tuple(diagram.get_matrix_i2c(child_two)) == (
+    assert tuple(child_two.matrix_i2c) == (
         1.0,
         0.0,
         0.0,


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

We needed to await an "update" to get the right `matrix_i2c` values.

### What is the new behavior?

The matrix is updated instantly based on the parent's matrix and it's own matrix.

Dropped `Diagram.get_matrix_i2c()`.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

### Other information
