### PR TITLE
Fix undo manager

### DIFF
--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -5,7 +5,7 @@ from gaphas.connector import Handle, LinePort, Position
 from gaphas.geometry import Rectangle, distance_rectangle_point
 
 from gaphor.core.modeling import Presentation
-from gaphor.diagram.presentation import Named, postload_connect
+from gaphor.diagram.presentation import HandlePositionUpdate, Named, postload_connect
 from gaphor.diagram.shapes import (
     Box,
     EditableText,
@@ -32,13 +32,14 @@ def text_position(position):
 
 
 @represents(sysml.ProxyPort)
-class ProxyPortItem(Presentation[sysml.ProxyPort], Named):
+class ProxyPortItem(Presentation[sysml.ProxyPort], HandlePositionUpdate, Named):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
         self._connections = diagram.connections
 
         h1 = Handle(connectable=True)
         self._handles = [h1]
+        self.watch_handle(h1)
 
         d = self.dimensions()
         top_left = Position(d.x, d.y)

--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -60,7 +60,6 @@ class ObjectNodePropertyPage(PropertyPageBase):
     @transactional
     def _on_ordering_show_change(self, button, gparam):
         self.item.show_ordering = button.get_active()
-        print("show_ordering", self.item.show_ordering)
 
 
 @PropertyPages.register(ForkNodeItem)

--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -15,6 +15,7 @@ class ObjectNodePropertyPage(PropertyPageBase):
     ORDERING_VALUES = ["unordered", "ordered", "LIFO", "FIFO"]
 
     subject: UML.ObjectNode
+    item: ObjectNodeItem
 
     def __init__(self, item):
         self.item = item
@@ -59,6 +60,7 @@ class ObjectNodePropertyPage(PropertyPageBase):
     @transactional
     def _on_ordering_show_change(self, button, gparam):
         self.item.show_ordering = button.get_active()
+        print("show_ordering", self.item.show_ordering)
 
 
 @PropertyPages.register(ForkNodeItem)

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -11,7 +11,7 @@ from gaphas.util import path_ellipse
 from gaphor import UML
 from gaphor.core.modeling import Presentation
 from gaphor.core.modeling.properties import association, relation_one
-from gaphor.diagram.presentation import ElementPresentation, Named
+from gaphor.diagram.presentation import ElementPresentation, HandlePositionUpdate, Named
 from gaphor.diagram.shapes import Box, EditableText, IconBox, Text, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.modelfactory import stereotypes_str
@@ -197,7 +197,7 @@ def draw_decision_node(_box, context, _bounding_box):
 
 
 @represents(UML.ForkNode)
-class ForkNodeItem(Presentation[UML.ForkNode], Named):
+class ForkNodeItem(Presentation[UML.ForkNode], HandlePositionUpdate, Named):
     """Representation of fork and join node."""
 
     def __init__(self, diagram, id=None):
@@ -206,6 +206,8 @@ class ForkNodeItem(Presentation[UML.ForkNode], Named):
         h1, h2 = Handle(), Handle()
         self._handles = [h1, h2]
         self._ports = [LinePort(h1.pos, h2.pos)]
+        self.watch_handle(h1)
+        self.watch_handle(h2)
 
         self.shape = IconBox(
             Box(style={"min-width": 0, "min-height": 45}, draw=self.draw_fork_node),

--- a/gaphor/UML/actions/flowconnect.py
+++ b/gaphor/UML/actions/flowconnect.py
@@ -182,7 +182,7 @@ class FlowForkDecisionNodeConnect(FlowConnect):
                 if len(join_node.outgoing) > 1:
                     assert len(join_node.incoming) < 2
                     UML.model.swap_element(join_node, fork_node_cls)
-                element.combined = None
+                del element.combined
 
     def connect_subject(self, handle):
         """In addition to a subject connect, the subject of the element may be

--- a/gaphor/UML/actions/objectnode.py
+++ b/gaphor/UML/actions/objectnode.py
@@ -1,10 +1,7 @@
 """Object node item."""
 
-import ast
-
-from gaphas.state import observed, reversible_property
-
 from gaphor import UML
+from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.presentation import ElementPresentation, Named
 from gaphor.diagram.shapes import Box, EditableText, IconBox, Text, draw_border
 from gaphor.diagram.support import represents
@@ -24,8 +21,6 @@ class ObjectNodeItem(ElementPresentation, Named):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self._show_ordering = False
-
         self.shape = IconBox(
             Box(
                 Text(
@@ -40,7 +35,7 @@ class ObjectNodeItem(ElementPresentation, Named):
                 and f"{{ upperBound = {self.subject.upperBound} }}",
             ),
             Text(
-                text=lambda: self._show_ordering
+                text=lambda: self.show_ordering
                 and self.subject.ordering
                 and f"{{ ordering = {self.subject.ordering} }}",
             ),
@@ -50,20 +45,6 @@ class ObjectNodeItem(ElementPresentation, Named):
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[ObjectNode].upperBound")
         self.watch("subject[ObjectNode].ordering")
+        self.watch("show_ordering")
 
-    @observed
-    def _set_show_ordering(self, value):
-        self._show_ordering = value
-        self.request_update()
-
-    show_ordering = reversible_property(lambda s: s._show_ordering, _set_show_ordering)
-
-    def save(self, save_func):
-        save_func("show-ordering", self._show_ordering)
-        super().save(save_func)
-
-    def load(self, name, value):
-        if name == "show-ordering":
-            self._show_ordering = ast.literal_eval(value)
-        else:
-            super().load(name, value)
+    show_ordering: attribute[bool] = attribute("show_ordering", bool, False)

--- a/gaphor/UML/actions/objectnode.py
+++ b/gaphor/UML/actions/objectnode.py
@@ -19,25 +19,33 @@ class ObjectNodeItem(ElementPresentation, Named):
     """
 
     def __init__(self, diagram, id=None):
-        super().__init__(diagram, id)
-
-        self.shape = IconBox(
-            Box(
-                Text(
-                    text=lambda: stereotypes_str(self.subject),
+        super().__init__(
+            diagram,
+            id,
+            shape=IconBox(
+                Box(
+                    Text(
+                        text=lambda: stereotypes_str(self.subject),
+                    ),
+                    EditableText(text=lambda: self.subject.name or ""),
+                    style={
+                        "min-width": 50,
+                        "min-height": 30,
+                        "padding": (5, 10, 5, 10),
+                    },
+                    draw=draw_border,
                 ),
-                EditableText(text=lambda: self.subject.name or ""),
-                style={"min-width": 50, "min-height": 30, "padding": (5, 10, 5, 10)},
-                draw=draw_border,
-            ),
-            Text(
-                text=lambda: self.subject.upperBound not in (None, DEFAULT_UPPER_BOUND)
-                and f"{{ upperBound = {self.subject.upperBound} }}",
-            ),
-            Text(
-                text=lambda: self.show_ordering
-                and self.subject.ordering
-                and f"{{ ordering = {self.subject.ordering} }}",
+                Text(
+                    text=lambda: self.subject.upperBound
+                    not in (None, DEFAULT_UPPER_BOUND)
+                    and f"{{ upperBound = {self.subject.upperBound} }}",
+                ),
+                Text(
+                    text=lambda: self.show_ordering
+                    and self.subject.ordering
+                    and f"{{ ordering = {self.subject.ordering} }}"
+                    or "",
+                ),
             ),
         )
 

--- a/gaphor/UML/actions/objectnode.py
+++ b/gaphor/UML/actions/objectnode.py
@@ -37,8 +37,9 @@ class ObjectNodeItem(ElementPresentation, Named):
                 ),
                 Text(
                     text=lambda: self.subject.upperBound
-                    not in (None, DEFAULT_UPPER_BOUND)
-                    and f"{{ upperBound = {self.subject.upperBound} }}",
+                    not in (None, "", DEFAULT_UPPER_BOUND)
+                    and f"{{ upperBound = {self.subject.upperBound} }}"
+                    or "",
                 ),
                 Text(
                     text=lambda: self.show_ordering

--- a/gaphor/UML/actions/objectnode.py
+++ b/gaphor/UML/actions/objectnode.py
@@ -57,3 +57,8 @@ class ObjectNodeItem(ElementPresentation, Named):
         self.watch("show_ordering")
 
     show_ordering: attribute[bool] = attribute("show_ordering", bool, False)
+
+    def load(self, name, value):
+        if name == "show-ordering":
+            name = "show_ordering"
+        super().load(name, value)

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -13,12 +13,13 @@ Plan:
 
 
 from math import atan2, pi
+from typing import Optional
 
+from gaphas.connector import Handle
 from gaphas.geometry import Rectangle, distance_rectangle_point
 
 from gaphor import UML
-from gaphor.core.modeling.presentation import Presentation, Transient
-from gaphor.core.modeling.properties import attribute
+from gaphor.core.modeling.properties import association, attribute
 from gaphor.core.styling import Style
 from gaphor.diagram.presentation import LinePresentation, Named
 from gaphor.diagram.shapes import (
@@ -106,19 +107,14 @@ class AssociationItem(LinePresentation[UML.Association], Named):
 
     def save(self, save_func):
         super().save(save_func)
-        if self._head_end.subject:
-            save_func("head-subject", self._head_end.subject)
-        if self._tail_end.subject:
-            save_func("tail-subject", self._tail_end.subject)
 
     def load(self, name, value):
         # end_head and end_tail were used in an older Gaphor version
-        if name in ("head_end", "head_subject", "head-subject"):
-            self._head_end.subject = value
-        elif name in ("tail_end", "tail_subject", "tail-subject"):
-            self._tail_end.subject = value
-        else:
-            super().load(name, value)
+        if name in ("head_end", "head-subject"):
+            name = "head_subject"
+        elif name in ("tail_end", "tail-subject"):
+            name = "tail_subject"
+        super().load(name, value)
 
     def postload(self):
         super().postload()
@@ -126,13 +122,9 @@ class AssociationItem(LinePresentation[UML.Association], Named):
         self._tail_end.set_text()
 
     head_end = property(lambda self: self._head_end)
-
     tail_end = property(lambda self: self._tail_end)
-
-    def unlink(self):
-        self._head_end.unlink()
-        self._tail_end.unlink()
-        super().unlink()
+    head_subject = association("head_subject", UML.Property, upper=1)
+    tail_subject = association("tail_subject", UML.Property, upper=1)
 
     def invert_direction(self):
         """Invert the direction of the association, this is done by swapping
@@ -157,8 +149,8 @@ class AssociationItem(LinePresentation[UML.Association], Named):
         handles = self.handles()
 
         # Update line endings:
-        head_subject = self._head_end.subject
-        tail_subject = self._tail_end.subject
+        head_subject = self.head_subject
+        tail_subject = self.tail_subject
 
         # Update line ends using the aggregation and isNavigable values:
         if head_subject and tail_subject:
@@ -183,7 +175,7 @@ class AssociationItem(LinePresentation[UML.Association], Named):
             else:
                 self.draw_tail = draw_default_tail
             if self.show_direction:
-                inverted = self.tail_end.subject is self.subject.memberEnd[0]
+                inverted = self.tail_subject is self.subject.memberEnd[0]
                 pos, angle = get_center_pos(self.handles(), inverted)
                 self._dir_pos = pos
                 self._dir_angle = angle
@@ -328,7 +320,7 @@ def draw_tail_navigable(context):
     cr.line_to(15, 6)
 
 
-class AssociationEnd(Presentation[UML.Property]):
+class AssociationEnd:
     """An association end represents one end of an association. An association
     has two ends. An association end has two labels: one for the name and one
     for the multiplicity (and maybe one for tagged values in the future).
@@ -337,8 +329,7 @@ class AssociationEnd(Presentation[UML.Property]):
     be recreated by the owning Association.
     """
 
-    def __init__(self, owner, end=None):
-        super().__init__(diagram=owner.diagram, id=Transient)
+    def __init__(self, owner: AssociationItem, end: Optional[str] = None):
         self._canvas = None
         self._owner = owner
         self._end = end
@@ -358,14 +349,18 @@ class AssociationEnd(Presentation[UML.Property]):
     name_bounds = property(lambda s: s._name_bounds)
 
     @property
-    def owner(self):
+    def owner(self) -> AssociationItem:  # type: ignore[override]
         """Override Element.owner."""
         return self._owner
 
     @property
-    def owner_handle(self):
+    def owner_handle(self) -> Handle:
         # handle(event) is the event handler method
         return self._owner.head if self is self._owner.head_end else self._owner.tail
+
+    @property
+    def subject(self) -> Optional[UML.Property]:  # type: ignore[override]
+        return getattr(self.owner, f"{self._end}_subject")  # type:ignore[no-any-return]
 
     def request_update(self):
         self._owner.request_update()

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -352,7 +352,7 @@ class AssociationEnd:
     name_bounds = property(lambda s: s._name_bounds)
 
     @property
-    def owner(self) -> AssociationItem:  # type: ignore[override]
+    def owner(self) -> AssociationItem:
         """Override Element.owner."""
         return self._owner
 
@@ -362,7 +362,7 @@ class AssociationEnd:
         return self._owner.head if self is self._owner.head_end else self._owner.tail
 
     @property
-    def subject(self) -> Optional[UML.Property]:  # type: ignore[override]
+    def subject(self) -> Optional[UML.Property]:
         return getattr(self.owner, f"{self._end}_subject")  # type:ignore[no-any-return]
 
     def request_update(self):

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -114,6 +114,9 @@ class AssociationItem(LinePresentation[UML.Association], Named):
             name = "head_subject"
         elif name in ("tail_end", "tail-subject"):
             name = "tail_subject"
+        elif name == "show-direction":
+            name = "show_direction"
+
         super().load(name, value)
 
     def postload(self):

--- a/gaphor/UML/classes/classconnect.py
+++ b/gaphor/UML/classes/classconnect.py
@@ -102,19 +102,18 @@ class AssociationConnect(UnaryRelationshipConnect):
             return True
 
         line = self.line
+        subject = line.subject
         is_head = handle is line.head
-        end = line.head_end if is_head else line.tail_end
-        assert end.subject
 
-        def is_connection_allowed(h):
+        def is_connection_allowed(p):
+            end = p.head_end if is_head else p.tail_end
+            h = end.owner_handle
             if h is handle:
                 return True
             connected = self.get_connected(h)
             return (not connected) or connected.subject is element.subject
 
-        return all(
-            is_connection_allowed(p.owner_handle) for p in end.subject.presentation
-        )
+        return all(is_connection_allowed(p) for p in subject.presentation)
 
     def connect_subject(self, handle):
         element = self.element
@@ -129,14 +128,14 @@ class AssociationConnect(UnaryRelationshipConnect):
             if not line.subject:
                 relation = UML.model.create_association(c1.subject, c2.subject)
                 relation.package = element.diagram.namespace
-                line.head_end.subject = relation.memberEnd[0]
-                line.tail_end.subject = relation.memberEnd[1]
+                line.head_subject = relation.memberEnd[0]
+                line.tail_subject = relation.memberEnd[1]
 
                 # Set subject last so that event handlers can trigger
                 line.subject = relation
 
-            line.head_end.subject.type = c1.subject  # type: ignore[assignment]
-            line.tail_end.subject.type = c2.subject  # type: ignore[assignment]
+            line.head_subject.type = c1.subject  # type: ignore[assignment]
+            line.tail_subject.type = c2.subject  # type: ignore[assignment]
 
     def reconnect(self, handle, port):
         line = self.line

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -504,9 +504,11 @@ class AssociationPropertyPage(PropertyPageBase):
             self.update_end_name(builder, end_name, event.element)
 
         def restore_nav_handler(event):
-            for end_name, end in (("head", head), ("tail", tail)):
-                combo = builder.get_object(f"{end_name}-navigation")
-                self._on_end_navigability_change(combo, end)
+            prop = event.element
+            if prop.type and prop.opposite and prop.opposite.type:
+                for end_name, end in (("head", head), ("tail", tail)):
+                    combo = builder.get_object(f"{end_name}-navigation")
+                    self._on_end_navigability_change(combo, end)
 
         # Watch on association end:
         self.watcher.watch("memberEnd[Property].name", name_handler).watch(

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -504,11 +504,9 @@ class AssociationPropertyPage(PropertyPageBase):
             self.update_end_name(builder, end_name, event.element)
 
         def restore_nav_handler(event):
-            prop = event.element
-            if prop.type and prop.opposite and prop.opposite.type:
-                for end_name, end in (("head", head), ("tail", tail)):
-                    combo = builder.get_object(f"{end_name}-navigation")
-                    self._on_end_navigability_change(combo, end)
+            for end_name, end in (("head", head), ("tail", tail)):
+                combo = builder.get_object(f"{end_name}-navigation")
+                self._on_end_navigability_change(combo, end)
 
         # Watch on association end:
         self.watcher.watch("memberEnd[Property].name", name_handler).watch(

--- a/gaphor/UML/classes/classestoolbox.py
+++ b/gaphor/UML/classes/classestoolbox.py
@@ -23,11 +23,11 @@ def create_association(
     assoc.memberEnd.append(assoc_item.model.create(UML.Property))
     assoc.memberEnd.append(assoc_item.model.create(UML.Property))
 
-    assoc_item.head_end.subject = assoc.memberEnd[0]
-    assoc_item.tail_end.subject = assoc.memberEnd[1]
+    assoc_item.head_subject = assoc.memberEnd[0]
+    assoc_item.tail_subject = assoc.memberEnd[1]
 
-    UML.model.set_navigability(assoc, assoc_item.head_end.subject, True)
-    assoc_item.head_end.subject.aggregation = association_type.value
+    UML.model.set_navigability(assoc, assoc_item.head_subject, True)
+    assoc_item.head_subject.aggregation = association_type.value
 
 
 def composite_association_config(assoc_item: diagramitems.AssociationItem) -> None:

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -260,7 +260,7 @@ class InterfaceItem(ElementPresentation, Classified):
 
     def pre_update(self, context):
         connected_items = [
-            c.item for c in self._connections.get_connections(connected=self)
+            c.item for c in self.diagram.connections.get_connections(connected=self)
         ]
         connectors = any(
             map(lambda i: isinstance(i.subject, UML.Connector), connected_items)
@@ -332,7 +332,7 @@ class InterfaceItem(ElementPresentation, Classified):
         if connectors is None:
             # distinguish between None and []
             connected_items = [
-                c.item for c in self._connections.get_connections(connected=self)
+                c.item for c in self.diagram.connections.get_connections(connected=self)
             ]
             connectors = any(
                 map(lambda i: isinstance(i.subject, UML.Connector), connected_items)

--- a/gaphor/UML/classes/tests/test_association.py
+++ b/gaphor/UML/classes/tests/test_association.py
@@ -19,8 +19,8 @@ class AssociationItemTestCase(TestCase):
         self.connect(self.assoc, self.assoc.tail, self.class2)
 
         assert isinstance(self.assoc.subject, UML.Association)
-        assert self.assoc.head_end.subject is not None
-        assert self.assoc.tail_end.subject is not None
+        assert self.assoc.head_subject is not None
+        assert self.assoc.tail_subject is not None
 
         assert not self.assoc.show_direction
 
@@ -32,8 +32,8 @@ class AssociationItemTestCase(TestCase):
         self.connect(self.assoc, self.assoc.head, self.class1)
         self.connect(self.assoc, self.assoc.tail, self.class2)
 
-        assert self.assoc.head_end.subject is self.assoc.subject.memberEnd[0]
-        assert self.assoc.tail_end.subject is self.assoc.subject.memberEnd[1]
+        assert self.assoc.head_subject is self.assoc.subject.memberEnd[0]
+        assert self.assoc.tail_subject is self.assoc.subject.memberEnd[1]
 
     def test_invert_direction(self):
         self.connect(self.assoc, self.assoc.head, self.class1)
@@ -42,8 +42,8 @@ class AssociationItemTestCase(TestCase):
         self.assoc.invert_direction()
 
         assert self.assoc.subject.memberEnd
-        assert self.assoc.head_end.subject is self.assoc.subject.memberEnd[1]
-        assert self.assoc.tail_end.subject is self.assoc.subject.memberEnd[0]
+        assert self.assoc.head_subject is self.assoc.subject.memberEnd[1]
+        assert self.assoc.tail_subject is self.assoc.subject.memberEnd[0]
 
     def test_association_end_updates(self):
         """Test association end navigability connected to a class."""
@@ -61,8 +61,8 @@ class AssociationItemTestCase(TestCase):
 
         assert a.subject.memberEnd, a.subject.memberEnd
 
-        assert a.subject.memberEnd[0] is a.head_end.subject
-        assert a.subject.memberEnd[1] is a.tail_end.subject
+        assert a.subject.memberEnd[0] is a.head_subject
+        assert a.subject.memberEnd[1] is a.tail_subject
         assert a.subject.memberEnd[0].name is None
 
         a.subject.memberEnd[0].name = "blah"

--- a/gaphor/UML/classes/tests/test_association.py
+++ b/gaphor/UML/classes/tests/test_association.py
@@ -1,4 +1,4 @@
-"""Unnit tests for AssociationItem."""
+"""Unit tests for AssociationItem."""
 
 from gaphor import UML
 from gaphor.tests import TestCase

--- a/gaphor/UML/classes/tests/test_associationconnect.py
+++ b/gaphor/UML/classes/tests/test_associationconnect.py
@@ -26,8 +26,8 @@ def clone(create):
     def _clone(item):
         new = create(type(item))
         new.subject = item.subject
-        new.head_end.subject = item.head_end.subject
-        new.tail_end.subject = item.tail_end.subject
+        new.head_subject = item.head_subject
+        new.tail_subject = item.tail_subject
         return new
 
     return _clone
@@ -50,15 +50,15 @@ def test_association_item_connect(connected_association, element_factory):
 
     # Diagram, Class *2, Property *2, Association
     assert len(element_factory.lselect()) == 6
-    assert asc.head_end.subject is not None
-    assert asc.tail_end.subject is not None
+    assert asc.head_subject is not None
+    assert asc.tail_subject is not None
 
 
 def test_association_item_reconnect(connected_association, create):
     asc, c1, c2 = connected_association
     c3 = create(ClassItem, UML.Class)
 
-    UML.model.set_navigability(asc.subject, asc.tail_end.subject, True)
+    UML.model.set_navigability(asc.subject, asc.tail_subject, True)
 
     a = asc.subject
 
@@ -69,7 +69,7 @@ def test_association_item_reconnect(connected_association, create):
     assert c1.subject in ends
     assert c3.subject in ends
     assert c2.subject not in ends
-    assert asc.tail_end.subject.navigability is True
+    assert asc.tail_subject.navigability is True
 
 
 def test_disconnect_should_disconnect_model(connected_association):
@@ -103,19 +103,19 @@ def test_disconnect_of_navigable_end_should_remove_owner_relationship(
 ):
     asc, c1, c2 = connected_association
 
-    UML.model.set_navigability(asc.subject, asc.head_end.subject, True)
+    UML.model.set_navigability(asc.subject, asc.head_subject, True)
 
-    assert asc.head_end.subject in c2.subject.ownedAttribute
+    assert asc.head_subject in c2.subject.ownedAttribute
 
     disconnect(asc, asc.head)
 
     assert asc.subject
     assert len(asc.subject.memberEnd) == 2
     assert asc.subject.memberEnd[0].type is None
-    assert asc.head_end.subject not in c2.subject.ownedAttribute
-    assert asc.tail_end.subject not in c1.subject.ownedAttribute
-    assert asc.head_end.subject.type is None
-    assert asc.tail_end.subject.type is None
+    assert asc.head_subject not in c2.subject.ownedAttribute
+    assert asc.tail_subject not in c1.subject.ownedAttribute
+    assert asc.head_subject.type is None
+    assert asc.tail_subject.type is None
 
 
 def test_allow_reconnect_for_single_presentation(connected_association, create):

--- a/gaphor/UML/components/tests/test_connect.py
+++ b/gaphor/UML/components/tests/test_connect.py
@@ -112,7 +112,7 @@ class InterfaceConnectTestCase(TestCase):
         comp = self.create(ComponentItem, UML.Component)
         line = self.create(ConnectorItem)
 
-        pport = iface.ports()[0]
+        pport = comp.ports()[0]
         rport = iface.ports()[2]
 
         self.connect(line, line.head, iface, rport)

--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -30,14 +30,16 @@ from gaphas.solver import WEAK
 
 from gaphor import UML
 from gaphor.core.modeling import Presentation
-from gaphor.diagram.presentation import postload_connect
+from gaphor.diagram.presentation import HandlePositionUpdate, postload_connect
 from gaphor.diagram.shapes import Box, draw_border
 from gaphor.diagram.support import represents
 
 
 @represents(UML.ExecutionSpecification)
 @represents(UML.BehaviorExecutionSpecification)
-class ExecutionSpecificationItem(Presentation[UML.ExecutionSpecification]):
+class ExecutionSpecificationItem(
+    Presentation[UML.ExecutionSpecification], HandlePositionUpdate
+):
     """Representation of interaction execution specification."""
 
     def __init__(self, diagram, id=None):
@@ -50,6 +52,8 @@ class ExecutionSpecificationItem(Presentation[UML.ExecutionSpecification]):
         ht.connectable = True
 
         self._handles = [ht, hb]
+        self.watch_handle(ht)
+        self.watch_handle(hb)
 
         self._connections.add_constraint(self, constraint(vertical=(ht.pos, hb.pos)))
 

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -180,7 +180,7 @@ class MessageLifelineConnect(BaseConnector):
         # if a message is delete message, then disconnection causes
         # lifeline to be no longer destroyed (note that there can be
         # only one delete message connected to lifeline)
-        if received and line.subject.messageSort == "deleteMessage":
+        if received and line.subject and line.subject.messageSort == "deleteMessage":
             assert isinstance(received, LifelineItem)
             received.is_destroyed = False
             received.request_update()

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -148,6 +148,8 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
 
         self._handles.append(top)
         self._handles.append(bottom)
+        self.watch_handle(top)
+        self.watch_handle(bottom)
         self._ports.append(self.lifetime.port)
 
         self.shape = Box(

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -138,6 +138,7 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
+        self._connections = diagram.connections
         self.is_destroyed = False
 
         self.lifetime = LifetimeItem()

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -9,9 +9,14 @@ from gaphor.UML.classes import ClassItem, GeneralizationItem
 from gaphor.UML.sanitizerservice import SanitizerService
 
 
+class MockUndoManager:
+    def in_undo_transaction(self):
+        return False
+
+
 @pytest.fixture(autouse=True)
 def sanitizer(event_manager):
-    sanitizer = SanitizerService(event_manager)
+    sanitizer = SanitizerService(event_manager, MockUndoManager())
     yield sanitizer
     sanitizer.shutdown()
 

--- a/gaphor/UML/tests/test_uml2.py
+++ b/gaphor/UML/tests/test_uml2.py
@@ -182,8 +182,6 @@ def test_realization(factory):
 def test_ids(factory):
     c = factory.create(UML.Class)
     assert c.id
-    p = factory.create_as(UML.Class, id=False)
-    assert p.id is False, p.id
 
 
 def test1(factory):

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -370,7 +370,6 @@ class Diagram(PackageableElement):
 
         self._resolved_items.clear()
 
-        # solve all constraints
         self._connections.solve()
 
         all_dirty_items.extend(self._resolved_items)

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -275,7 +275,7 @@ class Diagram(PackageableElement):
             raise TypeError(
                 f"Type {type} can not be added to a diagram as it is not a diagram item"
             )
-        # Avoid events that reference this element before it's created-event is emitted.
+        # Avoid events that reference this element before its created-event is emitted.
         with self.model.block_events():
             item = type(diagram=self, id=id)
         assert isinstance(

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -275,15 +275,17 @@ class Diagram(PackageableElement):
             raise TypeError(
                 f"Type {type} can not be added to a diagram as it is not a diagram item"
             )
-        item = type(diagram=self, id=id)
+        # Avoid events that reference this element before it's created-event is emitted.
+        with self.model.block_events():
+            item = type(diagram=self, id=id)
         assert isinstance(
             item, gaphas.Item
         ), f"Type {type} does not comply with Item protocol"
+        self.model.handle(DiagramItemCreated(self, item))
         if subject:
             item.subject = subject
         if parent:
             item.parent = parent
-        self.model.handle(DiagramItemCreated(self, item))
         self.request_update(item)
         return item
 

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -301,7 +301,7 @@ class Diagram(PackageableElement):
         self._watcher.unsubscribe_all()
         super().unlink()
 
-    def select(self, expression=None) -> Iterable[Presentation]:
+    def select(self, expression=None) -> Iterator[Presentation]:
         """Return a iterator of all canvas items that match expression."""
         if expression is None:
             yield from self.get_all_items()

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -6,16 +6,7 @@ from __future__ import annotations
 import logging
 import uuid
 from contextlib import contextmanager
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Iterator,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, Callable, Iterator, Optional, Type, TypeVar, overload
 
 from typing_extensions import Protocol
 
@@ -38,7 +29,7 @@ class UnlinkEvent:
         self.element = element
 
 
-Id = Union[str, bool]
+Id = str
 
 
 class Element:
@@ -66,7 +57,7 @@ class Element:
         A model can be provided to refer to the model this element belongs to.
         """
         super().__init__()
-        self._id: Id = id or (id is not False and str(uuid.uuid1()) or False)
+        self._id: Id = id or str(uuid.uuid1())
         # The model this element belongs to.
         self._model = model
         self._unlink_lock = 0

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -196,6 +196,9 @@ class RepositoryProtocol(Protocol):
     def select(self, expression: None) -> Iterator[Element]:
         ...
 
+    def lookup(self, id: str) -> Optional[Element]:
+        ...
+
     def watcher(
         self, element: Element, default_handler: Optional[Handler] = None
     ) -> EventWatcherProtocol:

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -51,8 +51,7 @@ class Element:
 
         Id is a serial number for the element. The default id is None and will
         result in an automatic creation of an id. An existing id (such as an
-        int or string) can be provided as well. An id False will result in no
-        id being  given (for "transient" or helper classes).
+        int or string) can be provided as well.
 
         A model can be provided to refer to the model this element belongs to.
         """

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from contextlib import contextmanager
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -205,6 +206,10 @@ class RepositoryProtocol(Protocol):
         ...
 
     def handle(self, event: object) -> None:
+        ...
+
+    @contextmanager
+    def block_events(self) -> Iterator[RepositoryProtocol]:
         ...
 
 

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -221,6 +221,23 @@ class DiagramItemDeleted:
         self.element = element
 
 
+class DiagramItemUpdated(ElementUpdated):
+    """A attribute has changed value."""
+
+    def __init__(self, element, attribute, old_value, new_value):
+        """Constructor.
+
+        The element parameter is the element with the changing
+        attribute.  The attribute parameter is the parameter element
+        that changed.  The old_value is the old value of the attribute
+        and the new_value is the new value of the attribute.
+        """
+
+        super().__init__(element, attribute)
+        self.old_value = old_value
+        self.new_value = new_value
+
+
 class ModelReady(ServiceEvent):
     """A generic element factory event."""
 

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -2,7 +2,7 @@
 from gaphor.event import ServiceEvent
 
 
-class ReversibleEvent:
+class RevertibeEvent:
     """Base type for all events that can be reversed.
 
     This event can be used as "low level" event for anything that should
@@ -12,7 +12,7 @@ class ReversibleEvent:
     def __init__(self, element):
         self.element = element
 
-    def reverse(self, target):
+    def revert(self, target):
         """Reverse whatever caused the event.
 
         `target` Is the element the action should be performed upon,

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -1,6 +1,25 @@
 """The core modeling events."""
-
 from gaphor.event import ServiceEvent
+
+
+class ReversibleEvent:
+    """Base type for all events that can be reversed.
+
+    This event can be used as "low level" event for anything that should
+    be revertible/undoable.
+    """
+
+    def __init__(self, element):
+        self.element = element
+
+    def reverse(self, target):
+        """Reverse whatever caused the event.
+
+        `target` Is the element the action should be performed upon,
+        which may be a different element than the one that caused the
+        event.
+        """
+        raise NotImplementedError("Method {self}.reverse() has not been implemented")
 
 
 class ElementUpdated:
@@ -219,24 +238,6 @@ class DiagramItemDeleted:
     def __init__(self, diagram, element):
         self.diagram = diagram
         self.element = element
-
-
-class DiagramItemUpdated(ElementUpdated):
-    """A attribute has changed value."""
-
-    def __init__(self, element, attribute, old_value, new_value, target=None):
-        """Constructor.
-
-        The element parameter is the element with the changing
-        attribute.  The attribute parameter is the parameter element
-        that changed.  The old_value is the old value of the attribute
-        and the new_value is the new value of the attribute.
-        """
-
-        super().__init__(element, attribute)
-        self.old_value = old_value
-        self.new_value = new_value
-        self.target = target
 
 
 class ModelReady(ServiceEvent):

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -224,7 +224,7 @@ class DiagramItemDeleted:
 class DiagramItemUpdated(ElementUpdated):
     """A attribute has changed value."""
 
-    def __init__(self, element, attribute, old_value, new_value):
+    def __init__(self, element, attribute, old_value, new_value, target=None):
         """Constructor.
 
         The element parameter is the element with the changing
@@ -236,6 +236,7 @@ class DiagramItemUpdated(ElementUpdated):
         super().__init__(element, attribute)
         self.old_value = old_value
         self.new_value = new_value
+        self.target = target
 
 
 class ModelReady(ServiceEvent):

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -21,7 +21,7 @@ class RevertibeEvent:
         which may be a different element than the one that caused the
         event.
         """
-        raise NotImplementedError("Method {self}.reverse() has not been implemented")
+        raise NotImplementedError("Method {self}.revert() has not been implemented")
 
 
 class ElementUpdated:

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -9,6 +9,8 @@ class RevertibeEvent:
     be revertible/undoable.
     """
 
+    requires_transaction = True
+
     def __init__(self, element):
         self.element = element
 

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -103,7 +103,6 @@ class Presentation(Matrices, Element, Generic[S]):
         if diagram:
             diagram.connections.remove_connections_to_item(self)
             self.unlink()
-            self.handle(DiagramItemDeleted(diagram, self))
         if event.new_value:
             raise ValueError("Can not change diagram for a presentation")
 

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -128,7 +128,10 @@ class Presentation(Matrices, Element, Generic[S]):
         if matrix is self.matrix:
             self.handle(
                 DiagramItemUpdated(
-                    self, Presentation.matrix, old_value, self.matrix.tuple()
+                    self,
+                    Presentation.matrix,
+                    old_value,
+                    self.matrix.tuple(),
                 )
             )
 

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -103,6 +103,7 @@ class Presentation(Matrices, Element, Generic[S]):
         if diagram:
             diagram.connections.remove_connections_to_item(self)
             self.unlink()
+            self.handle(DiagramItemDeleted(diagram, self))
         if event.new_value:
             raise ValueError("Can not change diagram for a presentation")
 

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -19,8 +19,6 @@ S = TypeVar("S", bound=Element)
 
 log = logging.getLogger(__name__)
 
-Transient = False
-
 
 class Presentation(Matrices, Element, Generic[S]):
     """This presentation is used to link the behaviors of
@@ -34,11 +32,8 @@ class Presentation(Matrices, Element, Generic[S]):
     """
 
     def __init__(self, diagram: Diagram, id=None):
-        if id is Transient:
-            super().__init__(id=id)
-        else:
-            super().__init__(id=id, model=diagram.model)
-            self.diagram = diagram
+        super().__init__(id=id, model=diagram.model)
+        self.diagram = diagram
 
         def update(event):
             if self.diagram:

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 from gaphas.item import Matrices
 
 from gaphor.core.modeling import Element
-from gaphor.core.modeling.event import DiagramItemDeleted
+from gaphor.core.modeling.event import DiagramItemDeleted, DiagramItemUpdated
 from gaphor.core.modeling.properties import association, relation_many, relation_one
 
 if TYPE_CHECKING:
@@ -119,11 +119,17 @@ class Presentation(Matrices, Element, Generic[S]):
             m = new_parent.matrix_i2c.inverse()
             self.matrix.set(*self.matrix.multiply(m))
 
-    def _on_matrix_changed(self, _matrix=None):
+    def _on_matrix_changed(self, matrix, old_value):
         if self.parent:
             self.matrix_i2c.set(*(self.matrix * self.parent.matrix_i2c))
         else:
             self.matrix_i2c.set(*self.matrix)
+        if matrix is self.matrix:
+            self.handle(
+                DiagramItemUpdated(
+                    self, Presentation.matrix, old_value, self.matrix.tuple()
+                )
+            )
 
 
 Element.presentation = association(

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -22,15 +22,6 @@ log = logging.getLogger(__name__)
 Transient = False
 
 
-class MatrixUpdated(ReversibleEvent):
-    def __init__(self, element, old_value):
-        super().__init__(element)
-        self.old_value = old_value
-
-    def reverse(self, target):
-        target.matrix.set(*self.old_value)
-
-
 class Presentation(Matrices, Element, Generic[S]):
     """This presentation is used to link the behaviors of
     `gaphor.core.modeling` and `gaphas.Item`.
@@ -134,6 +125,7 @@ class Presentation(Matrices, Element, Generic[S]):
             self.matrix_i2c.set(*(self.matrix * self.parent.matrix_i2c))
         else:
             self.matrix_i2c.set(*self.matrix)
+        self.request_update()
         if matrix is self.matrix:
             self.handle(MatrixUpdated(self, old_value))
 
@@ -145,3 +137,12 @@ Presentation.parent = association("parent", Presentation, upper=1, opposite="chi
 Presentation.children = association(
     "children", Presentation, composite=True, opposite="parent"
 )
+
+
+class MatrixUpdated(ReversibleEvent):
+    def __init__(self, element, old_value):
+        super().__init__(element)
+        self.old_value = old_value
+
+    def reverse(self, target):
+        target.matrix.set(*self.old_value)

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 from gaphas.item import Matrices
 
 from gaphor.core.modeling import Element
-from gaphor.core.modeling.event import DiagramItemDeleted, ReversibleEvent
+from gaphor.core.modeling.event import DiagramItemDeleted, RevertibeEvent
 from gaphor.core.modeling.properties import association, relation_many, relation_one
 
 if TYPE_CHECKING:
@@ -134,10 +134,10 @@ Presentation.children = association(
 )
 
 
-class MatrixUpdated(ReversibleEvent):
+class MatrixUpdated(RevertibeEvent):
     def __init__(self, element, old_value):
         super().__init__(element)
         self.old_value = old_value
 
-    def reverse(self, target):
+    def revert(self, target):
         target.matrix.set(*self.old_value)

--- a/gaphor/core/modeling/tests/test_presentation.py
+++ b/gaphor/core/modeling/tests/test_presentation.py
@@ -1,3 +1,4 @@
+import pytest
 from gaphas.constraint import BaseConstraint
 from gaphas.item import Item
 from gaphas.solver import Variable
@@ -55,7 +56,8 @@ def test_presentation_can_not_set_new_diagram(diagram, element_factory):
     presentation = diagram.create(Example)
     new_diagram = element_factory.create(Diagram)
 
-    presentation.diagram = new_diagram
+    with pytest.raises(ValueError):
+        presentation.diagram = new_diagram
 
     assert presentation.diagram is None
 

--- a/gaphor/diagram/diagramtools/__init__.py
+++ b/gaphor/diagram/diagramtools/__init__.py
@@ -10,6 +10,7 @@ from gaphas.tool import (
     zoom_tool,
 )
 
+import gaphor.diagram.diagramtools.connector
 import gaphor.diagram.diagramtools.grayout
 from gaphor.diagram.diagramtools.dropzone import drop_zone_tool
 from gaphor.diagram.diagramtools.placement import new_item_factory, placement_tool

--- a/gaphor/diagram/diagramtools/__init__.py
+++ b/gaphor/diagram/diagramtools/__init__.py
@@ -12,6 +12,7 @@ from gaphas.tool import (
 
 import gaphor.diagram.diagramtools.connector
 import gaphor.diagram.diagramtools.grayout
+import gaphor.diagram.diagramtools.segment
 from gaphor.diagram.diagramtools.dropzone import drop_zone_tool
 from gaphor.diagram.diagramtools.placement import new_item_factory, placement_tool
 from gaphor.diagram.diagramtools.shortcut import shortcut_tool

--- a/gaphor/diagram/diagramtools/connector.py
+++ b/gaphor/diagram/diagramtools/connector.py
@@ -83,13 +83,10 @@ class DisconnectHandle:
     This is an object so disconnection data can be serialized/deserialized
     using pickle.
 
-    :Variables:
-     item
-        Connecting item.
-     handle
-        Handle of connecting item.
-     disable
-        If set, then disconnection is disabled.
+    Args:
+      item (Item): Connecting item.
+      handle (Handle): Handle of connecting item.
+      connections (Connections): Connections object containing connection constraints.
     """
 
     def __init__(self, item, handle, connections):

--- a/gaphor/diagram/diagramtools/connector.py
+++ b/gaphor/diagram/diagramtools/connector.py
@@ -5,7 +5,7 @@ from gaphas.aspect.connector import Connector as ConnectorAspect
 from gaphas.aspect.connector import ItemConnector
 
 from gaphor.core import transactional
-from gaphor.core.modeling.event import ReversibleEvent
+from gaphor.core.modeling.event import RevertibeEvent
 from gaphor.diagram.connectors import Connector
 from gaphor.diagram.presentation import Presentation
 
@@ -116,14 +116,14 @@ class DisconnectHandle:
         )
 
 
-class ItemConnected(ReversibleEvent):
+class ItemConnected(RevertibeEvent):
     def __init__(self, element, handle, connected, port):
         self.element = element
         self.handle_index = element.handles().index(handle)
         self.connected = connected
         self.port_index = connected.ports().index(port)
 
-    def reverse(self, target):
+    def revert(self, target):
         # Reverse only the diagram level connection.
         # Associations have their own handlers
         connections = target.diagram.connections
@@ -135,14 +135,14 @@ class ItemConnected(ReversibleEvent):
         connector.disconnect()
 
 
-class ItemDisconnected(ReversibleEvent):
+class ItemDisconnected(RevertibeEvent):
     def __init__(self, element, handle, connected, port):
         self.element = element
         self.handle_index = element.handles().index(handle)
         self.connected = connected
         self.port_index = connected.ports().index(port)
 
-    def reverse(self, target):
+    def revert(self, target):
         # Reverse only the diagram level connection.
         # Associations have their own handlers
         connections = target.diagram.connections

--- a/gaphor/diagram/diagramtools/placement.py
+++ b/gaphor/diagram/diagramtools/placement.py
@@ -1,17 +1,13 @@
 import logging
 from typing import Callable, Optional, Type, TypeVar
 
-from gaphas.aspect.connector import Connector as ConnectorAspect
-from gaphas.aspect.connector import ItemConnector
 from gaphas.aspect.handlemove import HandleMove
 from gaphas.tool.itemtool import MoveType
 from gaphas.view import GtkView
 from gi.repository import Gtk
 
-from gaphor.core import transactional
 from gaphor.core.eventmanager import EventManager
 from gaphor.core.modeling import Diagram, Element
-from gaphor.diagram.connectors import Connector
 from gaphor.diagram.event import DiagramItemPlaced
 from gaphor.diagram.grouping import Group
 from gaphor.diagram.presentation import Presentation
@@ -131,98 +127,3 @@ def new_item_factory(
 
     item_factory.item_class = item_class  # type: ignore[attr-defined]
     return item_factory
-
-
-@ConnectorAspect.register(Presentation)
-class PresentationConnector(ItemConnector):
-    """Handle Tool (acts on item handles) that uses the Connector protocol to
-    connect items to one-another.
-
-    It also adds handles to lines when a line is grabbed on the middle
-    of a line segment (points are drawn by the LineSegmentPainter).
-    """
-
-    def allow(self, sink):
-        adapter = Connector(sink.item, self.item)
-        return adapter and adapter.allow(self.handle, sink.port)
-
-    @transactional
-    def connect(self, sink):
-        """Create connection at handle level and at model level."""
-        handle = self.handle
-        item = self.item
-        cinfo = self.connections.get_connection(handle)
-
-        try:
-            callback = DisconnectHandle(self.item, self.handle, self.connections)
-            if cinfo and cinfo.connected is sink.item:
-                # reconnect only constraint - leave model intact
-                log.debug("performing reconnect constraint")
-                constraint = sink.port.constraint(item, handle, sink.item)
-                self.connections.reconnect_item(
-                    item, handle, sink.port, constraint=constraint
-                )
-            elif cinfo:
-                # first disconnect but disable disconnection handle as
-                # reconnection is going to happen
-                adapter = Connector(sink.item, item)
-                try:
-                    connect = adapter.reconnect
-                except AttributeError:
-                    connect = adapter.connect
-                else:
-                    cinfo.callback.disable = True
-                self.disconnect()
-
-                # new connection
-                self.connect_handle(sink, callback=callback)
-
-                # adapter requires both ends to be connected.
-                connect(handle, sink.port)
-            else:
-                # new connection
-                adapter = Connector(sink.item, item)
-                self.connect_handle(sink, callback=callback)
-                adapter.connect(handle, sink.port)
-        except Exception:
-            log.error("Error during connect", exc_info=True)
-
-    @transactional
-    def disconnect(self):
-        super().disconnect()
-
-
-class DisconnectHandle:
-    """Callback for items disconnection using the adapters.
-
-    This is an object so disconnection data can be serialized/deserialized
-    using pickle.
-
-    :Variables:
-     item
-        Connecting item.
-     handle
-        Handle of connecting item.
-     disable
-        If set, then disconnection is disabled.
-    """
-
-    def __init__(self, item, handle, connections):
-        self.item = item
-        self.handle = handle
-        self.connections = connections
-        self.disable = False
-
-    def __call__(self):
-        handle = self.handle
-        item = self.item
-        connections = self.connections
-        cinfo = connections.get_connection(handle)
-
-        if self.disable:
-            log.debug(f"Not disconnecting {item}.{handle} (disabled)")
-        else:
-            log.debug(f"Disconnecting {item}.{handle}")
-            if cinfo:
-                adapter = Connector(cinfo.connected, item)
-                adapter.disconnect(handle)

--- a/gaphor/diagram/diagramtools/segment.py
+++ b/gaphor/diagram/diagramtools/segment.py
@@ -1,0 +1,41 @@
+from gaphas.segment import LineSegment, Segment
+
+from gaphor.core.modeling.event import ReversibleEvent
+from gaphor.diagram.presentation import LinePresentation
+
+
+@Segment.register(LinePresentation)
+class PresentationSegment(LineSegment):
+    def split_segment(self, segment, count=2):
+        handles, ports = super().split_segment(segment, count)
+        line = self.item
+        line.handle(LineSplitSegmentEvent(line, segment, count))
+        return handles, ports
+
+    def merge_segment(self, segment, count=2):
+        deleted_handles, deleted_ports = super().merge_segment(segment, count)
+        line = self.item
+        line.handle(LineMergeSegmentEvent(line, segment, count))
+        return deleted_handles, deleted_ports
+
+
+class LineSplitSegmentEvent(ReversibleEvent):
+    def __init__(self, element, segment, count):
+        super().__init__(element)
+        self.segment = segment
+        self.count = count
+
+    def reverse(self, target):
+        segment = Segment(target, target.diagram)
+        segment.merge_segment(self.segment, self.count)
+
+
+class LineMergeSegmentEvent(ReversibleEvent):
+    def __init__(self, element, segment, count):
+        super().__init__(element)
+        self.segment = segment
+        self.count = count
+
+    def reverse(self, target):
+        segment = Segment(target, target.diagram)
+        segment.split_segment(self.segment, self.count)

--- a/gaphor/diagram/diagramtools/segment.py
+++ b/gaphor/diagram/diagramtools/segment.py
@@ -1,6 +1,6 @@
 from gaphas.segment import LineSegment, Segment
 
-from gaphor.core.modeling.event import ReversibleEvent
+from gaphor.core.modeling.event import RevertibeEvent
 from gaphor.diagram.presentation import LinePresentation
 
 
@@ -19,23 +19,23 @@ class PresentationSegment(LineSegment):
         return deleted_handles, deleted_ports
 
 
-class LineSplitSegmentEvent(ReversibleEvent):
+class LineSplitSegmentEvent(RevertibeEvent):
     def __init__(self, element, segment, count):
         super().__init__(element)
         self.segment = segment
         self.count = count
 
-    def reverse(self, target):
+    def revert(self, target):
         segment = Segment(target, target.diagram)
         segment.merge_segment(self.segment, self.count)
 
 
-class LineMergeSegmentEvent(ReversibleEvent):
+class LineMergeSegmentEvent(RevertibeEvent):
     def __init__(self, element, segment, count):
         super().__init__(element)
         self.segment = segment
         self.count = count
 
-    def reverse(self, target):
+    def revert(self, target):
         segment = Segment(target, target.diagram)
         segment.split_segment(self.segment, self.count)

--- a/gaphor/diagram/diagramtools/tests/test_segment.py
+++ b/gaphor/diagram/diagramtools/tests/test_segment.py
@@ -1,0 +1,12 @@
+from gaphas.segment import Segment
+
+from gaphor.diagram.diagramtools.segment import PresentationSegment
+from gaphor.diagram.presentation import LinePresentation
+
+
+def test_presentation_segment_is_selected(diagram):
+    line = diagram.create(LinePresentation)
+
+    segment = Segment(line, diagram)
+
+    assert isinstance(segment, PresentationSegment)

--- a/gaphor/diagram/general/simpleitem.py
+++ b/gaphor/diagram/general/simpleitem.py
@@ -2,63 +2,19 @@
 
 import ast
 
-from gaphas.connector import Handle
 from gaphas.item import NW, Element
-from gaphas.item import Line as _Line
 from gaphas.util import path_ellipse
 
 from gaphor.core.modeling import Presentation
+from gaphor.diagram.presentation import LinePresentation
 from gaphor.diagram.shapes import stroke
 
 
-class Line(_Line, Presentation):
+class Line(LinePresentation):
     def __init__(self, diagram, id=None):
-        super().__init__(connections=diagram.connections, diagram=diagram, id=id)  # type: ignore[call-arg]
-        self.fuzziness = 2
+        super().__init__(diagram=diagram, id=id)
         self._handles[0].connectable = False
         self._handles[-1].connectable = False
-
-    def save(self, save_func):
-        save_func("matrix", tuple(self.matrix))
-        for prop in ("orthogonal", "horizontal"):
-            save_func(prop, getattr(self, prop))
-        points = [tuple(map(float, h.pos)) for h in self.handles()]
-        save_func("points", points)
-
-    def load(self, name, value):
-        if name == "horizontal":
-            self.horizontal = ast.literal_eval(value)
-        elif name == "matrix":
-            self.matrix.set(*ast.literal_eval(value))
-        elif name == "orthogonal":
-            self._load_orthogonal = ast.literal_eval(value)
-        elif name == "points":
-            points = ast.literal_eval(value)
-            for _ in range(len(points) - 2):
-                h = Handle((0, 0))
-                self._handles.insert(1, h)
-            for i, p in enumerate(points):
-                self.handles()[i].pos = p
-            self._update_ports()
-
-    def postload(self):
-        if hasattr(self, "_load_orthogonal"):
-            self.orthogonal = self._load_orthogonal
-            del self._load_orthogonal
-
-    def pre_update(self, context):
-        pass
-
-    def post_update(self, context):
-        pass
-
-    def draw(self, context):
-        cr = context.cairo
-        style = context.style
-        self.line_width = style["line-width"]
-        if style["color"]:
-            cr.set_source_rgba(*style["color"])
-        super().draw(context)
 
 
 class Box(Element, Presentation):

--- a/gaphor/diagram/general/simpleitem.py
+++ b/gaphor/diagram/general/simpleitem.py
@@ -1,12 +1,9 @@
 """Trivial drawing aids (box, line, ellipse)."""
 
-import ast
-
-from gaphas.item import NW, Element
+from gaphas.item import NW
 from gaphas.util import path_ellipse
 
-from gaphor.core.modeling import Presentation
-from gaphor.diagram.presentation import LinePresentation
+from gaphor.diagram.presentation import ElementPresentation, LinePresentation
 from gaphor.diagram.shapes import stroke
 
 
@@ -17,36 +14,14 @@ class Line(LinePresentation):
         self._handles[-1].connectable = False
 
 
-class Box(Element, Presentation):
+class Box(ElementPresentation):
     """A Box has 4 handles (for a start)::
 
     NW +---+ NE SW +---+ SE
     """
 
     def __init__(self, diagram, id=None):
-        super().__init__(connections=diagram.connections, diagram=diagram, id=id)  # type: ignore[call-arg]
-
-    def save(self, save_func):
-        save_func("matrix", tuple(self.matrix))
-        save_func("width", self.width)
-        save_func("height", self.height)
-
-    def load(self, name, value):
-        if name == "matrix":
-            self.matrix.set(*ast.literal_eval(value))
-        elif name == "width":
-            self.width = ast.literal_eval(value)
-        elif name == "height":
-            self.height = ast.literal_eval(value)
-
-    def postload(self):
-        pass
-
-    def pre_update(self, context):
-        pass
-
-    def post_update(self, context):
-        pass
+        super().__init__(diagram=diagram, id=id)
 
     def draw(self, context):
         cr = context.cairo
@@ -55,33 +30,11 @@ class Box(Element, Presentation):
         stroke(context)
 
 
-class Ellipse(Element, Presentation):
+class Ellipse(ElementPresentation):
     """"""
 
     def __init__(self, diagram, id=None):
-        super().__init__(connections=diagram.connections, diagram=diagram, id=id)  # type: ignore[call-arg]
-
-    def save(self, save_func):
-        save_func("matrix", tuple(self.matrix))
-        save_func("width", self.width)
-        save_func("height", self.height)
-
-    def load(self, name, value):
-        if name == "matrix":
-            self.matrix.set(*ast.literal_eval(value))
-        elif name == "width":
-            self.width = ast.literal_eval(value)
-        elif name == "height":
-            self.height = ast.literal_eval(value)
-
-    def postload(self):
-        pass
-
-    def pre_update(self, context):
-        pass
-
-    def post_update(self, context):
-        pass
+        super().__init__(diagram=diagram, id=id)
 
     def draw(self, context):
         cr = context.cairo

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -11,6 +11,7 @@ from gaphas.geometry import Rectangle, distance_rectangle_point
 from gaphas.item import matrix_i2i
 
 from gaphor.core.modeling.diagram import Diagram
+from gaphor.core.modeling.event import DiagramItemUpdated
 from gaphor.core.modeling.presentation import Presentation, S
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import Style
@@ -165,6 +166,8 @@ class LinePresentation(gaphas.Line, Presentation[S]):
         self.watch("orthogonal", self._on_orthogonal).watch(
             "horizontal", self._on_horizontal
         )
+        self.head.pos.add_handler(self._on_position_update)
+        self.head.pos.add_handler(self._on_position_update)
 
     head = property(lambda self: self._handles[0])
     tail = property(lambda self: self._handles[-1])
@@ -286,3 +289,13 @@ class LinePresentation(gaphas.Line, Presentation[S]):
 
     def _on_horizontal(self, event):
         self._set_horizontal(event.new_value)
+
+    def _on_position_update(self, position, old):
+        for index, handle in enumerate(self.handles()):
+            if handle.pos is position:
+                break
+        else:
+            return
+        self.handle(
+            DiagramItemUpdated(self, gaphas.Item.handles, old, position.tuple(), index)
+        )

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -106,6 +106,8 @@ class ElementPresentation(gaphas.Element, Presentation[S]):
         be drawn or when styling changes."""
 
     def pre_update(self, context):
+        if not self.shape:
+            self.update_shapes()
         self.min_width, self.min_height = self.shape.size(context)
 
     def post_update(self, context):

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -74,6 +74,9 @@ def postload_connect(item: gaphas.Item, handle: gaphas.Handle, target: gaphas.It
 
 
 class HandlePositionEvent(RevertibeEvent):
+
+    requires_transaction = False
+
     def __init__(self, element, index, old_value):
         super().__init__(element)
         self.index = index

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -123,7 +123,8 @@ class ElementPresentation(gaphas.Element, HandlePositionUpdate, Presentation[S])
     def pre_update(self, context):
         if not self.shape:
             self.update_shapes()
-        self.min_width, self.min_height = self.shape.size(context)
+        if self.shape:
+            self.min_width, self.min_height = self.shape.size(context)
 
     def post_update(self, context):
         pass

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -81,6 +81,7 @@ class HandlePositionEvent(ReversibleEvent):
 
     def reverse(self, target):
         target.handles()[self.index].pos = self.old_value
+        target.request_update()
 
 
 class HandlePositionUpdate:

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -11,7 +11,7 @@ from gaphas.geometry import Rectangle, distance_rectangle_point
 from gaphas.item import matrix_i2i
 
 from gaphor.core.modeling.diagram import Diagram
-from gaphor.core.modeling.event import ReversibleEvent
+from gaphor.core.modeling.event import RevertibeEvent
 from gaphor.core.modeling.presentation import Presentation, S
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import Style
@@ -73,13 +73,13 @@ def postload_connect(item: gaphas.Item, handle: gaphas.Handle, target: gaphas.It
     connector.connect(sink)
 
 
-class HandlePositionEvent(ReversibleEvent):
+class HandlePositionEvent(RevertibeEvent):
     def __init__(self, element, index, old_value):
         super().__init__(element)
         self.index = index
         self.old_value = old_value
 
-    def reverse(self, target):
+    def revert(self, target):
         target.handles()[self.index].pos = self.old_value
         target.request_update()
 

--- a/gaphor/diagram/tests/test_diagramtools.py
+++ b/gaphor/diagram/tests/test_diagramtools.py
@@ -42,8 +42,8 @@ class DiagramItemConnectorTestCase(TestCase):
         self.connect(a, a.tail, ci2)
 
         assert a.subject
-        assert a.head_end.subject
-        assert a.tail_end.subject
+        assert a.head_subject
+        assert a.tail_subject
 
         the_association = a.subject
 

--- a/gaphor/diagram/tests/test_presentation.py
+++ b/gaphor/diagram/tests/test_presentation.py
@@ -91,7 +91,7 @@ def test_line_saving(element_factory, diagram):
     p.save(save_func)
 
     assert properties["matrix"] == (1.0, 0.0, 0.0, 1.0, 0.0, 0.0)
-    assert properties["orthogonal"] is False
+    assert "orthogonal" not in properties
     assert properties["horizontal"] is False
     assert properties["points"] == [(0.0, 0.0), (10.0, 10.0)]
     assert properties["subject"] is subject

--- a/gaphor/services/tests/conftest.py
+++ b/gaphor/services/tests/conftest.py
@@ -5,7 +5,7 @@ from gaphor.services.undomanager import UndoManager
 
 
 @pytest.fixture
-def undo_manager(event_manager):
-    undo_manager = UndoManager(event_manager)
+def undo_manager(event_manager, element_factory):
+    undo_manager = UndoManager(event_manager, element_factory)
     yield undo_manager
     undo_manager.shutdown()

--- a/gaphor/services/tests/test_undo_diagram.py
+++ b/gaphor/services/tests/test_undo_diagram.py
@@ -1,0 +1,50 @@
+import pytest
+
+from gaphor import UML
+from gaphor.core import Transaction
+from gaphor.UML.classes import ClassItem
+
+
+class ViewMock:
+    def __init__(self, diagram):
+        self.updates = []
+        diagram.register_view(self)
+
+    def request_update(self, items=(), matrix_items=(), removed_items=()):
+        self.updates.append((items, matrix_items, removed_items))
+
+
+def test_undo_should_remove_show_item_on_diagram(
+    event_manager, element_factory, undo_manager
+):
+    with Transaction(event_manager):
+        diagram = element_factory.create(UML.Diagram)
+
+    view = ViewMock(diagram)
+
+    with Transaction(event_manager):
+        cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+
+    undo_manager.undo_transaction()
+
+    items, matrix_items, removed_items = view.updates[-1]
+
+    assert cls in removed_items, view.updates
+
+
+@pytest.mark.skip
+def test_redo_should_show_item_on_diagram(event_manager, element_factory, undo_manager):
+    with Transaction(event_manager):
+        diagram = element_factory.create(UML.Diagram)
+
+    view = ViewMock(diagram)
+
+    with Transaction(event_manager):
+        cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+
+    undo_manager.undo_transaction()
+    undo_manager.redo_transaction()
+
+    items, matrix_items, removed_items = view.updates[-1]
+
+    assert cls in items, view.updates

--- a/gaphor/services/tests/test_undo_presentation.py
+++ b/gaphor/services/tests/test_undo_presentation.py
@@ -16,6 +16,25 @@ from gaphor.UML import Class
 from gaphor.UML.classes import ClassItem, GeneralizationItem
 
 
+def test_line_create(diagram, undo_manager, event_manager, capsys):
+    with Transaction(event_manager):
+        LinePresentation(diagram)
+
+    assert diagram.ownedPresentation
+
+    undo_manager.undo_transaction()
+    # Errors in undo manager are reported on stdout
+    captured = capsys.readouterr()
+
+    assert not captured.out
+    assert not captured.err
+    assert not diagram.ownedPresentation
+
+    undo_manager.redo_transaction()
+
+    assert diagram.ownedPresentation
+
+
 def test_line_orthogonal_property(diagram, undo_manager, event_manager):
     with Transaction(event_manager):
         line = LinePresentation(diagram)

--- a/gaphor/services/tests/test_undo_presentation.py
+++ b/gaphor/services/tests/test_undo_presentation.py
@@ -131,7 +131,6 @@ def test_element_handle_position(diagram, undo_manager, event_manager, index):
 
 
 # TODO: test for insert/remove handle / split segment / merge segment
-# TODO: test handles of ElementPresentation
 
 
 def test_line_connections(diagram, undo_manager, element_factory, event_manager):

--- a/gaphor/services/tests/test_undo_presentation.py
+++ b/gaphor/services/tests/test_undo_presentation.py
@@ -98,7 +98,7 @@ def test_line_handle_position(diagram, undo_manager, event_manager):
 
     undo_manager.undo_transaction()
 
-    assert tuple(handle.pos) == (0, 0)
+    assert handle.pos.tuple() == (0, 0)
 
     undo_manager.redo_transaction()
 

--- a/gaphor/services/tests/test_undo_presentation.py
+++ b/gaphor/services/tests/test_undo_presentation.py
@@ -1,0 +1,128 @@
+"""Test undo, in particular for item specific properties:
+
+* Line: orthogonal, horizontal
+* Matrix updates
+* Variables
+* Solver: add_constraint, remove_constraint
+"""
+import pytest
+from gaphas.connector import Handle
+
+from gaphor.core import Transaction
+from gaphor.diagram.presentation import LinePresentation
+from gaphor.diagram.tests.fixtures import connect
+from gaphor.UML import Class
+from gaphor.UML.classes import ClassItem, GeneralizationItem
+
+
+def test_line_orthogonal_property(diagram, undo_manager, event_manager):
+    with Transaction(event_manager):
+        line = LinePresentation(diagram)
+        line.insert_handle(0, Handle())
+
+    with Transaction(event_manager):
+        line.orthogonal = True
+
+    assert line.orthogonal
+
+    undo_manager.undo_transaction()
+
+    assert not line.orthogonal
+
+    undo_manager.redo_transaction()
+
+    assert line.orthogonal
+
+
+def test_line_horizontal_property(diagram, undo_manager, event_manager):
+    with Transaction(event_manager):
+        line = LinePresentation(diagram)
+        line.insert_handle(0, Handle())
+
+    with Transaction(event_manager):
+        line.horizontal = True
+
+    assert line.horizontal
+
+    undo_manager.undo_transaction()
+
+    assert not line.horizontal
+
+    undo_manager.redo_transaction()
+
+    assert line.horizontal
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        lambda line: line.matrix.translate(10, 10),
+        lambda line: line.matrix.rotate(1),
+        lambda line: line.matrix.scale(2.5, 3.5),
+        lambda line: line.matrix.invert(),
+    ],
+)
+def test_matrix_operation(action, diagram, undo_manager, event_manager):
+
+    with Transaction(event_manager):
+        line = LinePresentation(diagram)
+        line.matrix.translate(10, 0)
+
+    original = tuple(line.matrix)
+
+    with Transaction(event_manager):
+        action(line)
+
+    assert tuple(line.matrix) != original
+
+    undo_manager.undo_transaction()
+
+    assert tuple(line.matrix) == original
+
+    undo_manager.redo_transaction()
+
+    assert tuple(line.matrix) != original
+
+
+def test_line_handle_position(diagram, undo_manager, event_manager):
+    with Transaction(event_manager):
+        line = diagram.create(LinePresentation)
+
+    handle = line.handles()[0]
+    new_pos = (30, 40)
+
+    with Transaction(event_manager):
+        handle.pos = new_pos
+
+    assert tuple(handle.pos) == new_pos
+
+    undo_manager.undo_transaction()
+
+    assert tuple(handle.pos) == (0, 0)
+
+    undo_manager.redo_transaction()
+
+    assert tuple(handle.pos) == new_pos
+
+
+def test_line_connections(diagram, undo_manager, element_factory, event_manager):
+    with Transaction(event_manager):
+        class_item = diagram.create(ClassItem, subject=element_factory.create(Class))
+        gen_item = diagram.create(GeneralizationItem)
+
+    handle = gen_item.handles()[0]
+
+    with Transaction(event_manager):
+        connect(gen_item, handle, class_item)
+
+    connections = diagram.connections
+
+    assert connections.get_connection(handle)
+
+    undo_manager.undo_transaction()
+
+    assert not connections.get_connection(handle)
+
+    undo_manager.redo_transaction()
+
+    assert connections.get_connection(handle)

--- a/gaphor/services/tests/test_undo_presentation.py
+++ b/gaphor/services/tests/test_undo_presentation.py
@@ -35,6 +35,23 @@ def test_line_create(diagram, undo_manager, event_manager, capsys):
     assert diagram.ownedPresentation
 
 
+def test_line_delete(diagram, undo_manager, event_manager):
+    with Transaction(event_manager):
+        line = LinePresentation(diagram)
+        line.insert_handle(1, Handle((20, 20)))
+        line.matrix.translate(10, 10)
+
+    with Transaction(event_manager):
+        line.unlink()
+
+    undo_manager.undo_transaction()
+
+    line = diagram.ownedPresentation[0]
+    assert len(line.handles()) == 3
+    assert line.handles()[1].pos.tuple() == (20, 20)
+    assert line.matrix.tuple() == (1, 0, 0, 1, 10, 10)
+
+
 def test_line_orthogonal_property(diagram, undo_manager, event_manager):
     with Transaction(event_manager):
         line = LinePresentation(diagram)

--- a/gaphor/services/tests/test_undo_presentation.py
+++ b/gaphor/services/tests/test_undo_presentation.py
@@ -105,6 +105,10 @@ def test_line_handle_position(diagram, undo_manager, event_manager):
     assert tuple(handle.pos) == new_pos
 
 
+# TODO: test for insert/remove handle / split segment / merge segment
+# TODO: test handles of ElementPresentation
+
+
 def test_line_connections(diagram, undo_manager, element_factory, event_manager):
     with Transaction(event_manager):
         class_item = diagram.create(ClassItem, subject=element_factory.create(Class))

--- a/gaphor/services/tests/test_undo_presentation.py
+++ b/gaphor/services/tests/test_undo_presentation.py
@@ -9,7 +9,7 @@ import pytest
 from gaphas.connector import Handle
 
 from gaphor.core import Transaction
-from gaphor.diagram.presentation import LinePresentation
+from gaphor.diagram.presentation import ElementPresentation, LinePresentation
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML import Class
 from gaphor.UML.classes import ClassItem, GeneralizationItem
@@ -84,11 +84,13 @@ def test_matrix_operation(action, diagram, undo_manager, event_manager):
     assert tuple(line.matrix) != original
 
 
-def test_line_handle_position(diagram, undo_manager, event_manager):
+@pytest.mark.parametrize("index", range(2))
+def test_line_handle_position(diagram, undo_manager, event_manager, index):
     with Transaction(event_manager):
         line = diagram.create(LinePresentation)
 
-    handle = line.handles()[0]
+    handle = line.handles()[index]
+    old_pos = handle.pos.tuple()
     new_pos = (30, 40)
 
     with Transaction(event_manager):
@@ -98,7 +100,30 @@ def test_line_handle_position(diagram, undo_manager, event_manager):
 
     undo_manager.undo_transaction()
 
-    assert handle.pos.tuple() == (0, 0)
+    assert handle.pos.tuple() == old_pos
+
+    undo_manager.redo_transaction()
+
+    assert tuple(handle.pos) == new_pos
+
+
+@pytest.mark.parametrize("index", range(4))
+def test_element_handle_position(diagram, undo_manager, event_manager, index):
+    with Transaction(event_manager):
+        line = diagram.create(ElementPresentation)
+
+    handle = line.handles()[index]
+    old_pos = handle.pos.tuple()
+    new_pos = (30, 40)
+
+    with Transaction(event_manager):
+        handle.pos = new_pos
+
+    assert tuple(handle.pos) == new_pos
+
+    undo_manager.undo_transaction()
+
+    assert handle.pos.tuple() == old_pos
 
     undo_manager.redo_transaction()
 

--- a/gaphor/services/tests/test_undo_presentation.py
+++ b/gaphor/services/tests/test_undo_presentation.py
@@ -16,18 +16,15 @@ from gaphor.UML import Class
 from gaphor.UML.classes import ClassItem, GeneralizationItem
 
 
-def test_line_create(diagram, undo_manager, event_manager, capsys):
+def test_line_create(diagram, undo_manager, event_manager, caplog):
     with Transaction(event_manager):
         LinePresentation(diagram)
 
     assert diagram.ownedPresentation
 
     undo_manager.undo_transaction()
-    # Errors in undo manager are reported on stdout
-    captured = capsys.readouterr()
 
-    assert not captured.out
-    assert not captured.err
+    assert not caplog.records
     assert not diagram.ownedPresentation
 
     undo_manager.redo_transaction()

--- a/gaphor/services/tests/test_undomanager.py
+++ b/gaphor/services/tests/test_undomanager.py
@@ -235,7 +235,7 @@ def test_element_factory_undo(element_factory, undo_manager):
     assert undo_manager.can_undo()
     assert not undo_manager.can_redo()
     assert element_factory.size() == 1
-    assert element_factory.lselect()[0] is p
+    assert element_factory.lookup(p.id)
 
 
 def test_element_factory_rollback(element_factory, undo_manager):
@@ -424,4 +424,4 @@ def test_redo_stack(event_manager, element_factory, undo_manager):
     assert not undo_manager.can_redo()
     assert element_factory.size() == 2
 
-    assert p in element_factory.lselect()
+    assert element_factory.lookup(p.id)

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -28,7 +28,7 @@ from gaphor.core.modeling.event import (
     ElementCreated,
     ElementDeleted,
     ModelReady,
-    ReversibleEvent,
+    RevertibeEvent,
 )
 from gaphor.core.modeling.properties import association as association_property
 from gaphor.diagram.copypaste import deserialize, serialize
@@ -314,13 +314,13 @@ class UndoManager(Service, ActionProvider):
         self.event_manager.unsubscribe(self.undo_association_add_event)
         self.event_manager.unsubscribe(self.undo_association_delete_event)
 
-    @event_handler(ReversibleEvent)
+    @event_handler(RevertibeEvent)
     def undo_reversible_event(self, event):
         element_id = event.element.id
 
         def _undo_reversible_event():
             element = self.deep_lookup(element_id)
-            event.reverse(element)
+            event.revert(element)
 
         _undo_reversible_event.__doc__ = (
             f"Reverse event {event.__class__.__name__} for element {event.element}."

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -13,8 +13,6 @@ NOTE: it would be nice to use actions in conjunction with functools.partial.
 import logging
 from typing import Callable, List, Optional
 
-from gaphas import state
-
 from gaphor.abc import ActionProvider, Service
 from gaphor.action import action
 from gaphor.core import event_handler
@@ -273,11 +271,6 @@ class UndoManager(Service, ActionProvider):
     # Undo Handlers
     #
 
-    def _gaphas_undo_handler(self, event):
-        self.add_undo_action(
-            lambda: state.saveapply(*event), requires_transaction=False
-        )
-
     def _register_undo_handlers(self):
 
         logger.debug("Registering undo handlers")
@@ -291,12 +284,6 @@ class UndoManager(Service, ActionProvider):
         self.event_manager.subscribe(self.undo_association_add_event)
         self.event_manager.subscribe(self.undo_association_delete_event)
 
-        #
-        # Direct revert-statements from gaphas to the undomanager
-        state.observers.add(state.revert_handler)
-
-        state.subscribers.add(self._gaphas_undo_handler)
-
     def _unregister_undo_handlers(self):
 
         logger.debug("Unregistering undo handlers")
@@ -309,10 +296,6 @@ class UndoManager(Service, ActionProvider):
         self.event_manager.unsubscribe(self.undo_association_set_event)
         self.event_manager.unsubscribe(self.undo_association_add_event)
         self.event_manager.unsubscribe(self.undo_association_delete_event)
-
-        state.observers.discard(state.revert_handler)
-
-        state.subscribers.discard(self._gaphas_undo_handler)
 
     @event_handler(ElementCreated)
     def undo_create_element_event(self, event):

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -315,7 +315,7 @@ class UndoManager(Service, ActionProvider):
         self.event_manager.unsubscribe(self.undo_association_delete_event)
 
     @event_handler(RevertibeEvent)
-    def undo_reversible_event(self, event):
+    def undo_reversible_event(self, event: RevertibeEvent):
         element_id = event.element.id
 
         def _undo_reversible_event():
@@ -326,10 +326,12 @@ class UndoManager(Service, ActionProvider):
             f"Reverse event {event.__class__.__name__} for element {event.element}."
         )
 
-        self.add_undo_action(_undo_reversible_event, requires_transaction=False)
+        self.add_undo_action(
+            _undo_reversible_event, requires_transaction=event.requires_transaction
+        )
 
     @event_handler(ElementCreated)
-    def undo_create_element_event(self, event):
+    def undo_create_element_event(self, event: ElementCreated):
         element_id = event.element.id
 
         def _undo_create_event():
@@ -342,7 +344,7 @@ class UndoManager(Service, ActionProvider):
         self.add_undo_action(_undo_create_event)
 
     @event_handler(ElementDeleted)
-    def undo_delete_element_event(self, event):
+    def undo_delete_element_event(self, event: ElementDeleted):
         element_type = type(event.element)
         element_id = event.element.id
 
@@ -356,7 +358,7 @@ class UndoManager(Service, ActionProvider):
         self.add_undo_action(_undo_delete_event)
 
     @event_handler(DiagramItemCreated)
-    def undo_create_diagram_item_event(self, event):
+    def undo_create_diagram_item_event(self, event: DiagramItemCreated):
         element_id = event.element.id
 
         def _undo_create_event():
@@ -369,7 +371,7 @@ class UndoManager(Service, ActionProvider):
         self.add_undo_action(_undo_create_event)
 
     @event_handler(DiagramItemDeleted)
-    def undo_delete_diagram_item_event(self, event):
+    def undo_delete_diagram_item_event(self, event: DiagramItemDeleted):
         diagram_id = event.diagram.id
         element_type = type(event.element)
         element_id = event.element.id
@@ -393,7 +395,7 @@ class UndoManager(Service, ActionProvider):
         self.add_undo_action(_undo_delete_event)
 
     @event_handler(AttributeUpdated)
-    def undo_attribute_change_event(self, event):
+    def undo_attribute_change_event(self, event: AttributeUpdated):
         attribute = event.property
         element_id = event.element.id
         value = event.old_value
@@ -410,7 +412,7 @@ class UndoManager(Service, ActionProvider):
         self.add_undo_action(_undo_attribute_change_event)
 
     @event_handler(AssociationSet)
-    def undo_association_set_event(self, event):
+    def undo_association_set_event(self, event: AssociationSet):
         association = event.property
         if type(association) is not association_property:
             return
@@ -430,7 +432,7 @@ class UndoManager(Service, ActionProvider):
         self.add_undo_action(_undo_association_set_event)
 
     @event_handler(AssociationAdded)
-    def undo_association_add_event(self, event):
+    def undo_association_add_event(self, event: AssociationAdded):
         association = event.property
         if type(association) is not association_property:
             return
@@ -450,7 +452,7 @@ class UndoManager(Service, ActionProvider):
         self.add_undo_action(_undo_association_add_event)
 
     @event_handler(AssociationDeleted)
-    def undo_association_delete_event(self, event):
+    def undo_association_delete_event(self, event: AssociationDeleted):
         association = event.property
         if type(association) is not association_property:
             return

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -51,7 +51,8 @@ def main(argv=sys.argv):
         return any(o in argv for o in options)
 
     if has_option("-v", "--verbose"):
-        logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
+        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+        logging.getLogger("gaphor").setLevel(logging.DEBUG)
     elif has_option("-q", "--quiet"):
         logging.basicConfig(level=logging.WARNING, format=LOG_FORMAT)
     else:

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -8,7 +8,7 @@ from gi.repository import Gtk
 
 from gaphor import UML
 from gaphor.diagram.connectors import Connector
-from gaphor.diagram.diagramtools.placement import PresentationConnector
+from gaphor.diagram.diagramtools.connector import PresentationConnector
 from gaphor.diagram.general.comment import CommentItem
 from gaphor.diagram.general.commentline import CommentLineItem
 from gaphor.ui.diagrams import Diagrams

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,70 +1,71 @@
 [[package]]
-name = "alabaster"
-version = "0.7.12"
+category = "dev"
 description = "A configurable sidebar-enabled Sphinx theme"
-category = "dev"
+name = "alabaster"
 optional = false
 python-versions = "*"
+version = "0.7.12"
 
 [[package]]
-name = "appdirs"
-version = "1.4.4"
+category = "dev"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+name = "appdirs"
 optional = false
 python-versions = "*"
+version = "1.4.4"
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.0"
+category = "dev"
 description = "Atomic file writes."
-category = "dev"
+marker = "sys_platform == \"win32\""
+name = "atomicwrites"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.4.0"
 
 [[package]]
-name = "attrs"
-version = "20.3.0"
-description = "Classes Without Boilerplate"
 category = "dev"
+description = "Classes Without Boilerplate"
+name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "20.3.0"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
-name = "babel"
-version = "2.9.0"
-description = "Internationalization utilities"
 category = "dev"
+description = "Internationalization utilities"
+name = "babel"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.9.0"
 
 [package.dependencies]
 pytz = ">=2015.7"
 
 [[package]]
-name = "babelgladeextractor"
-version = "0.7.0"
-description = "Babel l10n support for Glade, GtkBuilder, and .desktop files"
 category = "dev"
+description = "Babel l10n support for Glade, GtkBuilder, and .desktop files"
+name = "babelgladeextractor"
 optional = false
 python-versions = "*"
+version = "0.7.0"
 
 [package.dependencies]
 Babel = "*"
 
 [[package]]
-name = "black"
-version = "20.8b1"
-description = "The uncompromising code formatter."
 category = "dev"
+description = "The uncompromising code formatter."
+name = "black"
 optional = false
 python-versions = ">=3.6"
+version = "20.8b1"
 
 [package.dependencies]
 appdirs = "*"
@@ -81,197 +82,204 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
-name = "certifi"
-version = "2020.12.5"
-description = "Python package for providing Mozilla's CA Bundle."
 category = "dev"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
 optional = false
 python-versions = "*"
+version = "2020.12.5"
 
 [[package]]
-name = "cfgv"
-version = "3.2.0"
-description = "Validate configuration and produce human readable error messages."
 category = "dev"
+description = "Validate configuration and produce human readable error messages."
+name = "cfgv"
 optional = false
 python-versions = ">=3.6.1"
+version = "3.2.0"
 
 [[package]]
-name = "chardet"
-version = "4.0.0"
+category = "dev"
 description = "Universal encoding detector for Python 2 and 3"
-category = "dev"
+name = "chardet"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "4.0.0"
 
 [[package]]
-name = "click"
-version = "7.1.2"
+category = "dev"
 description = "Composable command line interface toolkit"
-category = "dev"
+name = "click"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.2"
 
 [[package]]
-name = "colorama"
-version = "0.4.4"
+category = "dev"
 description = "Cross-platform colored terminal text."
-category = "dev"
+marker = "sys_platform == \"win32\""
+name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.4"
 
 [[package]]
-name = "commonmark"
-version = "0.9.1"
-description = "Python parser for the CommonMark Markdown spec"
 category = "dev"
+description = "Python parser for the CommonMark Markdown spec"
+name = "commonmark"
 optional = false
 python-versions = "*"
+version = "0.9.1"
 
 [package.extras]
-test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
+test = ["flake8 (3.7.8)", "hypothesis (3.55.3)"]
 
 [[package]]
-name = "coverage"
-version = "5.3"
-description = "Code coverage measurement for Python"
 category = "dev"
+description = "Code coverage measurement for Python"
+name = "coverage"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.3.1"
 
 [package.extras]
 toml = ["toml"]
 
 [[package]]
-name = "distlib"
-version = "0.3.1"
-description = "Distribution utilities"
 category = "dev"
+description = "Distribution utilities"
+name = "distlib"
 optional = false
 python-versions = "*"
+version = "0.3.1"
 
 [[package]]
-name = "docutils"
-version = "0.16"
-description = "Docutils -- Python Documentation Utilities"
 category = "dev"
+description = "Docutils -- Python Documentation Utilities"
+name = "docutils"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.16"
 
 [[package]]
-name = "filelock"
-version = "3.0.12"
-description = "A platform independent file lock."
 category = "dev"
+description = "A platform independent file lock."
+name = "filelock"
 optional = false
 python-versions = "*"
+version = "3.0.12"
 
 [[package]]
-name = "flake8"
-version = "3.8.4"
-description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
+description = "the modular source code checker: pep8 pyflakes and co"
+name = "flake8"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "3.8.4"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
 
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
+
 [[package]]
-name = "gaphas"
-version = "3.0.0b3"
-description = "Gaphas is a GTK+ based diagramming widget"
 category = "main"
+description = "Gaphas is a GTK+ based diagramming widget"
+name = "gaphas"
 optional = false
 python-versions = ">=3.7,<4.0"
+version = "3.0.0b4"
 
 [package.dependencies]
-pycairo = ">=1.13.0,<2.0.0"
 PyGObject = ">=3.20.0,<4.0.0"
+pycairo = ">=1.13.0,<2.0.0"
 typing-extensions = ">=3.7.4,<4.0.0"
 
 [[package]]
-name = "generic"
-version = "1.0.0"
-description = "Generic programming library for Python"
 category = "main"
+description = "Generic programming library for Python"
+name = "generic"
 optional = false
 python-versions = ">=3.7,<4.0"
+version = "1.0.0"
 
 [[package]]
-name = "identify"
-version = "1.5.10"
-description = "File identification library for Python"
 category = "dev"
+description = "File identification library for Python"
+name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "1.5.12"
 
 [package.extras]
 license = ["editdistance"]
 
 [[package]]
-name = "idna"
-version = "2.10"
+category = "dev"
 description = "Internationalized Domain Names in Applications (IDNA)"
-category = "dev"
+name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.10"
 
 [[package]]
-name = "imagesize"
-version = "1.2.0"
+category = "dev"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
-category = "dev"
+name = "imagesize"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.2.0"
 
 [[package]]
-name = "importlib-metadata"
-version = "3.3.0"
-description = "Read metadata from Python packages"
 category = "main"
+description = "Read metadata from Python packages"
+name = "importlib-metadata"
 optional = false
 python-versions = ">=3.6"
+version = "3.3.0"
 
 [package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
+
+[package.dependencies.typing-extensions]
+python = "<3.8"
+version = ">=3.6.4"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
-name = "iniconfig"
-version = "1.1.1"
-description = "iniconfig: brain-dead simple config-ini parsing"
 category = "dev"
+description = "iniconfig: brain-dead simple config-ini parsing"
+name = "iniconfig"
 optional = false
 python-versions = "*"
+version = "1.1.1"
 
 [[package]]
-name = "isort"
-version = "5.7.0"
-description = "A Python utility / library to sort Python imports."
 category = "dev"
+description = "A Python utility / library to sort Python imports."
+name = "isort"
 optional = false
 python-versions = ">=3.6,<4.0"
+version = "5.7.0"
 
 [package.extras]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
 pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
 
 [[package]]
-name = "jinja2"
-version = "2.11.2"
-description = "A very fast and expressive template engine."
 category = "dev"
+description = "A very fast and expressive template engine."
+name = "jinja2"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.11.2"
 
 [package.dependencies]
 MarkupSafe = ">=0.23"
@@ -280,28 +288,28 @@ MarkupSafe = ">=0.23"
 i18n = ["Babel (>=0.8)"]
 
 [[package]]
-name = "markupsafe"
-version = "1.1.1"
-description = "Safely add untrusted strings to HTML/XML markup."
 category = "dev"
+description = "Safely add untrusted strings to HTML/XML markup."
+name = "markupsafe"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "1.1.1"
 
 [[package]]
-name = "mccabe"
-version = "0.6.1"
-description = "McCabe checker, plugin for flake8"
 category = "dev"
+description = "McCabe checker, plugin for flake8"
+name = "mccabe"
 optional = false
 python-versions = "*"
+version = "0.6.1"
 
 [[package]]
-name = "mypy"
-version = "0.790"
-description = "Optional static typing for Python"
 category = "dev"
+description = "Optional static typing for Python"
+name = "mypy"
 optional = false
 python-versions = ">=3.5"
+version = "0.790"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
@@ -312,202 +320,210 @@ typing-extensions = ">=3.7.4"
 dmypy = ["psutil (>=4.0)"]
 
 [[package]]
-name = "mypy-extensions"
-version = "0.4.3"
+category = "dev"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
-category = "dev"
+name = "mypy-extensions"
 optional = false
 python-versions = "*"
+version = "0.4.3"
 
 [[package]]
-name = "nodeenv"
-version = "1.5.0"
+category = "dev"
 description = "Node.js virtual environment builder"
-category = "dev"
+name = "nodeenv"
 optional = false
 python-versions = "*"
+version = "1.5.0"
 
 [[package]]
-name = "packaging"
-version = "20.8"
-description = "Core utilities for Python packages"
 category = "dev"
+description = "Core utilities for Python packages"
+name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "20.8"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
 
 [[package]]
-name = "pathspec"
-version = "0.8.1"
-description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.8.1"
 
 [[package]]
-name = "pluggy"
-version = "0.13.1"
-description = "plugin and hook calling mechanisms for python"
 category = "dev"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.13.1"
 
 [package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-name = "pre-commit"
-version = "2.9.3"
-description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+name = "pre-commit"
 optional = false
 python-versions = ">=3.6.1"
+version = "2.9.3"
 
 [package.dependencies]
 cfgv = ">=2.0.0"
 identify = ">=1.0.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 toml = "*"
 virtualenv = ">=20.0.8"
 
-[[package]]
-name = "py"
-version = "1.10.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
 
 [[package]]
-name = "pycairo"
-version = "1.20.0"
-description = "Python interface for cairo"
+category = "dev"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+name = "py"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.10.0"
+
+[[package]]
 category = "main"
+description = "Python interface for cairo"
+name = "pycairo"
 optional = false
 python-versions = ">=3.6, <4"
+version = "1.20.0"
 
 [[package]]
-name = "pycodestyle"
-version = "2.6.0"
+category = "dev"
 description = "Python style guide checker"
-category = "dev"
+name = "pycodestyle"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.6.0"
 
 [[package]]
-name = "pyflakes"
-version = "2.2.0"
+category = "dev"
 description = "passive checker of Python programs"
-category = "dev"
+name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.2.0"
 
 [[package]]
-name = "pygments"
-version = "2.7.3"
-description = "Pygments is a syntax highlighting package written in Python."
 category = "dev"
+description = "Pygments is a syntax highlighting package written in Python."
+name = "pygments"
 optional = false
 python-versions = ">=3.5"
+version = "2.7.3"
 
 [[package]]
-name = "pygobject"
-version = "3.38.0"
-description = "Python bindings for GObject Introspection"
 category = "main"
+description = "Python bindings for GObject Introspection"
+name = "pygobject"
 optional = false
 python-versions = ">=3.5, <4"
+version = "3.38.0"
 
 [package.dependencies]
 pycairo = ">=1.11.1"
 
 [[package]]
-name = "pyparsing"
-version = "2.4.7"
-description = "Python parsing module"
 category = "dev"
+description = "Python parsing module"
+name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.4.7"
 
 [[package]]
-name = "pytest"
-version = "6.2.1"
-description = "pytest: simple powerful testing with Python"
 category = "dev"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
 optional = false
 python-versions = ">=3.6"
+version = "6.2.1"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+atomicwrites = ">=1.0"
 attrs = ">=19.2.0"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+colorama = "*"
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<1.0.0a1"
 py = ">=1.8.2"
 toml = "*"
 
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-name = "pytest-cov"
-version = "2.10.1"
-description = "Pytest plugin for measuring coverage."
 category = "dev"
+description = "Pytest plugin for measuring coverage."
+name = "pytest-cov"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.10.1"
 
 [package.dependencies]
 coverage = ">=4.4"
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
-name = "pytest-runner"
-version = "5.2"
-description = "Invoke py.test as distutils command with dependency resolution"
 category = "dev"
+description = "Invoke py.test as distutils command with dependency resolution"
+name = "pytest-runner"
 optional = false
 python-versions = ">=2.7"
+version = "5.2"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs", "pytest-flake8", "pytest-black-multipy", "pytest-cov", "pytest-virtualenv"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs", "pytest-flake8", "pytest-black-multipy", "pytest-cov", "pytest-virtualenv"]
 
 [[package]]
-name = "pytz"
-version = "2020.4"
-description = "World timezone definitions, modern and historical"
 category = "dev"
+description = "World timezone definitions, modern and historical"
+name = "pytz"
 optional = false
 python-versions = "*"
+version = "2020.5"
 
 [[package]]
-name = "pyyaml"
-version = "5.3.1"
-description = "YAML parser and emitter for Python"
 category = "dev"
+description = "YAML parser and emitter for Python"
+name = "pyyaml"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "5.3.1"
 
 [[package]]
-name = "recommonmark"
-version = "0.7.1"
-description = "A docutils-compatibility bridge to CommonMark, enabling you to write CommonMark inside of Docutils & Sphinx projects."
 category = "dev"
+description = "A docutils-compatibility bridge to CommonMark, enabling you to write CommonMark inside of Docutils & Sphinx projects."
+name = "recommonmark"
 optional = false
 python-versions = "*"
+version = "0.7.1"
 
 [package.dependencies]
 commonmark = ">=0.8.1"
@@ -515,20 +531,20 @@ docutils = ">=0.11"
 sphinx = ">=1.3.1"
 
 [[package]]
-name = "regex"
-version = "2020.11.13"
-description = "Alternative regular expression module, to replace re."
 category = "dev"
+description = "Alternative regular expression module, to replace re."
+name = "regex"
 optional = false
 python-versions = "*"
+version = "2020.11.13"
 
 [[package]]
-name = "requests"
-version = "2.25.1"
-description = "Python HTTP for Humans."
 category = "dev"
+description = "Python HTTP for Humans."
+name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.25.1"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -538,42 +554,43 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
-name = "six"
-version = "1.15.0"
-description = "Python 2 and 3 compatibility utilities"
 category = "dev"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.15.0"
 
 [[package]]
-name = "snowballstemmer"
-version = "2.0.0"
-description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
 category = "dev"
+description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
+name = "snowballstemmer"
 optional = false
 python-versions = "*"
+version = "2.0.0"
 
 [[package]]
-name = "sphinx"
-version = "3.4.3"
-description = "Python documentation generator"
 category = "dev"
+description = "Python documentation generator"
+name = "sphinx"
 optional = false
 python-versions = ">=3.5"
+version = "3.4.3"
 
 [package.dependencies]
+Jinja2 = ">=2.3"
+Pygments = ">=2.0"
 alabaster = ">=0.7,<0.8"
 babel = ">=1.3"
-colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
+colorama = ">=0.3.5"
 docutils = ">=0.12"
 imagesize = "*"
-Jinja2 = ">=2.3"
 packaging = "*"
-Pygments = ">=2.0"
 requests = ">=2.5.0"
+setuptools = "*"
 snowballstemmer = ">=1.1"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
@@ -588,12 +605,12 @@ lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.790)", "docutils-stubs"]
 test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 
 [[package]]
-name = "sphinx-rtd-theme"
-version = "0.5.1"
-description = "Read the Docs theme for Sphinx"
 category = "dev"
+description = "Read the Docs theme for Sphinx"
+name = "sphinx-rtd-theme"
 optional = false
 python-versions = "*"
+version = "0.5.1"
 
 [package.dependencies]
 sphinx = "*"
@@ -602,83 +619,83 @@ sphinx = "*"
 dev = ["transifex-client", "sphinxcontrib-httpdomain", "bump2version"]
 
 [[package]]
-name = "sphinxcontrib-applehelp"
-version = "1.0.2"
+category = "dev"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
-category = "dev"
+name = "sphinxcontrib-applehelp"
 optional = false
 python-versions = ">=3.5"
-
-[package.extras]
-lint = ["flake8", "mypy", "docutils-stubs"]
-test = ["pytest"]
-
-[[package]]
-name = "sphinxcontrib-devhelp"
 version = "1.0.2"
-description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
-category = "dev"
-optional = false
-python-versions = ">=3.5"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-name = "sphinxcontrib-htmlhelp"
-version = "1.0.3"
-description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "dev"
+description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
+name = "sphinxcontrib-devhelp"
 optional = false
 python-versions = ">=3.5"
+version = "1.0.2"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
+name = "sphinxcontrib-htmlhelp"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.3"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest", "html5lib"]
 
 [[package]]
-name = "sphinxcontrib-jsmath"
-version = "1.0.1"
-description = "A sphinx extension which renders display math in HTML via JavaScript"
 category = "dev"
+description = "A sphinx extension which renders display math in HTML via JavaScript"
+name = "sphinxcontrib-jsmath"
 optional = false
 python-versions = ">=3.5"
+version = "1.0.1"
 
 [package.extras]
 test = ["pytest", "flake8", "mypy"]
 
 [[package]]
-name = "sphinxcontrib-qthelp"
-version = "1.0.3"
+category = "dev"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
-category = "dev"
+name = "sphinxcontrib-qthelp"
 optional = false
 python-versions = ">=3.5"
+version = "1.0.3"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-name = "sphinxcontrib-serializinghtml"
-version = "1.1.4"
+category = "dev"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
-category = "dev"
+name = "sphinxcontrib-serializinghtml"
 optional = false
 python-versions = ">=3.5"
+version = "1.1.4"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-name = "tinycss2"
-version = "1.1.0"
-description = "tinycss2"
 category = "main"
+description = "tinycss2"
+name = "tinycss2"
 optional = false
 python-versions = ">=3.6"
+version = "1.1.0"
 
 [package.dependencies]
 webencodings = ">=0.4"
@@ -688,93 +705,96 @@ doc = ["sphinx", "sphinx-rtd-theme"]
 test = ["pytest", "pytest-cov", "pytest-flake8", "pytest-isort", "coverage"]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.10.2"
 
 [[package]]
-name = "tomlkit"
-version = "0.7.0"
-description = "Style preserving TOML library"
 category = "dev"
+description = "Style preserving TOML library"
+name = "tomlkit"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.7.0"
 
 [[package]]
-name = "typed-ast"
-version = "1.4.1"
+category = "dev"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "dev"
+name = "typed-ast"
 optional = false
 python-versions = "*"
+version = "1.4.2"
 
 [[package]]
-name = "typing-extensions"
-version = "3.7.4.3"
-description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+name = "typing-extensions"
 optional = false
 python-versions = "*"
+version = "3.7.4.3"
 
 [[package]]
-name = "urllib3"
-version = "1.26.2"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "dev"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.26.2"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
-name = "virtualenv"
-version = "20.2.2"
-description = "Virtual Python Environment builder"
 category = "dev"
+description = "Virtual Python Environment builder"
+name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "20.2.2"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 six = ">=1.9.0,<2"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-xdist (>=1.31.0)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
 
 [[package]]
-name = "webencodings"
-version = "0.5.1"
-description = "Character encoding aliases for legacy web content"
 category = "main"
+description = "Character encoding aliases for legacy web content"
+name = "webencodings"
 optional = false
 python-versions = "*"
+version = "0.5.1"
 
 [[package]]
-name = "zipp"
-version = "3.4.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+name = "zipp"
 optional = false
 python-versions = ">=3.6"
+version = "3.4.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-lock-version = "1.1"
-python-versions = "^3.7"
 content-hash = "9c9d71109f2bb45b26c9e6ca81848a1c3aab7068d986e6ac6ea324144f99ac26"
+lock-version = "1.0"
+python-versions = "^3.7"
 
 [metadata.files]
 alabaster = [
@@ -828,40 +848,55 @@ commonmark = [
     {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
 coverage = [
-    {file = "coverage-5.3-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270"},
-    {file = "coverage-5.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:9342dd70a1e151684727c9c91ea003b2fb33523bf19385d4554f7897ca0141d4"},
-    {file = "coverage-5.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:63808c30b41f3bbf65e29f7280bf793c79f54fb807057de7e5238ffc7cc4d7b9"},
-    {file = "coverage-5.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:4d6a42744139a7fa5b46a264874a781e8694bb32f1d76d8137b68138686f1729"},
-    {file = "coverage-5.3-cp27-cp27m-win32.whl", hash = "sha256:86e9f8cd4b0cdd57b4ae71a9c186717daa4c5a99f3238a8723f416256e0b064d"},
-    {file = "coverage-5.3-cp27-cp27m-win_amd64.whl", hash = "sha256:7858847f2d84bf6e64c7f66498e851c54de8ea06a6f96a32a1d192d846734418"},
-    {file = "coverage-5.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:530cc8aaf11cc2ac7430f3614b04645662ef20c348dce4167c22d99bec3480e9"},
-    {file = "coverage-5.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:381ead10b9b9af5f64646cd27107fb27b614ee7040bb1226f9c07ba96625cbb5"},
-    {file = "coverage-5.3-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:71b69bd716698fa62cd97137d6f2fdf49f534decb23a2c6fc80813e8b7be6822"},
-    {file = "coverage-5.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1d44bb3a652fed01f1f2c10d5477956116e9b391320c94d36c6bf13b088a1097"},
-    {file = "coverage-5.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:1c6703094c81fa55b816f5ae542c6ffc625fec769f22b053adb42ad712d086c9"},
-    {file = "coverage-5.3-cp35-cp35m-win32.whl", hash = "sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636"},
-    {file = "coverage-5.3-cp35-cp35m-win_amd64.whl", hash = "sha256:7f43286f13d91a34fadf61ae252a51a130223c52bfefb50310d5b2deb062cf0f"},
-    {file = "coverage-5.3-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:c851b35fc078389bc16b915a0a7c1d5923e12e2c5aeec58c52f4aa8085ac8237"},
-    {file = "coverage-5.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:aac1ba0a253e17889550ddb1b60a2063f7474155465577caa2a3b131224cfd54"},
-    {file = "coverage-5.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2b31f46bf7b31e6aa690d4c7a3d51bb262438c6dcb0d528adde446531d0d3bb7"},
-    {file = "coverage-5.3-cp36-cp36m-win32.whl", hash = "sha256:c5f17ad25d2c1286436761b462e22b5020d83316f8e8fcb5deb2b3151f8f1d3a"},
-    {file = "coverage-5.3-cp36-cp36m-win_amd64.whl", hash = "sha256:aef72eae10b5e3116bac6957de1df4d75909fc76d1499a53fb6387434b6bcd8d"},
-    {file = "coverage-5.3-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"},
-    {file = "coverage-5.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:29a6272fec10623fcbe158fdf9abc7a5fa032048ac1d8631f14b50fbfc10d17f"},
-    {file = "coverage-5.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2d43af2be93ffbad25dd959899b5b809618a496926146ce98ee0b23683f8c51c"},
-    {file = "coverage-5.3-cp37-cp37m-win32.whl", hash = "sha256:c3888a051226e676e383de03bf49eb633cd39fc829516e5334e69b8d81aae751"},
-    {file = "coverage-5.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9669179786254a2e7e57f0ecf224e978471491d660aaca833f845b72a2df3709"},
-    {file = "coverage-5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516"},
-    {file = "coverage-5.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:582ddfbe712025448206a5bc45855d16c2e491c2dd102ee9a2841418ac1c629f"},
-    {file = "coverage-5.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0f313707cdecd5cd3e217fc68c78a960b616604b559e9ea60cc16795c4304259"},
-    {file = "coverage-5.3-cp38-cp38-win32.whl", hash = "sha256:78e93cc3571fd928a39c0b26767c986188a4118edc67bc0695bc7a284da22e82"},
-    {file = "coverage-5.3-cp38-cp38-win_amd64.whl", hash = "sha256:8f264ba2701b8c9f815b272ad568d555ef98dfe1576802ab3149c3629a9f2221"},
-    {file = "coverage-5.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:50691e744714856f03a86df3e2bff847c2acede4c191f9a1da38f088df342978"},
-    {file = "coverage-5.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9361de40701666b034c59ad9e317bae95c973b9ff92513dd0eced11c6adf2e21"},
-    {file = "coverage-5.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:c1b78fb9700fc961f53386ad2fd86d87091e06ede5d118b8a50dea285a071c24"},
-    {file = "coverage-5.3-cp39-cp39-win32.whl", hash = "sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7"},
-    {file = "coverage-5.3-cp39-cp39-win_amd64.whl", hash = "sha256:47a11bdbd8ada9b7ee628596f9d97fbd3851bd9999d398e9436bd67376dbece7"},
-    {file = "coverage-5.3.tar.gz", hash = "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0"},
+    {file = "coverage-5.3.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:fabeeb121735d47d8eab8671b6b031ce08514c86b7ad8f7d5490a7b6dcd6267d"},
+    {file = "coverage-5.3.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:7e4d159021c2029b958b2363abec4a11db0ce8cd43abb0d9ce44284cb97217e7"},
+    {file = "coverage-5.3.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:378ac77af41350a8c6b8801a66021b52da8a05fd77e578b7380e876c0ce4f528"},
+    {file = "coverage-5.3.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:e448f56cfeae7b1b3b5bcd99bb377cde7c4eb1970a525c770720a352bc4c8044"},
+    {file = "coverage-5.3.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:cc44e3545d908ecf3e5773266c487ad1877be718d9dc65fc7eb6e7d14960985b"},
+    {file = "coverage-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:08b3ba72bd981531fd557f67beee376d6700fba183b167857038997ba30dd297"},
+    {file = "coverage-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:8dacc4073c359f40fcf73aede8428c35f84639baad7e1b46fce5ab7a8a7be4bb"},
+    {file = "coverage-5.3.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:ee2f1d1c223c3d2c24e3afbb2dd38be3f03b1a8d6a83ee3d9eb8c36a52bee899"},
+    {file = "coverage-5.3.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:9a9d4ff06804920388aab69c5ea8a77525cf165356db70131616acd269e19b36"},
+    {file = "coverage-5.3.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:782a5c7df9f91979a7a21792e09b34a658058896628217ae6362088b123c8500"},
+    {file = "coverage-5.3.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:fda29412a66099af6d6de0baa6bd7c52674de177ec2ad2630ca264142d69c6c7"},
+    {file = "coverage-5.3.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:f2c6888eada180814b8583c3e793f3f343a692fc802546eed45f40a001b1169f"},
+    {file = "coverage-5.3.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:8f33d1156241c43755137288dea619105477961cfa7e47f48dbf96bc2c30720b"},
+    {file = "coverage-5.3.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b239711e774c8eb910e9b1ac719f02f5ae4bf35fa0420f438cdc3a7e4e7dd6ec"},
+    {file = "coverage-5.3.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:f54de00baf200b4539a5a092a759f000b5f45fd226d6d25a76b0dff71177a714"},
+    {file = "coverage-5.3.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:be0416074d7f253865bb67630cf7210cbc14eb05f4099cc0f82430135aaa7a3b"},
+    {file = "coverage-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:c46643970dff9f5c976c6512fd35768c4a3819f01f61169d8cdac3f9290903b7"},
+    {file = "coverage-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9a4f66259bdd6964d8cf26142733c81fb562252db74ea367d9beb4f815478e72"},
+    {file = "coverage-5.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c6e5174f8ca585755988bc278c8bb5d02d9dc2e971591ef4a1baabdf2d99589b"},
+    {file = "coverage-5.3.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:3911c2ef96e5ddc748a3c8b4702c61986628bb719b8378bf1e4a6184bbd48fe4"},
+    {file = "coverage-5.3.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c5ec71fd4a43b6d84ddb88c1df94572479d9a26ef3f150cef3dacefecf888105"},
+    {file = "coverage-5.3.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f51dbba78d68a44e99d484ca8c8f604f17e957c1ca09c3ebc2c7e3bbd9ba0448"},
+    {file = "coverage-5.3.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:a2070c5affdb3a5e751f24208c5c4f3d5f008fa04d28731416e023c93b275277"},
+    {file = "coverage-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:535dc1e6e68fad5355f9984d5637c33badbdc987b0c0d303ee95a6c979c9516f"},
+    {file = "coverage-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:a4857f7e2bc6921dbd487c5c88b84f5633de3e7d416c4dc0bb70256775551a6c"},
+    {file = "coverage-5.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fac3c432851038b3e6afe086f777732bcf7f6ebbfd90951fa04ee53db6d0bcdd"},
+    {file = "coverage-5.3.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:cd556c79ad665faeae28020a0ab3bda6cd47d94bec48e36970719b0b86e4dcf4"},
+    {file = "coverage-5.3.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a66ca3bdf21c653e47f726ca57f46ba7fc1f260ad99ba783acc3e58e3ebdb9ff"},
+    {file = "coverage-5.3.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ab110c48bc3d97b4d19af41865e14531f300b482da21783fdaacd159251890e8"},
+    {file = "coverage-5.3.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e52d3d95df81c8f6b2a1685aabffadf2d2d9ad97203a40f8d61e51b70f191e4e"},
+    {file = "coverage-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:fa10fee7e32213f5c7b0d6428ea92e3a3fdd6d725590238a3f92c0de1c78b9d2"},
+    {file = "coverage-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:ce6f3a147b4b1a8b09aae48517ae91139b1b010c5f36423fa2b866a8b23df879"},
+    {file = "coverage-5.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:93a280c9eb736a0dcca19296f3c30c720cb41a71b1f9e617f341f0a8e791a69b"},
+    {file = "coverage-5.3.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:3102bb2c206700a7d28181dbe04d66b30780cde1d1c02c5f3c165cf3d2489497"},
+    {file = "coverage-5.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8ffd4b204d7de77b5dd558cdff986a8274796a1e57813ed005b33fd97e29f059"},
+    {file = "coverage-5.3.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a607ae05b6c96057ba86c811d9c43423f35e03874ffb03fbdcd45e0637e8b631"},
+    {file = "coverage-5.3.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:3a3c3f8863255f3c31db3889f8055989527173ef6192a283eb6f4db3c579d830"},
+    {file = "coverage-5.3.1-cp38-cp38-win32.whl", hash = "sha256:ff1330e8bc996570221b450e2d539134baa9465f5cb98aff0e0f73f34172e0ae"},
+    {file = "coverage-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:3498b27d8236057def41de3585f317abae235dd3a11d33e01736ffedb2ef8606"},
+    {file = "coverage-5.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ceb499d2b3d1d7b7ba23abe8bf26df5f06ba8c71127f188333dddcf356b4b63f"},
+    {file = "coverage-5.3.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:3b14b1da110ea50c8bcbadc3b82c3933974dbeea1832e814aab93ca1163cd4c1"},
+    {file = "coverage-5.3.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:76b2775dda7e78680d688daabcb485dc87cf5e3184a0b3e012e1d40e38527cc8"},
+    {file = "coverage-5.3.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:cef06fb382557f66d81d804230c11ab292d94b840b3cb7bf4450778377b592f4"},
+    {file = "coverage-5.3.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f61319e33222591f885c598e3e24f6a4be3533c1d70c19e0dc59e83a71ce27d"},
+    {file = "coverage-5.3.1-cp39-cp39-win32.whl", hash = "sha256:cc6f8246e74dd210d7e2b56c76ceaba1cc52b025cd75dbe96eb48791e0250e98"},
+    {file = "coverage-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:2757fa64e11ec12220968f65d086b7a29b6583d16e9a544c889b22ba98555ef1"},
+    {file = "coverage-5.3.1-pp36-none-any.whl", hash = "sha256:723d22d324e7997a651478e9c5a3120a0ecbc9a7e94071f7e1954562a8806cf3"},
+    {file = "coverage-5.3.1-pp37-none-any.whl", hash = "sha256:c89b558f8a9a5a6f2cfc923c304d49f0ce629c3bd85cb442ca258ec20366394c"},
+    {file = "coverage-5.3.1.tar.gz", hash = "sha256:38f16b1317b8dd82df67ed5daa5f5e7c959e46579840d77a67a4ceb9cef0a50b"},
 ]
 distlib = [
     {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
@@ -880,16 +915,16 @@ flake8 = [
     {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
 ]
 gaphas = [
-    {file = "gaphas-3.0.0b3-py3-none-any.whl", hash = "sha256:c4b460599634338d5ae1c46716f6c46c5f18458a2ed73eaead6d5261039ce9fe"},
-    {file = "gaphas-3.0.0b3.tar.gz", hash = "sha256:4b11dcce3f2c555aa678fa9ae5f2e149ae2334fe48d5b255790df6f13d0a1668"},
+    {file = "gaphas-3.0.0b4-py3-none-any.whl", hash = "sha256:50b43d3016f16443f0b62ec7d4991971f5f110eb452344e325aae7f38f6d6e58"},
+    {file = "gaphas-3.0.0b4.tar.gz", hash = "sha256:197d5cf65cb4f3c36f9d62dd3dad8e61e18545e7a2f665b846ea88435fc517f6"},
 ]
 generic = [
     {file = "generic-1.0.0-py3-none-any.whl", hash = "sha256:a8dbb3133929223149272fcc70a95967cf3b24e3fa12601f91c67fb61efe29d4"},
     {file = "generic-1.0.0.tar.gz", hash = "sha256:c7651fb460feae762065b4a29afbfe2a346b2b18dccd4a8495a7e978498f66bc"},
 ]
 identify = [
-    {file = "identify-1.5.10-py2.py3-none-any.whl", hash = "sha256:cc86e6a9a390879dcc2976cef169dd9cc48843ed70b7380f321d1b118163c60e"},
-    {file = "identify-1.5.10.tar.gz", hash = "sha256:943cd299ac7f5715fcb3f684e2fc1594c1e0f22a90d15398e5888143bd4144b5"},
+    {file = "identify-1.5.12-py2.py3-none-any.whl", hash = "sha256:18994e850ba50c37bcaed4832be8b354d6a06c8fb31f54e0e7ece76d32f69bc8"},
+    {file = "identify-1.5.12.tar.gz", hash = "sha256:892473bf12e655884132a3a32aca737a3cbefaa34a850ff52d501773a45837bc"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1041,8 +1076,8 @@ pytest-runner = [
     {file = "pytest_runner-5.2-py2.py3-none-any.whl", hash = "sha256:5534b08b133ef9a5e2c22c7886a8f8508c95bb0b0bdc6cc13214f269c3c70d51"},
 ]
 pytz = [
-    {file = "pytz-2020.4-py2.py3-none-any.whl", hash = "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"},
-    {file = "pytz-2020.4.tar.gz", hash = "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268"},
+    {file = "pytz-2020.5-py2.py3-none-any.whl", hash = "sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4"},
+    {file = "pytz-2020.5.tar.gz", hash = "sha256:180befebb1927b16f6b57101720075a984c019ac16b1b7575673bea42c6c3da5"},
 ]
 pyyaml = [
     {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
@@ -1163,36 +1198,36 @@ tomlkit = [
     {file = "tomlkit-0.7.0.tar.gz", hash = "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"},
 ]
 typed-ast = [
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
-    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
-    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
-    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d"},
-    {file = "typed_ast-1.4.1-cp39-cp39-win32.whl", hash = "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395"},
-    {file = "typed_ast-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c"},
-    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496"},
+    {file = "typed_ast-1.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win32.whl", hash = "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937"},
+    {file = "typed_ast-1.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win32.whl", hash = "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440"},
+    {file = "typed_ast-1.4.2.tar.gz", hash = "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},

--- a/test-models/decision-fork-nodes.gaphor
+++ b/test-models/decision-fork-nodes.gaphor
@@ -1,0 +1,1529 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.1.1">
+<StyleSheet id="745f31ac-4cf6-11eb-a938-8fcfae32d12c"/>
+<Package id="745f31ad-4cf6-11eb-a938-8fcfae32d12c">
+<name>
+<val>New model</val>
+</name>
+<ownedClassifier>
+<reflist>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</ownedClassifier>
+<ownedDiagram>
+<reflist>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</ownedDiagram>
+</Package>
+<Diagram id="745f31ae-4cf6-11eb-a938-8fcfae32d12c">
+<name>
+<val>main</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="77ddf08f-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="7afe967f-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="7d1bc77f-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="831af0c8-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="881bfd38-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="8ca3561d-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="90f4e8cb-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="92799c54-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="95217af8-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="9a6e9ba9-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="a25334aa-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="a5c53d68-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="a909b149-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="aa257fdb-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="de036614-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="e1260d24-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="e48d6b4d-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="ea0a2651-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="f1ecaac9-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="f4a1136c-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="f6dc1654-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="fed0247d-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="ffcc793f-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="ffcc7941-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="0199bcd7-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="1249281e-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="14b025bc-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="19539aa5-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="1cb700b4-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="1fa4eeb2-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="245e3896-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="271f0c40-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</ownedPresentation>
+<package>
+<ref refid="745f31ad-4cf6-11eb-a938-8fcfae32d12c"/>
+</package>
+<canvas>
+<item id="77ddf08f-4cf6-11eb-a938-8fcfae32d12c" type="ObjectNodeItem">
+<show-ordering>
+<val>0</val>
+</show-ordering>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 190.0, 162.0)</val>
+</matrix>
+<width>
+<val>62.0</val>
+</width>
+<height>
+<val>34.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="77ddf08e-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="7afe967f-4cf6-11eb-a938-8fcfae32d12c" type="ObjectNodeItem">
+<show-ordering>
+<val>0</val>
+</show-ordering>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 190.0, 239.0)</val>
+</matrix>
+<width>
+<val>65.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="7afe967e-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="7d1bc77f-4cf6-11eb-a938-8fcfae32d12c" type="DecisionNodeItem">
+<combined>
+<ref refid="963fb563-4cf6-11eb-a938-8fcfae32d12c"/>
+</combined>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 410.0, 199.0)</val>
+</matrix>
+<width>
+<val>20.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="7d1bc77e-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="831af0c8-4cf6-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="831af0c9-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 324.0, 179.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-72.0, 2.2666666666666515), (86.0, 26.0)]</val>
+</points>
+<head-connection>
+<ref refid="77ddf08f-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="7d1bc77f-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="881bfd38-4cf6-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="89ac996e-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 327.0, 259.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-72.0, -3.0), (83.0, -37.0)]</val>
+</points>
+<head-connection>
+<ref refid="7afe967f-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="7d1bc77f-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="8ca3561d-4cf6-11eb-a938-8fcfae32d12c" type="ObjectNodeItem">
+<show-ordering>
+<val>0</val>
+</show-ordering>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 522.0, 166.0)</val>
+</matrix>
+<width>
+<val>66.5</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="8ca3561c-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="90f4e8cb-4cf6-11eb-a938-8fcfae32d12c" type="ObjectNodeItem">
+<show-ordering>
+<val>0</val>
+</show-ordering>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 522.0, 239.0)</val>
+</matrix>
+<width>
+<val>66.5</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="90f4e8ca-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="92799c54-4cf6-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="30f039e6-4cf8-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 431.0, 210.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-1.0, 0.0), (91.0, -30.0)]</val>
+</points>
+<head-connection>
+<ref refid="7d1bc77f-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="8ca3561d-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="95217af8-4cf6-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="30f039e7-4cf8-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 430.0, 224.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(0.0, 0.0), (92.0, 32.0)]</val>
+</points>
+<head-connection>
+<ref refid="7d1bc77f-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="90f4e8cb-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="9a6e9ba9-4cf6-11eb-a938-8fcfae32d12c" type="ForkNodeItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 786.0, 186.0)</val>
+</matrix>
+<height>
+<val>56.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="9a6e9ba8-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="a25334aa-4cf6-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="a40ddebc-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 654.0, 181.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-65.5, 0.0), (132.0, 17.0)]</val>
+</points>
+<head-connection>
+<ref refid="8ca3561d-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="9a6e9ba9-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="a5c53d68-4cf6-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="a72b96ca-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 657.0, 258.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-68.5, 0.0), (129.0, -36.0)]</val>
+</points>
+<head-connection>
+<ref refid="90f4e8cb-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="9a6e9ba9-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="a909b149-4cf6-11eb-a938-8fcfae32d12c" type="ObjectNodeItem">
+<show-ordering>
+<val>0</val>
+</show-ordering>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 874.0, 149.0)</val>
+</matrix>
+<width>
+<val>69.0</val>
+</width>
+<height>
+<val>32.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="a909b148-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="aa257fdb-4cf6-11eb-a938-8fcfae32d12c" type="ObjectNodeItem">
+<show-ordering>
+<val>0</val>
+</show-ordering>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 874.0, 229.0)</val>
+</matrix>
+<width>
+<val>69.0</val>
+</width>
+<height>
+<val>33.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="aa257fda-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="de036614-4cf6-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="df83445a-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 797.0, 199.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-11.0, 0.0), (77.0, -31.0)]</val>
+</points>
+<head-connection>
+<ref refid="9a6e9ba9-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="a909b149-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="e1260d24-4cf6-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 794.0, 222.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(0.0, 0.0), (80.0, 23.0)]</val>
+</points>
+<tail-connection>
+<ref refid="aa257fdb-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="e48d6b4d-4cf6-11eb-a938-8fcfae32d12c" type="ActionItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 227.0, 356.0)</val>
+</matrix>
+<width>
+<val>50.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="e48d6b4c-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="ea0a2651-4cf6-11eb-a938-8fcfae32d12c" type="ActionItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 227.0, 431.0)</val>
+</matrix>
+<width>
+<val>50.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="ea0a2650-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="f1ecaac9-4cf6-11eb-a938-8fcfae32d12c" type="DecisionNodeItem">
+<combined>
+<ref refid="14b025be-4cf7-11eb-a938-8fcfae32d12c"/>
+</combined>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 382.0, 392.0)</val>
+</matrix>
+<width>
+<val>20.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="f1ecaac8-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="f4a1136c-4cf6-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="f4a1136d-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 278.0, 372.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-1.0, 0.0), (104.0, 30.0)]</val>
+</points>
+<head-connection>
+<ref refid="e48d6b4d-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="f1ecaac9-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="f6dc1654-4cf6-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="f6dc1655-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 278.0, 451.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-1.0, 0.0), (104.0, -33.0)]</val>
+</points>
+<head-connection>
+<ref refid="ea0a2651-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="f1ecaac9-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="fed0247d-4cf6-11eb-a938-8fcfae32d12c" type="ActionItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 527.75, 362.0)</val>
+</matrix>
+<width>
+<val>55.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="fed0247c-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="ffcc793f-4cf6-11eb-a938-8fcfae32d12c" type="ActionItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 510.25, 422.0)</val>
+</matrix>
+<width>
+<val>63.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="ffcc793e-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="ffcc7941-4cf6-11eb-a938-8fcfae32d12c" type="ActionItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 814.5, 359.0)</val>
+</matrix>
+<width>
+<val>94.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="ffcc7940-4cf6-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="0199bcd7-4cf7-11eb-a938-8fcfae32d12c" type="ActionItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 814.5, 436.0)</val>
+</matrix>
+<width>
+<val>94.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="0199bcd6-4cf7-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="1249281e-4cf7-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="30f039e8-4cf8-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 400.0, 402.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(2.0, 0.0), (127.75, -24.0)]</val>
+</points>
+<head-connection>
+<ref refid="f1ecaac9-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="fed0247d-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="14b025bc-4cf7-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="30f039e9-4cf8-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 401.0, 415.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(1.0, 0.0), (109.25, 20.0)]</val>
+</points>
+<head-connection>
+<ref refid="f1ecaac9-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="ffcc793f-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="19539aa5-4cf7-11eb-a938-8fcfae32d12c" type="ForkNodeItem">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 677.0, 383.0)</val>
+</matrix>
+<height>
+<val>64.0</val>
+</height>
+<combined>
+<ref refid="271f0c42-4cf7-11eb-a938-8fcfae32d12c"/>
+</combined>
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="19539aa4-4cf7-11eb-a938-8fcfae32d12c"/>
+</subject>
+</item>
+<item id="1cb700b4-4cf7-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="1dc5b784-4cf7-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 583.0, 379.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-0.25, 0.0), (94.0, 27.0)]</val>
+</points>
+<head-connection>
+<ref refid="fed0247d-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="19539aa5-4cf7-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="1fa4eeb2-4cf7-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="20964f50-4cf7-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 588.0, 447.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-14.75, -9.0), (89.0, -22.0)]</val>
+</points>
+<head-connection>
+<ref refid="ffcc793f-4cf6-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="19539aa5-4cf7-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="245e3896-4cf7-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="30f039ea-4cf8-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 690.0, 427.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-13.0, 0.0), (124.5, 24.0)]</val>
+</points>
+<head-connection>
+<ref refid="19539aa5-4cf7-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="0199bcd7-4cf7-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+<item id="271f0c40-4cf7-11eb-a938-8fcfae32d12c" type="FlowItem">
+<diagram>
+<ref refid="745f31ae-4cf6-11eb-a938-8fcfae32d12c"/>
+</diagram>
+<subject>
+<ref refid="30f039eb-4cf8-11eb-a938-8fcfae32d12c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 690.0, 398.0)</val>
+</matrix>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<horizontal>
+<val>0</val>
+</horizontal>
+<points>
+<val>[(-13.0, 0.0), (124.5, -23.0)]</val>
+</points>
+<head-connection>
+<ref refid="19539aa5-4cf7-11eb-a938-8fcfae32d12c"/>
+</head-connection>
+<tail-connection>
+<ref refid="ffcc7941-4cf6-11eb-a938-8fcfae32d12c"/>
+</tail-connection>
+</item>
+</canvas>
+</Diagram>
+<ObjectNode id="77ddf08e-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<name>
+<val>A</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="831af0c9-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="77ddf08f-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</ObjectNode>
+<Activity id="77ddf090-4cf6-11eb-a938-8fcfae32d12c">
+<edge>
+<reflist>
+<ref refid="831af0c9-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="89ac996e-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="937069d0-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="963fb562-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="a40ddebc-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="a72b96ca-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="df83445a-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="f4a1136d-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="f6dc1655-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="1249281f-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="14b025bd-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="1dc5b784-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="20964f50-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="2587791c-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="271f0c41-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e6-4cf8-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e7-4cf8-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e8-4cf8-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e9-4cf8-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039ea-4cf8-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039eb-4cf8-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</edge>
+<name>
+<val>Activity</val>
+</name>
+<node>
+<reflist>
+<ref refid="77ddf08e-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="7afe967e-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="7d1bc77e-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="8ca3561c-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="90f4e8ca-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="9a6e9ba8-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="a909b148-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="aa257fda-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="e48d6b4c-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="ea0a2650-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="f1ecaac8-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="fed0247c-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="ffcc793e-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="ffcc7940-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="0199bcd6-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="19539aa4-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</node>
+<package>
+<ref refid="745f31ad-4cf6-11eb-a938-8fcfae32d12c"/>
+</package>
+</Activity>
+<ObjectNode id="7afe967e-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<name>
+<val>B</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="89ac996e-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="7afe967f-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</ObjectNode>
+<MergeNode id="7d1bc77e-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="831af0c9-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="89ac996e-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<name>
+<val></val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="963fb564-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e6-4cf8-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e7-4cf8-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="7d1bc77f-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</MergeNode>
+<ObjectFlow id="831af0c9-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="831af0c8-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="77ddf08e-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="7d1bc77e-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ObjectFlow>
+<ObjectFlow id="89ac996e-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="881bfd38-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="7afe967e-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="7d1bc77e-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ObjectFlow>
+<ObjectNode id="8ca3561c-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="937069d0-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e6-4cf8-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<name>
+<val>C</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="a40ddebc-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="8ca3561d-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</ObjectNode>
+<ObjectNode id="90f4e8ca-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="963fb562-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e7-4cf8-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<name>
+<val>D</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="a72b96ca-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="90f4e8cb-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</ObjectNode>
+<ObjectFlow id="937069d0-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<source>
+<ref refid="963fb563-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="8ca3561c-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ObjectFlow>
+<ObjectFlow id="963fb562-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<source>
+<ref refid="963fb563-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="90f4e8ca-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ObjectFlow>
+<DecisionNode id="963fb563-4cf6-11eb-a938-8fcfae32d12c">
+<incoming>
+<reflist>
+<ref refid="963fb564-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<outgoing>
+<reflist>
+<ref refid="937069d0-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="963fb562-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+</DecisionNode>
+<ObjectFlow id="963fb564-4cf6-11eb-a938-8fcfae32d12c">
+<source>
+<ref refid="7d1bc77e-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="963fb563-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ObjectFlow>
+<JoinNode id="9a6e9ba8-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="a40ddebc-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="a72b96ca-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<name>
+<val>NewJoinNode</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="df83445a-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="9a6e9ba9-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</JoinNode>
+<ObjectFlow id="a40ddebc-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="a25334aa-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="8ca3561c-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="9a6e9ba8-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ObjectFlow>
+<ObjectFlow id="a72b96ca-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="a5c53d68-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="90f4e8ca-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="9a6e9ba8-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ObjectFlow>
+<ObjectNode id="a909b148-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="df83445a-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<name>
+<val>E</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="a909b149-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</ObjectNode>
+<ObjectNode id="aa257fda-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<name>
+<val>F</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="aa257fdb-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</ObjectNode>
+<ObjectFlow id="df83445a-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="de036614-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="9a6e9ba8-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="a909b148-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ObjectFlow>
+<Action id="e48d6b4c-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<name>
+<val>G</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="f4a1136d-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="e48d6b4d-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</Action>
+<Action id="ea0a2650-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<name>
+<val>H</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="f6dc1655-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="ea0a2651-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</Action>
+<MergeNode id="f1ecaac8-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="f4a1136d-4cf6-11eb-a938-8fcfae32d12c"/>
+<ref refid="f6dc1655-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<name>
+<val></val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="14b025bf-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e8-4cf8-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e9-4cf8-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="f1ecaac9-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</MergeNode>
+<ControlFlow id="f4a1136d-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="f4a1136c-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="e48d6b4c-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="f1ecaac8-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<ControlFlow id="f6dc1655-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="f6dc1654-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="ea0a2650-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="f1ecaac8-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<Action id="fed0247c-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="1249281f-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e8-4cf8-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<name>
+<val>I</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="1dc5b784-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="fed0247d-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</Action>
+<Action id="ffcc793e-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="14b025bd-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039e9-4cf8-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<name>
+<val>J</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="20964f50-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="ffcc793f-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</Action>
+<Action id="ffcc7940-4cf6-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="271f0c41-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039eb-4cf8-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<name>
+<val>K</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="ffcc7941-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</Action>
+<Action id="0199bcd6-4cf7-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="2587791c-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039ea-4cf8-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<name>
+<val>L</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="0199bcd7-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</Action>
+<ControlFlow id="1249281f-4cf7-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<source>
+<ref refid="14b025be-4cf7-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="fed0247c-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<ControlFlow id="14b025bd-4cf7-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<source>
+<ref refid="14b025be-4cf7-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="ffcc793e-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<DecisionNode id="14b025be-4cf7-11eb-a938-8fcfae32d12c">
+<incoming>
+<reflist>
+<ref refid="14b025bf-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<outgoing>
+<reflist>
+<ref refid="1249281f-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="14b025bd-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+</DecisionNode>
+<ControlFlow id="14b025bf-4cf7-11eb-a938-8fcfae32d12c">
+<source>
+<ref refid="f1ecaac8-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="14b025be-4cf7-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<JoinNode id="19539aa4-4cf7-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="1dc5b784-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="20964f50-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<name>
+<val>NewJoinNode</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="271f0c43-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039ea-4cf8-11eb-a938-8fcfae32d12c"/>
+<ref refid="30f039eb-4cf8-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="19539aa5-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+</JoinNode>
+<ControlFlow id="1dc5b784-4cf7-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="1cb700b4-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="fed0247c-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="19539aa4-4cf7-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<ControlFlow id="20964f50-4cf7-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="1fa4eeb2-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="ffcc793e-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="19539aa4-4cf7-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<ControlFlow id="2587791c-4cf7-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<source>
+<ref refid="271f0c42-4cf7-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="0199bcd6-4cf7-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<ControlFlow id="271f0c41-4cf7-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<source>
+<ref refid="271f0c42-4cf7-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="ffcc7940-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<ForkNode id="271f0c42-4cf7-11eb-a938-8fcfae32d12c">
+<incoming>
+<reflist>
+<ref refid="271f0c43-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</incoming>
+<outgoing>
+<reflist>
+<ref refid="2587791c-4cf7-11eb-a938-8fcfae32d12c"/>
+<ref refid="271f0c41-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</outgoing>
+</ForkNode>
+<ControlFlow id="271f0c43-4cf7-11eb-a938-8fcfae32d12c">
+<source>
+<ref refid="19539aa4-4cf7-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="271f0c42-4cf7-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<ObjectFlow id="30f039e6-4cf8-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="92799c54-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="7d1bc77e-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="8ca3561c-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ObjectFlow>
+<ObjectFlow id="30f039e7-4cf8-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="95217af8-4cf6-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="7d1bc77e-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="90f4e8ca-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ObjectFlow>
+<ControlFlow id="30f039e8-4cf8-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="1249281e-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="f1ecaac8-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="fed0247c-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<ControlFlow id="30f039e9-4cf8-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="14b025bc-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="f1ecaac8-4cf6-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="ffcc793e-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<ControlFlow id="30f039ea-4cf8-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="245e3896-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="19539aa4-4cf7-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="0199bcd6-4cf7-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+<ControlFlow id="30f039eb-4cf8-11eb-a938-8fcfae32d12c">
+<activity>
+<ref refid="77ddf090-4cf6-11eb-a938-8fcfae32d12c"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="271f0c40-4cf7-11eb-a938-8fcfae32d12c"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="19539aa4-4cf7-11eb-a938-8fcfae32d12c"/>
+</source>
+<target>
+<ref refid="ffcc7940-4cf6-11eb-a938-8fcfae32d12c"/>
+</target>
+</ControlFlow>
+</gaphor>

--- a/test-models/simple-items.gaphor
+++ b/test-models/simple-items.gaphor
@@ -26,15 +26,18 @@
 </package>
 <canvas>
 <item id="DCE:6719E9C4-3A1D-11DC-8B61-000D93868322" type="Line">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 336.0, 113.0)</val>
-</matrix>
-<orthogonal>
-<val>0</val>
-</orthogonal>
+<diagram>
+<ref refid="DCE:658E851A-3A1D-11DC-8B61-000D93868322"/>
+</diagram>
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 336.0, 113.0)</val>
+</matrix>
 <points>
 <val>[(0.0, 0.0), (93.0, -2.0), (87.0, 83.0)]</val>
 </points>

--- a/test-models/simple-items.gaphor
+++ b/test-models/simple-items.gaphor
@@ -47,11 +47,14 @@
 <val>(1.0, 0.0, 0.0, 1.0, 215.0, 121.0)</val>
 </matrix>
 <width>
-<val>97.0</val>
+<val>96.0</val>
 </width>
 <height>
-<val>74.0</val>
+<val>71.0</val>
 </height>
+<diagram>
+<ref refid="DCE:658E851A-3A1D-11DC-8B61-000D93868322"/>
+</diagram>
 </item>
 <item id="DCE:68ECCFB2-3A1D-11DC-8B61-000D93868322" type="Ellipse">
 <matrix>
@@ -63,6 +66,9 @@
 <height>
 <val>60.0</val>
 </height>
+<diagram>
+<ref refid="DCE:658E851A-3A1D-11DC-8B61-000D93868322"/>
+</diagram>
 </item>
 </canvas>
 </Diagram>

--- a/tests/test_issue_gaphas.py
+++ b/tests/test_issue_gaphas.py
@@ -22,8 +22,8 @@ def sanitizer_service(event_manager):
 
 
 @pytest.fixture(autouse=True)
-def undo_manager(event_manager):
-    return UndoManager(event_manager)
+def undo_manager(event_manager, element_factory):
+    return UndoManager(event_manager, element_factory)
 
 
 def test_remove_class_with_association(create, diagram, element_factory, event_manager):

--- a/tests/test_multiple_associations.py
+++ b/tests/test_multiple_associations.py
@@ -84,8 +84,8 @@ def test_delete_copied_associations(class_and_association_with_copy, event_manag
     assert a.subject.memberEnd[1].type
     assert a.subject.memberEnd[0].type is c.subject
     assert a.subject.memberEnd[1].type is c.subject
-    assert a.subject.memberEnd[0] is a.head_end.subject
-    assert a.subject.memberEnd[1] is a.tail_end.subject
+    assert a.subject.memberEnd[0] is a.head_subject
+    assert a.subject.memberEnd[1] is a.tail_subject
     assert a.subject.memberEnd[0] in a.subject.memberEnd[1].type.ownedAttribute
 
     # Delete the copy and all is fine
@@ -97,8 +97,8 @@ def test_delete_copied_associations(class_and_association_with_copy, event_manag
     assert a.subject.memberEnd[1].type
     assert a.subject.memberEnd[0].type is c.subject
     assert a.subject.memberEnd[1].type is c.subject
-    assert a.subject.memberEnd[0] is a.head_end.subject
-    assert a.subject.memberEnd[1] is a.tail_end.subject
+    assert a.subject.memberEnd[0] is a.head_subject
+    assert a.subject.memberEnd[1] is a.tail_subject
     assert a.subject.memberEnd[0] in a.subject.memberEnd[1].type.ownedAttribute
 
 
@@ -110,8 +110,8 @@ def test_delete_original_association(class_and_association_with_copy, event_mana
     assert aa.subject.memberEnd[1].type
     assert aa.subject.memberEnd[0].type is c.subject
     assert aa.subject.memberEnd[1].type is c.subject
-    assert aa.subject.memberEnd[0] is aa.head_end.subject
-    assert aa.subject.memberEnd[1] is aa.tail_end.subject
+    assert aa.subject.memberEnd[0] is aa.head_subject
+    assert aa.subject.memberEnd[1] is aa.tail_subject
     assert aa.subject.memberEnd[0] in aa.subject.memberEnd[1].type.ownedAttribute
 
     # Now, when the original is deleted, the model is changed and made invalid
@@ -123,6 +123,6 @@ def test_delete_original_association(class_and_association_with_copy, event_mana
     assert aa.subject.memberEnd[1].type
     assert aa.subject.memberEnd[0].type is c.subject
     assert aa.subject.memberEnd[1].type is c.subject
-    assert aa.subject.memberEnd[0] is aa.head_end.subject
-    assert aa.subject.memberEnd[1] is aa.tail_end.subject
+    assert aa.subject.memberEnd[0] is aa.head_subject
+    assert aa.subject.memberEnd[1] is aa.tail_subject
     assert aa.subject.memberEnd[0] in aa.subject.memberEnd[1].type.ownedAttribute

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -5,8 +5,9 @@ import pytest
 from gaphor import UML
 from gaphor.application import Application
 from gaphor.core import Transaction
+from gaphor.core.modeling import Diagram
 from gaphor.diagram.tests.fixtures import connect
-from gaphor.UML.classes import AssociationItem, ClassItem
+from gaphor.UML.classes import AssociationItem, ClassItem, GeneralizationItem
 
 
 @pytest.fixture
@@ -38,7 +39,7 @@ def undo_manager(session):
 
 def test_class_association_undo_redo(event_manager, element_factory, undo_manager):
     with Transaction(event_manager):
-        diagram = element_factory.create(UML.Diagram)
+        diagram = element_factory.create(Diagram)
 
     assert 0 == len(diagram.connections.solver.constraints)
 
@@ -94,7 +95,7 @@ def test_class_association_undo_redo(event_manager, element_factory, undo_manage
 def test_diagram_item_can_undo_(event_manager, element_factory, undo_manager, caplog):
     caplog.set_level(logging.INFO)
     with Transaction(event_manager):
-        diagram = element_factory.create(UML.Diagram)
+        diagram = element_factory.create(Diagram)
 
     with Transaction(event_manager):
         cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
@@ -111,7 +112,7 @@ def test_diagram_item_should_not_end_up_in_element_factory(
     event_manager, element_factory, undo_manager
 ):
     with Transaction(event_manager):
-        diagram = element_factory.create(UML.Diagram)
+        diagram = element_factory.create(Diagram)
 
     with Transaction(event_manager):
         cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
@@ -126,7 +127,7 @@ def test_deleted_diagram_item_should_not_end_up_in_element_factory(
     event_manager, element_factory, undo_manager
 ):
     with Transaction(event_manager):
-        diagram = element_factory.create(UML.Diagram)
+        diagram = element_factory.create(Diagram)
         cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
     with Transaction(event_manager):
@@ -146,7 +147,7 @@ def test_undo_should_not_cause_warnings(
 ):
     caplog.set_level(logging.INFO)
     with Transaction(event_manager):
-        diagram = element_factory.create(UML.Diagram)
+        diagram = element_factory.create(Diagram)
 
     with Transaction(event_manager):
         diagram.create(ClassItem, subject=element_factory.create(UML.Class))
@@ -156,4 +157,70 @@ def test_undo_should_not_cause_warnings(
     undo_manager.undo_transaction()
 
     assert not diagram.ownedPresentation
+    assert not caplog.records
+
+
+def test_can_undo_connected_generalization(
+    event_manager, element_factory, undo_manager, caplog
+):
+    caplog.set_level(logging.INFO)
+    with Transaction(event_manager):
+        diagram: Diagram = element_factory.create(Diagram)
+        general = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+        specific = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+
+    with Transaction(event_manager):
+        generalization = diagram.create(GeneralizationItem)
+        connect(generalization, generalization.head, general)
+        connect(generalization, generalization.tail, specific)
+
+    assert not caplog.records
+
+    undo_manager.undo_transaction()
+
+    assert not list(diagram.select(GeneralizationItem))
+    assert not caplog.records
+
+    undo_manager.redo_transaction()
+    new_generalization_item = next(diagram.select(GeneralizationItem))
+    new_generalization = next(element_factory.select(UML.Generalization))
+
+    assert len(list(diagram.select(GeneralizationItem))) == 1
+    assert len(element_factory.lselect(UML.Generalization)) == 1
+    assert new_generalization_item.subject is new_generalization
+    assert not caplog.records
+
+
+def test_can_undo_connected_association(
+    event_manager, element_factory, undo_manager, caplog
+):
+    caplog.set_level(logging.INFO)
+    with Transaction(event_manager):
+        diagram: Diagram = element_factory.create(Diagram)
+        parent = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+        child = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+
+    with Transaction(event_manager):
+        association = diagram.create(AssociationItem)
+        connect(association, association.head, parent)
+        connect(association, association.tail, child)
+
+    assert not caplog.records
+
+    undo_manager.undo_transaction()
+
+    assert not list(diagram.select(AssociationItem))
+    assert not caplog.records
+
+    undo_manager.redo_transaction()
+    new_association_item = next(diagram.select(AssociationItem))
+    new_association = next(element_factory.select(UML.Association))
+
+    assert len(list(diagram.select(AssociationItem))) == 1
+    assert len(element_factory.lselect(UML.Association)) == 1
+
+    assert len(new_association.memberEnd) == 2
+    assert new_association_item.subject is new_association
+    assert new_association_item.head_subject
+    assert new_association_item.tail_subject
     assert not caplog.records

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -81,7 +81,7 @@ def test_class_association_undo_redo(event_manager, element_factory, undo_manage
 
         undo_manager.undo_transaction()
 
-        assert 14 == len(diagram.connections.solver.constraints)
+        assert 13 == len(diagram.connections.solver.constraints)
 
         assert ci1 == get_connected(a.head)
         assert ci2 == get_connected(a.tail)

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -81,10 +81,10 @@ def test_class_association_undo_redo(event_manager, element_factory, undo_manage
 
         undo_manager.undo_transaction()
 
-        assert 13 == len(diagram.connections.solver.constraints)
+        assert 14 == len(diagram.connections.solver.constraints)
 
         assert ci1 == get_connected(a.head)
-        assert ci2 == get_connected(a.tail)
+        assert ci2.id == get_connected(a.tail).id
 
         undo_manager.redo_transaction()
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [X] Feature
- ~Code style update (formatting, local variables)~
- [X] Refactoring (no functional changes, no api changes)
-  ~Documentation content changes~

### What is the current behavior?

Undo behavior is a bit broken when using Gaphas 3.

I ran into some trouble that made be decide to recreate elements, instead of reusing them, not sure what that was though. Recreating elements does render Gaphas' state recorder useless.

If we drop the state recorder, new events have to be created for:
- handle (position) changes
- matrix updates
- connect/disconnect
- line splitting and merging

Issue Number: #585 

### What is the new behavior?

- [X] Undo manager stores undo data using element id's, not the element itself.
- [X]  Fix ObjectNodeItem's show ordering property
- [X] Elements and diagram items are recreated on undo/redo, instead of reused.
- [X] No longer use Gaphas' `state` module
  - [X] Fix update behavior for matrix and Handle updates -> special "reversible events"
  - [X] Special events for connect and disconnect
  - [X] Special events for split and merge of line segments
  - [x] Only handle/position updates are allowed to happen outside of a transaction (due to constraint solving)
  - [x] All handles are watched for state changes
- [X] ElementDispatcher no longer catches exceptions thrown from handlers
- [X] attribute and association properties revert their state when an exception is raised from a handler
- [X] Diagram can not be updated on a Presentation (because constraints are connected to the diagram's Connections instance)
- [X] Simple items (line, box, ellipse) inherit from LinePresentation and ElementPresentation now -> reduce code
- [x] Issue: Undo manager does not play well with the UML Sanitizer service -> bypass sanitizer when undoing a transaction?
- [X] Diagram item state is not properly restores (after paste item ends up in top-left corner) -> should save values  of old item. When an item is removed, no updates for matrix, handles, etc. are recorded. Hence, they should be stored on the undo event.
- [x] Remove concept of "transient" model elements. This does not play well with undo.
