### PR TITLE
Simplify presentation update method

### DIFF
--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -36,9 +36,8 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], HandlePositionUpdate, Named):
         super().__init__(diagram, id)
         self._connections = diagram.connections
 
-        h1 = Handle(connectable=True)
-        self._handles = [h1]
-        self.watch_handle(h1)
+        self._handle = Handle(connectable=True)
+        self.watch_handle(self._handle)
 
         d = self.dimensions()
         top_left = Position(d.x, d.y)
@@ -57,7 +56,7 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], HandlePositionUpdate, Named):
         self.update_shapes()
 
     def handles(self):
-        return self._handles
+        return [self._handle]
 
     def ports(self):
         return self._ports
@@ -72,12 +71,12 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], HandlePositionUpdate, Named):
         self.request_update()
 
     def connected_side(self) -> Optional[str]:
-        cinfo = self._connections.get_connection(self._handles[0])
+        cinfo = self._connections.get_connection(self._handle)
 
         return cinfo.connected.port_side(cinfo.port) if cinfo else None
 
     def dimensions(self):
-        x, y = self._handles[0].pos
+        x, y = self._handle.pos
         return Rectangle(x - 8, y - 8, 16, 16)
 
     def point(self, x, y):
@@ -86,7 +85,7 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], HandlePositionUpdate, Named):
     def save(self, save_func):
         save_func("matrix", tuple(self.matrix))
 
-        c = self._connections.get_connection(self.handles()[0])
+        c = self._connections.get_connection(self._handle)
         if c:
             save_func("connection", c.connected)
 
@@ -103,7 +102,7 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], HandlePositionUpdate, Named):
     def postload(self):
         super().postload()
         if hasattr(self, "_load_connection"):
-            postload_connect(self, self.handles()[0], self._load_connection)
+            postload_connect(self, self._handle, self._load_connection)
             del self._load_connection
 
         self.update_shapes()

--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -108,16 +108,13 @@ class ProxyPortItem(Presentation[sysml.ProxyPort], HandlePositionUpdate, Named):
 
         self.update_shapes()
 
-    def pre_update(self, context):
+    def update(self, context):
         side = self.connected_side()
         if self._last_connected_side != side:
             self._last_connected_side = side
             self.update_shapes()
 
         self.shape.size(context)
-
-    def post_update(self, context):
-        pass
 
     def draw(self, context):
         self.shape.draw(context, self.dimensions())

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -240,9 +240,6 @@ class ForkNodeItem(Presentation[UML.ForkNode], HandlePositionUpdate, Named):
     def ports(self):
         return self._ports
 
-    def update(self, context):
-        pass
-
     def save(self, save_func):
         save_func("matrix", tuple(self.matrix))
         save_func("height", float(self._handles[1].pos.y))

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -240,10 +240,7 @@ class ForkNodeItem(Presentation[UML.ForkNode], HandlePositionUpdate, Named):
     def ports(self):
         return self._ports
 
-    def pre_update(self, context):
-        pass
-
-    def post_update(self, context):
+    def update(self, context):
         pass
 
     def save(self, save_func):

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -254,7 +254,7 @@ class ForkNodeItem(Presentation[UML.ForkNode], HandlePositionUpdate, Named):
             super().load(name, value)
 
     def draw(self, context):
-        h1, h2 = self.handles()
+        h1, h2 = self._handles
         height = h2.pos.y - h1.pos.y
         self.shape.draw(context, Rectangle(0, 0, 1, height))
 

--- a/gaphor/UML/actions/partition.py
+++ b/gaphor/UML/actions/partition.py
@@ -31,7 +31,7 @@ class PartitionItem(ElementPresentation):
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("partition.name")
-        self.watch("partition")
+        self.watch("partition", self.update_partition)
 
     partition = association("partition", UML.ActivityPartition, composite=True)
 
@@ -40,9 +40,10 @@ class PartitionItem(ElementPresentation):
         if self.subject and self.subject not in self.partition:
             self.partition = self.subject
 
-    def pre_update(self, context: DrawContext) -> None:
+    def update_partition(self, context: DrawContext) -> None:
         """Set the min width of all the swimlanes."""
         self.min_width = 150 * len(self.partition)
+        self.request_update()
 
     def draw_swimlanes(
         self, box: Box, context: DrawContext, bounding_box: Rectangle

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -139,12 +139,6 @@ class AssociationItem(LinePresentation[UML.Association], Named):
         """Handle events and update text on association end."""
         for end in (self._head_end, self._tail_end):
             end.set_text()
-        self.request_update()
-
-    def post_update(self, context):
-        """Update the shapes and sub-items of the association."""
-
-        handles = self.handles()
 
         # Update line endings:
         head_subject = self.head_subject
@@ -181,14 +175,7 @@ class AssociationItem(LinePresentation[UML.Association], Named):
             self.draw_head = draw_default_head
             self.draw_tail = draw_default_tail
 
-        # update relationship after self.set calls to avoid circural updates
-        super().post_update(context)
-
-        # Calculate alignment of the head name and multiplicity
-        self._head_end.post_update(context, handles[0].pos, handles[1].pos)
-
-        # Calculate alignment of the tail name and multiplicity
-        self._tail_end.post_update(context, handles[-1].pos, handles[-2].pos)
+        self.request_update()
 
     def point(self, x, y):
         """Returns the distance from the Association to the (mouse) cursor."""
@@ -198,6 +185,15 @@ class AssociationItem(LinePresentation[UML.Association], Named):
 
     def draw(self, context):
         super().draw(context)
+
+        handles = self.handles()
+
+        # Calculate alignment of the head name and multiplicity
+        self._head_end.update_position(context, handles[0].pos, handles[1].pos)
+
+        # Calculate alignment of the tail name and multiplicity
+        self._tail_end.update_position(context, handles[-1].pos, handles[-2].pos)
+
         self._head_end.draw(context)
         self._tail_end.draw(context)
         if self.show_direction:
@@ -376,7 +372,7 @@ class AssociationEnd:
     def get_mult(self):
         return self._mult
 
-    def post_update(self, context, p1, p2):
+    def update_position(self, context, p1, p2):
         """Update label placement for association's name and multiplicity
         label.
 

--- a/gaphor/UML/classes/dependency.py
+++ b/gaphor/UML/classes/dependency.py
@@ -38,7 +38,7 @@ class DependencyItem(LinePresentation, Named):
     """
 
     def __init__(self, diagram, id=None):
-        super().__init__(diagram, id, style={"dash-style": (7.0, 5.0)})
+        super().__init__(diagram, id)
 
         self._dependency_type = UML.Dependency
         # auto_dependency is used by connection logic, not in this class itself
@@ -76,20 +76,18 @@ class DependencyItem(LinePresentation, Named):
             self._dependency_type = self.subject.__class__
         super().postload()
 
-    def connected_to_folded_interface(self):
+    @property
+    def on_folded_interface(self):
         connection = self._connections.get_connection(self.head)
         return (
-            connection
-            and isinstance(connection.port, InterfacePort)
-            and connection.connected.folded != Folded.NONE
+            (
+                connection
+                and isinstance(connection.port, InterfacePort)
+                and connection.connected.folded != Folded.NONE
+            )
+            and "true"
+            or "false"
         )
-
-    def post_update(self, context):
-        super().post_update(context)
-        if self.connected_to_folded_interface():
-            self.style["dash-style"] = ()
-        else:
-            self.style["dash-style"] = (7.0, 5.0)
 
     def set_dependency_type(self, dependency_type):
         self._dependency_type = dependency_type

--- a/gaphor/UML/classes/dependency.py
+++ b/gaphor/UML/classes/dependency.py
@@ -101,5 +101,5 @@ class DependencyItem(LinePresentation, Named):
             cr.move_to(15, -6)
             cr.line_to(0, 0)
             cr.line_to(15, 6)
-            stroke(context)
+            stroke(context, dash=False)
         cr.move_to(0, 0)

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -158,7 +158,9 @@ class InterfaceItem(ElementPresentation, Classified):
     RADIUS_REQUIRED = 14
 
     def __init__(self, diagram, id=None):
-        super().__init__(diagram, id)
+        super().__init__(
+            diagram, id, width=self.RADIUS_PROVIDED * 2, height=self.RADIUS_PROVIDED * 2
+        )
         self._folded = Folded.NONE
         self.side = Side.N
 
@@ -235,15 +237,7 @@ class InterfaceItem(ElementPresentation, Classified):
             else:  # required interface or assembly icon mode
                 icon_size = self.RADIUS_REQUIRED * 2
 
-            self.min_width, self.min_height = icon_size, icon_size
-            self.width, self.height = icon_size, icon_size
-
-            # update only h_se handle - rest of handles should be updated by
-            # constraints
-            h_nw = self._handles[NW]
-            h_se = self._handles[SE]
-            h_se.pos.x = h_nw.pos.x + self.min_width
-            h_se.pos.y = h_nw.pos.y + self.min_height
+            self.min_width = self.min_height = self.width = self.height = icon_size
 
             movable = False
 
@@ -258,7 +252,7 @@ class InterfaceItem(ElementPresentation, Classified):
         doc="Check or set folded notation, see Folded.* enum.",
     )
 
-    def pre_update(self, context):
+    def update_shapes(self, event=None):
         connected_items = [
             c.item for c in self.diagram.connections.get_connections(connected=self)
         ]
@@ -281,10 +275,7 @@ class InterfaceItem(ElementPresentation, Classified):
                 self.folded = Folded.REQUIRED
             else:
                 self.folded = Folded.PROVIDED
-            self.update_shapes(connectors=connectors)
-        super().pre_update(context)
 
-    def update_shapes(self, event=None, connectors=None):
         if self._folded == Folded.NONE:
             self.shape = self.class_shape()
         else:

--- a/gaphor/UML/classes/interfacerealization.py
+++ b/gaphor/UML/classes/interfacerealization.py
@@ -46,5 +46,5 @@ class InterfaceRealizationItem(LinePresentation, Named):
             cr.line_to(15, -10)
             cr.line_to(15, 10)
             cr.close_path()
-            stroke(context)
+            stroke(context, dash=False)
             cr.move_to(15, 0)

--- a/gaphor/UML/classes/interfacerealization.py
+++ b/gaphor/UML/classes/interfacerealization.py
@@ -13,7 +13,7 @@ from gaphor.UML.modelfactory import stereotypes_str
 @represents(UML.InterfaceRealization)
 class InterfaceRealizationItem(LinePresentation, Named):
     def __init__(self, diagram, id=None):
-        super().__init__(diagram, id, style={"dash-style": (7.0, 5.0)})
+        super().__init__(diagram, id)
 
         self.shape_middle = Box(
             Text(
@@ -25,20 +25,18 @@ class InterfaceRealizationItem(LinePresentation, Named):
         self.watch("subject.appliedStereotype.classifier.name")
         self._inline_style: Style = {}
 
-    def connected_to_folded_interface(self):
+    @property
+    def on_folded_interface(self):
         connection = self._connections.get_connection(self.head)
         return (
-            connection
-            and isinstance(connection.port, InterfacePort)
-            and connection.connected.folded != Folded.NONE
+            (
+                connection
+                and isinstance(connection.port, InterfacePort)
+                and connection.connected.folded != Folded.NONE
+            )
+            and "true"
+            or "false"
         )
-
-    def post_update(self, context):
-        super().post_update(context)
-        if self.connected_to_folded_interface():
-            self.style["dash-style"] = ()
-        else:
-            self.style["dash-style"] = (7.0, 5.0)
 
     def draw_head(self, context):
         cr = context.cairo

--- a/gaphor/UML/classes/tests/test_interfaceconnect.py
+++ b/gaphor/UML/classes/tests/test_interfaceconnect.py
@@ -1,81 +1,102 @@
 """Test connections to folded interface."""
 
 from gaphor import UML
+from gaphor.core.modeling import StyleSheet
+from gaphor.core.modeling.diagram import StyledItem
+from gaphor.diagram.tests.fixtures import connect, disconnect
 from gaphor.UML.classes.dependency import DependencyItem
 from gaphor.UML.classes.interface import Folded, InterfaceItem
 from gaphor.UML.classes.interfacerealization import InterfaceRealizationItem
 from gaphor.UML.classes.klass import ClassItem
 
 
-class TestInterfaceRealization:
-    def test_default_line_style(self, case):
-        impl = case.create(InterfaceRealizationItem)
+def test_interface_realization_default_line_style(element_factory, diagram):
+    element_factory.create(StyleSheet)
+    impl = diagram.create(InterfaceRealizationItem)
+    style = diagram.style(StyledItem(impl))
 
-        assert impl.style["dash-style"]
-
-    def test_folded_interface_connection(self, case):
-        """Test connecting implementation to folded interface."""
-        iface = case.create(InterfaceItem, UML.Interface)
-        iface.folded = Folded.PROVIDED
-        impl = case.create(InterfaceRealizationItem)
-
-        case.connect(impl, impl.head, iface)
-        case.diagram.update_now((iface, impl))
-
-        assert not impl.style["dash-style"]
-
-    def test_folded_interface_disconnection(self, case):
-        """Test disconnection implementation from folded interface."""
-        iface = case.create(InterfaceItem, UML.Interface)
-        iface.folded = Folded.PROVIDED
-        impl = case.create(InterfaceRealizationItem)
-
-        case.connect(impl, impl.head, iface)
-        case.disconnect(impl, impl.head)
-        impl.request_update()
-
-        assert impl.style["dash-style"]
+    assert style["dash-style"]
 
 
-class TestDependency:
-    def test_default_line_style(self, case):
-        dep = case.create(DependencyItem)
+def test_interface_realization_folded_interface_connection(element_factory, diagram):
+    """Test connecting implementation to folded interface."""
+    element_factory.create(StyleSheet)
+    iface = diagram.create(InterfaceItem, subject=element_factory.create(UML.Interface))
+    iface.folded = Folded.PROVIDED
+    impl = diagram.create(InterfaceRealizationItem)
 
-        assert dep.style["dash-style"]
+    connect(impl, impl.head, iface)
+    diagram.update_now((iface, impl))
 
-    def test_folded_interface_connection(self, case):
-        """Test connecting dependency to folded interface."""
-        clazz = case.create(ClassItem, UML.Class)
-        iface = case.create(InterfaceItem, UML.Interface)
-        iface.folded = Folded.PROVIDED
-        dep = case.create(DependencyItem)
+    style = diagram.style(StyledItem(impl))
+    assert not style["dash-style"]
 
-        case.connect(dep, dep.head, iface)
-        case.connect(dep, dep.tail, clazz)
-        iface.update_shapes()
-        case.diagram.update_now((clazz, iface, dep))
 
-        assert dep.subject
-        assert not dep.style["dash-style"]
-        assert iface.folded == Folded.REQUIRED
+def test_interface_realization_folded_interface_disconnection(element_factory, diagram):
+    """Test disconnection implementation from folded interface."""
+    element_factory.create(StyleSheet)
+    iface = diagram.create(InterfaceItem, subject=element_factory.create(UML.Interface))
+    iface.folded = Folded.PROVIDED
+    impl = diagram.create(InterfaceRealizationItem)
 
-    def test_folded_interface_disconnection(self, case):
-        """Test disconnection dependency from folded interface."""
-        iface = case.create(InterfaceItem, UML.Interface)
-        iface.folded = Folded.PROVIDED
-        dep = case.create(DependencyItem)
+    connect(impl, impl.head, iface)
+    disconnect(impl, impl.head)
+    impl.request_update()
+    style = diagram.style(StyledItem(impl))
 
-        case.connect(dep, dep.head, iface)
-        case.disconnect(dep, dep.head)
-        dep.request_update()
+    assert style["dash-style"]
 
-        assert dep.style["dash-style"]
-        assert iface.folded == Folded.PROVIDED
 
-    def test_unfolded_interface_connection(self, case):
-        """Test disconnection dependency from unfolded interface."""
-        iface = case.create(InterfaceItem, UML.Interface)
-        dep = case.create(DependencyItem)
+def test_dependency_default_line_style(element_factory, diagram):
+    element_factory.create(StyleSheet)
+    dep = diagram.create(DependencyItem)
+    style = diagram.style(StyledItem(dep))
 
-        case.connect(dep, dep.head, iface)
-        assert (7.0, 5.0) == dep.style["dash-style"]
+    assert style["dash-style"]
+
+
+def test_dependency_folded_interface_connection(element_factory, diagram):
+    """Test connecting dependency to folded interface."""
+    element_factory.create(StyleSheet)
+    clazz = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    iface = diagram.create(InterfaceItem, subject=element_factory.create(UML.Interface))
+    iface.folded = Folded.PROVIDED
+    dep = diagram.create(DependencyItem)
+
+    connect(dep, dep.head, iface)
+    connect(dep, dep.tail, clazz)
+    iface.update_shapes()
+    diagram.update_now((clazz, iface, dep))
+    style = diagram.style(StyledItem(dep))
+
+    assert dep.subject
+    assert not style["dash-style"]
+    assert iface.folded == Folded.REQUIRED
+
+
+def test_dependency_folded_interface_disconnection(element_factory, diagram):
+    """Test disconnection dependency from folded interface."""
+    element_factory.create(StyleSheet)
+    iface = diagram.create(InterfaceItem, subject=element_factory.create(UML.Interface))
+    iface.folded = Folded.PROVIDED
+    dep = diagram.create(DependencyItem)
+
+    connect(dep, dep.head, iface)
+    disconnect(dep, dep.head)
+    dep.request_update()
+    style = diagram.style(StyledItem(dep))
+
+    assert style["dash-style"]
+    assert iface.folded == Folded.PROVIDED
+
+
+def test_dependency_unfolded_interface_connection(element_factory, diagram):
+    """Test disconnection dependency from unfolded interface."""
+    element_factory.create(StyleSheet)
+    iface = diagram.create(InterfaceItem, subject=element_factory.create(UML.Interface))
+    dep = diagram.create(DependencyItem)
+
+    connect(dep, dep.head, iface)
+    style = diagram.style(StyledItem(dep))
+
+    assert (7.0, 5.0) == style["dash-style"]

--- a/gaphor/UML/classes/tests/test_interfaceconnect.py
+++ b/gaphor/UML/classes/tests/test_interfaceconnect.py
@@ -52,7 +52,7 @@ class TestDependency:
 
         case.connect(dep, dep.head, iface)
         case.connect(dep, dep.tail, clazz)
-        iface.request_update()
+        iface.update_shapes()
         case.diagram.update_now((clazz, iface, dep))
 
         assert dep.subject

--- a/gaphor/UML/components/tests/test_connect.py
+++ b/gaphor/UML/components/tests/test_connect.py
@@ -116,7 +116,7 @@ class TestInterfaceConnect:
 
         case.connect(line, line.head, iface)
         case.connect(line, line.tail, comp)
-        iface.request_update()
+        iface.update_shapes()
         case.diagram.update_now((iface, comp, line))
 
         # interface goes into assembly mode

--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -112,11 +112,11 @@ class ExecutionSpecificationItem(
             if c:
                 save_func(name, c.connected)
 
-        points = [tuple(map(float, h.pos)) for h in self.handles()]
+        points = [tuple(map(float, h.pos)) for h in self._handles]
 
         save_func("matrix", tuple(self.matrix))
         save_func("points", points)
-        save_connection("head-connection", self.handles()[0])
+        save_connection("head-connection", self._handles[0])
         super().save(save_func)
 
     def load(self, name, value):
@@ -124,7 +124,7 @@ class ExecutionSpecificationItem(
             self.matrix.set(*ast.literal_eval(value))
         elif name == "points":
             points = ast.literal_eval(value)
-            for h, p in zip(self.handles(), points):
+            for h, p in zip(self._handles, points):
                 h.pos = p
         elif name == "head-connection":
             self._load_head_connection = value
@@ -133,7 +133,7 @@ class ExecutionSpecificationItem(
 
     def postload(self):
         if hasattr(self, "_load_head_connection"):
-            postload_connect(self, self.handles()[0], self._load_head_connection)
+            postload_connect(self, self._handles[0], self._load_head_connection)
             del self._load_head_connection
 
         super().postload()

--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -100,10 +100,7 @@ class ExecutionSpecificationItem(
         pt, pb = (h.pos for h in self._handles)
         return Rectangle(pt.x - d / 2, pt.y, d, y1=pb.y)
 
-    def pre_update(self, context):
-        pass
-
-    def post_update(self, context):
+    def update(self, context):
         pass
 
     def draw(self, context):

--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -100,9 +100,6 @@ class ExecutionSpecificationItem(
         pt, pb = (h.pos for h in self._handles)
         return Rectangle(pt.x - d / 2, pt.y, d, y1=pb.y)
 
-    def update(self, context):
-        pass
-
     def draw(self, context):
         self.shape.draw(context, self.dimensions())
 

--- a/gaphor/UML/interactions/message.py
+++ b/gaphor/UML/interactions/message.py
@@ -93,16 +93,6 @@ class MessageItem(LinePresentation[UML.Message], Named):
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
 
-    def post_update(self, context):
-        """Update communication diagram information."""
-        super().post_update(context)
-
-        self._is_communication = self.is_communication()
-        if self._is_communication:
-            pos, angle = self._get_center_pos()
-            self._arrow_pos = pos
-            self._arrow_angle = angle
-
     def _get_center_pos(self):
         """Return position in the centre of middle segment of a line.
 
@@ -226,7 +216,11 @@ class MessageItem(LinePresentation[UML.Message], Named):
 
         # on communication diagram draw decorating arrows for messages and
         # inverted messages
+        self._is_communication = self.is_communication()
         if self._is_communication:
+            pos, angle = self._get_center_pos()
+            self._arrow_pos = pos
+            self._arrow_angle = angle
             cr = context.cairo
             self._draw_decorating_arrow(cr)
 
@@ -236,8 +230,10 @@ class MessageItem(LinePresentation[UML.Message], Named):
         c1 = self._connections.get_connection(self.head)
         c2 = self._connections.get_connection(self.tail)
         return (
-            isinstance(c1, LifelineItem)
+            c1
+            and isinstance(c1.connected, LifelineItem)
             and not c1.connected.lifetime.visible
-            or isinstance(c2, LifelineItem)
+            or c2
+            and isinstance(c2.connected, LifelineItem)
             and not c2.connected.lifetime.visible
         )

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -370,8 +370,9 @@ class Diagram(PackageableElement):
 
     def _update_items(self, items):
         for item in items:
-            context = UpdateContext(style=self.style(StyledItem(item)))
-            item.update(context)
+            update = getattr(item, "update", None)
+            if update:
+                update(UpdateContext(style=self.style(StyledItem(item))))
 
     def _on_constraint_solved(self, cinfo: gaphas.connections.Connection) -> None:
         dirty_items = set()

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -230,10 +230,6 @@ class Diagram(PackageableElement):
         self._watcher = self.watcher()
         self._watcher.watch("ownedPresentation", self._presentation_removed)
 
-        # Record all items changed during constraint solving,
-        # so their `post_update()` method can be called.
-        self._resolved_items: Set[gaphas.item.Item] = set()
-
     ownedPresentation: relation_many[Presentation] = association(
         "ownedPresentation", Presentation, composite=True, opposite="diagram"
     )
@@ -360,7 +356,6 @@ class Diagram(PackageableElement):
         dirty_matrix_items: Sequence[Presentation] = (),
     ) -> None:
         """Update the diagram canvas."""
-
         sort = self.sort
 
         def dirty_items_with_ancestors():
@@ -371,11 +366,7 @@ class Diagram(PackageableElement):
         all_dirty_items = list(reversed(list(sort(dirty_items_with_ancestors()))))
         self._update_items(all_dirty_items)
 
-        self._resolved_items.clear()
-
         self._connections.solve()
-
-        all_dirty_items.extend(self._resolved_items)
 
     def _update_items(self, items):
         for item in items:
@@ -386,10 +377,8 @@ class Diagram(PackageableElement):
         dirty_items = set()
         if cinfo.item:
             dirty_items.add(cinfo.item)
-            self._resolved_items.add(cinfo.item)
         if cinfo.connected:
             dirty_items.add(cinfo.connected)
-            self._resolved_items.add(cinfo.connected)
         if dirty_items:
             self._update_views(dirty_items)
 

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -369,29 +369,18 @@ class Diagram(PackageableElement):
                 yield from gaphas.canvas.ancestors(self, item)
 
         all_dirty_items = list(reversed(list(sort(dirty_items_with_ancestors()))))
-        contexts = self._pre_update_items(all_dirty_items)
+        self._update_items(all_dirty_items)
 
         self._resolved_items.clear()
 
         self._connections.solve()
 
         all_dirty_items.extend(self._resolved_items)
-        self._post_update_items(reversed(list(sort(all_dirty_items))), contexts)
 
-    def _pre_update_items(self, items):
-        contexts = {}
+    def _update_items(self, items):
         for item in items:
             context = UpdateContext(style=self.style(StyledItem(item)))
-            item.pre_update(context)
-            contexts[item] = context
-        return contexts
-
-    def _post_update_items(self, items, contexts):
-        for item in items:
-            context = contexts.get(item)
-            if not context:
-                context = UpdateContext(style=self.style(StyledItem(item)))
-            item.post_update(context)
+            item.update(context)
 
     def _on_constraint_solved(self, cinfo: gaphas.connections.Connection) -> None:
         dirty_items = set()

--- a/gaphor/core/modeling/stylesheet.py
+++ b/gaphor/core/modeling/stylesheet.py
@@ -30,6 +30,16 @@ SYSTEM_STYLE_SHEET = textwrap.dedent(
     diagram {
      background-color: white;
     }
+
+    dependency,
+    interfacerealization {
+        dash-style: 7 5;
+    }
+
+    dependency[on_folded_interface = true],
+    interfacerealization[on_folded_interface = true] {
+        dash-style: 0;
+    }
     """
 )
 

--- a/gaphor/core/styling/declarations.py
+++ b/gaphor/core/styling/declarations.py
@@ -162,6 +162,8 @@ def parse_padding(prop, value) -> Optional[Padding]:
 def parse_sequence_numbers(
     prop, value: Union[Number, Sequence[Number]]
 ) -> Optional[Sequence[Number]]:
+    if value == 0:
+        return ()
     if isinstance(value, number):
         return (value, value)
     elif all(isinstance(v, (int, float)) for v in value):

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -278,7 +278,6 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
 
         draw_line_end(handles[-1], handles[-2], self.draw_tail)
 
-        cr.set_dash(style.get("dash-style", ()), 0)
         stroke(context)
 
         for shape, rect in (

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -99,9 +99,6 @@ class ElementPresentation(gaphas.Element, HandlePositionUpdate, Presentation[S])
     implement the method `update_shapes()` and set self.shape there.
     """
 
-    width: int
-    height: int
-
     _port_sides = ("top", "right", "bottom", "left")
 
     def __init__(self, diagram: Diagram, id=None, shape=None, width=100, height=50):

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -221,9 +221,6 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
         self.remove_watch_handle(handle)
         super().remove_handle(handle)
 
-    def update(self, context):
-        pass
-
     def update_shape_bounds(self, context):
         def shape_bounds(shape, align):
             if shape:

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -128,14 +128,11 @@ class ElementPresentation(gaphas.Element, HandlePositionUpdate, Presentation[S])
         """Updating the shape configuration, e.g. when extra elements have to
         be drawn or when styling changes."""
 
-    def pre_update(self, context):
+    def update(self, context):
         if not self.shape:
             self.update_shapes()
         if self.shape:
             self.min_width, self.min_height = self.shape.size(context)
-
-    def post_update(self, context):
-        pass
 
     def draw(self, context):
         x, y = self.handles()[0].pos
@@ -224,10 +221,10 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
         self.remove_watch_handle(handle)
         super().remove_handle(handle)
 
-    def pre_update(self, context):
+    def update(self, context):
         pass
 
-    def post_update(self, context):
+    def update_shape_bounds(self, context):
         def shape_bounds(shape, align):
             if shape:
                 size = shape.size(context)
@@ -268,6 +265,7 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
         style = merge_styles(context.style, self.style)
         context = replace(context, style=style)
 
+        self.update_shape_bounds(context)
         cr = context.cairo
 
         handles = self._handles

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -110,7 +110,7 @@ class Box:
         return self.children[index]
 
     def size(self, context: UpdateContext):
-        style: Style = merge_styles(context.style, self._inline_style)
+        style = merge_styles(context.style, self._inline_style)
         min_width = style.get("min-width", 0)
         min_height = style.get("min-height", 0)
         padding_top, padding_right, padding_bottom, padding_left = style["padding"]
@@ -131,7 +131,7 @@ class Box:
             return min_width, min_height
 
     def draw(self, context: DrawContext, bounding_box: Rectangle):
-        style: Style = merge_styles(context.style, self._inline_style)
+        style = merge_styles(context.style, self._inline_style)
         new_context = replace(context, style=style)
         padding_top, padding_right, padding_bottom, padding_left = style["padding"]
         valign = style.get("vertical-align", VerticalAlign.MIDDLE)

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -23,7 +23,7 @@ class cairo_state:
         self._cr.restore()
 
 
-def stroke(context: DrawContext, fill=True):
+def stroke(context: DrawContext, fill=True, dash=True):
     style = context.style
     cr = context.cairo
     fill_color = style.get("background-color")
@@ -39,6 +39,8 @@ def stroke(context: DrawContext, fill=True):
         line_width = style.get("line-width")
         if line_width:
             cr.set_line_width(line_width)
+        if dash:
+            cr.set_dash(style.get("dash-style", ()), 0)
         cr.stroke()
 
 
@@ -301,16 +303,23 @@ def draw_default_tail(context: DrawContext):
 
 def draw_arrow_head(context: DrawContext):
     cr = context.cairo
+    cr.save()
     cr.set_dash((), 0)
     cr.move_to(15, -6)
     cr.line_to(0, 0)
     cr.line_to(15, 6)
+    stroke(context, dash=False)
+    cr.restore()
     cr.move_to(0, 0)
 
 
 def draw_arrow_tail(context: DrawContext):
     cr = context.cairo
     cr.line_to(0, 0)
+    cr.save()
+    cr.set_dash((), 0)
     cr.move_to(15, -6)
     cr.line_to(0, 0)
     cr.line_to(15, 6)
+    stroke(context, dash=False)
+    cr.restore()


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (~no functional changes~, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Presentation elements have a (relatively) complex update model, with a `pre_update()` and a `post_update()` method. 

### What is the new behavior?

Remove `post_update()`, and rename `pre_update()` to `update()`.

As an extra, the style of Dependency and Interface Realization item is set via CSS.

### Does this PR introduce a breaking change?
- [X] Yes
- [ ] No
