### PR TITLE
Improve drag and drop for TreeView

### DIFF
--- a/gaphor/diagram/inlineeditors.py
+++ b/gaphor/diagram/inlineeditors.py
@@ -89,9 +89,9 @@ def show_popover(widget, view, box, escape=None):
     if Gtk.get_major_version() == 3:
 
         def on_escape3(popover, event):
-            return on_escape(popover, event.keyval, event.keycode, event.get_state())
+            return on_escape(popover, event.keyval, 0, event.get_state())
 
-        popover.connect("key-press-event", on_escape)
+        popover.connect("key-press-event", on_escape3)
         popover.popup()
     else:
         controller = Gtk.EventControllerKey.new()

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -24,7 +24,7 @@ from gaphor.ui.namespacemodel import (
     NamespaceModel,
     NamespaceModelRefreshed,
 )
-from gaphor.ui.namespaceview import NamespaceView
+from gaphor.ui.namespaceview import namespace_view
 
 if TYPE_CHECKING:
     from gaphor.core.eventmanager import EventManager
@@ -80,12 +80,13 @@ class Namespace(UIComponent):
         self.element_factory = element_factory
 
         self.model: Optional[NamespaceModel] = None
-        self.view: Optional[NamespaceView] = None
+        self.view: Optional[Gtk.TreeView] = None
         self.scrolled_window: Optional[Gtk.ScrolledWindow] = None
         self.ctrl: Set[Gtk.EventController] = set()
 
     def open(self):
         self.model = NamespaceModel(self.event_manager, self.element_factory)
+        view = namespace_view(self.model)
         self.event_manager.subscribe(self._on_model_refreshed)
         self.event_manager.subscribe(self._on_diagram_selection_changed)
 
@@ -111,7 +112,6 @@ class Namespace(UIComponent):
 
             return not matched  # False means match found!
 
-        view = NamespaceView(self.model)
         view.set_search_equal_func(search_func)
 
         scrolled_window = Gtk.ScrolledWindow()

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -90,8 +90,6 @@ class Namespace(UIComponent):
         self.event_manager.subscribe(self._on_model_refreshed)
         self.event_manager.subscribe(self._on_diagram_selection_changed)
 
-        sorted_model = self.model.sorted()
-
         def search_func(model, column, key, rowiter):
             # Note that this function returns `False` for a match!
             assert column == 0
@@ -114,7 +112,7 @@ class Namespace(UIComponent):
 
             return not matched  # False means match found!
 
-        view = NamespaceView(sorted_model, self.element_factory)
+        view = NamespaceView(self.model, self.element_factory)
         view.set_search_equal_func(search_func)
 
         scrolled_window = Gtk.ScrolledWindow()

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -112,7 +112,7 @@ class Namespace(UIComponent):
 
             return not matched  # False means match found!
 
-        view = NamespaceView(self.model, self.element_factory)
+        view = NamespaceView(self.model)
         view.set_search_equal_func(search_func)
 
         scrolled_window = Gtk.ScrolledWindow()

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -21,6 +21,7 @@ from gaphor.ui.event import DiagramOpened, DiagramSelectionChanged
 from gaphor.ui.namespacemodel import (
     RELATIONSHIPS,
     NamespaceModel,
+    NamespaceModelElementDropped,
     NamespaceModelRefreshed,
 )
 from gaphor.ui.namespaceview import namespace_view
@@ -87,6 +88,7 @@ class Namespace(UIComponent):
         self.model = NamespaceModel(self.event_manager, self.element_factory)
         view = namespace_view(self.model)
         self.event_manager.subscribe(self._on_model_refreshed)
+        self.event_manager.subscribe(self._on_model_dropped)
         self.event_manager.subscribe(self._on_diagram_selection_changed)
 
         scrolled_window = Gtk.ScrolledWindow()
@@ -143,6 +145,7 @@ class Namespace(UIComponent):
             self.model.shutdown()
             self.model = None
         self.event_manager.unsubscribe(self._on_model_refreshed)
+        self.event_manager.unsubscribe(self._on_model_dropped)
         self.event_manager.unsubscribe(self._on_diagram_selection_changed)
 
     @event_handler(NamespaceModelRefreshed)
@@ -151,6 +154,11 @@ class Namespace(UIComponent):
         if self.view:
             self.view.expand_row(path=Gtk.TreePath.new_first(), open_all=False)
             self._on_view_cursor_changed(self.view)
+
+    @event_handler(NamespaceModelElementDropped)
+    def _on_model_dropped(self, event):
+        element = event.element
+        self.select_element(element)
 
     @event_handler(DiagramSelectionChanged)
     def _on_diagram_selection_changed(self, event):

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -14,7 +14,6 @@ from gi.repository import Gdk, Gio, GLib, Gtk
 
 from gaphor import UML
 from gaphor.core import action, event_handler, gettext, transactional
-from gaphor.core.format import format
 from gaphor.core.modeling import Diagram, Element, Presentation
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.actiongroup import create_action_group
@@ -89,30 +88,6 @@ class Namespace(UIComponent):
         view = namespace_view(self.model)
         self.event_manager.subscribe(self._on_model_refreshed)
         self.event_manager.subscribe(self._on_diagram_selection_changed)
-
-        def search_func(model, column, key, rowiter):
-            # Note that this function returns `False` for a match!
-            assert column == 0
-            row = model[rowiter]
-            matched = False
-
-            # Search in child rows.  If any element in the underlying
-            # tree matches, it will expand.
-            for inner in row.iterchildren():
-                if not search_func(model, column, key, inner.iter):
-                    view.expand_to_path(row.path)
-                    matched = True
-
-            element = list(row)[column]
-            s = format(element)
-            if s and key.lower() in s.lower():
-                matched = True
-            elif not matched:
-                view.collapse_row(row.path)
-
-            return not matched  # False means match found!
-
-        view.set_search_equal_func(search_func)
 
         scrolled_window = Gtk.ScrolledWindow()
         scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -251,12 +251,10 @@ class Namespace(UIComponent):
         assert self.view
 
         model = self.view.get_model()
-        child_iter = self.model.iter_for_element(element)
-        if not child_iter:
+        tree_iter = self.model.iter_for_element(element)
+        if not tree_iter:
             return
 
-        ok, tree_iter = model.convert_child_iter_to_iter(child_iter)
-        assert ok, "Could not convert model iterator to view"
         path = model.get_path(tree_iter)
         path_indices = path.get_indices()
 

--- a/gaphor/ui/namespacemodel.py
+++ b/gaphor/ui/namespacemodel.py
@@ -76,7 +76,7 @@ class NamespaceModel:
 
     def sorted(self):
         """Get a sorted version of this model."""
-        sorted_model = Gtk.TreeModelSort(model=self.model)
+        sorted_model = self.model
 
         def sort_func(model, iter_a, iter_b, userdata):
             va = model.get_value(iter_a, 0)

--- a/gaphor/ui/namespacemodel.py
+++ b/gaphor/ui/namespacemodel.py
@@ -212,11 +212,11 @@ class NamespaceModel(Gtk.TreeStore):
         target = str(selection_data.get_target())
         row = self[path]
         element = row[0]
-        if target == "gaphor/element-id":
+        if target == "GTK_TREE_MODEL_ROW":
+            return Gtk.tree_set_row_drag_data(selection_data, self, path)
+        elif target == "gaphor/element-id":
             selection_data.set(selection_data.get_target(), 8, str(element.id).encode())
             return True
-        elif target == "GTK_TREE_MODEL_ROW":
-            return Gtk.tree_set_row_drag_data(selection_data, self, path)
         return False
 
     def do_row_drop_possible(self, dest_path, selection_data):

--- a/gaphor/ui/namespacemodel.py
+++ b/gaphor/ui/namespacemodel.py
@@ -55,6 +55,12 @@ class NamespaceModelRefreshed:
         self.model = model
 
 
+class NamespaceModelElementDropped:
+    def __init__(self, model, element):
+        self.model = model
+        self.element = element
+
+
 class NamespaceModel(Gtk.TreeStore):
     def __init__(self, event_manager: EventManager, element_factory: ElementFactory):
         super().__init__(object)
@@ -275,6 +281,7 @@ class NamespaceModel(Gtk.TreeStore):
                     del element.package
                 else:
                     element.package = dest_element
+                self.event_manager.handle(NamespaceModelElementDropped(self, element))
             return True
         except AttributeError as e:
             log.info(f"Unable to drop data {e}")

--- a/gaphor/ui/namespacemodel.py
+++ b/gaphor/ui/namespacemodel.py
@@ -55,10 +55,149 @@ class NamespaceModelRefreshed:
         self.model = model
 
 
-class NamespaceTreeStore(Gtk.TreeStore):
-    def __init__(self, types, event_manager):
-        super().__init__(*types)
+class NamespaceModel(Gtk.TreeStore):
+    def __init__(self, event_manager: EventManager, element_factory: ElementFactory):
+        super().__init__(object)
         self.event_manager = event_manager
+        self.element_factory = element_factory
+
+        event_manager.subscribe(self.refresh)
+        event_manager.subscribe(self._on_element_create)
+        event_manager.subscribe(self._on_element_delete)
+        event_manager.subscribe(self._on_association_set)
+        event_manager.subscribe(self._on_attribute_change)
+
+        self.set_sort_func(0, sort_func, None)
+        self.set_sort_column_id(0, Gtk.SortType.ASCENDING)
+
+    def shutdown(self):
+        em = self.event_manager
+        em.unsubscribe(self.refresh)
+        em.unsubscribe(self._on_element_create)
+        em.unsubscribe(self._on_element_delete)
+        em.unsubscribe(self._on_association_set)
+        em.unsubscribe(self._on_attribute_change)
+
+    def get_element(self, iter):
+        return self.get_value(iter, 0)
+
+    def iter_for_element(self, element, old_owner=0):
+        """Get the Gtk.TreeIter for an element in the Namespace.
+
+        Args:
+            element: The element contained in the Namespace.
+            old_owner: The old owner containing the element, optional.
+
+        Returns: Gtk.TreeIter object of the model (not the sorted one!)
+        """
+
+        # Using `0` as sentinel
+        if old_owner != 0:
+            parent_iter = self.iter_for_element(old_owner)
+        elif element and element.owner:
+            parent_iter = self.iter_for_element(element.owner)
+        else:
+            parent_iter = None
+
+        if isinstance(element, UML.Relationship):
+            parent_iter = relationship_iter(self, parent_iter)
+
+        child_iter = self.iter_children(parent_iter)
+        while child_iter:
+            if self.get_value(child_iter, 0) is element:
+                return child_iter
+            child_iter = self.iter_next(child_iter)
+        return None
+
+    def _visible(self, element):
+        return isinstance(
+            element, (UML.Relationship, UML.NamedElement)
+        ) and not isinstance(
+            element, (UML.InstanceSpecification, UML.OccurrenceSpecification)
+        )
+
+    def _add(self, element, iter=None):
+        if self._visible(element):
+            if isinstance(element, UML.Relationship):
+                iter = relationship_iter(self, iter)
+            child_iter = self.append(iter, [element])
+            for e in element.ownedElement:
+                # check if owned element is indeed within parent's owner
+                # This is important since we should be able to traverse this relation both ways
+                if element is e.owner:
+                    self._add(e, child_iter)
+
+    def _remove(self, iter):
+        if iter:
+            parent_iter = self.iter_parent(iter)
+            self.remove(iter)
+            if (
+                parent_iter
+                and not self.iter_has_child(parent_iter)
+                and self.get_value(parent_iter, 0) is RELATIONSHIPS
+            ):
+                self.remove(parent_iter)
+
+    @event_handler(ModelReady, ModelFlushed)
+    def refresh(self, event=None):
+        """Load a new model completely."""
+        log.debug("Rebuilding namespace model")
+
+        self.clear()
+
+        toplevel = self.element_factory.select(
+            lambda e: self._visible(e) and not e.owner
+        )
+
+        for element in toplevel:
+            if self._visible(element):
+                self._add(element)
+
+        self.event_manager.handle(NamespaceModelRefreshed(self))
+
+    @event_handler(ElementCreated)
+    def _on_element_create(self, event: ElementCreated):
+        element = event.element
+        if self._visible(element) and not self.iter_for_element(element):
+            iter = self.iter_for_element(element.owner)
+            self._add(element, iter)
+
+    @event_handler(ElementDeleted)
+    def _on_element_delete(self, event: ElementDeleted):
+        element = event.element
+        iter = self.iter_for_element(element)
+        self._remove(iter)
+
+    @event_handler(DerivedSet)
+    def _on_association_set(self, event: DerivedSet):
+        if event.property is not UML.Element.owner:
+            return
+        old_value, new_value = event.old_value, event.new_value
+
+        element = event.element
+        old_iter = self.iter_for_element(element, old_owner=old_value)
+        self._remove(old_iter)
+
+        if self._visible(element):
+            new_iter = self.iter_for_element(new_value)
+            # Should be either set (sub node) or unset (root node)
+            if bool(new_iter) == bool(new_value):
+                self._add(element, new_iter)
+
+    @event_handler(AttributeUpdated)
+    def _on_attribute_change(self, event: AttributeUpdated):
+        """Element changed, update appropriate row."""
+        if (
+            event.property is UML.Classifier.isAbstract
+            or event.property is UML.BehavioralFeature.isAbstract
+            or event.property is UML.NamedElement.name
+        ):
+            element = event.element
+
+            iter = self.iter_for_element(element)
+            if iter:
+                path = self.get_path(iter)
+                self.row_changed(path, iter)
 
     def do_row_draggable(self, path):
         return True
@@ -139,176 +278,20 @@ class NamespaceTreeStore(Gtk.TreeStore):
         return False
 
 
-class NamespaceModel:
-    def __init__(self, event_manager: EventManager, element_factory: ElementFactory):
-        self.event_manager = event_manager
-        self.element_factory = element_factory
-        self.model = NamespaceTreeStore(types=[object], event_manager=event_manager)
+def sort_func(model, iter_a, iter_b, userdata):
+    va = model.get_value(iter_a, 0)
+    vb = model.get_value(iter_b, 0)
 
-        event_manager.subscribe(self.refresh)
-        event_manager.subscribe(self._on_element_create)
-        event_manager.subscribe(self._on_element_delete)
-        event_manager.subscribe(self._on_association_set)
-        event_manager.subscribe(self._on_attribute_change)
+    # Put Relationships pseudo-node at top
+    if va is RELATIONSHIPS:
+        return -1
+    if vb is RELATIONSHIPS:
+        return 1
 
-    def shutdown(self):
-        em = self.event_manager
-        em.unsubscribe(self.refresh)
-        em.unsubscribe(self._on_element_create)
-        em.unsubscribe(self._on_element_delete)
-        em.unsubscribe(self._on_association_set)
-        em.unsubscribe(self._on_attribute_change)
-
-    def sorted(self):
-        """Get a sorted version of this model."""
-        sorted_model = self.model
-
-        def sort_func(model, iter_a, iter_b, userdata):
-            va = model.get_value(iter_a, 0)
-            vb = model.get_value(iter_b, 0)
-
-            # Put Relationships pseudo-node at top
-            if va is RELATIONSHIPS:
-                return -1
-            if vb is RELATIONSHIPS:
-                return 1
-
-            a = (format(va) or "").lower()
-            b = (format(vb) or "").lower()
-            if a == b:
-                return 0
-            if a > b:
-                return 1
-            return -1
-
-        sorted_model.set_sort_func(0, sort_func, None)
-        sorted_model.set_sort_column_id(0, Gtk.SortType.ASCENDING)
-
-        return sorted_model
-
-    def iter_children(self, iter):
-        return self.model.iter_children(iter)
-
-    def iter_n_children(self, iter):
-        return self.model.iter_n_children(iter)
-
-    def get_element(self, iter):
-        return self.model.get_value(iter, 0)
-
-    def iter_for_element(self, element, old_owner=0):
-        """Get the Gtk.TreeIter for an element in the Namespace.
-
-        Args:
-            element: The element contained in the Namespace.
-            old_owner: The old owner containing the element, optional.
-
-        Returns: Gtk.TreeIter object of the model (not the sorted one!)
-        """
-
-        # Using `0` as sentinel
-        if old_owner != 0:
-            parent_iter = self.iter_for_element(old_owner)
-        elif element and element.owner:
-            parent_iter = self.iter_for_element(element.owner)
-        else:
-            parent_iter = None
-
-        if isinstance(element, UML.Relationship):
-            parent_iter = relationship_iter(self.model, parent_iter)
-
-        child_iter = self.model.iter_children(parent_iter)
-        while child_iter:
-            if self.model.get_value(child_iter, 0) is element:
-                return child_iter
-            child_iter = self.model.iter_next(child_iter)
-        return None
-
-    def _visible(self, element):
-        return isinstance(
-            element, (UML.Relationship, UML.NamedElement)
-        ) and not isinstance(
-            element, (UML.InstanceSpecification, UML.OccurrenceSpecification)
-        )
-
-    def _add(self, element, iter=None):
-        if self._visible(element):
-            if isinstance(element, UML.Relationship):
-                iter = relationship_iter(self.model, iter)
-            child_iter = self.model.append(iter, [element])
-            for e in element.ownedElement:
-                # check if owned element is indeed within parent's owner
-                # This is important since we should be able to traverse this relation both ways
-                if element is e.owner:
-                    self._add(e, child_iter)
-
-    def _remove(self, iter):
-        if iter:
-            parent_iter = self.model.iter_parent(iter)
-            self.model.remove(iter)
-            if (
-                parent_iter
-                and not self.model.iter_has_child(parent_iter)
-                and self.model.get_value(parent_iter, 0) is RELATIONSHIPS
-            ):
-                self.model.remove(parent_iter)
-
-    @event_handler(ModelReady, ModelFlushed)
-    def refresh(self, event=None):
-        """Load a new model completely."""
-        log.debug("Rebuilding namespace model")
-
-        self.model.clear()
-
-        toplevel = self.element_factory.select(
-            lambda e: self._visible(e) and not e.owner
-        )
-
-        for element in toplevel:
-            if self._visible(element):
-                self._add(element)
-
-        self.event_manager.handle(NamespaceModelRefreshed(self))
-
-    @event_handler(ElementCreated)
-    def _on_element_create(self, event: ElementCreated):
-        element = event.element
-        if self._visible(element) and not self.iter_for_element(element):
-            iter = self.iter_for_element(element.owner)
-            self._add(element, iter)
-
-    @event_handler(ElementDeleted)
-    def _on_element_delete(self, event: ElementDeleted):
-        element = event.element
-        iter = self.iter_for_element(element)
-        self._remove(iter)
-
-    @event_handler(DerivedSet)
-    def _on_association_set(self, event: DerivedSet):
-        if event.property is not UML.Element.owner:
-            return
-        old_value, new_value = event.old_value, event.new_value
-
-        element = event.element
-        old_iter = self.iter_for_element(element, old_owner=old_value)
-        self._remove(old_iter)
-
-        if self._visible(element):
-            new_iter = self.iter_for_element(new_value)
-            # Should be either set (sub node) or unset (root node)
-            if bool(new_iter) == bool(new_value):
-                self._add(element, new_iter)
-
-    @event_handler(AttributeUpdated)
-    def _on_attribute_change(self, event: AttributeUpdated):
-        """Element changed, update appropriate row."""
-        if (
-            event.property is UML.Classifier.isAbstract
-            or event.property is UML.BehavioralFeature.isAbstract
-            or event.property is UML.NamedElement.name
-        ):
-            element = event.element
-
-            iter = self.iter_for_element(element)
-            if iter:
-                path = self.model.get_path(iter)
-                self.model.row_changed(path, iter)
+    a = (format(va) or "").lower()
+    b = (format(vb) or "").lower()
+    if a == b:
+        return 0
+    if a > b:
+        return 1
+    return -1

--- a/gaphor/ui/namespacemodel.py
+++ b/gaphor/ui/namespacemodel.py
@@ -241,28 +241,31 @@ class NamespaceModel(Gtk.TreeStore):
         element = src_row[0]
 
         dest_path.up()
-        try:
-            iter = self.get_iter(dest_path)
-        except ValueError:
-            log.debug(f"Invalid path: '{dest_path}'")
-            return False
+        if not dest_path:
+            dest_element = None
+        else:
+            try:
+                iter = self.get_iter(dest_path)
+            except ValueError:
+                log.debug(f"Invalid path: '{dest_path}'")
+                return False
 
-        dest_element = self.get_value(iter, 0)
-
-        if dest_element is RELATIONSHIPS:
-            iter = relationship_iter_parent(self, iter)
             dest_element = self.get_value(iter, 0)
 
-        if element.package is dest_element:
-            return False
+            if dest_element is RELATIONSHIPS:
+                iter = relationship_iter_parent(self, iter)
+                dest_element = self.get_value(iter, 0)
 
-        # Check if element is part of the namespace of dest_element:
-        ns = dest_element
-        while ns:
-            if ns is element:
-                log.info("Can not create a cycle")
+            if element.package is dest_element:
                 return False
-            ns = ns.namespace
+
+            # Check if element is part of the namespace of dest_element:
+            ns = dest_element
+            while ns:
+                if ns is element:
+                    log.info("Can not create a cycle")
+                    return False
+                ns = ns.namespace
 
         try:
             # Set package. This only works for classifiers, packages and

--- a/gaphor/ui/namespaceview.py
+++ b/gaphor/ui/namespaceview.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 from gi.repository import Gdk, Gtk, Pango
 
 from gaphor import UML
 from gaphor.core import gettext, transactional
 from gaphor.core.format import format, parse
-from gaphor.core.modeling import Diagram, Element
+from gaphor.core.modeling import Diagram
 from gaphor.diagram.iconname import get_icon_name
 from gaphor.ui.namespacemodel import RELATIONSHIPS
 
@@ -78,13 +77,6 @@ class NamespaceView(Gtk.TreeView):
                 Gdk.DragAction.MOVE,
             )
         self._controller = tree_view_expand_collapse(self)
-
-    def get_selected_element(self) -> Optional[Element]:
-        selection = self.get_selection()
-        model, iter = selection.get_selected()
-        if not iter:
-            return None
-        return model.get_value(iter, 0)  # type: ignore[no-any-return]
 
     def _set_pixbuf(self, column, cell, model, iter, data):
         element = model.get_value(iter, 0)

--- a/gaphor/ui/namespaceview.py
+++ b/gaphor/ui/namespaceview.py
@@ -20,11 +20,8 @@ if TYPE_CHECKING:
 
 class NamespaceView(Gtk.TreeView):
     if Gtk.get_major_version() == 3:
-        TARGET_STRING = 0
-        TARGET_ELEMENT_ID = 1
+        TARGET_ELEMENT_ID = 0
         DND_TARGETS = [
-            Gtk.TargetEntry.new("STRING", 0, TARGET_STRING),
-            Gtk.TargetEntry.new("text/plain", 0, TARGET_STRING),
             Gtk.TargetEntry.new("gaphor/element-id", 0, TARGET_ELEMENT_ID),
         ]
 

--- a/gaphor/ui/namespaceview.py
+++ b/gaphor/ui/namespaceview.py
@@ -14,124 +14,122 @@ from gaphor.ui.namespacemodel import RELATIONSHIPS
 log = logging.getLogger(__name__)
 
 
-class NamespaceView(Gtk.TreeView):
+def namespace_view(model: Gtk.TreeModel):
     if Gtk.get_major_version() == 3:
-        TARGET_ELEMENT_ID = 0
-        TARGET_GTK_TREE_MODEL_ROW = 1
         DND_TARGETS = [
             Gtk.TargetEntry.new(
                 "GTK_TREE_MODEL_ROW",
                 Gtk.TargetFlags.SAME_APP,
-                TARGET_GTK_TREE_MODEL_ROW,
+                0,
             ),
-            Gtk.TargetEntry.new(
-                "gaphor/element-id", Gtk.TargetFlags.SAME_APP, TARGET_ELEMENT_ID
-            ),
+            Gtk.TargetEntry.new("gaphor/element-id", Gtk.TargetFlags.SAME_APP, 1),
         ]
     else:
         DND_TARGETS = Gdk.ContentFormats.new(
             ["gaphor/element-id", "GTK_TREE_MODEL_ROW"]
         )
 
-    def __init__(self, model: Gtk.TreeModel):
-        Gtk.TreeView.__init__(self)
-        self.set_model(model)
+    view = Gtk.TreeView.new_with_model(model)
 
-        self.set_property("headers-visible", False)
-        self.set_property("search-column", 0)
+    view.set_property("headers-visible", False)
+    view.set_property("search-column", 0)
 
-        selection = self.get_selection()
-        selection.set_mode(Gtk.SelectionMode.BROWSE)
-        column = Gtk.TreeViewColumn.new()
-        # First cell in the column is for an image...
-        cell = Gtk.CellRendererPixbuf()
-        column.pack_start(cell, 0)
-        column.set_cell_data_func(cell, self._set_pixbuf, None)
+    selection = view.get_selection()
+    selection.set_mode(Gtk.SelectionMode.BROWSE)
+    column = Gtk.TreeViewColumn.new()
+    # First cell in the column is for an image...
+    cell = Gtk.CellRendererPixbuf()
+    column.pack_start(cell, 0)
+    column.set_cell_data_func(cell, _set_pixbuf, None)
 
-        # Second cell if for the name of the object...
-        cell = Gtk.CellRendererText()
-        cell.connect("edited", self._text_edited)
-        column.pack_start(cell, 0)
-        column.set_cell_data_func(cell, self._set_text, None)
+    # Second cell if for the name of the object...
+    cell = Gtk.CellRendererText()
+    cell.connect("edited", _text_edited, model)
+    column.pack_start(cell, 0)
+    column.set_cell_data_func(cell, _set_text, None)
 
-        self.append_column(column)
+    view.append_column(column)
 
-        if Gtk.get_major_version() == 3:
-            self.enable_model_drag_source(
-                Gdk.ModifierType.BUTTON1_MASK | Gdk.ModifierType.BUTTON3_MASK,
-                NamespaceView.DND_TARGETS,
-                Gdk.DragAction.COPY | Gdk.DragAction.MOVE,
-            )
-            self.enable_model_drag_dest(
-                NamespaceView.DND_TARGETS,
-                Gdk.DragAction.MOVE,
-            )
-        else:
-            self.enable_model_drag_source(
-                Gdk.ModifierType.BUTTON1_MASK | Gdk.ModifierType.BUTTON3_MASK,
-                NamespaceView.DND_TARGETS,
-                Gdk.DragAction.COPY | Gdk.DragAction.MOVE,
-            )
-            self.enable_model_drag_dest(
-                NamespaceView.DND_TARGETS,
-                Gdk.DragAction.MOVE,
-            )
-        self._controller = tree_view_expand_collapse(self)
-
-    def _set_pixbuf(self, column, cell, model, iter, data):
-        element = model.get_value(iter, 0)
-
-        if element is RELATIONSHIPS:
-            cell.set_property("icon-name", None)
-            cell.set_property("visible", False)
-        elif isinstance(element, (UML.Property, UML.Operation)):
-            cell.set_property("icon-name", None)
-            cell.set_property("visible", False)
-        else:
-            icon_name = get_icon_name(element)
-            cell.set_property("visible", True)
-
-            if icon_name:
-                cell.set_property("icon-name", icon_name)
-
-    def _set_text(self, column, cell, model, iter, data):
-        """Set font and of model elements in tree view."""
-        element = model.get_value(iter, 0)
-
-        cell.set_property(
-            "weight",
-            Pango.Weight.BOLD if isinstance(element, Diagram) else Pango.Weight.NORMAL,
+    if Gtk.get_major_version() == 3:
+        view.enable_model_drag_source(
+            Gdk.ModifierType.BUTTON1_MASK | Gdk.ModifierType.BUTTON3_MASK,
+            DND_TARGETS,
+            Gdk.DragAction.COPY | Gdk.DragAction.MOVE,
         )
-
-        cell.set_property(
-            "style",
-            Pango.Style.ITALIC
-            if isinstance(element, (UML.Classifier, UML.BehavioralFeature))
-            and element.isAbstract
-            else Pango.Style.NORMAL,
+        view.enable_model_drag_dest(
+            DND_TARGETS,
+            Gdk.DragAction.MOVE,
         )
+    else:
+        view.enable_model_drag_source(
+            Gdk.ModifierType.BUTTON1_MASK | Gdk.ModifierType.BUTTON3_MASK,
+            DND_TARGETS,
+            Gdk.DragAction.COPY | Gdk.DragAction.MOVE,
+        )
+        view.enable_model_drag_dest(
+            DND_TARGETS,
+            Gdk.DragAction.MOVE,
+        )
+    view._controller = tree_view_expand_collapse(view)
 
-        if element is RELATIONSHIPS:
-            text = gettext("<Relationships>")
-        else:
-            text = format(element) or "<None>"
-        cell.set_property("text", text)
+    return view
 
-    @transactional
-    def _text_edited(self, cell, path_str, new_text):
-        """The text has been edited.
 
-        This method updates the data object. Note that 'path_str' is a
-        string where the fields are separated by colons ':', like this:
-        '0:1:1'. We first turn them into a tuple.
-        """
-        model = self.get_property("model")
-        iter = model.get_iter_from_string(path_str)
-        element = model.get_value(iter, 0)
-        try:
-            parse(element, new_text)
-        except TypeError:
-            log.debug(f"No parser for {element}")
+def _set_pixbuf(column, cell, model, iter, data):
+    element = model.get_value(iter, 0)
+
+    if element is RELATIONSHIPS:
+        cell.set_property("icon-name", None)
+        cell.set_property("visible", False)
+    elif isinstance(element, (UML.Property, UML.Operation)):
+        cell.set_property("icon-name", None)
+        cell.set_property("visible", False)
+    else:
+        icon_name = get_icon_name(element)
+        cell.set_property("visible", True)
+
+        if icon_name:
+            cell.set_property("icon-name", icon_name)
+
+
+def _set_text(column, cell, model, iter, data):
+    """Set font and of model elements in tree view."""
+    element = model.get_value(iter, 0)
+
+    cell.set_property(
+        "weight",
+        Pango.Weight.BOLD if isinstance(element, Diagram) else Pango.Weight.NORMAL,
+    )
+
+    cell.set_property(
+        "style",
+        Pango.Style.ITALIC
+        if isinstance(element, (UML.Classifier, UML.BehavioralFeature))
+        and element.isAbstract
+        else Pango.Style.NORMAL,
+    )
+
+    if element is RELATIONSHIPS:
+        text = gettext("<Relationships>")
+    else:
+        text = format(element) or "<None>"
+    cell.set_property("text", text)
+
+
+@transactional
+def _text_edited(cell, path_str, new_text, model):
+    """The text has been edited.
+
+    This method updates the data object. Note that 'path_str' is a
+    string where the fields are separated by colons ':', like this:
+    '0:1:1'. We first turn them into a tuple.
+    """
+    iter = model.get_iter_from_string(path_str)
+    element = model.get_value(iter, 0)
+    try:
+        parse(element, new_text)
+    except TypeError:
+        log.debug(f"No parser for {element}")
 
 
 def tree_view_expand_collapse(view):

--- a/gaphor/ui/tests/test_namespace.py
+++ b/gaphor/ui/tests/test_namespace.py
@@ -21,7 +21,7 @@ def test_popup_model(namespace, diagram, element_factory):
     )
     namespace.select_element(item.subject)
 
-    popup = popup_model(namespace.view)
+    popup = popup_model(namespace.get_selected_element())
 
     assert popup
 

--- a/gaphor/ui/tests/test_namespacemodel.py
+++ b/gaphor/ui/tests/test_namespacemodel.py
@@ -100,7 +100,7 @@ def test_change_element_name(namespace, element_factory):
     def handle_row_changed(*args):
         events.append(args)
 
-    namespace.model.connect("row-changed", handle_row_changed)
+    namespace.connect("row-changed", handle_row_changed)
 
     p1.name = "pack"
 

--- a/gaphor/ui/tests/test_namespacemodel.py
+++ b/gaphor/ui/tests/test_namespacemodel.py
@@ -1,4 +1,5 @@
 import pytest
+from gi.repository import Gtk
 
 import gaphor.core.eventmanager
 from gaphor import UML
@@ -166,3 +167,59 @@ def test_relationship__in_non_package_element(namespace, element_factory):
     assert namespace.iter_n_children(None) == 1
     assert namespace.iter_n_children(iter) == 1
     assert namespace.iter_for_element(g)
+
+
+def test_all_elements_are_draggable(namespace, element_factory):
+    assert namespace.do_row_draggable((0,))
+
+
+class MockSelectionData:
+    def __init__(self, target="GTK_TREE_MODEL_ROW"):
+        self._target = target
+        self.set_data = None
+
+    def get_target(self):
+        return self._target
+
+    def set(self, mock_type, mock_format, data):
+        self.set_data = (mock_type, mock_format, data)
+
+
+def test_droppable(namespace, element_factory, mocker):
+    element_factory.create(UML.Class)
+    selection_data = MockSelectionData()
+    tree_get_row_drag_data = mocker.patch.object(Gtk, "tree_get_row_drag_data")
+    tree_get_row_drag_data.return_value = (True, namespace, (0,))
+
+    assert namespace.do_row_drop_possible((1,), selection_data)
+
+
+def test_drag_data_get_for_model_row(namespace, element_factory, mocker):
+    element_factory.create(UML.Class)
+    selection_data = MockSelectionData()
+    tree_set_row_drag_data = mocker.patch.object(Gtk, "tree_set_row_drag_data")
+    tree_set_row_drag_data.return_value = True
+
+    assert namespace.do_drag_data_get((0,), selection_data)
+    tree_set_row_drag_data.assert_called_once()
+
+
+def test_drag_data_get_element_id(namespace, element_factory):
+    c = element_factory.create(UML.Class)
+    selection_data = MockSelectionData(target="gaphor/element-id")
+    assert namespace.do_drag_data_get((0,), selection_data)
+    type, format, data = selection_data.set_data
+
+    assert data == c.id.encode()
+
+
+def test_drag_data_received(namespace, element_factory, mocker):
+    element_factory.create(UML.Class)
+    element_factory.create(UML.Package)
+    selection_data = MockSelectionData()
+    tree_get_row_drag_data = mocker.patch.object(Gtk, "tree_get_row_drag_data")
+    tree_get_row_drag_data.return_value = (True, namespace, (0,))
+
+    assert namespace.do_drag_data_received(
+        Gtk.TreePath.new_from_indices((1, 0)), selection_data
+    )


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Drag-n-drop only works for GTK+ 3.

Issue Number: #618 

### What is the new behavior?

Clean up DnD code for GTK+ 3 and enable it in GTK 4

DnD works better for GTK+ 3:

* elements are selected after drop
* nodes are expanded
* scrolling kinda works
* Fix expand/collapse keys in tree view for GTK 3.

TreeView in GTK 4 still contain issues, see #756.