### PR TITLE
Fix build fails when GitHub Actions secrets are not available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,6 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     if: "!contains(github.event.head_commit.message, 'skip ci')"
-    env:
-      SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     if: "!contains(github.event.head_commit.message, 'skip ci')"
+    env:
+      SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -98,6 +100,7 @@ jobs:
       MSYS2_ARCH: x86_64
       CHERE_INVOKING: yes
       PY_IGNORE_IMPORTMISMATCH: yes
+      SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -138,6 +141,7 @@ jobs:
           timestampUrl: http://timestamp.digicert.com
           installer: "packaging/dist/gaphor-${{ steps.meta.outputs.version }}-installer.exe"
           portable: "packaging/dist/gaphor-${{ steps.meta.outputs.version }}-portable.exe"
+        if: env.SECRETS_AVAILABLE != null
         shell: powershell
         run: |
           $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
@@ -148,11 +152,13 @@ jobs:
           Remove-Item 'certificate.pfx'
       - name: Upload gaphor-${{ steps.meta.outputs.version }}-installer.exe
         uses: actions/upload-artifact@v2
+        if: env.SECRETS_AVAILABLE != null
         with:
           name: gaphor-${{ steps.meta.outputs.version }}-installer.exe
           path: packaging/dist/gaphor-${{ steps.meta.outputs.version }}-installer.exe
       - name: Upload gaphor-${{ steps.meta.outputs.version }}-portable.exe
         uses: actions/upload-artifact@v2
+        if: env.SECRETS_AVAILABLE != null
         with:
           name: gaphor-${{ steps.meta.outputs.version }}-portable.exe
           path: packaging/dist/gaphor-${{ steps.meta.outputs.version }}-portable.exe
@@ -171,6 +177,7 @@ jobs:
     env:
       LDFLAGS: -L/usr/local/opt/python@3.8/lib
       PKG_CONFIG_PATH: /usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/python@3.8/lib/pkgconfig:${PKG_CONFIG_PATH:-}
+      SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -201,6 +208,7 @@ jobs:
           make all
       - name: Import codesign certificate
         uses: apple-actions/import-codesign-certs@v1
+        if: env.SECRETS_AVAILABLE != null
         with:
           p12-file-base64: ${{ secrets.BASE64_ENCODED_P12 }}
           p12-password: ${{ secrets.CERTPASSWORD_P12 }}
@@ -213,15 +221,18 @@ jobs:
           -o runtime "dist/Gaphor.app"
       - name: Notarize app
         uses: devbotsxyz/xcode-notarize@v1
+        if: env.SECRETS_AVAILABLE != null
         with:
           product-path: "packaging/dist/Gaphor.app"
           appstore-connect-username: ${{ secrets.AC_USERNAME }}
           appstore-connect-password: ${{ secrets.AC_PASSWORD }}
       - name: Staple app
         uses: devbotsxyz/xcode-staple@v1
+        if: env.SECRETS_AVAILABLE != null
         with:
           product-path: "packaging/dist/Gaphor.app"
       - name: Create dmg
+        if: env.SECRETS_AVAILABLE != null
         run: >
           cd packaging
 
@@ -233,6 +244,7 @@ jobs:
           "dist/Gaphor.app"
       - name: Notarize dmg
         uses: devbotsxyz/xcode-notarize@v1
+        if: env.SECRETS_AVAILABLE != null
         with:
           product-path: "packaging/dist/Gaphor-${{ steps.meta.outputs.version }}.dmg"
           appstore-connect-username: ${{ secrets.AC_USERNAME }}
@@ -240,10 +252,12 @@ jobs:
           primary-bundle-id: org.gaphor.gaphor
       - name: Staple .dmg
         uses: devbotsxyz/xcode-staple@v1
+        if: env.SECRETS_AVAILABLE != null
         with:
           product-path: "packaging/dist/Gaphor-${{ steps.meta.outputs.version }}.dmg"
       - name: Upload Gaphor-${{ steps.meta.outputs.version }}.dmg
         uses: actions/upload-artifact@v2
+        if: env.SECRETS_AVAILABLE != null
         with:
           name: Gaphor-${{ steps.meta.outputs.version }}.dmg
           path: packaging/dist/Gaphor-${{ steps.meta.outputs.version }}.dmg


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

This PR checks if secrets are available before running a step where a secret is needed. This is to stop dependabot builds from failing due to changes made to made in GitHub Actions to make them read-only:
https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
Dependabot builds are failing

Issue Number: N/A

### What is the new behavior?
Hopefully they now pass :)

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
