### PR TITLE
Link toolbox and diagrams

### DIFF
--- a/gaphor/diagram/tests/conftest.py
+++ b/gaphor/diagram/tests/conftest.py
@@ -3,4 +3,5 @@ from gaphor.diagram.tests.fixtures import (
     element_factory,
     event_manager,
     loader,
+    modeling_language,
 )

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -317,15 +317,9 @@ class DiagramPage:
     def _on_diagram_item_placed(self, event):
         if self.properties.get("reset-tool-after-create", True):
             assert self.widget
-            if Gtk.get_major_version() == 3:
-                self.widget.action_group.actions.lookup_action("select-tool").activate(
-                    GLib.Variant.new_string("toolbox-pointer")
-                )
-            else:
-                assert self.view
-                self.view.activate_action(
-                    "diagram.select-tool", GLib.Variant.new_string("toolbox-pointer")
-                )
+            self.widget.action_group.actions.lookup_action("select-tool").activate(
+                GLib.Variant.new_string("toolbox-pointer")
+            )
 
     def set_drawing_style(self):
         """Set the drawing style for the diagram based on the active style

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -11,7 +11,7 @@ from gaphas.view import GtkView
 from gi.repository import Gdk, GdkPixbuf, Gtk
 
 from gaphor import UML
-from gaphor.core import action, event_handler, gettext
+from gaphor.core import event_handler, gettext
 from gaphor.core.modeling import StyleSheet
 from gaphor.core.modeling.diagram import StyledDiagram
 from gaphor.core.modeling.event import AttributeUpdated, ElementDeleted
@@ -22,7 +22,6 @@ from gaphor.diagram.painter import ItemPainter
 from gaphor.diagram.selection import Selection
 from gaphor.diagram.support import get_diagram_item
 from gaphor.transaction import Transaction
-from gaphor.ui.actiongroup import create_action_group
 from gaphor.ui.event import DiagramSelectionChanged, Notification, ToolSelected
 
 log = logging.getLogger(__name__)
@@ -161,14 +160,8 @@ class DiagramPage:
             scrolled_window.add(view)
             scrolled_window.show_all()
             view.connect("drag-data-received", self._on_drag_data_received)
-            scrolled_window.action_group = create_action_group(self, "diagram")
         else:
             scrolled_window.set_child(view)
-            scrolled_window.action_group = create_action_group(self, "diagram")
-            _, shortcuts = scrolled_window.action_group
-            ctrl = Gtk.ShortcutController.new_for_model(shortcuts)
-            ctrl.set_scope(Gtk.ShortcutScope.LOCAL)
-            scrolled_window.add_controller(ctrl)
 
         view.selection.add_handler(self._on_view_selection_changed)
 
@@ -256,46 +249,6 @@ class DiagramPage:
         self.event_manager.unsubscribe(self._on_style_sheet_updated)
         self.event_manager.unsubscribe(self._on_tool_selected)
         self.view = None
-
-    @action(
-        name="diagram.zoom-in",
-        shortcut="<Primary>plus",
-    )
-    def zoom_in(self):
-        assert self.view
-        self.view.zoom(1.2)
-
-    @action(
-        name="diagram.zoom-out",
-        shortcut="<Primary>minus",
-    )
-    def zoom_out(self):
-        assert self.view
-        self.view.zoom(1 / 1.2)
-
-    @action(
-        name="diagram.zoom-100",
-        shortcut="<Primary>0",
-    )
-    def zoom_100(self):
-        assert self.view
-        zx = self.view.matrix[0]
-        self.view.zoom(1 / zx)
-
-    @action(
-        name="diagram.select-all",
-        shortcut="<Primary>a",
-    )
-    def select_all(self):
-        assert self.view
-        if self.view.has_focus():
-            self.view.selection.select_items(*self.view.model.get_all_items())
-
-    @action(name="diagram.unselect-all", shortcut="<Primary><Shift>a")
-    def unselect_all(self):
-        assert self.view
-        if self.view.has_focus():
-            self.view.selection.unselect_all()
 
     def select_tool(self, tool_name: str):
         if self.view:

--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -15,11 +15,15 @@ log = logging.getLogger(__name__)
 
 
 class Diagrams(UIComponent, ActionProvider):
-    def __init__(self, event_manager, element_factory, properties, modeling_language):
+
+    def __init__(
+        self, event_manager, element_factory, properties, modeling_language, toolbox
+    ):
         self.event_manager = event_manager
         self.element_factory = element_factory
         self.properties = properties
         self.modeling_language = modeling_language
+        self.toolbox = toolbox
         self._notebook: Gtk.Notebook = None
         self._page_handler_ids: List[int] = []
 
@@ -193,24 +197,20 @@ class Diagrams(UIComponent, ActionProvider):
         log.debug(f"pages changed: {self.properties.get('opened-diagrams')}")
 
     def _add_ui_settings(self, page):
+        self.toolbox.set_actions(page.action_group.actions)
         if Gtk.get_major_version() == 3:
-            window = page.get_toplevel()
-            window.insert_action_group("diagram", page.action_group.actions)
-            window.add_accel_group(page.action_group.shortcuts)
+            page.get_toplevel().add_accel_group(page.action_group.shortcuts)
         else:
-            window = page.get_root()
-            print("adding", page.action_group.actions)
-            window.insert_action_group("diagram", page.action_group.actions)
-            print("done", page.action_group.actions)
+            # TODO: GTK4 - set shortcuts
+            pass
 
     def _clear_ui_settings(self, page):
+        self.toolbox.set_actions(None)
         if Gtk.get_major_version() == 3:
-            window = page.get_toplevel()
-            window.insert_action_group("diagram", None)
-            window.remove_accel_group(page.action_group.shortcuts)
+            page.get_toplevel().remove_accel_group(page.action_group.shortcuts)
         else:
-            window = page.get_root()
-            window.insert_action_group("diagram", None)
+            # TODO: GTK4 - unset shortcuts
+            pass
 
     @action(name="close-current-tab", shortcut="<Primary>w")
     def close_current_tab(self):

--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -221,6 +221,7 @@ class Diagrams(UIComponent, ActionProvider):
 
         apply_tool_select_controller(widget, self.toolbox)
         self.create_tab(diagram.name, widget)
+        page.select_tool(self.toolbox.active_tool_name)
         self.get_current_view().grab_focus()
         self._update_action_state()
         return page

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -176,7 +176,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Zoom In</property>
-                    <property name="action_name">diagram.zoom-in</property>
+                    <property name="action_name">win.zoom-in</property>
                     <child>
                       <object class="GtkImage">
                         <property name="visible">True</property>
@@ -197,7 +197,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Zoom 100%</property>
-                    <property name="action_name">diagram.zoom-100</property>
+                    <property name="action_name">win.zoom-100</property>
                     <child>
                       <object class="GtkImage">
                         <property name="visible">True</property>
@@ -218,7 +218,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Zoom Out</property>
-                    <property name="action_name">diagram.zoom-out</property>
+                    <property name="action_name">win.zoom-out</property>
                     <child>
                       <object class="GtkImage">
                         <property name="visible">True</property>

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -103,7 +103,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                   <object class="GtkButton">
                     <property name="receives_default">1</property>
                     <property name="tooltip_text" translatable="yes">Zoom In</property>
-                    <property name="action_name">diagram.zoom-in</property>
+                    <property name="action_name">win.zoom-in</property>
                     <child>
                       <object class="GtkImage">
                         <property name="icon_name">zoom-in-symbolic</property>
@@ -115,7 +115,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                   <object class="GtkButton">
                     <property name="receives_default">1</property>
                     <property name="tooltip_text" translatable="yes">Zoom 100%</property>
-                    <property name="action_name">diagram.zoom-100</property>
+                    <property name="action_name">win.zoom-100</property>
                     <child>
                       <object class="GtkImage">
                         <property name="icon_name">zoom-original-symbolic</property>
@@ -127,7 +127,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                   <object class="GtkButton">
                     <property name="receives_default">1</property>
                     <property name="tooltip_text" translatable="yes">Zoom Out</property>
-                    <property name="action_name">diagram.zoom-out</property>
+                    <property name="action_name">win.zoom-out</property>
                     <child>
                       <object class="GtkImage">
                         <property name="icon_name">zoom-out-symbolic</property>

--- a/gaphor/ui/event.py
+++ b/gaphor/ui/event.py
@@ -18,6 +18,11 @@ class DiagramSelectionChanged:
         self.selected_items = selected_items
 
 
+class ToolSelected:
+    def __init__(self, tool_name):
+        self.tool_name = tool_name
+
+
 class Notification:
     def __init__(self, message):
         self.message = message

--- a/gaphor/ui/mainwindow.glade
+++ b/gaphor/ui/mainwindow.glade
@@ -179,7 +179,7 @@
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
             <property name="tooltip-text" translatable="yes">New diagram</property>
-            <property name="action-name">tree-view.create-diagram</property>
+            <property name="action-name">win.create-diagram</property>
             <child>
               <object class="GtkImage">
                 <property name="visible">True</property>

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -199,19 +199,6 @@ class MainWindow(Service, ActionProvider):
         def _factory(name):
             comp = self.get_ui_component(name)
             widget = comp.open()
-
-            # Okay, this may be hackish. Action groups on component level are also added
-            # to the main window. This ensures that we can call those items from the
-            # (main) menus as well. Also this makes enabling/disabling work.
-            if Gtk.get_major_version() == 3:
-                for prefix in widget.list_action_prefixes():
-                    assert prefix not in ("app", "win")
-                    self.window.insert_action_group(
-                        prefix, widget.get_action_group(prefix)
-                    )
-            else:
-                # TODO: GTK4 - attach shortcuts
-                pass
             return widget
 
         with importlib.resources.open_text("gaphor.ui", "layout.xml") as f:

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -198,8 +198,7 @@ class MainWindow(Service, ActionProvider):
 
         def _factory(name):
             comp = self.get_ui_component(name)
-            widget = comp.open()
-            return widget
+            return comp.open()
 
         with importlib.resources.open_text("gaphor.ui", "layout.xml") as f:
             main_content = builder.get_object("main-content")

--- a/gaphor/ui/mainwindow.ui
+++ b/gaphor/ui/mainwindow.ui
@@ -55,7 +55,7 @@
         </child>
         <child>
           <object class="GtkButton">
-            <property name="action_name">tree-view.create-diagram</property>
+            <property name="action_name">win.create-diagram</property>
             <property name="icon_name">gaphor-new-diagram-symbolic</property>
           </object>
         </child>

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional, Set
 from gi.repository import Gdk, Gio, GLib, Gtk
 
 from gaphor import UML
+from gaphor.abc import ActionProvider
 from gaphor.core import action, event_handler, gettext, transactional
 from gaphor.core.modeling import Diagram, Element, Presentation
 from gaphor.ui.abc import UIComponent
@@ -43,7 +44,7 @@ def popup_model(element):
     model.append_section(None, part)
 
     part = Gio.Menu.new()
-    part.append(gettext("New _Diagram"), "tree-view.create-diagram")
+    part.append(gettext("New _Diagram"), "win.create-diagram")
     part.append(gettext("New _Package"), "tree-view.create-package")
     model.append_section(None, part)
 
@@ -74,7 +75,7 @@ def popup_model(element):
     return model
 
 
-class Namespace(UIComponent):
+class Namespace(UIComponent, ActionProvider):
     def __init__(self, event_manager: EventManager, element_factory: ElementFactory):
         self.event_manager = event_manager
         self.element_factory = element_factory
@@ -282,7 +283,7 @@ class Namespace(UIComponent):
             view.set_cursor(path, column, True)
             cell.set_property("editable", 0)
 
-    @action(name="tree-view.create-diagram")
+    @action(name="win.create-diagram")
     @transactional
     def tree_view_create_diagram(self):
         assert self.view

--- a/gaphor/ui/tests/conftest.py
+++ b/gaphor/ui/tests/conftest.py
@@ -1,6 +1,11 @@
 import pytest
 
-from gaphor.diagram.tests.fixtures import diagram, element_factory, event_manager
+from gaphor.diagram.tests.fixtures import (
+    diagram,
+    element_factory,
+    event_manager,
+    modeling_language,
+)
 
 
 @pytest.fixture

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -13,14 +13,17 @@ from gaphor.diagram.general.comment import CommentItem
 from gaphor.diagram.general.commentline import CommentLineItem
 from gaphor.ui.diagrams import Diagrams
 from gaphor.ui.event import DiagramOpened
+from gaphor.ui.toolbox import Toolbox
 from gaphor.UML.modelinglanguage import UMLModelingLanguage
 from gaphor.UML.usecases.actor import ActorItem
 
 
 @pytest.fixture
 def diagrams(event_manager, element_factory, properties):
+    modeling_language = UMLModelingLanguage()
+    toolbox = Toolbox(event_manager, properties, modeling_language)
     diagrams = Diagrams(
-        event_manager, element_factory, properties, UMLModelingLanguage()
+        event_manager, element_factory, properties, modeling_language, toolbox
     )
     if Gtk.get_major_version() == 3:
         window = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)

--- a/gaphor/ui/tests/test_namespacemodel.py
+++ b/gaphor/ui/tests/test_namespacemodel.py
@@ -194,6 +194,7 @@ def test_droppable(namespace, element_factory, mocker):
     assert namespace.do_row_drop_possible((1,), selection_data)
 
 
+@pytest.mark.skipif(Gtk.get_major_version() != 3, reason="Works only for GTK+ 3")
 def test_drag_data_get_for_model_row(namespace, element_factory, mocker):
     element_factory.create(UML.Class)
     selection_data = MockSelectionData()

--- a/gaphor/ui/tests/test_toolbox.py
+++ b/gaphor/ui/tests/test_toolbox.py
@@ -1,0 +1,22 @@
+import pytest
+
+from gaphor.ui.toolbox import Toolbox
+
+
+@pytest.fixture
+def toolbox(event_manager, modeling_language):
+    return Toolbox(
+        event_manager=event_manager, properties={}, modeling_language=modeling_language
+    )
+
+
+def test_toolbox_construction(toolbox):
+    widget = toolbox.open()
+
+    assert widget
+
+
+def test_current_tool(toolbox):
+    tool_name = toolbox.active_tool_name
+
+    assert tool_name == "toolbox-pointer"

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -8,16 +8,23 @@ from typing import Optional, Sequence, Tuple
 
 from gi.repository import Gdk, Gio, GLib, Gtk
 
+<<<<<<< HEAD
 from gaphor.abc import ActionProvider
+=======
+from gaphor.core import action, gettext
+>>>>>>> 3b251489 (Move tool selection to toolbox)
 from gaphor.core.eventmanager import event_handler
 from gaphor.diagram.diagramtoolbox import ToolDef
+from gaphor.diagram.event import DiagramItemPlaced
 from gaphor.services.modelinglanguage import ModelingLanguageChanged
 from gaphor.ui.abc import UIComponent
+from gaphor.ui.actiongroup import create_action_group
+from gaphor.ui.event import ToolSelected
 
 log = logging.getLogger(__name__)
 
 
-class Toolbox(UIComponent, ActionProvider):
+class Toolbox(UIComponent):
 
     if Gtk.get_major_version() == 3:
         TARGET_STRING = 0
@@ -34,13 +41,14 @@ class Toolbox(UIComponent, ActionProvider):
         self.event_manager = event_manager
         self.properties = properties
         self.modeling_language = modeling_language
+        self._action_group, self._shortcuts = create_action_group(self, "toolbox")
         self._toolbox: Optional[Gtk.Box] = None
         self._toolbox_container: Optional[Gtk.ScrolledWindow] = None
-        self._toolbox_action_group: Optional[Gio.ActionGroup] = None
 
     def open(self) -> Gtk.ScrolledWindow:
         toolbox = self.create_toolbox(self.modeling_language.toolbox_definition)
         toolbox_container = self.create_toolbox_container(toolbox)
+        self.event_manager.subscribe(self._on_diagram_item_placed)
         self.event_manager.subscribe(self._on_modeling_language_changed)
         self._toolbox = toolbox
         self._toolbox_container = toolbox_container
@@ -54,6 +62,7 @@ class Toolbox(UIComponent, ActionProvider):
                 self._toolbox_container.unparent()
             self._toolbox = None
         self.event_manager.unsubscribe(self._on_modeling_language_changed)
+        self.event_manager.unsubscribe(self._on_diagram_item_placed)
 
     def set_actions(self, action_group: Optional[Gio.ActionGroup]) -> None:
         if self._toolbox_container:
@@ -80,7 +89,7 @@ class Toolbox(UIComponent, ActionProvider):
         else:
             icon = Gtk.Image.new_from_icon_name(icon_name)
             button.set_child(icon)
-        button.set_action_name("diagram.select-tool")
+        button.set_action_name("toolbox.select-tool")
         button.set_action_target_value(GLib.Variant.new_string(action_name))
         button.get_style_context().add_class("flat")
         if label:
@@ -114,6 +123,7 @@ class Toolbox(UIComponent, ActionProvider):
         toolbox = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
         toolbox.set_name("toolbox")
         toolbox.connect("destroy", self._on_toolbox_destroyed)
+        toolbox.insert_action_group("toolbox", self._action_group)
         collapsed = self.properties.get("toolbox-collapsed", {})
 
         def on_expanded(widget, prop, index):
@@ -151,10 +161,22 @@ class Toolbox(UIComponent, ActionProvider):
         toolbox_container.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         if Gtk.get_major_version() == 3:
             toolbox_container.add(toolbox)
+            toolbox_container.show()
         else:
             toolbox_container.set_child(toolbox)
-        toolbox_container.show()
         return toolbox_container
+
+    @action(name="toolbox.select-tool", state="toolbox-pointer")
+    def select_tool(self, tool_name: str):
+        print("select tool", tool_name)
+        self.event_manager.handle(ToolSelected(tool_name))
+
+    @event_handler(DiagramItemPlaced)
+    def _on_diagram_item_placed(self, event):
+        if self.properties.get("reset-tool-after-create", True):
+            self._action_group.lookup_action("select-tool").activate(
+                GLib.Variant.new_string("toolbox-pointer")
+            )
 
     @event_handler(ModelingLanguageChanged)
     def _on_modeling_language_changed(self, event) -> None:

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -9,11 +9,7 @@ from typing import Optional, Sequence, Tuple
 
 from gi.repository import Gdk, GLib, Gtk
 
-<<<<<<< HEAD
-from gaphor.abc import ActionProvider
-=======
-from gaphor.core import action, gettext
->>>>>>> 3b251489 (Move tool selection to toolbox)
+from gaphor.core import action
 from gaphor.core.eventmanager import event_handler
 from gaphor.diagram.diagramtoolbox import ToolDef
 from gaphor.diagram.event import DiagramItemPlaced

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -6,7 +6,7 @@ This is the toolbox in the lower left of the screen.
 import logging
 from typing import Optional, Sequence, Tuple
 
-from gi.repository import Gdk, GLib, Gtk
+from gi.repository import Gdk, Gio, GLib, Gtk
 
 from gaphor.abc import ActionProvider
 from gaphor.core.eventmanager import event_handler
@@ -36,6 +36,7 @@ class Toolbox(UIComponent, ActionProvider):
         self.modeling_language = modeling_language
         self._toolbox: Optional[Gtk.Box] = None
         self._toolbox_container: Optional[Gtk.ScrolledWindow] = None
+        self._toolbox_action_group: Optional[Gio.ActionGroup] = None
 
     def open(self) -> Gtk.ScrolledWindow:
         toolbox = self.create_toolbox(self.modeling_language.toolbox_definition)
@@ -53,6 +54,11 @@ class Toolbox(UIComponent, ActionProvider):
                 self._toolbox_container.unparent()
             self._toolbox = None
         self.event_manager.unsubscribe(self._on_modeling_language_changed)
+
+    def set_actions(self, action_group: Optional[Gio.ActionGroup]) -> None:
+        if self._toolbox_container:
+            self._toolbox_container.insert_action_group("diagram", action_group)
+            self._toolbox_action_group = action_group
 
     def create_toolbox_button(
         self, action_name: str, icon_name: str, label: str, shortcut: Optional[str]

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -15,7 +15,7 @@ from gaphor.diagram.diagramtoolbox import ToolDef
 from gaphor.diagram.event import DiagramItemPlaced
 from gaphor.services.modelinglanguage import ModelingLanguageChanged
 from gaphor.ui.abc import UIComponent
-from gaphor.ui.actiongroup import create_action_group
+from gaphor.ui.actiongroup import create_action_group, from_variant
 from gaphor.ui.event import ToolSelected
 
 log = logging.getLogger(__name__)
@@ -75,6 +75,11 @@ class Toolbox(UIComponent):
                     )
                     return True
         return False
+
+    @property
+    def active_tool_name(self):
+        gvar = self._action_group.get_action_state("select-tool")
+        return gvar and from_variant(gvar)
 
     def create_toolbox_button(
         self, action_name: str, icon_name: str, label: str, shortcut: Optional[str]


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Action groups in Gaphor are "magically" set on the main window. The comment already says it's hacky.

... and it doesn't port nicely to GTK 4.

Issue Number: N/A

### What is the new behavior?

Clean up the action code:
* handle toolbox related code in the toolbox component
* When a tool is selected, it can be applied on all diagrams (before, each diagram had its own action group)
* move DiagramPage actions to Diagrams level. This makes the action handling simpler
* make relation between diagrams and toolbox expicit
* remove hacky code

### Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

To do:

- [x] Set the appropriate selected tool when a new diagram is opened.