### PR TITLE
Define Gtk version once, at the top of the package

### DIFF
--- a/gaphor/__init__.py
+++ b/gaphor/__init__.py
@@ -1,3 +1,7 @@
-#!/usr/bin/env python
-
 """Gaphor is the simple modeling tool written in Python."""
+
+import gi
+
+gi.require_version("PangoCairo", "1.0")
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")

--- a/gaphor/diagram/__init__.py
+++ b/gaphor/diagram/__init__.py
@@ -1,9 +1,3 @@
 """The diagram package contains items (to be drawn on the diagram), tools (used
 for interacting with the diagram) and interfaces (used for adapting the
 diagram)."""
-
-import gi
-
-gi.require_version("PangoCairo", "1.0")
-gi.require_version("Gtk", "3.0")
-gi.require_version("Gdk", "3.0")

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -2,18 +2,13 @@
 
 from typing import Tuple, Union
 
-import gi
 from gaphas.canvas import instant_cairo_context
 from gaphas.geometry import Rectangle
 from gaphas.painter.boundingboxpainter import CairoBoundingBoxContext
 from gaphas.painter.freehand import FreeHandCairoContext
+from gi.repository import GLib, Pango, PangoCairo
 
 from gaphor.core.styling import FontStyle, FontWeight, Style, TextAlign, TextDecoration
-
-# fmt: off
-gi.require_version('PangoCairo', '1.0')  # noqa: isort:skip
-from gi.repository import GLib, Pango, PangoCairo  # noqa: isort:skip
-# fmt: on
 
 
 class Layout:

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -7,21 +7,13 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-import gi
+from gi.repository import Gdk, Gio, GLib, Gtk
 
 from gaphor.application import Application
 from gaphor.core import event_handler
 from gaphor.event import ApplicationShutdown, SessionCreated
 from gaphor.ui.actiongroup import apply_application_actions
-
-# fmt: off
-gi.require_version("Gtk", "3.0")  # noqa: isort:skip
-gi.require_version("Gdk", "3.0")  # noqa: isort:skip
-from gi.repository import GLib, Gdk, Gio, Gtk  # noqa: isort:skip
 from gaphor.ui.macosshim import macos_init
-
-# fmt: on
-
 
 APPLICATION_ID = "org.gaphor.Gaphor"
 

--- a/gaphor/ui/actiongroup.py
+++ b/gaphor/ui/actiongroup.py
@@ -1,13 +1,8 @@
 from typing import NamedTuple
 
-import gi
+from gi.repository import Gio, GLib, Gtk
 
 from gaphor.abc import ActionProvider
-
-# fmt: off
-gi.require_version("Gtk", "3.0")  # noqa: isort:skip
-from gi.repository import Gio, GLib, Gtk  # noqa: isort:skip
-# fmt: on
 
 
 class ActionGroup(NamedTuple):


### PR DESCRIPTION
This suppresses all GI warnings related to undefined versions.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [x] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

GTK and friends are required in a lot of places. Basically the application and it's scripts (such as `gaphorconvert`) can not run without GTK being available.

Issue Number: N/A

### What is the new behavior?

Set GTK, GDK and PangoCairo version once, on top level.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

```
$ grep -r "from gi.repository" *
gaphor/ui/questiondialog.py:from gi.repository import Gtk
gaphor/ui/gidlethread.py:from gi.repository import GLib
gaphor/ui/actiongroup.py:from gi.repository import Gio, GLib, Gtk  # noqa: isort:skip
gaphor/ui/recentfiles.py:from gi.repository import Gio, GLib, Gtk
gaphor/ui/namespaceview.py:from gi.repository import Gdk, Gtk, Pango
gaphor/ui/__init__.py:from gi.repository import GLib, Gdk, Gio, Gtk  # noqa: isort:skip
gaphor/ui/mainwindow.py:from gi.repository import Gdk, Gio, GLib, Gtk
gaphor/ui/layout.py:from gi.repository import Gtk
gaphor/ui/statuswindow.py:from gi.repository import Gdk, GLib, Gtk, Pango
gaphor/ui/tests/test_recentfiles.py:from gi.repository import GLib
gaphor/ui/tests/test_handletool.py:from gi.repository import Gtk
gaphor/ui/tests/test_actiongroup.py:from gi.repository import Gio, GLib
gaphor/ui/notification.py:from gi.repository import GLib
gaphor/ui/elementeditor.py:from gi.repository import GLib, Gtk
gaphor/ui/namespace.py:from gi.repository import Gdk, Gio, GLib, Gtk
gaphor/ui/errorhandler.py:from gi.repository import Gtk
gaphor/ui/namespacemodel.py:from gi.repository import Gtk
gaphor/ui/macosshim.py:    from gi.repository import GtkosxApplication
gaphor/ui/diagrams.py:from gi.repository import Gtk
gaphor/ui/menufragment.py:from gi.repository import Gio
gaphor/ui/diagrampage.py:from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
gaphor/ui/filemanager.py:from gi.repository import Gtk
gaphor/ui/toolbox.py:from gi.repository import Gdk, GLib, Gtk
gaphor/ui/filedialog.py:from gi.repository import Gtk
gaphor/SysML/propertypages.py:from gi.repository import Gtk
gaphor/diagram/inlineeditors.py:from gi.repository import Gdk, Gtk
gaphor/diagram/propertypages.py:from gi.repository import Gdk, Gtk
gaphor/diagram/diagramtools/shortcut.py:from gi.repository import Gdk, GLib, Gtk
gaphor/diagram/diagramtools/txtool.py:from gi.repository import Gtk
gaphor/diagram/diagramtools/tests/test_txtool.py:from gi.repository import Gtk
gaphor/diagram/diagramtools/textedit.py:from gi.repository import Gdk, Gtk
gaphor/diagram/diagramtools/placement.py:from gi.repository import Gtk
gaphor/diagram/diagramtools/dropzone.py:from gi.repository import Gtk
gaphor/diagram/tests/test_diagramtools.py:from gi.repository import Gdk
gaphor/diagram/text.py:from gi.repository import GLib, Pango, PangoCairo  # noqa: isort:skip
gaphor/diagram/general/generalpropertypages.py:from gi.repository import Gtk
gaphor/diagram/general/generaleditors.py:from gi.repository import Gtk
gaphor/UML/profiles/tests/test_stereotypepage.py:from gi.repository import Gtk
gaphor/UML/profiles/tests/test_metaclasspropertypage.py:from gi.repository import Gtk
gaphor/UML/profiles/metaclasspropertypage.py:from gi.repository import Gtk
gaphor/UML/profiles/stereotypepropertypages.py:from gi.repository import Gtk
gaphor/UML/classes/tests/test_propertypages.py:from gi.repository import Gtk
gaphor/UML/classes/classespropertypages.py:from gi.repository import Gtk
gaphor/UML/tests/test_diagrampage_tools.py:from gi.repository import Gtk
gaphor/UML/actions/partitionpage.py:from gi.repository import Gtk
gaphor/services/properties.py:from gi.repository import GLib
gaphor/services/helpservice/__init__.py:from gi.repository import Gtk
gaphor/services/copyservice.py:from gi.repository import Gdk, Gtk
gaphor/plugins/console/console.py:from gi.repository import Gdk, Gtk, Pango
gaphor/plugins/console/consolewindow.py:from gi.repository import Gdk, Gtk
gaphor/plugins/console/tests/test_console.py:from gi.repository import Gdk, Gtk
tests/test_load_model.py:from gi.repository import GLib, Gtk
```