### PR TITLE
Connect start of line when placed inside an element

### DIFF
--- a/gaphor/diagram/diagramtools/grayout.py
+++ b/gaphor/diagram/diagramtools/grayout.py
@@ -44,3 +44,7 @@ class GrayOutLineHandleMove(LineHandleMove):
         sink = super().glue(pos, distance)
         self.view.selection.dropzone_item = sink and sink.item
         return sink
+
+    def connect(self, pos: Pos) -> None:
+        super().connect(pos)
+        self.view.selection.dropzone_item = None

--- a/gaphor/diagram/diagramtools/placement.py
+++ b/gaphor/diagram/diagramtools/placement.py
@@ -92,11 +92,12 @@ def on_drag_update(gesture, offset_x, offset_y, placement_state):
 
 def on_drag_end(gesture, offset_x, offset_y, placement_state):
     if placement_state.moving:
+        view = gesture.get_widget()
         _, x, y = gesture.get_start_point()
+        item = placement_state.moving.item
         placement_state.moving.stop_move((x + offset_x, y + offset_y))
-        placement_state.event_manager.handle(
-            DiagramItemPlaced(placement_state.moving.item)
-        )
+        connect_opposite_handle(view, item, x, y, placement_state.handle_index)
+        placement_state.event_manager.handle(DiagramItemPlaced(item))
 
 
 def new_item_factory(


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

The line end is connected to an element when placed on a diagram. The line head is not.

Issue Number: N/A

### What is the new behavior?

Also connect line head after a line is connected.

### Other information

To reproduce:
1. create 2 classes
2. Draw an Association from the center of class 1 to the center of class 2
3. The association should connect on both sides.