### PR TITLE
Upload Linux assets during release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,15 @@ jobs:
         with:
           name: Gaphor-${{ steps.meta.outputs.version }}-x86_64.AppImage
           path: packaging/dist/Gaphor-${{ steps.meta.outputs.version }}-x86_64.AppImage
+      - name: Upload Assets (release only)
+        uses: AButler/upload-release-assets@v2.0
+        if: github.event_name == 'release'
+        with:
+          files: |
+            "packaging/dist/Gaphor-${{ steps.meta.outputs.version }}-x86_64.AppImage;
+            dist/gaphor-${{ steps.meta.outputs.version }}-py3-none-any.whl;
+            dist/gaphor-${{ steps.meta.outputs.version }}.tar.gz"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PyPI (release only)
         if: github.event_name == 'release'
         run: poetry publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Although the assets were being uploaded during each CI build, during a release, the Linux assets were not being uploaded to the release itself.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
All Linux assets were missing and had to be uploaded manually

Issue Number: N/A

### What is the new behavior?
Linux assets are uploaded

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
