### PR TITLE
Fix delete and undo of a diagram

### DIFF
--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -329,14 +329,14 @@ class UndoManager(Service, ActionProvider):
     def undo_create_element_event(self, event: ElementCreated):
         element_id = event.element.id
 
-        def c_undo_create_event():
+        def d_undo_create_event():
             element = self.deep_lookup(element_id)
             element.unlink()
 
-        c_undo_create_event.__doc__ = f"Undo create element {event.element}."
+        d_undo_create_event.__doc__ = f"Undo create element {event.element}."
         del event
 
-        self.add_undo_action(c_undo_create_event)
+        self.add_undo_action(d_undo_create_event)
 
     @event_handler(ElementDeleted)
     def undo_delete_element_event(self, event: ElementDeleted):
@@ -356,14 +356,14 @@ class UndoManager(Service, ActionProvider):
     def undo_create_diagram_item_event(self, event: DiagramItemCreated):
         element_id = event.element.id
 
-        def c_undo_create_event():
+        def d_undo_create_event():
             element = self.deep_lookup(element_id)
             element.unlink()
 
-        c_undo_create_event.__doc__ = f"Undo create diagram item {event.element}."
+        d_undo_create_event.__doc__ = f"Undo create diagram item {event.element}."
         del event
 
-        self.add_undo_action(c_undo_create_event)
+        self.add_undo_action(d_undo_create_event)
 
     @event_handler(DiagramItemDeleted)
     def undo_delete_diagram_item_event(self, event: DiagramItemDeleted):
@@ -377,17 +377,17 @@ class UndoManager(Service, ActionProvider):
 
         event.element.save(save_func)
 
-        def a_undo_delete_event():
+        def b_undo_delete_event():
             diagram: Diagram = self.deep_lookup(diagram_id)  # type: ignore[assignment]
             element = diagram.create_as(element_type, element_id)
             for name, ser in data.items():
                 for value in deserialize(ser, lambda ref: None):
                     element.load(name, value)
 
-        a_undo_delete_event.__doc__ = f"Undo delete diagram item {event.element}."
+        b_undo_delete_event.__doc__ = f"Undo delete diagram item {event.element}."
         del event
 
-        self.add_undo_action(a_undo_delete_event)
+        self.add_undo_action(b_undo_delete_event)
 
     @event_handler(AttributeUpdated)
     def undo_attribute_change_event(self, event: AttributeUpdated):
@@ -395,16 +395,16 @@ class UndoManager(Service, ActionProvider):
         element_id = event.element.id
         value = event.old_value
 
-        def b_undo_attribute_change_event():
+        def c_undo_attribute_change_event():
             element = self.deep_lookup(element_id)
             attribute._set(element, value)
 
-        b_undo_attribute_change_event.__doc__ = (
+        c_undo_attribute_change_event.__doc__ = (
             f"Revert {event.element}.{attribute.name} to {value}."
         )
         del event
 
-        self.add_undo_action(b_undo_attribute_change_event)
+        self.add_undo_action(c_undo_attribute_change_event)
 
     @event_handler(AssociationSet)
     def undo_association_set_event(self, event: AssociationSet):
@@ -414,17 +414,17 @@ class UndoManager(Service, ActionProvider):
         element_id = event.element.id
         value_id = event.old_value and event.old_value.id
 
-        def b_undo_association_set_event():
+        def c_undo_association_set_event():
             element = self.deep_lookup(element_id)
             value = value_id and self.deep_lookup(value_id)
             association._set(element, value, from_opposite=True)
 
-        b_undo_association_set_event.__doc__ = (
+        c_undo_association_set_event.__doc__ = (
             f"Revert {event.element}.{association.name} to {event.old_value}."
         )
         del event
 
-        self.add_undo_action(b_undo_association_set_event)
+        self.add_undo_action(c_undo_association_set_event)
 
     @event_handler(AssociationAdded)
     def undo_association_add_event(self, event: AssociationAdded):
@@ -434,17 +434,17 @@ class UndoManager(Service, ActionProvider):
         element_id = event.element.id
         value_id = event.new_value.id
 
-        def b_undo_association_add_event():
+        def c_undo_association_add_event():
             element = self.deep_lookup(element_id)
             value = self.deep_lookup(value_id)
             association._del(element, value, from_opposite=True)
 
-        b_undo_association_add_event.__doc__ = (
+        c_undo_association_add_event.__doc__ = (
             f"{event.element}.{association.name} delete {event.new_value}."
         )
         del event
 
-        self.add_undo_action(b_undo_association_add_event)
+        self.add_undo_action(c_undo_association_add_event)
 
     @event_handler(AssociationDeleted)
     def undo_association_delete_event(self, event: AssociationDeleted):
@@ -454,14 +454,14 @@ class UndoManager(Service, ActionProvider):
         element_id = event.element.id
         value_id = event.old_value.id
 
-        def b_undo_association_delete_event():
+        def c_undo_association_delete_event():
             element = self.deep_lookup(element_id)
             value = self.deep_lookup(value_id)
             association._set(element, value, from_opposite=True)
 
-        b_undo_association_delete_event.__doc__ = (
+        c_undo_association_delete_event.__doc__ = (
             f"{event.element}.{association.name} add {event.old_value}."
         )
         del event
 
-        self.add_undo_action(b_undo_association_delete_event)
+        self.add_undo_action(c_undo_association_delete_event)

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -279,3 +279,19 @@ def test_can_undo_connected_association(
     assert new_association_item.head_subject
     assert new_association_item.tail_subject
     assert not caplog.records
+
+
+def test_can_undo_diagram_with_content(event_manager, element_factory, undo_manager):
+    with Transaction(event_manager):
+        diagram: Diagram = element_factory.create(Diagram)
+        diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+
+    with Transaction(event_manager):
+        diagram.unlink()
+
+    undo_manager.undo_transaction()
+
+    new_diagram = next(element_factory.select(Diagram))
+
+    assert new_diagram
+    assert new_diagram.ownedPresentation

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -291,7 +291,7 @@ def test_can_undo_diagram_with_content(event_manager, element_factory, undo_mana
 
     undo_manager.undo_transaction()
 
-    new_diagram = next(element_factory.select(Diagram))
+    new_diagram = element_factory.lookup(diagram.id)
 
     assert new_diagram
     assert new_diagram.ownedPresentation


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

If you delete a diagram with an item in it
this causes the item to also be deleted.

Undoing this change raises an exception.

Issue Number: N/A

### What is the new behavior?

Delete and undo of a diagram should just work.


### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

