### PR TITLE
Everything transactional

### DIFF
--- a/gaphor/UML/classes/tests/conftest.py
+++ b/gaphor/UML/classes/tests/conftest.py
@@ -1,14 +1,8 @@
 import pytest
 
-from gaphor.diagram.tests.fixtures import diagram, element_factory, event_manager
-
-
-@pytest.fixture
-def create(diagram, element_factory):
-    def _create(item_class, element_class=None):
-        return diagram.create(
-            item_class,
-            subject=(element_factory.create(element_class) if element_class else None),
-        )
-
-    return _create
+from gaphor.diagram.tests.fixtures import (
+    create,
+    diagram,
+    element_factory,
+    event_manager,
+)

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -400,7 +400,11 @@ class association(umlproperty):
 
         if value is not None:
             setattr(obj, self._name, value)
-            self._set_opposite(obj, value, from_opposite)
+            try:
+                self._set_opposite(obj, value, from_opposite)
+            except Exception:
+                setattr(obj, self._name, old)
+                raise
 
         self.handle(AssociationSet(obj, self, old, value))
 
@@ -414,7 +418,11 @@ class association(umlproperty):
             return
 
         c.items.append(value)
-        self._set_opposite(obj, value, from_opposite)
+        try:
+            self._set_opposite(obj, value, from_opposite)
+        except Exception:
+            c.items.pop()
+            raise
 
         self.handle(AssociationAdded(obj, self, value))
 

--- a/gaphor/diagram/general/tests/conftest.py
+++ b/gaphor/diagram/general/tests/conftest.py
@@ -1,1 +1,6 @@
-from gaphor.diagram.tests.fixtures import diagram, element_factory, event_manager
+from gaphor.diagram.tests.fixtures import (
+    create,
+    diagram,
+    element_factory,
+    event_manager,
+)

--- a/gaphor/diagram/general/tests/test_comment.py
+++ b/gaphor/diagram/general/tests/test_comment.py
@@ -1,8 +1,6 @@
 """Comment and comment line items connection adapters tests."""
 
-from typing import Type, TypeVar
-
-import pytest
+from typing import TypeVar
 
 from gaphor import UML
 from gaphor.core.modeling import Comment
@@ -14,19 +12,6 @@ from gaphor.UML.classes.klass import ClassItem
 from gaphor.UML.usecases.actor import ActorItem
 
 T = TypeVar("T")
-
-
-@pytest.fixture
-def create(element_factory, diagram):
-    def create(item_cls: Type[T], subject_cls=None, subject=None) -> T:
-        """Create an item with specified subject."""
-        if subject_cls:
-            subject = element_factory.create(subject_cls)
-        item = diagram.create(item_cls, subject=subject)
-        diagram.update_now((item,), ())
-        return item
-
-    return create
 
 
 # NOTE: Still have to test what happens if one Item at the CommentLineItem

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -22,9 +22,11 @@ def event_manager():
 
 @pytest.fixture
 def element_factory(event_manager):
-    return ElementFactory(
+    element_factory = ElementFactory(
         event_manager, ElementDispatcher(event_manager, UMLModelingLanguage())
     )
+    yield element_factory
+    element_factory.shutdown()
 
 
 @pytest.fixture

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -4,6 +4,7 @@ import pytest
 from gaphas.aspect.connector import ConnectionSink
 from gaphas.aspect.connector import Connector as ConnectorAspect
 
+from gaphor.core import Transaction
 from gaphor.core.eventmanager import EventManager
 from gaphor.core.modeling import Diagram, ElementFactory
 from gaphor.core.modeling.elementdispatcher import ElementDispatcher
@@ -32,10 +33,23 @@ def modeling_language():
 
 
 @pytest.fixture
-def diagram(element_factory) -> Diagram:
-    diagram = element_factory.create(Diagram)
+def diagram(element_factory, event_manager) -> Diagram:
+    with Transaction(event_manager):
+        diagram = element_factory.create(Diagram)
     yield diagram
-    diagram.unlink()
+    with Transaction(event_manager):
+        diagram.unlink()
+
+
+@pytest.fixture
+def create(diagram, element_factory):
+    def _create(item_class, element_class=None):
+        return diagram.create(
+            item_class,
+            subject=(element_factory.create(element_class) if element_class else None),
+        )
+
+    return _create
 
 
 @pytest.fixture

--- a/gaphor/services/tests/conftest.py
+++ b/gaphor/services/tests/conftest.py
@@ -6,4 +6,6 @@ from gaphor.services.undomanager import UndoManager
 
 @pytest.fixture
 def undo_manager(event_manager):
-    return UndoManager(event_manager)
+    undo_manager = UndoManager(event_manager)
+    yield undo_manager
+    undo_manager.shutdown()

--- a/gaphor/services/tests/conftest.py
+++ b/gaphor/services/tests/conftest.py
@@ -1,1 +1,9 @@
+import pytest
+
 from gaphor.diagram.tests.fixtures import diagram, element_factory, event_manager
+from gaphor.services.undomanager import UndoManager
+
+
+@pytest.fixture
+def undo_manager(event_manager):
+    return UndoManager(event_manager)

--- a/gaphor/services/tests/test_copyservice.py
+++ b/gaphor/services/tests/test_copyservice.py
@@ -1,78 +1,32 @@
+import pytest
+
 from gaphor import UML
 from gaphor.diagram.general import CommentItem
 from gaphor.services.copyservice import CopyService
-from gaphor.storage.verify import orphan_references
-from gaphor.tests.testcase import TestCase
-from gaphor.UML.classes import AssociationItem, ClassItem
 
 
-class CopyServiceTestCase(TestCase):
+class DiagramsStub:
+    def get_current_view(self):
+        return None
 
-    services = TestCase.services + [
-        "main_window",
-        "diagrams",
-        "properties",
-        "undo_manager",
-        "export_menu",
-        "tools_menu",
-    ]
 
-    def setUp(self):
-        super().setUp()
-        self.service = CopyService(
-            self.get_service("event_manager"),
-            self.get_service("element_factory"),
-            self.get_service("diagrams"),
-        )
+@pytest.fixture
+def diagrams():
+    return DiagramsStub()
 
-    def test_copy(self):
-        service = self.service
 
-        ef = self.element_factory
-        diagram = ef.create(UML.Diagram)
-        ci = diagram.create(CommentItem, subject=ef.create(UML.Comment))
+@pytest.fixture
+def copy_service(event_manager, element_factory, diagrams):
+    return CopyService(event_manager, element_factory, diagrams)
 
-        service.copy({ci})
-        assert list(diagram.get_all_items()) == [ci]
 
-        service.paste(diagram)
+def test_copy(copy_service, element_factory):
+    diagram = element_factory.create(UML.Diagram)
+    ci = diagram.create(CommentItem, subject=element_factory.create(UML.Comment))
 
-        assert len(list(diagram.get_all_items())) == 2, list(diagram.get_all_items())
+    copy_service.copy({ci})
+    assert list(diagram.get_all_items()) == [ci]
 
-    def _skip_test_copy_paste_undo(self):
-        """Test if copied data is undoable."""
+    copy_service.paste(diagram)
 
-        service = self.service
-
-        # Setting the stage:
-        ci1 = self.create(ClassItem, UML.Class)
-        ci2 = self.create(ClassItem, UML.Class)
-        a = self.create(AssociationItem)
-
-        self.connect(a, a.head, ci1)
-        self.connect(a, a.tail, ci2)
-
-        assert a.subject
-        assert a.head_end.subject
-        assert a.tail_end.subject
-
-        # The act: copy and paste, perform undo afterwards
-        service.copy([ci1, ci2, a])
-
-        service.paste(self.diagram)
-
-        all_items = list(self.diagram.get_all_items())
-
-        assert len(all_items) == 6
-        assert not orphan_references(self.element_factory)
-
-        assert all_items[0].subject is all_items[3].subject
-        assert all_items[1].subject is all_items[4].subject
-        assert all_items[2].subject is all_items[5].subject
-
-        undo_manager = self.get_service("undo_manager")
-
-        undo_manager.undo_transaction()
-
-        assert len(list(self.diagram.get_all_items())) == 3
-        assert not orphan_references(self.element_factory)
+    assert len(list(diagram.get_all_items())) == 2, list(diagram.get_all_items())

--- a/gaphor/services/tests/test_undomanager.py
+++ b/gaphor/services/tests/test_undomanager.py
@@ -4,384 +4,389 @@ from gaphor.core import event_handler
 from gaphor.core.eventmanager import EventManager
 from gaphor.core.modeling import ElementFactory
 from gaphor.services.undomanager import UndoManager
-from gaphor.tests.testcase import TestCase
 from gaphor.transaction import Transaction
 
 
-class TestUndoManager(TestCase):
-    def test_transactions(self):
+def test_transactions():
 
-        event_manager = EventManager()
-        undo_manager = UndoManager(event_manager)
+    event_manager = EventManager()
+    undo_manager = UndoManager(event_manager)
 
-        assert not undo_manager._current_transaction
+    assert not undo_manager._current_transaction
 
-        tx = Transaction(event_manager)
+    tx = Transaction(event_manager)
 
-        assert undo_manager._current_transaction
+    assert undo_manager._current_transaction
 
-        current = undo_manager._current_transaction
-        tx2 = Transaction(event_manager)
-        assert undo_manager._current_transaction is current
+    current = undo_manager._current_transaction
+    tx2 = Transaction(event_manager)
+    assert undo_manager._current_transaction is current
 
-        tx2.commit()
+    tx2.commit()
 
-        assert undo_manager._current_transaction is current
+    assert undo_manager._current_transaction is current
 
-        tx.commit()
-        assert undo_manager._current_transaction is None
+    tx.commit()
+    assert undo_manager._current_transaction is None
 
-        undo_manager.shutdown()
+    undo_manager.shutdown()
 
-    def test_not_in_transaction(self):
-        event_manager = EventManager()
-        undo_manager = UndoManager(event_manager)
 
-        action = object()
-        undo_manager.add_undo_action(action)
-        assert undo_manager._current_transaction is None
+def test_not_in_transaction():
+    event_manager = EventManager()
+    undo_manager = UndoManager(event_manager)
 
-        undo_manager.begin_transaction()
-        undo_manager.add_undo_action(action)
-        assert undo_manager._current_transaction
-        assert undo_manager.can_undo()
-        assert len(undo_manager._current_transaction._actions) == 1
+    action = object()
+    undo_manager.add_undo_action(action)
+    assert undo_manager._current_transaction is None
 
-        undo_manager.shutdown()
+    undo_manager.begin_transaction()
+    undo_manager.add_undo_action(action)
+    assert undo_manager._current_transaction
+    assert undo_manager.can_undo()
+    assert len(undo_manager._current_transaction._actions) == 1
 
-    def test_actions(self):
-        undone = [0]
+    undo_manager.shutdown()
 
-        def undo_action(undone=undone):
-            undone[0] = 1
-            undo_manager.add_undo_action(redo_action)
 
-        def redo_action(undone=undone):
-            undone[0] = -1
-            undo_manager.add_undo_action(undo_action)
+def test_actions():
+    undone = [0]
 
-        event_manager = EventManager()
-        undo_manager = UndoManager(event_manager)
+    def undo_action(undone=undone):
+        undone[0] = 1
+        undo_manager.add_undo_action(redo_action)
 
-        tx = Transaction(event_manager)
+    def redo_action(undone=undone):
+        undone[0] = -1
         undo_manager.add_undo_action(undo_action)
-        assert undo_manager._current_transaction
-        assert undo_manager.can_undo()
-        assert len(undo_manager._current_transaction._actions) == 1
 
-        tx.commit()
+    event_manager = EventManager()
+    undo_manager = UndoManager(event_manager)
 
-        undo_manager.undo_transaction()
-        assert not undo_manager.can_undo(), undo_manager._undo_stack
-        assert undone[0] == 1, undone
+    tx = Transaction(event_manager)
+    undo_manager.add_undo_action(undo_action)
+    assert undo_manager._current_transaction
+    assert undo_manager.can_undo()
+    assert len(undo_manager._current_transaction._actions) == 1
 
-        undone[0] = 0
+    tx.commit()
 
-        assert undo_manager.can_redo(), undo_manager._redo_stack
+    undo_manager.undo_transaction()
+    assert not undo_manager.can_undo(), undo_manager._undo_stack
+    assert undone[0] == 1, undone
 
-        undo_manager.redo_transaction()
-        assert not undo_manager.can_redo()
-        assert undo_manager.can_undo()
-        assert undone[0] == -1, undone
+    undone[0] = 0
 
-        undo_manager.shutdown()
+    assert undo_manager.can_redo(), undo_manager._redo_stack
 
-    def test_undo_attribute(self):
-        from gaphor.core.modeling import Element
-        from gaphor.core.modeling.properties import attribute
+    undo_manager.redo_transaction()
+    assert not undo_manager.can_redo()
+    assert undo_manager.can_undo()
+    assert undone[0] == -1, undone
 
-        event_manager = EventManager()
-        undo_manager = UndoManager(event_manager)
-        element_factory = ElementFactory(event_manager)
+    undo_manager.shutdown()
 
-        class A(Element):
-            attr = attribute("attr", bytes, default="default")
 
+def test_undo_attribute():
+    from gaphor.core.modeling import Element
+    from gaphor.core.modeling.properties import attribute
+
+    event_manager = EventManager()
+    undo_manager = UndoManager(event_manager)
+    element_factory = ElementFactory(event_manager)
+
+    class A(Element):
+        attr = attribute("attr", bytes, default="default")
+
+    a = element_factory.create(A)
+    assert a.attr == "default", a.attr
+    undo_manager.begin_transaction()
+    a.attr = "five"
+
+    undo_manager.commit_transaction()
+    assert a.attr == "five"
+
+    undo_manager.undo_transaction()
+    assert a.attr == "default", a.attr
+
+    undo_manager.redo_transaction()
+    assert a.attr == "five"
+
+    undo_manager.shutdown()
+
+
+def test_undo_association_1_x():
+    from gaphor.core.modeling import Element
+    from gaphor.core.modeling.properties import association
+
+    event_manager = EventManager()
+    undo_manager = UndoManager(event_manager)
+    element_factory = ElementFactory(event_manager)
+
+    class A(Element):
+        pass
+
+    class B(Element):
+        pass
+
+    A.one = association("one", B, 0, 1, opposite="two")
+    B.two = association("two", A, 0, 1)
+
+    a = element_factory.create(A)
+    b = element_factory.create(B)
+
+    assert a.one is None
+    assert b.two is None
+
+    undo_manager.begin_transaction()
+    a.one = b
+
+    undo_manager.commit_transaction()
+    assert a.one is b
+    assert b.two is a
+    assert len(undo_manager._undo_stack) == 1
+    assert len(undo_manager._undo_stack[0]._actions) == 2, undo_manager._undo_stack[
+        0
+    ]._actions
+
+    undo_manager.undo_transaction()
+    assert a.one is None
+    assert b.two is None
+    assert undo_manager.can_redo()
+    assert len(undo_manager._redo_stack) == 1
+    assert len(undo_manager._redo_stack[0]._actions) == 2, undo_manager._redo_stack[
+        0
+    ]._actions
+
+    undo_manager.redo_transaction()
+    assert len(undo_manager._undo_stack) == 1
+    assert len(undo_manager._undo_stack[0]._actions) == 2, undo_manager._undo_stack[
+        0
+    ]._actions
+    assert b.two is a
+    assert a.one is b
+
+    undo_manager.shutdown()
+
+
+def test_undo_association_1_n():
+    from gaphor.core.modeling import Element
+    from gaphor.core.modeling.properties import association
+
+    event_manager = EventManager()
+    undo_manager = UndoManager(event_manager)
+    element_factory = ElementFactory(event_manager)
+
+    class A(Element):
+        pass
+
+    class B(Element):
+        pass
+
+    A.one = association("one", B, lower=0, upper=1, opposite="two")
+    B.two = association("two", A, lower=0, upper="*", opposite="one")
+
+    a1 = element_factory.create(A)
+    a2 = element_factory.create(A)
+    b1 = element_factory.create(B)
+    element_factory.create(B)
+
+    undo_manager.begin_transaction()
+    b1.two = a1
+
+    undo_manager.commit_transaction()
+    assert a1 in b1.two
+    assert b1 is a1.one
+    assert len(undo_manager._undo_stack) == 1
+    assert len(undo_manager._undo_stack[0]._actions) == 2, undo_manager._undo_stack[
+        0
+    ]._actions
+
+    undo_manager.undo_transaction()
+    assert len(b1.two) == 0
+    assert a1.one is None
+    assert undo_manager.can_redo()
+    assert len(undo_manager._redo_stack) == 1
+    assert len(undo_manager._redo_stack[0]._actions) == 2, undo_manager._redo_stack[
+        0
+    ]._actions
+
+    undo_manager.redo_transaction()
+    assert a1 in b1.two
+    assert b1 is a1.one
+
+    undo_manager.begin_transaction()
+    b1.two = a2
+
+    undo_manager.commit_transaction()
+    assert a1 in b1.two
+    assert a2 in b1.two
+    assert b1 is a1.one
+    assert b1 is a2.one
+
+    undo_manager.shutdown()
+
+
+def test_element_factory_undo():
+    from gaphor.core.modeling import Element
+
+    event_manager = EventManager()
+    undo_manager = UndoManager(event_manager)
+    element_factory = ElementFactory(event_manager)
+
+    undo_manager.begin_transaction()
+    p = element_factory.create(Element)
+
+    assert undo_manager._current_transaction
+    assert undo_manager._current_transaction._actions
+    assert undo_manager.can_undo()
+
+    undo_manager.commit_transaction()
+    assert undo_manager.can_undo()
+    assert element_factory.size() == 1
+
+    undo_manager.undo_transaction()
+    assert not undo_manager.can_undo()
+    assert undo_manager.can_redo()
+    assert element_factory.size() == 0
+
+    undo_manager.redo_transaction()
+    assert undo_manager.can_undo()
+    assert not undo_manager.can_redo()
+    assert element_factory.size() == 1
+    assert element_factory.lselect()[0] is p
+
+    undo_manager.shutdown()
+
+
+def test_element_factory_rollback():
+    from gaphor.core.modeling import Element
+
+    event_manager = EventManager()
+    undo_manager = UndoManager(event_manager)
+    element_factory = ElementFactory(event_manager)
+
+    undo_manager.begin_transaction()
+    element_factory.create(Element)
+
+    assert undo_manager._current_transaction
+    assert undo_manager._current_transaction._actions
+    assert undo_manager.can_undo()
+
+    undo_manager.rollback_transaction()
+    assert not undo_manager.can_undo()
+    assert element_factory.size() == 0
+
+    undo_manager.shutdown()
+
+
+def test_uml_associations():
+
+    from gaphor.core.modeling.event import AssociationUpdated
+    from gaphor.core.modeling.properties import association, derivedunion
+    from gaphor.UML import Element
+
+    event_manager = EventManager()
+    undo_manager = UndoManager(event_manager)
+    element_factory = ElementFactory(event_manager)
+
+    class A(Element):
+        is_unlinked = False
+
+        def unlink(self):
+            self.is_unlinked = True
+            Element.unlink(self)
+
+    A.a1 = association("a1", A, upper=1)
+    A.a2 = association("a2", A, upper=1)
+    A.b1 = association("b1", A, upper="*")
+    A.b2 = association("b2", A, upper="*")
+    A.b3 = association("b3", A, upper=1)
+
+    A.derived_a = derivedunion("derived_a", A, 0, 1, A.a1, A.a2)
+    A.derived_b = derivedunion("derived_b", A, 0, "*", A.b1, A.b2, A.b3)
+
+    events = []
+
+    @event_handler(AssociationUpdated)
+    def handler(event, events=events):
+        events.append(event)
+
+    event_manager.subscribe(handler)
+    try:
         a = element_factory.create(A)
-        assert a.attr == "default", a.attr
-        undo_manager.begin_transaction()
-        a.attr = "five"
 
+        undo_manager.begin_transaction()
+
+        a.a1 = element_factory.create(A)
         undo_manager.commit_transaction()
-        assert a.attr == "five"
 
-        undo_manager.undo_transaction()
-        assert a.attr == "default", a.attr
-
-        undo_manager.redo_transaction()
-        assert a.attr == "five"
-
-        undo_manager.shutdown()
-
-    def test_undo_association_1_x(self):
-        from gaphor.core.modeling import Element
-        from gaphor.core.modeling.properties import association
-
-        event_manager = EventManager()
-        undo_manager = UndoManager(event_manager)
-        element_factory = ElementFactory(event_manager)
-
-        class A(Element):
-            pass
-
-        class B(Element):
-            pass
-
-        A.one = association("one", B, 0, 1, opposite="two")
-        B.two = association("two", A, 0, 1)
-
-        a = element_factory.create(A)
-        b = element_factory.create(B)
-
-        assert a.one is None
-        assert b.two is None
-
-        undo_manager.begin_transaction()
-        a.one = b
-
-        undo_manager.commit_transaction()
-        assert a.one is b
-        assert b.two is a
-        assert len(undo_manager._undo_stack) == 1
-        assert len(undo_manager._undo_stack[0]._actions) == 2, undo_manager._undo_stack[
-            0
-        ]._actions
-
-        undo_manager.undo_transaction()
-        assert a.one is None
-        assert b.two is None
-        assert undo_manager.can_redo()
-        assert len(undo_manager._redo_stack) == 1
-        assert len(undo_manager._redo_stack[0]._actions) == 2, undo_manager._redo_stack[
-            0
-        ]._actions
-
-        undo_manager.redo_transaction()
-        assert len(undo_manager._undo_stack) == 1
-        assert len(undo_manager._undo_stack[0]._actions) == 2, undo_manager._undo_stack[
-            0
-        ]._actions
-        assert b.two is a
-        assert a.one is b
-
-        undo_manager.shutdown()
-
-    def test_undo_association_1_n(self):
-        from gaphor.core.modeling import Element
-        from gaphor.core.modeling.properties import association
-
-        event_manager = EventManager()
-        undo_manager = UndoManager(event_manager)
-        element_factory = ElementFactory(event_manager)
-
-        class A(Element):
-            pass
-
-        class B(Element):
-            pass
-
-        A.one = association("one", B, lower=0, upper=1, opposite="two")
-        B.two = association("two", A, lower=0, upper="*", opposite="one")
-
-        a1 = element_factory.create(A)
-        a2 = element_factory.create(A)
-        b1 = element_factory.create(B)
-        element_factory.create(B)
-
-        undo_manager.begin_transaction()
-        b1.two = a1
-
-        undo_manager.commit_transaction()
-        assert a1 in b1.two
-        assert b1 is a1.one
-        assert len(undo_manager._undo_stack) == 1
-        assert len(undo_manager._undo_stack[0]._actions) == 2, undo_manager._undo_stack[
-            0
-        ]._actions
-
-        undo_manager.undo_transaction()
-        assert len(b1.two) == 0
-        assert a1.one is None
-        assert undo_manager.can_redo()
-        assert len(undo_manager._redo_stack) == 1
-        assert len(undo_manager._redo_stack[0]._actions) == 2, undo_manager._redo_stack[
-            0
-        ]._actions
-
-        undo_manager.redo_transaction()
-        assert a1 in b1.two
-        assert b1 is a1.one
-
-        undo_manager.begin_transaction()
-        b1.two = a2
-
-        undo_manager.commit_transaction()
-        assert a1 in b1.two
-        assert a2 in b1.two
-        assert b1 is a1.one
-        assert b1 is a2.one
-
-        undo_manager.shutdown()
-
-    def test_element_factory_undo(self):
-        from gaphor.core.modeling import Element
-
-        event_manager = EventManager()
-        undo_manager = UndoManager(event_manager)
-        element_factory = ElementFactory(event_manager)
-
-        undo_manager.begin_transaction()
-        p = element_factory.create(Element)
-
-        assert undo_manager._current_transaction
-        assert undo_manager._current_transaction._actions
+        assert len(events) == 2, events  # both  AssociationSet and DerivedSet events
+        assert events[0].property is A.a1
         assert undo_manager.can_undo()
-
-        undo_manager.commit_transaction()
-        assert undo_manager.can_undo()
-        assert element_factory.size() == 1
 
         undo_manager.undo_transaction()
         assert not undo_manager.can_undo()
         assert undo_manager.can_redo()
-        assert element_factory.size() == 0
+        assert len(events) == 4, events
+        assert events[2].property is A.a1
 
-        undo_manager.redo_transaction()
-        assert undo_manager.can_undo()
-        assert not undo_manager.can_redo()
-        assert element_factory.size() == 1
-        assert element_factory.lselect()[0] is p
-
+    finally:
+        event_manager.unsubscribe(handler)
         undo_manager.shutdown()
 
-    def test_element_factory_rollback(self):
-        from gaphor.core.modeling import Element
 
-        event_manager = EventManager()
-        undo_manager = UndoManager(event_manager)
-        element_factory = ElementFactory(event_manager)
+def test_redo_stack():
+    from gaphor.core.modeling import Element
 
-        undo_manager.begin_transaction()
+    event_manager = EventManager()
+    undo_manager = UndoManager(event_manager)
+    element_factory = ElementFactory(event_manager)
+
+    undo_manager.begin_transaction()
+
+    p = element_factory.create(Element)
+
+    assert undo_manager._current_transaction
+    assert undo_manager._current_transaction._actions
+    assert undo_manager.can_undo()
+
+    undo_manager.commit_transaction()
+    assert undo_manager.can_undo()
+    assert element_factory.size() == 1, element_factory.size()
+
+    with Transaction(event_manager):
         element_factory.create(Element)
 
-        assert undo_manager._current_transaction
-        assert undo_manager._current_transaction._actions
-        assert undo_manager.can_undo()
+    assert undo_manager.can_undo()
+    assert not undo_manager.can_redo()
+    assert element_factory.size() == 2
 
-        undo_manager.rollback_transaction()
-        assert not undo_manager.can_undo()
-        assert element_factory.size() == 0
+    undo_manager.undo_transaction()
+    assert undo_manager.can_undo()
+    assert 1 == len(undo_manager._undo_stack)
+    assert 1 == len(undo_manager._redo_stack)
+    assert undo_manager.can_redo()
+    assert element_factory.size() == 1
 
-        undo_manager.shutdown()
+    undo_manager.undo_transaction()
+    assert not undo_manager.can_undo()
+    assert undo_manager.can_redo()
+    assert 0 == len(undo_manager._undo_stack)
+    assert 2 == len(undo_manager._redo_stack)
 
-    def test_uml_associations(self):
+    undo_manager.redo_transaction()
+    assert 1 == len(undo_manager._undo_stack)
+    assert 1 == len(undo_manager._redo_stack)
+    assert undo_manager.can_undo()
+    assert undo_manager.can_redo()
+    assert element_factory.size() == 1
 
-        from gaphor.core.modeling.event import AssociationUpdated
-        from gaphor.core.modeling.properties import association, derivedunion
-        from gaphor.UML import Element
+    undo_manager.redo_transaction()
+    assert undo_manager.can_undo()
+    assert not undo_manager.can_redo()
+    assert element_factory.size() == 2
 
-        event_manager = EventManager()
-        undo_manager = UndoManager(event_manager)
-        element_factory = ElementFactory(event_manager)
+    assert p in element_factory.lselect()
 
-        class A(Element):
-            is_unlinked = False
-
-            def unlink(self):
-                self.is_unlinked = True
-                Element.unlink(self)
-
-        A.a1 = association("a1", A, upper=1)
-        A.a2 = association("a2", A, upper=1)
-        A.b1 = association("b1", A, upper="*")
-        A.b2 = association("b2", A, upper="*")
-        A.b3 = association("b3", A, upper=1)
-
-        A.derived_a = derivedunion("derived_a", A, 0, 1, A.a1, A.a2)
-        A.derived_b = derivedunion("derived_b", A, 0, "*", A.b1, A.b2, A.b3)
-
-        events = []
-
-        @event_handler(AssociationUpdated)
-        def handler(event, events=events):
-            events.append(event)
-
-        event_manager.subscribe(handler)
-        try:
-            a = element_factory.create(A)
-
-            undo_manager.begin_transaction()
-
-            a.a1 = element_factory.create(A)
-            undo_manager.commit_transaction()
-
-            assert (
-                len(events) == 2
-            ), events  # both  AssociationSet and DerivedSet events
-            assert events[0].property is A.a1
-            assert undo_manager.can_undo()
-
-            undo_manager.undo_transaction()
-            assert not undo_manager.can_undo()
-            assert undo_manager.can_redo()
-            assert len(events) == 4, events
-            assert events[2].property is A.a1
-
-        finally:
-            event_manager.unsubscribe(handler)
-            undo_manager.shutdown()
-
-    def test_redo_stack(self):
-        from gaphor.core.modeling import Element
-
-        event_manager = EventManager()
-        undo_manager = UndoManager(event_manager)
-        element_factory = ElementFactory(event_manager)
-
-        undo_manager.begin_transaction()
-
-        p = element_factory.create(Element)
-
-        assert undo_manager._current_transaction
-        assert undo_manager._current_transaction._actions
-        assert undo_manager.can_undo()
-
-        undo_manager.commit_transaction()
-        assert undo_manager.can_undo()
-        assert element_factory.size() == 1, element_factory.size()
-
-        with Transaction(event_manager):
-            element_factory.create(Element)
-
-        assert undo_manager.can_undo()
-        assert not undo_manager.can_redo()
-        assert element_factory.size() == 2
-
-        undo_manager.undo_transaction()
-        assert undo_manager.can_undo()
-        assert 1 == len(undo_manager._undo_stack)
-        assert 1 == len(undo_manager._redo_stack)
-        assert undo_manager.can_redo()
-        assert element_factory.size() == 1
-
-        undo_manager.undo_transaction()
-        assert not undo_manager.can_undo()
-        assert undo_manager.can_redo()
-        assert 0 == len(undo_manager._undo_stack)
-        assert 2 == len(undo_manager._redo_stack)
-
-        undo_manager.redo_transaction()
-        assert 1 == len(undo_manager._undo_stack)
-        assert 1 == len(undo_manager._redo_stack)
-        assert undo_manager.can_undo()
-        assert undo_manager.can_redo()
-        assert element_factory.size() == 1
-
-        undo_manager.redo_transaction()
-        assert undo_manager.can_undo()
-        assert not undo_manager.can_redo()
-        assert element_factory.size() == 2
-
-        assert p in element_factory.lselect()
-
-        undo_manager.shutdown()
+    undo_manager.shutdown()

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -129,13 +129,12 @@ class UndoManager(Service, ActionProvider):
         assert not self._current_transaction
         self._current_transaction = ActionStack()
 
-    def add_undo_action(self, action, only_transactional=True):
+    def add_undo_action(self, action, requires_transaction=True):
         """Add an action to undo."""
         if self._current_transaction:
             self._current_transaction.add(action)
-            # TODO: should this be placed here?
             self._action_executed()
-        elif only_transactional:
+        elif requires_transaction:
             undo_stack = list(self._undo_stack)
             redo_stack = list(self._redo_stack)
 
@@ -259,7 +258,9 @@ class UndoManager(Service, ActionProvider):
     #
 
     def _gaphas_undo_handler(self, event):
-        self.add_undo_action(lambda: state.saveapply(*event), only_transactional=False)
+        self.add_undo_action(
+            lambda: state.saveapply(*event), requires_transaction=False
+        )
 
     def _register_undo_handlers(self):
 

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -136,6 +136,17 @@ class UndoManager(Service, ActionProvider):
             # TODO: should this be placed here?
             self._action_executed()
         elif only_transactional:
+            undo_stack = list(self._undo_stack)
+            redo_stack = list(self._redo_stack)
+
+            try:
+                with Transaction(self.event_manager):
+                    action()
+            finally:
+                # Restore stacks and act like nothing happened
+                self._redo_stack = redo_stack
+                self._undo_stack = undo_stack
+
             raise NotInTransactionException("Updating state outside of a transaction.")
 
     @event_handler(TransactionCommit)

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -177,9 +177,8 @@ class UndoManager(Service, ActionProvider):
             with Transaction(self.event_manager):
                 try:
                     erroneous_tx.execute()
-                except Exception as e:
-                    logger.error("Could not roolback transaction")
-                    logger.error(e)
+                except Exception:
+                    logger.error("Could not rollback transaction", exc_info=True)
         finally:
             # Discard all data collected in the rollback "transaction"
             self._undo_stack = undo_stack

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -233,7 +233,6 @@ class MainWindow(Service, ActionProvider):
     @event_handler(ModelReady)
     def _new_model_content(self, event):
         """Open the toplevel element and load toplevel diagrams."""
-        # TODO: Make handlers for ModelReady from within the GUI obj
         for diagram in self.element_factory.select(
             lambda e: e.isKindOf(Diagram)
             and not (e.namespace and e.namespace.namespace)

--- a/tests/test_issue_gaphas.py
+++ b/tests/test_issue_gaphas.py
@@ -1,26 +1,47 @@
+# flake8: noqa F401,F811
+import pytest
+
 from gaphor import UML
+from gaphor.core import Transaction
+from gaphor.diagram.tests.fixtures import (
+    connect,
+    create,
+    diagram,
+    element_factory,
+    event_manager,
+)
+from gaphor.services.undomanager import UndoManager
 from gaphor.tests import TestCase
 from gaphor.UML.classes import AssociationItem, ClassItem
+from gaphor.UML.sanitizerservice import SanitizerService
 
 
-class GaphasTest(TestCase):
+@pytest.fixture(autouse=True)
+def sanitizer_service(event_manager):
+    return SanitizerService(event_manager)
 
-    services = TestCase.services + ["sanitizer_service", "undo_manager"]
 
-    def test_remove_class_with_association(self):
-        c1 = self.create(ClassItem, UML.Class)
+@pytest.fixture(autouse=True)
+def undo_manager(event_manager):
+    return UndoManager(event_manager)
+
+
+def test_remove_class_with_association(create, diagram, element_factory, event_manager):
+    with Transaction(event_manager):
+        c1 = create(ClassItem, UML.Class)
         c1.name = "klassitem1"
-        c2 = self.create(ClassItem, UML.Class)
+        c2 = create(ClassItem, UML.Class)
         c2.name = "klassitem2"
 
-        a = self.create(AssociationItem)
+        a = create(AssociationItem)
 
-        assert len(list(self.diagram.get_all_items())) == 3
+        assert len(list(diagram.get_all_items())) == 3
 
-        self.connect(a, a.head, c1)
-        self.connect(a, a.tail, c2)
+        connect(a, a.head, c1)
+        connect(a, a.tail, c2)
 
-        assert a.subject
-        assert self.element_factory.lselect(UML.Association)[0] is a.subject
+    assert a.subject
+    assert element_factory.lselect(UML.Association)[0] is a.subject
 
+    with Transaction(event_manager):
         c1.unlink()

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -35,20 +35,24 @@ def undo_manager(session):
 
 
 def test_class_association_undo_redo(event_manager, element_factory, undo_manager):
-    diagram = element_factory.create(UML.Diagram)
+    with Transaction(event_manager):
+        diagram = element_factory.create(UML.Diagram)
 
     assert 0 == len(diagram.connections.solver.constraints)
 
-    ci1 = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    with Transaction(event_manager):
+        ci1 = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
     assert 6 == len(diagram.connections.solver.constraints)
 
-    ci2 = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    with Transaction(event_manager):
+        ci2 = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
     assert 12 == len(diagram.connections.solver.constraints)
 
-    a = diagram.create(AssociationItem)
+    with Transaction(event_manager):
+        a = diagram.create(AssociationItem)
 
-    connect(a, a.head, ci1)
-    connect(a, a.tail, ci2)
+        connect(a, a.head, ci1)
+        connect(a, a.tail, ci2)
 
     # Diagram, Association, 2x Class, Property, LiteralSpecification
     assert 6 == len(element_factory.lselect())
@@ -88,7 +92,8 @@ def test_class_association_undo_redo(event_manager, element_factory, undo_manage
 def test_diagram_item_should_not_end_up_in_element_factory(
     event_manager, element_factory, undo_manager
 ):
-    diagram = element_factory.create(UML.Diagram)
+    with Transaction(event_manager):
+        diagram = element_factory.create(UML.Diagram)
 
     with Transaction(event_manager):
         cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
@@ -102,8 +107,9 @@ def test_diagram_item_should_not_end_up_in_element_factory(
 def test_deleted_diagram_item_should_not_end_up_in_element_factory(
     event_manager, element_factory, undo_manager
 ):
-    diagram = element_factory.create(UML.Diagram)
-    cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    with Transaction(event_manager):
+        diagram = element_factory.create(UML.Diagram)
+        cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
     with Transaction(event_manager):
         cls.unlink()


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Currently it's possible to make changes to the model at any given point. We want proper Undo/redo behaviour, but can not guarantee that every change happens in a transaction.

### What is the new behavior?

An exception is raised when a change is made to the model without being properly encapsulated in a transaction.
If the undo manager finds a (reversible) action to be performed outside of a transaction, it will instantly revert the action and it will raise an exception.

It was good to see that I could not trigger the exception from using the GUI.

There were some tests that used the old `TestCase` class, and therefore implicitly activated the undo-manager service. Those tests have been rewritten to pytest tests.


### Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

All changed need to happen within a transaction.


### Other information
