### PR TITLE
Improve CSS text editor

### DIFF
--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -252,7 +252,7 @@ class SettingsStack:
         self.style_sheet_view.set_auto_indent(True)
         self.style_sheet_view.set_indent_width(2)
         self.style_sheet_view.set_input_hints(Gtk.InputHints.NO_EMOJI)
-        self.style_sheet_view.set_insert_spaces_instead_of_tabs(True) 
+        self.style_sheet_view.set_insert_spaces_instead_of_tabs(True)
 
         self.event_manager.subscribe(self._model_ready)
         self.event_manager.subscribe(self._style_sheet_created)

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -249,6 +249,10 @@ class SettingsStack:
     def open(self, builder):
         self.style_sheet_buffer = builder.get_object("style-sheet-buffer")
         self.style_sheet_view = builder.get_object("style-sheet-view")
+        self.style_sheet_view.set_auto_indent(True)
+        self.style_sheet_view.set_indent_width(2)
+        self.style_sheet_view.set_input_hints(Gtk.InputHints.NO_EMOJI)
+        self.style_sheet_view.set_insert_spaces_instead_of_tabs(True) 
 
         self.event_manager.subscribe(self._model_ready)
         self.event_manager.subscribe(self._style_sheet_created)


### PR DESCRIPTION
This improves the CSS text editor to insert spaces instead of tabs, and to use 2-space indention and auto-indent.