### PR TITLE
Left align the toolbox header labels

### DIFF
--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -109,7 +109,11 @@ class Toolbox(UIComponent, ActionProvider):
             self.properties.set("toolbox-collapsed", collapsed)
 
         for index, (title, items) in enumerate(toolbox_actions):
-            tool_item_group = Gtk.ToolItemGroup.new(title)
+            tool_item_group = Gtk.ToolItemGroup.new("")
+            label = Gtk.Label.new(title)
+            label.set_halign(Gtk.Align.START)
+            label.show()
+            tool_item_group.set_label_widget(label)
             tool_item_group.set_property("collapsed", collapsed.get(index, False))
             tool_item_group.connect("notify::collapsed", on_collapsed, index)
             for action_name, label, icon_name, shortcut, *rest in items:


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

This PR left justifies the toolbox header labels.

![image](https://user-images.githubusercontent.com/10014976/111932210-57098780-8a93-11eb-940e-0a1da6ff9138.png)


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
Toolbox header labels are centered

Issue Number: #498 

### What is the new behavior?
Toolbox header labels are left aligned
### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

### Other information
