### PR TITLE
Speed up rendering by determining gray-out colors upfront

### DIFF
--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -157,7 +157,7 @@ class StyledItem:
         assert item.diagram
         self.item = item
         self.diagram = item.diagram
-        self.selection = selection or gaphas.view.Selection()
+        self.selection = selection
 
     def name(self) -> str:
         return removesuffix(type(self.item).__name__, "Item").lower()
@@ -185,10 +185,14 @@ class StyledItem:
         item = self.item
         selection = self.selection
         return (
-            "active" if item in selection.selected_items else "",
-            "focus" if item is selection.focused_item else "",
-            "hover" if item is selection.hovered_item else "",
-            "drop" if item is selection.dropzone_item else "",
+            (
+                "active" if item in selection.selected_items else "",
+                "focus" if item is selection.focused_item else "",
+                "hover" if item is selection.hovered_item else "",
+                "drop" if item is selection.dropzone_item else "",
+            )
+            if selection
+            else ()
         )
 
 

--- a/gaphor/diagram/propertypages.glade
+++ b/gaphor/diagram/propertypages.glade
@@ -585,6 +585,7 @@ Use -/= to move items up or down.</property>
               <object class="GtkTextView" id="comment">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="wrap_mode">word</property>
               </object>
             </child>
           </object>


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [x] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Rendering of diagrams is relatively slow. It turns out the `push_group()` and `paint_with_alpha()` methods of Cairo take quite some resources.

```
         23215400 function calls (22809223 primitive calls) in 31.074 seconds

   Ordered by: internal time
   List reduced from 3143 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1   11.381   11.381   31.075   31.075 Gio.py:40(run)
     3123    3.144    0.001    3.144    0.001 {method 'paint_with_alpha' of 'cairo.Context' objects}
     3123    2.648    0.001    2.648    0.001 {method 'push_group' of 'cairo.Context' objects}
        1    1.335    1.335    1.342    1.342 Gtk.py:577(run)
     8297    1.120    0.000    1.723    0.000 elementfactory.py:114(<genexpr>)
  9382800    0.885    0.000    0.933    0.000 {built-in method builtins.isinstance}
1662486/1619526    0.513    0.000    0.679    0.000 {built-in method builtins.getattr}
      364    0.513    0.001    0.513    0.001 {method 'paint' of 'cairo.Context' objects}
      229    0.373    0.002    8.888    0.039 gtkview.py:389(update_back_buffer)
```

Issue Number: N/A

### What is the new behavior?

Calculate the gray-out colors upfront.

```
         22959648 function calls (22561010 primitive calls) in 22.434 seconds

   Ordered by: internal time
   List reduced from 3144 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1   10.349   10.349   22.435   22.435 Gio.py:40(run)
        1    1.224    1.224    1.230    1.230 Gtk.py:577(run)
     8475    1.057    0.000    1.686    0.000 elementfactory.py:114(<genexpr>)
  9446278    0.827    0.000    0.870    0.000 {built-in method builtins.isinstance}
      380    0.626    0.002    0.626    0.002 {method 'paint' of 'cairo.Context' objects}
      237    0.444    0.002    2.774    0.012 gtkview.py:389(update_back_buffer)
```

Drawing the diagram reduced from 0.039s to 0.012s.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
