### PR TITLE
Allow spaces in attribute and operation name and type

### DIFF
--- a/gaphor/UML/tests/test_umlfmt.py
+++ b/gaphor/UML/tests/test_umlfmt.py
@@ -31,7 +31,7 @@ def add_tag_is_foo_metadata_field(e, factory):
     "text,formatted_text",
     [
         ("", ""),
-        ("not an attribute===foobar", "+ not an attribute===foobar"),
+        ("an attribute===foobar", "+ an attribute = ==foobar"),
         ("myattr", "+ myattr"),
         ("myattr:int", "+ myattr: int"),
         ("- myattr:int[3]", "- myattr: int[3]"),
@@ -60,7 +60,8 @@ def test_attribute_with_applied_stereotype(factory):
     "text,name_part, mult_part",
     [
         ("", "", ""),
-        ("not an association end[3]", "+ not an association end[3]", ""),
+        ("errorous (name)[3]", "+ errorous (name)[3]", ""),
+        ("association end with spaces[3]", "+ association end with spaces", "3"),
         ("myattr", "+ myattr", ""),
         ("myattr[0..1]", "+ myattr", "0..1"),
         ("- myattr[0..1]", "- myattr", "0..1"),

--- a/gaphor/UML/tests/test_umllex.py
+++ b/gaphor/UML/tests/test_umllex.py
@@ -69,6 +69,16 @@ def test_parse_property_complex(factory):
     assert '"aap"' == a.defaultValue
 
 
+def test_parse_property_with_space_in_name(factory):
+    a = factory.create(UML.Property)
+
+    parse(a, "+ name with space : str")
+
+    assert "public" == a.visibility
+    assert "name with space" == a.name
+    assert "str" == a.typeValue
+
+
 def test_parse_property_invalid(factory):
     """Test parsing property with invalid syntax."""
     a = factory.create(UML.Property)
@@ -127,10 +137,10 @@ def test_parse_association_end_derived_end(factory):
     a = factory.create(UML.Association)
     p = factory.create(UML.Property)
     p.association = a
-    parse(p, "-/end[*] { mytag}")
+    parse(p, "-/end name[*] { mytag}")
     assert "private" == p.visibility
     assert p.isDerived
-    assert "end" == p.name
+    assert "end name" == p.name
     assert not p.typeValue
     assert not p.lowerValue
     assert "*" == p.upperValue
@@ -197,6 +207,14 @@ def test_parse_operation_1_param(factory):
     assert "a" == o.formalParameter[0].name
     assert "node" == o.formalParameter[0].typeValue
     assert o.formalParameter[0].defaultValue is None
+
+
+def test_parse_operation_with_spaces(factory):
+    o = factory.create(UML.Operation)
+    parse(o, "- name with space (param with space: some node ): double")
+    assert "name with space" == o.name
+    assert "param with space" == o.formalParameter[0].name
+    assert "some node" == o.formalParameter[0].typeValue
 
 
 def test_parse_operation_invalid_syntax(factory):

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -20,14 +20,14 @@ vis_subpat = r"\s*(?P<vis>[-+#])?"
 derived_subpat = r"\s*(?P<derived>/)?"
 
 # name (required) ::= name
-name_subpat = r"\s*(?P<name>[a-zA-Z_]\w*)"
+name_subpat = r"\s*(?P<name>[a-zA-Z_]\w*( +\w+)*)"
 
 # Multiplicity ::= '[' [mult_l ..] mult_u ']'
 mult_subpat = r"\s*(\[\s*((?P<mult_l>[0-9]+)\s*\.\.)?\s*(?P<mult_u>([0-9]+|\*))\s*\])?"
 multa_subpat = r"\s*(\[?((?P<mult_l>[0-9]+)\s*\.\.)?\s*(?P<mult_u>([0-9]+|\*))\]?)?"
 
 # Type and multiplicity (optional) ::= ':' type
-type_subpat = r"\s*(:\s*(?P<type>\w+))?"
+type_subpat = r"\s*(:\s*(?P<type>[a-zA-Z_]\w*( +\w+)*))?"
 
 # default value (optional) ::= '=' default
 default_subpat = r"\s*(=\s*(?P<default>\S+))?"


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Spaces are not allowed in attribute and operation names and types.

Issue Number: #601

### What is the new behavior?

Spaces can be used in attributes and operations. Expressions like this can be parsed:

```
+ attr with spaces: some type
operation with spaces(some param : some type) : some return type
```

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
