### PR TITLE
Property page should only set navigability if both ends are connected

### DIFF
--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -703,11 +703,14 @@ class AssociationPropertyPage(PropertyPageBase):
 
     @transactional
     def _on_end_navigability_change(self, combo, end):
-        UML.model.set_navigability(
-            end.subject.association, end.subject, self.NAVIGABILITY[combo.get_active()]
-        )
-        # Call this again, or non-navigability will not be displayed
-        self.item.update_ends()
+        if end.subject and end.subject.opposite and end.subject.opposite.type:
+            UML.model.set_navigability(
+                end.subject.association,
+                end.subject,
+                self.NAVIGABILITY[combo.get_active()],
+            )
+            # Call this again, or non-navigability will not be displayed
+            self.item.update_ends()
 
     @transactional
     def _on_end_aggregation_change(self, combo, end):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

An error is raised when a composite association is added to a diagram and connected to two classes.

Issue Number: #814

### What is the new behavior?

No exception, association is properly set.
