### PR TITLE
Drop and gray out style

### DIFF
--- a/docs/style_sheets.md
+++ b/docs/style_sheets.md
@@ -132,8 +132,6 @@ family, size, weight.
                         ``background-color: rgb(255, 255, 255);`` |br|
                         ``background-color: hsl(130, 95%, 10%);``
 ``color``               Color used for lines
-``highlight-color``     Color used for highlight, e.g. when dragging
-                        an item over another item.
 ``text-color``          Color for text
 ======================= =======================================
 ```

--- a/docs/style_sheets.md
+++ b/docs/style_sheets.md
@@ -133,6 +133,8 @@ family, size, weight.
                         ``background-color: hsl(130, 95%, 10%);``
 ``color``               Color used for lines
 ``text-color``          Color for text
+``opacity``             Color opacity factor (``0.0`` - ``1.0``),
+                        applied to all colors
 ======================= =======================================
 ```
 

--- a/docs/style_sheets.md
+++ b/docs/style_sheets.md
@@ -145,7 +145,7 @@ family, size, weight.
 ```eval_rst
 ======================= =======================================
 ``font-family``         A single font name (e.g. ``sans``, ``serif``, ``courier``)
-``font-size``           Font size: ``font-size: 14``
+``font-size``           An absolute size (e.g. ``14``) or a size value (e.g. ``small``)
 ``font-style``          Either ``normal`` or ``italic``
 ``font-weight``         Either ``normal`` or ``bold``
 ``text-align``          Either ``left``, ``center``, ``right``
@@ -161,6 +161,8 @@ family, size, weight.
 
 * `font-family` can be only one font name, not a list of (fallback) names, as
   is used for HTML.
+* `font-size` can be a number or [CSS absolute-size values](https://drafts.csswg.org/css-fonts-3/#font-size-prop).
+  Only the values `x-small`, `small`, `medium`, `large` and `x-large` are supported.
 
 ### Drawing and spacing
 

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -74,7 +74,7 @@ class RequirementItem(ElementPresentation[Requirement], Classified):
                 ),
                 Text(
                     text=lambda: from_package_str(self),
-                    style={"font-size": 10, "min-width": 0, "min-height": 0},
+                    style={"font-size": "x-small", "min-width": 0, "min-height": 0},
                 ),
                 style={"padding": (12, 4, 12, 4)},
             ),

--- a/gaphor/UML/actions/action.py
+++ b/gaphor/UML/actions/action.py
@@ -58,7 +58,7 @@ class SendSignalActionItem(ElementPresentation, Named):
         cr.line_to(0, height)
         cr.close_path()
 
-        stroke(context, highlight=True)
+        stroke(context)
 
 
 @represents(UML.AcceptEventAction)
@@ -89,4 +89,4 @@ class AcceptEventActionItem(ElementPresentation, Named):
         cr.line_to(d, height / 2)
         cr.close_path()
 
-        stroke(context, highlight=True)
+        stroke(context)

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -12,14 +12,7 @@ from gaphor import UML
 from gaphor.core.modeling import Presentation
 from gaphor.core.modeling.properties import association, relation_one
 from gaphor.diagram.presentation import ElementPresentation, HandlePositionUpdate, Named
-from gaphor.diagram.shapes import (
-    Box,
-    EditableText,
-    IconBox,
-    Text,
-    draw_highlight,
-    stroke,
-)
+from gaphor.diagram.shapes import Box, EditableText, IconBox, Text, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.modelfactory import stereotypes_str
 
@@ -71,7 +64,6 @@ def draw_initial_node(_box, context, _bounding_box):
     r = 10
     d = r * 2
     path_ellipse(cr, r, r, d, d)
-    draw_highlight(context)
     cr.set_line_width(0.01)
     cr.fill()
 
@@ -117,7 +109,7 @@ def draw_activity_final_node(_box, context, _bounding_box):
     path_ellipse(cr, r, r, d, d)
     cr.set_line_width(0.01)
     cr.set_line_width(2)
-    stroke(context, highlight=True)
+    stroke(context)
 
     d = inner_radius * 2
     path_ellipse(cr, r, r, d, d)
@@ -155,7 +147,7 @@ def draw_flow_final_node(_box, context, _bounding_box):
     r = 10
     d = r * 2
     path_ellipse(cr, r, r, d, d)
-    stroke(context, highlight=True)
+    stroke(context)
 
     dr = (1 - math.sin(math.pi / 4)) * r
     cr.move_to(dr, dr)
@@ -201,7 +193,7 @@ def draw_decision_node(_box, context, _bounding_box):
     cr.line_to(r2, r * 2)
     cr.line_to(0, r)
     cr.close_path()
-    stroke(context, highlight=True)
+    stroke(context)
 
 
 @represents(UML.ForkNode)
@@ -288,7 +280,6 @@ class ForkNodeItem(Presentation[UML.ForkNode], HandlePositionUpdate, Named):
         h1, h2 = self._handles
         cr.move_to(h1.pos.x, h1.pos.y)
         cr.line_to(h2.pos.x, h2.pos.y)
-        draw_highlight(context)
         cr.stroke()
 
     def point(self, x, y):

--- a/gaphor/UML/actions/partition.py
+++ b/gaphor/UML/actions/partition.py
@@ -7,7 +7,7 @@ from gaphor.core.modeling import DrawContext
 from gaphor.core.modeling.properties import association
 from gaphor.core.styling import VerticalAlign
 from gaphor.diagram.presentation import ElementPresentation
-from gaphor.diagram.shapes import Box, cairo_state, draw_highlight, stroke
+from gaphor.diagram.shapes import Box, cairo_state, stroke
 from gaphor.diagram.support import represents
 from gaphor.diagram.text import Layout
 
@@ -97,7 +97,6 @@ class PartitionItem(ElementPresentation):
         cr.line_to(0, 0)
         cr.line_to(bounding_box.width, 0)
         cr.line_to(bounding_box.width, bounding_box.height)
-        draw_highlight(context)
         cr.move_to(0, bounding_box.height)
         cr.line_to(0, HEADER_HEIGHT)
         cr.line_to(0 + bounding_box.width, HEADER_HEIGHT)

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -337,7 +337,7 @@ class AssociationEnd:
         self._name_layout = Layout("")
         self._mult_layout = Layout("")
 
-        self._inline_style: Style = {"font-size": 10}
+        self._inline_style: Style = {"font-size": "x-small"}
 
     name_bounds = property(lambda s: s._name_bounds)
 

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -20,14 +20,13 @@ from gaphas.geometry import Rectangle, distance_rectangle_point
 
 from gaphor import UML
 from gaphor.core.modeling.properties import association, attribute
-from gaphor.core.styling import Style
+from gaphor.core.styling import Style, merge_styles
 from gaphor.diagram.presentation import LinePresentation, Named
 from gaphor.diagram.shapes import (
     Box,
     EditableText,
     Text,
     cairo_state,
-    combined_style,
     draw_default_head,
     draw_default_tail,
     stroke,
@@ -385,7 +384,7 @@ class AssociationEnd:
 
         p1 is the line end and p2 is the last but one point of the line.
         """
-        style = combined_style(context.style, self._inline_style)
+        style = merge_styles(context.style, self._inline_style)
         ofs = 5
 
         dx = float(p2[0]) - float(p1[0])

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -272,10 +272,10 @@ def draw_tail_composite(context):
     at association tail."""
     cr = context.cairo
     cr.line_to(20, 0)
-    stroke(context, highlight=True)
+    stroke(context)
     _draw_diamond(cr)
     cr.fill_preserve()
-    stroke(context, highlight=True)
+    stroke(context)
 
 
 def draw_head_shared(context):

--- a/gaphor/UML/classes/dependency.py
+++ b/gaphor/UML/classes/dependency.py
@@ -103,5 +103,5 @@ class DependencyItem(LinePresentation, Named):
             cr.move_to(15, -6)
             cr.line_to(0, 0)
             cr.line_to(15, 6)
-            stroke(context, highlight=True)
+            stroke(context)
         cr.move_to(0, 0)

--- a/gaphor/UML/classes/generalization.py
+++ b/gaphor/UML/classes/generalization.py
@@ -26,5 +26,5 @@ class GeneralizationItem(LinePresentation):
         cr.line_to(15, -10)
         cr.line_to(15, 10)
         cr.close_path()
-        stroke(context, highlight=True)
+        stroke(context)
         cr.move_to(15, 0)

--- a/gaphor/UML/classes/implementation.py
+++ b/gaphor/UML/classes/implementation.py
@@ -48,5 +48,5 @@ class ImplementationItem(LinePresentation, Named):
             cr.line_to(15, -10)
             cr.line_to(15, 10)
             cr.close_path()
-            stroke(context, highlight=True)
+            stroke(context)
             cr.move_to(15, 0)

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -303,7 +303,7 @@ class InterfaceItem(ElementPresentation, Classified):
                 ),
                 Text(
                     text=lambda: from_package_str(self),
-                    style={"font-size": 10, "min-width": 0, "min-height": 0},
+                    style={"font-size": "x-small", "min-width": 0, "min-height": 0},
                 ),
                 style={"padding": (12, 4, 12, 4)},
             ),

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -86,7 +86,7 @@ class ClassItem(ElementPresentation[UML.Class], Classified):
                 ),
                 Text(
                     text=lambda: from_package_str(self),
-                    style={"font-size": 10, "min-width": 0, "min-height": 0},
+                    style={"font-size": "x-small", "min-width": 0, "min-height": 0},
                 ),
                 style={"padding": (12, 4, 12, 4)},
             ),

--- a/gaphor/UML/classes/package.py
+++ b/gaphor/UML/classes/package.py
@@ -27,7 +27,7 @@ class PackageItem(ElementPresentation, Named):
             ),
             Text(
                 text=lambda: from_package_str(self),
-                style={"font-size": 10, "min-width": 0, "min-height": 0},
+                style={"font-size": "x-small", "min-width": 0, "min-height": 0},
             ),
             style={"min-width": 50, "min-height": 70, "padding": (25, 10, 5, 10)},
             draw=draw_package,

--- a/gaphor/UML/classes/package.py
+++ b/gaphor/UML/classes/package.py
@@ -52,4 +52,4 @@ def draw_package(box, context, bounding_box):
         cr.line_to(w, h)
         cr.line_to(w, y)
         cr.line_to(o, y)
-        stroke(context, highlight=True)
+        stroke(context)

--- a/gaphor/UML/components/node.py
+++ b/gaphor/UML/components/node.py
@@ -17,14 +17,7 @@ module.
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.presentation import Classified, ElementPresentation
-from gaphor.diagram.shapes import (
-    Box,
-    EditableText,
-    Text,
-    VerticalAlign,
-    draw_highlight,
-    stroke,
-)
+from gaphor.diagram.shapes import Box, EditableText, Text, VerticalAlign, stroke
 from gaphor.diagram.support import represents
 from gaphor.diagram.text import FontWeight
 from gaphor.UML.classes.stereotype import stereotype_compartments
@@ -89,8 +82,6 @@ def draw_node(box, context, bounding_box):
     h = bounding_box.height
 
     cr.rectangle(0, 0, w, h)
-
-    draw_highlight(context)
 
     cr.move_to(0, 0)
     cr.line_to(d, -d)

--- a/gaphor/UML/interactions/interaction.py
+++ b/gaphor/UML/interactions/interaction.py
@@ -44,7 +44,7 @@ class InteractionItem(ElementPresentation, Named):
 def draw_interaction(box, context, bounding_box):
     cr = context.cairo
     cr.rectangle(0, 0, bounding_box.width, bounding_box.height)
-    stroke(context, highlight=True)
+    stroke(context)
     # draw pentagon
     w, h = box.sizes[0]
     h2 = h / 2.0

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -207,7 +207,7 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
         """
         cr = context.cairo
         cr.rectangle(0, 0, self.width, self.height)
-        stroke(context, highlight=True)
+        stroke(context)
 
         if (
             context.hovered
@@ -222,7 +222,7 @@ class LifelineItem(ElementPresentation[UML.Lifeline], Named):
                 top = self.lifetime.top
                 cr.move_to(top.pos.x, top.pos.y)
                 cr.line_to(bottom.pos.x, bottom.pos.y)
-                stroke(context, highlight=True)
+                stroke(context)
 
             # draw destruction event
             if self.is_destroyed:

--- a/gaphor/UML/interactions/message.py
+++ b/gaphor/UML/interactions/message.py
@@ -167,7 +167,7 @@ class MessageItem(LinePresentation[UML.Message], Named):
             cr.set_dash((7.0, 5.0), 0)
 
         cr.line_to(0, 0)
-        stroke(context, highlight=True)
+        stroke(context)
 
         cr.set_dash((), 0)
 
@@ -184,7 +184,7 @@ class MessageItem(LinePresentation[UML.Message], Named):
         else:
             self._draw_arrow(cr)
 
-        stroke(context, highlight=True)
+        stroke(context)
 
     def _draw_decorating_arrow(self, cr, inverted=False):
         with cairo_state(cr):

--- a/gaphor/UML/states/finalstate.py
+++ b/gaphor/UML/states/finalstate.py
@@ -37,7 +37,7 @@ def draw_final_state(box, context, bounding_box):
     path_ellipse(cr, r, r, d, d)
     cr.set_line_width(0.01)
     cr.set_line_width(2)
-    stroke(context, highlight=True)
+    stroke(context)
 
     stroke_color = context.style["color"]
     if stroke_color:

--- a/gaphor/UML/states/pseudostates.py
+++ b/gaphor/UML/states/pseudostates.py
@@ -7,14 +7,7 @@ from gaphas.util import path_ellipse
 
 from gaphor import UML
 from gaphor.diagram.presentation import ElementPresentation
-from gaphor.diagram.shapes import (
-    Box,
-    EditableText,
-    IconBox,
-    Text,
-    draw_highlight,
-    stroke,
-)
+from gaphor.diagram.shapes import Box, EditableText, IconBox, Text, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.modelfactory import stereotypes_str
 from gaphor.UML.states.state import VertexItem
@@ -59,7 +52,6 @@ def draw_initial_pseudostate(box, context, bounding_box):
     r = 10
     d = r * 2
     path_ellipse(cr, r, r, d, d)
-    draw_highlight(context)
     cr.set_line_width(0.01)
     cr.fill()
 
@@ -69,7 +61,7 @@ def draw_history_pseudostate(box, context, bounding_box):
     r = 15
     d = r * 2
     path_ellipse(cr, r, r, d, d)
-    stroke(context, highlight=True)
+    stroke(context)
 
     cr.move_to(12, 10)
     cr.line_to(12, 20)

--- a/gaphor/UML/usecases/actor.py
+++ b/gaphor/UML/usecases/actor.py
@@ -67,4 +67,4 @@ def draw_actor(box, context, bounding_box):
     cr.move_to(0, (HEAD + NECK + BODY + ARM) * fy)
     cr.line_to(ARM * fx, (HEAD + NECK + BODY) * fy)
     cr.line_to(ARM * 2 * fx, (HEAD + NECK + BODY + ARM) * fy)
-    stroke(context, fill=False, highlight=True)
+    stroke(context, fill=False)

--- a/gaphor/UML/usecases/usecase.py
+++ b/gaphor/UML/usecases/usecase.py
@@ -40,4 +40,4 @@ def draw_usecase(box, context, bounding_box):
 
     cr.move_to(bounding_box.width, ry)
     path_ellipse(cr, rx, ry, bounding_box.width, bounding_box.height)
-    stroke(context, highlight=True)
+    stroke(context)

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -248,10 +248,7 @@ class Diagram(PackageableElement):
 
     def style(self, node: StyleNode) -> Style:
         style_sheet = self.styleSheet
-        return {
-            **FALLBACK_STYLE,  # type: ignore[misc]
-            **(style_sheet.match(node) if style_sheet else {}),
-        }
+        return style_sheet.match(node) if style_sheet else FALLBACK_STYLE
 
     def save(self, save_func):
         """Apply the supplied save function to this diagram and the canvas."""

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -190,6 +190,7 @@ class StyledItem:
                 "focus" if item is selection.focused_item else "",
                 "hover" if item is selection.hovered_item else "",
                 "drop" if item is selection.dropzone_item else "",
+                "disabled" if item in selection.grayed_out_items else "",
             )
             if selection
             else ()

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -33,7 +33,6 @@ FALLBACK_STYLE: Style = {
     "color": (0, 0, 0, 1),
     "font-family": "sans",
     "font-size": 14,
-    "highlight-color": (0, 0, 1, 0.4),
     "line-width": 2,
     "padding": (0, 0, 0, 0),
 }

--- a/gaphor/core/modeling/stylesheet.py
+++ b/gaphor/core/modeling/stylesheet.py
@@ -19,6 +19,10 @@ DEFAULT_STYLE_SHEET = textwrap.dedent(
      padding: 0;
     }
 
+    *:disabled {
+     color: #bbbbbb;
+    }
+
     diagram {
      background-color: white;
      line-style: normal;

--- a/gaphor/core/modeling/stylesheet.py
+++ b/gaphor/core/modeling/stylesheet.py
@@ -24,9 +24,7 @@ SYSTEM_STYLE_SHEET = textwrap.dedent(
     }
 
     *:disabled {
-     text-color: #b0b0b0;
-     color: #b0b0b0;
-     backgound-color: transparent;
+     opacity: 0.5;
     }
 
     diagram {

--- a/gaphor/core/modeling/stylesheet.py
+++ b/gaphor/core/modeling/stylesheet.py
@@ -14,13 +14,19 @@ DEFAULT_STYLE_SHEET = textwrap.dedent(
      color: black;
      font-family: sans;
      font-size: 14;
-     highlight-color: rgba(0, 0, 255, 0.4);
      line-width: 2;
      padding: 0;
     }
 
+    *:drop {
+     color: hsl(210, 100%, 25%);
+     line-width: 3;
+    }
+
     *:disabled {
-     color: #bbbbbb;
+     text-color: #b0b0b0;
+     color: #b0b0b0;
+     backgound-color: transparent;
     }
 
     diagram {

--- a/gaphor/core/modeling/stylesheet.py
+++ b/gaphor/core/modeling/stylesheet.py
@@ -7,7 +7,7 @@ from gaphor.core.modeling.event import AttributeUpdated
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import CompiledStyleSheet, Style, StyleNode
 
-DEFAULT_STYLE_SHEET = textwrap.dedent(
+SYSTEM_STYLE_SHEET = textwrap.dedent(
     """\
     * {
      background-color: transparent;
@@ -31,7 +31,20 @@ DEFAULT_STYLE_SHEET = textwrap.dedent(
 
     diagram {
      background-color: white;
-     line-style: normal;
+    }
+    """
+)
+
+DEFAULT_STYLE_SHEET = textwrap.dedent(
+    """\
+    * {
+     background-color: transparent;
+     color: black;
+     font-family: sans;
+     font-size: 14;
+    }
+
+    diagram {
      /* line-style: sloppy 0.3; */
     }
     """
@@ -49,7 +62,9 @@ class StyleSheet(Element):
     styleSheet: attribute[str] = attribute("styleSheet", str, DEFAULT_STYLE_SHEET)
 
     def compile_style_sheet(self) -> None:
-        self._compiled_style_sheet = CompiledStyleSheet(self.styleSheet)
+        self._compiled_style_sheet = CompiledStyleSheet(
+            SYSTEM_STYLE_SHEET, self.styleSheet
+        )
 
     def match(self, node: StyleNode) -> Style:
         return self._compiled_style_sheet.match(node)

--- a/gaphor/core/modeling/tests/test_diagram_style.py
+++ b/gaphor/core/modeling/tests/test_diagram_style.py
@@ -3,7 +3,12 @@ import pytest
 
 from gaphor.core.eventmanager import EventManager
 from gaphor.core.modeling import ElementFactory, Presentation, StyleSheet
-from gaphor.core.modeling.diagram import Diagram, StyledDiagram, StyledItem
+from gaphor.core.modeling.diagram import (
+    FALLBACK_STYLE,
+    Diagram,
+    StyledDiagram,
+    StyledItem,
+)
 
 
 @pytest.fixture
@@ -52,3 +57,17 @@ def test_style_sheet_has_default_style():
     style_sheet = StyleSheet()
 
     assert "* {" in style_sheet.styleSheet
+
+
+def test_system_style_sheet_covers_fallback_styles(diagram):
+    style_sheet = StyleSheet()
+    style_sheet.styleSheet = ""
+    style_sheet.compile_style_sheet()
+
+    item = diagram.create(DemoItem)
+    node = StyledItem(item)
+
+    style = style_sheet.match(node)
+
+    for prop, value in FALLBACK_STYLE.items():
+        assert style[prop] == value

--- a/gaphor/core/styling/__init__.py
+++ b/gaphor/core/styling/__init__.py
@@ -7,7 +7,11 @@ from typing import Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Un
 import tinycss2
 from typing_extensions import Literal, Protocol
 
-from gaphor.core.styling.declarations import parse_declarations
+from gaphor.core.styling.declarations import (
+    FONT_SIZE_VALUES,
+    number,
+    parse_declarations,
+)
 from gaphor.core.styling.parser import SelectorError
 from gaphor.core.styling.properties import (
     Color,
@@ -46,8 +50,15 @@ Rule = Union[
 
 def merge_styles(*styles: Style) -> Style:
     style = Style()
+    abs_font_size = None
     for s in styles:
+        font_size = s.get("font-size")
+        if font_size and isinstance(font_size, number):
+            abs_font_size = font_size
         style.update(s)
+
+    if abs_font_size and style["font-size"] in FONT_SIZE_VALUES:
+        style["font-size"] = abs_font_size * FONT_SIZE_VALUES[style["font-size"]]  # type: ignore[index]
 
     if "opacity" in style:
         opacity = style["opacity"]

--- a/gaphor/core/styling/__init__.py
+++ b/gaphor/core/styling/__init__.py
@@ -43,7 +43,7 @@ Rule = Union[
 ]
 
 
-def merge_styles(styles) -> Style:
+def merge_styles(*styles) -> Style:
     style: Style = {}
     for s in styles:
         style.update(s)
@@ -67,7 +67,7 @@ class CompiledStyleSheet:
             ),
             key=MATCH_SORT_KEY,
         )
-        return merge_styles(decl for _, _, decl in results)
+        return merge_styles(*(decl for _, _, decl in results))
 
 
 def parse_style_sheets(*css: str) -> Iterator[Rule]:

--- a/gaphor/core/styling/declarations.py
+++ b/gaphor/core/styling/declarations.py
@@ -108,10 +108,18 @@ def parse_color(prop, value):
     "line-width",
     "vertical-spacing",
     "border-radius",
-    "opacity",
 )
 def parse_positive_number(prop, value) -> Optional[Number]:
-    if isinstance(value, number) and value > 0:
+    if isinstance(value, number) and value >= 0:
+        return value
+    return None
+
+
+@declarations.register(
+    "opacity",
+)
+def parse_factor(prop, value) -> Optional[Number]:
+    if isinstance(value, number) and 0 <= value <= 1:
         return value
     return None
 

--- a/gaphor/core/styling/declarations.py
+++ b/gaphor/core/styling/declarations.py
@@ -85,7 +85,7 @@ def _clip_color(c):
     return c
 
 
-@declarations.register("background-color", "color", "highlight-color", "text-color")
+@declarations.register("background-color", "color", "text-color")
 def parse_color(prop, value):
     try:
         color = tinycss2.color3.parse_color(value)

--- a/gaphor/core/styling/declarations.py
+++ b/gaphor/core/styling/declarations.py
@@ -13,6 +13,14 @@ from gaphor.core.styling.properties import (
     VerticalAlign,
 )
 
+FONT_SIZE_VALUES = {
+    "x-small": 3 / 4,
+    "small": 8 / 9,
+    "medium": 1,
+    "large": 6 / 5,
+    "x-large": 3 / 2,
+}
+
 
 class _Declarations:
     """Convert raw CSS declarations into Gaphor styling declarations."""
@@ -100,7 +108,6 @@ def parse_color(prop, value):
     "line-width",
     "vertical-spacing",
     "border-radius",
-    "font-size",
     "opacity",
 )
 def parse_positive_number(prop, value) -> Optional[Number]:
@@ -115,6 +122,15 @@ def parse_string(prop, value) -> Optional[str]:
         return value
     elif value:
         return " ".join(str(v) for v in value)
+    return None
+
+
+@declarations.register("font-size")
+def parse_font_size(prop, value) -> Union[None, int, float, str]:
+    if isinstance(value, number) and value > 0:
+        return value
+    if isinstance(value, str) and value in FONT_SIZE_VALUES:
+        return value
     return None
 
 

--- a/gaphor/core/styling/declarations.py
+++ b/gaphor/core/styling/declarations.py
@@ -101,6 +101,7 @@ def parse_color(prop, value):
     "vertical-spacing",
     "border-radius",
     "font-size",
+    "opacity",
 )
 def parse_positive_number(prop, value) -> Optional[Number]:
     if isinstance(value, number) and value > 0:

--- a/gaphor/core/styling/properties.py
+++ b/gaphor/core/styling/properties.py
@@ -54,6 +54,7 @@ Style = TypedDict(
         "line-width": Number,
         "min-width": Number,
         "min-height": Number,
+        "opacity": Number,
         "text-decoration": TextDecoration,
         "text-align": TextAlign,
         "text-color": Color,

--- a/gaphor/core/styling/properties.py
+++ b/gaphor/core/styling/properties.py
@@ -50,7 +50,6 @@ Style = TypedDict(
         "font-size": Number,
         "font-style": FontStyle,
         "font-weight": FontWeight,
-        "highlight-color": Color,
         "line-style": Number,
         "line-width": Number,
         "min-width": Number,

--- a/gaphor/core/styling/properties.py
+++ b/gaphor/core/styling/properties.py
@@ -47,7 +47,7 @@ Style = TypedDict(
         "dash-style": Sequence[Number],
         "padding": Padding,
         "font-family": str,
-        "font-size": Number,
+        "font-size": Union[int, float, str],
         "font-style": FontStyle,
         "font-weight": FontWeight,
         "line-style": Number,

--- a/gaphor/core/styling/selectors.py
+++ b/gaphor/core/styling/selectors.py
@@ -111,7 +111,7 @@ def compile_pseudo_class_selector(selector: parser.PseudoClassSelector):
     name = selector.name
     if name == "empty":
         return lambda el: not next(el.children(), 0)
-    elif name in ("root", "hover", "focus", "active", "drop"):
+    elif name in ("root", "hover", "focus", "active", "drop", "disabled"):
         return lambda el: name in el.state()
     else:
         raise parser.SelectorError("Unknown pseudo-class", name)

--- a/gaphor/core/styling/tests/test_cascading.py
+++ b/gaphor/core/styling/tests/test_cascading.py
@@ -1,0 +1,49 @@
+import pytest
+
+from gaphor.core.styling import merge_styles
+
+
+def test_merge_opacity():
+    style = merge_styles({"color": (0, 0, 1, 1), "opacity": 0.7})
+
+    assert style["color"] == (0, 0, 1, 0.7)
+
+
+def test_merge_opacity_with_transparent():
+    style = merge_styles({"color": (0, 0, 0, 0), "opacity": 0.7})
+
+    assert style["color"] == (0, 0, 0, 0)
+
+
+def test_merge_opacity_with_transparency():
+    style = merge_styles({"color": (0, 0, 0, 0.8), "opacity": 0.5})
+
+    assert style["color"] == (0, 0, 0, 0.4)
+
+
+@pytest.mark.parametrize(
+    "font_size,factor",
+    [
+        ["x-small", 3 / 4],
+        ["small", 8 / 9],
+        ["medium", 1],
+        ["large", 6 / 5],
+        ["x-large", 3 / 2],
+    ],
+)
+def test_font_size(font_size, factor):
+    style = merge_styles({"font-size": 10}, {"font-size": font_size})
+
+    assert style["font-size"] == 10 * factor
+
+
+def test_final_font_size_is_a_number():
+    style = merge_styles({"font-size": 10}, {"font-size": "x-small"}, {"font-size": 24})
+
+    assert style["font-size"] == 24
+
+
+def test_font_size_override_with_relative_size():
+    style = merge_styles({"font-size": 10}, {"font-size": 24}, {"font-size": "x-small"})
+
+    assert style["font-size"] == 24 * 3 / 4

--- a/gaphor/core/styling/tests/test_css.py
+++ b/gaphor/core/styling/tests/test_css.py
@@ -222,6 +222,26 @@ def test_line_style(css_value, result):
     assert props.get("line-style") == result
 
 
+@pytest.mark.parametrize(
+    "css_value,result",
+    [
+        [0.5, 0.5],
+        [0, 0.0],
+        [1, 1.0],
+        [-0.1, None],
+        [1.1, None],
+        ["wrong", None],
+    ],
+)
+def test_opacity(css_value, result):
+    css = f"mytype {{ opacity: {css_value} }}"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    props = compiled_style_sheet.match(Node("mytype"))
+
+    assert props.get("opacity") == result
+
+
 def test_broken_line_style():
     # diagram css is missing the closing bracket
     css = "diagram { line-style: sloppy * { }"

--- a/gaphor/core/styling/tests/test_css.py
+++ b/gaphor/core/styling/tests/test_css.py
@@ -150,18 +150,34 @@ def test_compiled_style_sheet():
     """
 
     compiled_style_sheet = CompiledStyleSheet(css)
-
     props = compiled_style_sheet.match(Node("mytype"))
 
     assert props.get("font-family") == "sans"
     assert props.get("font-size") == 42
 
 
+@pytest.mark.parametrize(
+    "font_size", ["x-small", "small", "medium", "large", "x-large"]
+)
+def test_relative_font_size(font_size):
+    css = f"* {{ font-size: {font_size} }}"
+
+    props = first_decl_block(css)
+    assert props.get("font-size") == font_size
+
+
+@pytest.mark.parametrize("font_size", ["foo", "xx-small", "xx-large"])
+def test_faulty_font_size(font_size):
+    css = f"* {{ font-size: {font_size} }}"
+
+    props = first_decl_block(css)
+    assert props.get("font-size") is None
+
+
 def test_empty_compiled_style_sheet():
     css = ""
 
     compiled_style_sheet = CompiledStyleSheet(css)
-
     props = compiled_style_sheet.match(Node("mytype"))
 
     assert props == {}
@@ -171,7 +187,6 @@ def test_color():
     css = "mytype { color: #00ff00 }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-
     props = compiled_style_sheet.match(Node("mytype"))
 
     assert props.get("color") == (0, 1, 0, 1)
@@ -181,7 +196,6 @@ def test_color_typing_in_progress():
     css = "mytype { color: # }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-
     props = compiled_style_sheet.match(Node("mytype"))
 
     assert props.get("color") is None
@@ -203,7 +217,6 @@ def test_line_style(css_value, result):
     css = f"mytype {{ line-style: {css_value} }}"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-
     props = compiled_style_sheet.match(Node("mytype"))
 
     assert props.get("line-style") == result
@@ -214,6 +227,6 @@ def test_broken_line_style():
     css = "diagram { line-style: sloppy * { }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-
     props = compiled_style_sheet.match(Node("mytype"))
+
     assert props.get("line-style") is None

--- a/gaphor/core/styling/tests/test_selector.py
+++ b/gaphor/core/styling/tests/test_selector.py
@@ -208,7 +208,7 @@ def test_empty_pseudo_selector_with_name():
 
 @pytest.mark.parametrize(
     "state",
-    ["root", "hover", "focus", "active", "drop"],
+    ["root", "hover", "focus", "active", "drop", "disabled"],
 )
 def test_hovered_pseudo_selector(state):
 

--- a/gaphor/diagram/general/comment.py
+++ b/gaphor/diagram/general/comment.py
@@ -46,4 +46,4 @@ class CommentItem(ElementPresentation):
         line_to(x, h)
         line_to(w, h)
         line_to(w, y + ear)
-        stroke(context, highlight=True)
+        stroke(context)

--- a/gaphor/diagram/painter.py
+++ b/gaphor/diagram/painter.py
@@ -20,24 +20,6 @@ from gaphor.diagram.selection import Selection
 TOLERANCE = 0.8
 
 
-def maybe_gray_out(style, item, selection):
-    """Update color properties if item is grayed out."""
-    if item not in selection.grayed_out_items:
-        return style
-
-    for style_prop in (
-        "background-color",
-        "color",
-        "highlight-color",
-        "text-color",
-    ):
-        value = style.get(style_prop)
-        if value is not None:
-            style[style_prop] = value[:3] + (value[3] * 0.4,)
-
-    return style
-
-
 class ItemPainter:
     def __init__(self, selection: Optional[Selection] = None):
         self.selection: Selection = selection or Selection()
@@ -45,9 +27,7 @@ class ItemPainter:
     def paint_item(self, item, cairo):
         selection = self.selection
         diagram = item.diagram
-        style = maybe_gray_out(
-            diagram.style(StyledItem(item, selection)), item, selection
-        )
+        style = diagram.style(StyledItem(item, selection))
 
         cairo.save()
         try:

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -14,8 +14,7 @@ from gaphor.core.modeling.diagram import Diagram
 from gaphor.core.modeling.event import RevertibeEvent
 from gaphor.core.modeling.presentation import Presentation, S
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import Style
-from gaphor.diagram.shapes import combined_style
+from gaphor.core.styling import Style, merge_styles
 from gaphor.diagram.text import TextAlign, text_point_at_line
 
 
@@ -245,7 +244,7 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
             finally:
                 cr.restore()
 
-        style = combined_style(context.style, self.style)
+        style = merge_styles(context.style, self.style)
         context = replace(context, style=style)
 
         cr = context.cairo

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -249,7 +249,7 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
         context = replace(context, style=style)
 
         cr = context.cairo
-        cr.set_line_width(self.line_width)
+        cr.set_line_width(style["line-width"])
         cr.set_dash(style.get("dash-style", ()), 0)
         stroke = style["color"]
         if stroke:

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -15,7 +15,7 @@ from gaphor.core.modeling.event import RevertibeEvent
 from gaphor.core.modeling.presentation import Presentation, S
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import Style
-from gaphor.diagram.shapes import combined_style, draw_highlight
+from gaphor.diagram.shapes import combined_style
 from gaphor.diagram.text import TextAlign, text_point_at_line
 
 
@@ -263,7 +263,6 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
 
         draw_line_end(handles[-1], handles[-2], self.draw_tail)
 
-        draw_highlight(context)
         cr.stroke()
 
         for shape, rect in (

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -28,7 +28,7 @@ def combined_style(item_style: Style, inline_style: Style = {}) -> Style:
     return {**item_style, **inline_style}  # type: ignore[misc]
 
 
-def stroke(context: DrawContext, fill=True, highlight=False):
+def stroke(context: DrawContext, fill=True):
     style = context.style
     cr = context.cairo
     fill_color = style.get("background-color")
@@ -36,9 +36,6 @@ def stroke(context: DrawContext, fill=True, highlight=False):
         with cairo_state(cr):
             cr.set_source_rgba(*fill_color)
             cr.fill_preserve()
-
-    if highlight:
-        draw_highlight(context)
 
     with cairo_state(cr):
         stroke = style.get("color")
@@ -72,8 +69,6 @@ def draw_border(box, context: DrawContext, bounding_box: Rectangle):
 
     cr.close_path()
 
-    draw_highlight(context)
-
     stroke(context)
 
 
@@ -84,16 +79,6 @@ def draw_top_separator(box: Box, context: DrawContext, bounding_box: Rectangle):
     cr.line_to(x + w, y)
 
     stroke(context, fill=False)
-
-
-def draw_highlight(context: DrawContext):
-    if not context.dropzone:
-        return
-    with cairo_state(context.cairo) as cr:
-        highlight_color = context.style["highlight-color"]
-        cr.set_source_rgba(*highlight_color)
-        cr.set_line_width(cr.get_line_width() + 3.8)
-        cr.stroke_preserve()
 
 
 class Box:

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -7,7 +7,7 @@ from typing import Callable, List, Optional, Tuple
 from gaphas.geometry import Rectangle
 
 from gaphor.core.modeling import DrawContext, UpdateContext
-from gaphor.core.styling import Style, TextAlign, VerticalAlign
+from gaphor.core.styling import Style, TextAlign, VerticalAlign, merge_styles
 from gaphor.diagram.text import Layout, focus_box_pos
 
 
@@ -21,11 +21,6 @@ class cairo_state:
 
     def __exit__(self, _type, _value, _traceback):
         self._cr.restore()
-
-
-def combined_style(item_style: Style, inline_style: Style = {}) -> Style:
-    """Combine context style and inline styles into one style."""
-    return {**item_style, **inline_style}  # type: ignore[misc]
 
 
 def stroke(context: DrawContext, fill=True):
@@ -113,7 +108,7 @@ class Box:
         return self.children[index]
 
     def size(self, context: UpdateContext):
-        style: Style = combined_style(context.style, self._inline_style)
+        style: Style = merge_styles(context.style, self._inline_style)
         min_width = style.get("min-width", 0)
         min_height = style.get("min-height", 0)
         padding_top, padding_right, padding_bottom, padding_left = style["padding"]
@@ -134,7 +129,7 @@ class Box:
             return min_width, min_height
 
     def draw(self, context: DrawContext, bounding_box: Rectangle):
-        style: Style = combined_style(context.style, self._inline_style)
+        style: Style = merge_styles(context.style, self._inline_style)
         new_context = replace(context, style=style)
         padding_top, padding_right, padding_bottom, padding_left = style["padding"]
         valign = style.get("vertical-align", VerticalAlign.MIDDLE)
@@ -177,7 +172,7 @@ class IconBox:
         self._inline_style = style
 
     def size(self, context: UpdateContext):
-        style = combined_style(context.style, self._inline_style)
+        style = merge_styles(context.style, self._inline_style)
         min_width = style.get("min-width", 0)
         min_height = style.get("min-height", 0)
         padding_top, padding_right, padding_bottom, padding_left = style["padding"]
@@ -221,7 +216,7 @@ class IconBox:
         )
 
     def draw(self, context: DrawContext, bounding_box: Rectangle):
-        style = combined_style(context.style, self._inline_style)
+        style = merge_styles(context.style, self._inline_style)
         new_context = replace(context, style=style)
         padding_top, padding_right, padding_bottom, padding_left = style["padding"]
         x = bounding_box.x + padding_left
@@ -250,7 +245,7 @@ class Text:
             return ""
 
     def size(self, context: UpdateContext):
-        style = combined_style(context.style, self._inline_style)
+        style = merge_styles(context.style, self._inline_style)
         min_w = style.get("min-width", 0)
         min_h = style.get("min-height", 0)
         text_align = style.get("text-align", TextAlign.CENTER)
@@ -278,7 +273,7 @@ class Text:
 
     def draw(self, context: DrawContext, bounding_box: Rectangle):
         """Draw the text, return the location and size."""
-        style = combined_style(context.style, self._inline_style)
+        style = merge_styles(context.style, self._inline_style)
         min_w = max(style.get("min-width", 0), bounding_box.width)
         min_h = max(style.get("min-height", 0), bounding_box.height)
         text_box = self.text_box(style, bounding_box)
@@ -314,7 +309,7 @@ class EditableText(Text):
     def draw(self, context: DrawContext, bounding_box: Rectangle):
         """Draw the editable text."""
         super().draw(context, bounding_box)
-        style = combined_style(context.style, self._inline_style)
+        style = merge_styles(context.style, self._inline_style)
 
         text_box = self.text_box(style, bounding_box)
         text_align = style.get("text-align", TextAlign.CENTER)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

There was special code that dealt with drop hover and grayed out states.

Issue Number: #632 

### What is the new behavior?

All style changes are managed via CSS.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

* Config grayed out (`disabled`) items via CSS
* Add `opacity` CSS property
* Added absolute size values for fonts (`small`, `large`, etc.)
* Add a system style sheet


Items that can be dropped upon now display slightly different, 'cause I removed the `highlight-color` property. Use the `:drop` pseudo selector instead.


