### PR TITLE
Fix element dispatcher warnings

### DIFF
--- a/gaphor/core/modeling/elementdispatcher.py
+++ b/gaphor/core/modeling/elementdispatcher.py
@@ -196,8 +196,12 @@ class ElementDispatcher(Service):
         try:
             del handlers[handler]
         except KeyError:
-            self.logger.warning(
-                f"Handler {handler} is not registered for {element}.{property}"
+            self.logger.debug(
+                "Handler %s is not registered for %s.%s",
+                handler,
+                element,
+                property,
+                exc_info=True,
             )
 
         if not handlers:

--- a/gaphor/core/modeling/elementdispatcher.py
+++ b/gaphor/core/modeling/elementdispatcher.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from logging import getLogger
+import logging
 from typing import Dict, List, Optional, Set, Tuple
 
 from gaphor.abc import Service
@@ -16,6 +16,8 @@ from gaphor.core.modeling.event import (
     ModelReady,
 )
 from gaphor.core.modeling.properties import umlproperty
+
+log = logging.getLogger(__name__)
 
 
 class EventWatcher:
@@ -93,8 +95,6 @@ class ElementDispatcher(Service):
     dispatcher table is updated accordingly (so the right handlers are fired
     every time).
     """
-
-    logger = getLogger("ElementDispatcher")
 
     def __init__(self, event_manager, modeling_language):
         self.event_manager = event_manager
@@ -196,7 +196,7 @@ class ElementDispatcher(Service):
         try:
             del handlers[handler]
         except KeyError:
-            self.logger.debug(
+            log.debug(
                 "Handler %s is not registered for %s.%s",
                 handler,
                 element,
@@ -240,9 +240,7 @@ class ElementDispatcher(Service):
                 try:
                     handler(event)
                 except Exception:
-                    self.logger.error(
-                        f"Problem executing handler {handler}", exc_info=True
-                    )
+                    log.error(f"Problem executing handler {handler}", exc_info=True)
 
             # Handle add/removal of handlers based on the kind of event
             # Filter out handlers that have no remaining properties

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -76,10 +76,6 @@ class Presentation(Matrices, Element, Generic[S]):
         self._watcher.watch(path, handler)
         return self
 
-    def unsubscribe_all(self):
-        """Unsubscribe all watched paths, as defined through `watch()`."""
-        self._watcher.unsubscribe_all()
-
     def postload(self):
         super().postload()
         if self.parent:

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -121,3 +121,23 @@ def test_deleted_diagram_item_should_not_end_up_in_element_factory(
     undo_manager.redo_transaction()
 
     assert cls not in element_factory.lselect(), element_factory.lselect()
+
+
+def test_undo_should_not_cause_warnings(
+    event_manager, element_factory, undo_manager, capsys
+):
+    with Transaction(event_manager):
+        diagram = element_factory.create(UML.Diagram)
+
+    with Transaction(event_manager):
+        diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    undo_manager.undo_transaction()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Element dispatcher is logging warning messages when handlers are disconnected.

On Element dispatcher, handlers can be registered multiple times, but once a handler is registered, subsequent registrations have no effect. When unregistering, however, a warning message is displayed when a handle can not be found.

Issue Number: #585

### What is the new behavior?

The warning level message is demoted to debug.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
