### PR TITLE
Sign only builds on the master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
           timestampUrl: http://timestamp.digicert.com
           installer: "packaging/dist/gaphor-${{ steps.meta.outputs.version }}-installer.exe"
           portable: "packaging/dist/gaphor-${{ steps.meta.outputs.version }}-portable.exe"
-        if: env.SECRETS_AVAILABLE != null
+        if: env.SECRETS_AVAILABLE != null && github.ref == 'refs/heads/master'
         shell: powershell
         run: |
           $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
@@ -215,12 +215,12 @@ jobs:
           make all
       - name: Import codesign certificate
         uses: apple-actions/import-codesign-certs@v1.0.4
-        if: env.SECRETS_AVAILABLE != null
+        if: env.SECRETS_AVAILABLE != null && github.ref == 'refs/heads/master'
         with:
           p12-file-base64: ${{ secrets.BASE64_ENCODED_P12 }}
           p12-password: ${{ secrets.CERTPASSWORD_P12 }}
       - name: Sign app
-        if: env.SECRETS_AVAILABLE != null
+        if: env.SECRETS_AVAILABLE != null && github.ref == 'refs/heads/master'
         run: >
           cd packaging
 
@@ -229,18 +229,17 @@ jobs:
           -o runtime "dist/Gaphor.app"
       - name: Notarize app
         uses: devbotsxyz/xcode-notarize@v1
-        if: env.SECRETS_AVAILABLE != null
+        if: env.SECRETS_AVAILABLE != null && github.ref == 'refs/heads/master'
         with:
           product-path: "packaging/dist/Gaphor.app"
           appstore-connect-username: ${{ secrets.AC_USERNAME }}
           appstore-connect-password: ${{ secrets.AC_PASSWORD }}
       - name: Staple app
         uses: devbotsxyz/xcode-staple@v1
-        if: env.SECRETS_AVAILABLE != null
+        if: env.SECRETS_AVAILABLE != null && github.ref == 'refs/heads/master'
         with:
           product-path: "packaging/dist/Gaphor.app"
       - name: Create dmg
-        if: env.SECRETS_AVAILABLE != null
         run: >
           cd packaging
 
@@ -252,7 +251,7 @@ jobs:
           "dist/Gaphor.app"
       - name: Notarize dmg
         uses: devbotsxyz/xcode-notarize@v1
-        if: env.SECRETS_AVAILABLE != null
+        if: env.SECRETS_AVAILABLE != null && github.ref == 'refs/heads/master'
         with:
           product-path: "packaging/dist/Gaphor-${{ steps.meta.outputs.version }}.dmg"
           appstore-connect-username: ${{ secrets.AC_USERNAME }}
@@ -260,12 +259,11 @@ jobs:
           primary-bundle-id: org.gaphor.gaphor
       - name: Staple .dmg
         uses: devbotsxyz/xcode-staple@v1
-        if: env.SECRETS_AVAILABLE != null
+        if: env.SECRETS_AVAILABLE != null && github.ref == 'refs/heads/master'
         with:
           product-path: "packaging/dist/Gaphor-${{ steps.meta.outputs.version }}.dmg"
       - name: Upload Gaphor-${{ steps.meta.outputs.version }}.dmg
         uses: actions/upload-artifact@v2
-        if: env.SECRETS_AVAILABLE != null
         with:
           name: Gaphor-${{ steps.meta.outputs.version }}.dmg
           path: packaging/dist/Gaphor-${{ steps.meta.outputs.version }}.dmg


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

This PR hopefully reduces errors on branches due to timeouts of the notarizing service. Also builds will be a little faster.

Rationale: we do not distribute versions from branches, so there's no need to sign them. Maybe it's even better not to sign them, cause these branches (or PR's) can be created by anyone.

