### PR TITLE
Organize element events

### DIFF
--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -280,7 +280,7 @@ class Diagram(Element):
         assert isinstance(
             item, gaphas.Item
         ), f"Type {type} does not comply with Item protocol"
-        self.model.handle(DiagramItemCreated(self, item))
+        self.model.handle(DiagramItemCreated(self.model, item, self))
         if subject:
             item.subject = subject
         if parent:

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -14,7 +14,7 @@ import gaphas
 
 from gaphor.core.modeling.collection import collection
 from gaphor.core.modeling.element import Element, Id, RepositoryProtocol
-from gaphor.core.modeling.event import AssociationDeleted, DiagramItemCreated
+from gaphor.core.modeling.event import AssociationDeleted, ElementCreated
 from gaphor.core.modeling.presentation import Presentation
 from gaphor.core.modeling.properties import (
     association,
@@ -280,7 +280,7 @@ class Diagram(Element):
         assert isinstance(
             item, gaphas.Item
         ), f"Type {type} does not comply with Item protocol"
-        self.model.handle(DiagramItemCreated(self.model, item, self))
+        self.model.handle(ElementCreated(self.model, item, self))
         if subject:
             item.subject = subject
         if parent:

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -64,8 +64,7 @@ class ElementFactory(Service):
 
     def create(self, type: Type[T]) -> T:
         """Create a new model element of type ``type``."""
-        obj = self.create_as(type, str(uuid.uuid1()))
-        return obj
+        return self.create_as(type, str(uuid.uuid1()))
 
     def create_as(self, type: Type[T], id: str) -> T:
         """Create a new model element of type 'type' with 'id' as its ID.

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -65,7 +65,6 @@ class ElementFactory(Service):
     def create(self, type: Type[T]) -> T:
         """Create a new model element of type ``type``."""
         obj = self.create_as(type, str(uuid.uuid1()))
-        self.handle(ElementCreated(self, obj))
         return obj
 
     def create_as(self, type: Type[T], id: str) -> T:
@@ -78,6 +77,7 @@ class ElementFactory(Service):
             raise TypeError(f"Type {type} is not a valid model element")
         obj = type(id, self)
         self._elements[id] = obj
+        self.handle(ElementCreated(self, obj))
         return obj
 
     def size(self) -> int:

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -226,20 +226,20 @@ class ElementDeleted(ServiceEvent):
         self.element = element
 
 
-class DiagramItemCreated:
+class DiagramItemCreated(ElementCreated):
     """A diagram item has been created."""
 
     def __init__(self, diagram, element):
+        super().__init__(diagram, element)
         self.diagram = diagram
-        self.element = element
 
 
-class DiagramItemDeleted:
+class DiagramItemDeleted(ElementDeleted):
     """A diagram item has been deleted."""
 
     def __init__(self, diagram, element):
+        super().__init__(diagram, element)
         self.diagram = diagram
-        self.element = element
 
 
 class ModelReady(ServiceEvent):

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -201,7 +201,7 @@ class RedefinedDeleted(AssociationDeleted):
 class ElementCreated(ServiceEvent):
     """An element has been created."""
 
-    def __init__(self, service, element):
+    def __init__(self, service, element, diagram=None):
         """Constructor.
 
         The service parameter is the service responsible for creating
@@ -210,12 +210,13 @@ class ElementCreated(ServiceEvent):
         """
         super().__init__(service)
         self.element = element
+        self.diagram = diagram
 
 
 class ElementDeleted(ServiceEvent):
     """An element has been deleted."""
 
-    def __init__(self, service, element):
+    def __init__(self, service, element, diagram=None):
         """Constructor.
 
         The service parameter is the service responsible for deleting
@@ -224,22 +225,13 @@ class ElementDeleted(ServiceEvent):
         """
         super().__init__(service)
         self.element = element
-
-
-class DiagramItemCreated(ElementCreated):
-    """A diagram item has been created."""
-
-    def __init__(self, diagram, element):
-        super().__init__(diagram, element)
         self.diagram = diagram
 
 
-class DiagramItemDeleted(ElementDeleted):
-    """A diagram item has been deleted."""
+DiagramItemCreated = ElementCreated
 
-    def __init__(self, diagram, element):
-        super().__init__(diagram, element)
-        self.diagram = diagram
+
+DiagramItemDeleted = ElementDeleted
 
 
 class ModelReady(ServiceEvent):

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -228,12 +228,6 @@ class ElementDeleted(ServiceEvent):
         self.diagram = diagram
 
 
-DiagramItemCreated = ElementCreated
-
-
-DiagramItemDeleted = ElementDeleted
-
-
 class ModelReady(ServiceEvent):
     """A generic element factory event."""
 

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -90,7 +90,7 @@ class Presentation(Matrices, Element, Generic[S]):
             diagram.connections.remove_connections_to_item(self)
         super().unlink()
         if diagram:
-            self.handle(DiagramItemDeleted(diagram, self))
+            self.handle(DiagramItemDeleted(self.model, self, diagram))
 
     def _on_diagram_changed(self, event):
         log.debug("Diagram changed. Unlinking %s.", self)
@@ -98,7 +98,7 @@ class Presentation(Matrices, Element, Generic[S]):
         if diagram:
             diagram.connections.remove_connections_to_item(self)
             self.unlink()
-            self.handle(DiagramItemDeleted(diagram, self))
+            self.handle(DiagramItemDeleted(self.model, self, diagram))
         if event.new_value:
             raise ValueError("Can not change diagram for a presentation")
 

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 from gaphas.item import Matrices
 
 from gaphor.core.modeling.element import Element
-from gaphor.core.modeling.event import DiagramItemDeleted, RevertibeEvent
+from gaphor.core.modeling.event import ElementDeleted, RevertibeEvent
 from gaphor.core.modeling.properties import association, relation_many, relation_one
 
 if TYPE_CHECKING:
@@ -27,8 +27,8 @@ class Presentation(Matrices, Element, Generic[S]):
     Note that Presentations are not managed by the Element Factory.
     Instead, Presentation objects are owned by Diagram. As a result they
     do not emit ElementCreated and ElementDeleted events. Presentations
-    have their own create and delete events: DiagramItemCreated and
-    DiagramItemDeleted.
+    have their own create and delete events: ElementCreated and
+    ElementDeleted.
     """
 
     def __init__(self, diagram: Diagram, id=None):
@@ -90,7 +90,7 @@ class Presentation(Matrices, Element, Generic[S]):
             diagram.connections.remove_connections_to_item(self)
         super().unlink()
         if diagram:
-            self.handle(DiagramItemDeleted(self.model, self, diagram))
+            self.handle(ElementDeleted(self.model, self, diagram))
 
     def _on_diagram_changed(self, event):
         log.debug("Diagram changed. Unlinking %s.", self)
@@ -98,7 +98,7 @@ class Presentation(Matrices, Element, Generic[S]):
         if diagram:
             diagram.connections.remove_connections_to_item(self)
             self.unlink()
-            self.handle(DiagramItemDeleted(self.model, self, diagram))
+            self.handle(ElementDeleted(self.model, self, diagram))
         if event.new_value:
             raise ValueError("Can not change diagram for a presentation")
 

--- a/gaphor/core/modeling/tests/test_presentation.py
+++ b/gaphor/core/modeling/tests/test_presentation.py
@@ -5,7 +5,7 @@ from gaphas.solver import Variable
 
 from gaphor.core.eventmanager import event_handler
 from gaphor.core.modeling.diagram import Diagram
-from gaphor.core.modeling.event import DiagramItemDeleted
+from gaphor.core.modeling.event import ElementDeleted
 from gaphor.core.modeling.presentation import Presentation
 
 
@@ -29,7 +29,7 @@ def test_should_emit_event_when_unlinked(diagram, event_manager):
     presentation = diagram.create(Example)
     events = []
 
-    @event_handler(DiagramItemDeleted)
+    @event_handler(ElementDeleted)
     def handler(event):
         events.append(event)
 
@@ -66,7 +66,7 @@ def test_should_emit_event_when_diagram_changes(diagram, event_manager):
     presentation = diagram.create(Example)
     events = []
 
-    @event_handler(DiagramItemDeleted)
+    @event_handler(ElementDeleted)
     def handler(event):
         events.append(event)
 

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -356,6 +356,7 @@ class UndoManager(Service, ActionProvider):
 
             undo_delete_event = b_undo_delete_event
         else:
+
             def a_undo_delete_event():
                 self.element_factory.create_as(element_type, element_id)
 

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -344,8 +344,7 @@ class UndoManager(Service, ActionProvider):
         element_id = event.element.id
 
         def a_undo_delete_event():
-            element = self.element_factory.create_as(element_type, element_id)
-            self.event_manager.handle(ElementCreated(self.element_factory, element))
+            self.element_factory.create_as(element_type, element_id)
 
         a_undo_delete_event.__doc__ = f"Recreate element {element_type} ({element_id})."
         del event

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -325,7 +325,6 @@ class UndoManager(Service, ActionProvider):
     @event_handler(ElementCreated)
     def undo_create_element_event(self, event: ElementCreated):
         if isinstance(event.element, Presentation):
-            assert isinstance(event, DiagramItemCreated)
             self.undo_create_diagram_item_event(event)
             return
 
@@ -343,7 +342,6 @@ class UndoManager(Service, ActionProvider):
     @event_handler(ElementDeleted)
     def undo_delete_element_event(self, event: ElementDeleted):
         if isinstance(event.element, Presentation):
-            assert isinstance(event, DiagramItemDeleted)
             self.undo_delete_diagram_item_event(event)
             return
 

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -23,8 +23,6 @@ from gaphor.core.modeling.event import (
     AssociationDeleted,
     AssociationSet,
     AttributeUpdated,
-    DiagramItemCreated,
-    DiagramItemDeleted,
     ElementCreated,
     ElementDeleted,
     ModelReady,
@@ -356,7 +354,7 @@ class UndoManager(Service, ActionProvider):
 
         self.add_undo_action(a_undo_delete_event)
 
-    def undo_create_diagram_item_event(self, event: DiagramItemCreated):
+    def undo_create_diagram_item_event(self, event: ElementCreated):
         element_id = event.element.id
 
         def d_undo_create_event():
@@ -368,7 +366,7 @@ class UndoManager(Service, ActionProvider):
 
         self.add_undo_action(d_undo_create_event)
 
-    def undo_delete_diagram_item_event(self, event: DiagramItemDeleted):
+    def undo_delete_diagram_item_event(self, event: ElementDeleted):
         diagram_id = event.diagram.id
         element_type = type(event.element)
         element_id = event.element.id

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -30,6 +30,7 @@ from gaphor.core.modeling.event import (
     ModelReady,
     RevertibeEvent,
 )
+from gaphor.core.modeling.presentation import Presentation
 from gaphor.core.modeling.properties import association as association_property
 from gaphor.diagram.copypaste import deserialize, serialize
 from gaphor.event import (
@@ -288,8 +289,6 @@ class UndoManager(Service, ActionProvider):
         self.event_manager.subscribe(self.undo_reversible_event)
         self.event_manager.subscribe(self.undo_create_element_event)
         self.event_manager.subscribe(self.undo_delete_element_event)
-        self.event_manager.subscribe(self.undo_create_diagram_item_event)
-        self.event_manager.subscribe(self.undo_delete_diagram_item_event)
         self.event_manager.subscribe(self.undo_attribute_change_event)
         self.event_manager.subscribe(self.undo_association_set_event)
         self.event_manager.subscribe(self.undo_association_add_event)
@@ -302,8 +301,6 @@ class UndoManager(Service, ActionProvider):
         self.event_manager.unsubscribe(self.undo_reversible_event)
         self.event_manager.unsubscribe(self.undo_create_element_event)
         self.event_manager.unsubscribe(self.undo_delete_element_event)
-        self.event_manager.unsubscribe(self.undo_create_diagram_item_event)
-        self.event_manager.unsubscribe(self.undo_delete_diagram_item_event)
         self.event_manager.unsubscribe(self.undo_attribute_change_event)
         self.event_manager.unsubscribe(self.undo_association_set_event)
         self.event_manager.unsubscribe(self.undo_association_add_event)
@@ -327,6 +324,11 @@ class UndoManager(Service, ActionProvider):
 
     @event_handler(ElementCreated)
     def undo_create_element_event(self, event: ElementCreated):
+        if isinstance(event.element, Presentation):
+            assert isinstance(event, DiagramItemCreated)
+            self.undo_create_diagram_item_event(event)
+            return
+
         element_id = event.element.id
 
         def d_undo_create_event():
@@ -340,6 +342,11 @@ class UndoManager(Service, ActionProvider):
 
     @event_handler(ElementDeleted)
     def undo_delete_element_event(self, event: ElementDeleted):
+        if isinstance(event.element, Presentation):
+            assert isinstance(event, DiagramItemDeleted)
+            self.undo_delete_diagram_item_event(event)
+            return
+
         element_type = type(event.element)
         element_id = event.element.id
 
@@ -351,7 +358,6 @@ class UndoManager(Service, ActionProvider):
 
         self.add_undo_action(a_undo_delete_event)
 
-    @event_handler(DiagramItemCreated)
     def undo_create_diagram_item_event(self, event: DiagramItemCreated):
         element_id = event.element.id
 
@@ -364,7 +370,6 @@ class UndoManager(Service, ActionProvider):
 
         self.add_undo_action(d_undo_create_event)
 
-    @event_handler(DiagramItemDeleted)
     def undo_delete_diagram_item_event(self, event: DiagramItemDeleted):
         diagram_id = event.diagram.id
         element_type = type(event.element)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Gaphor makes a distinction between model elements and diagram items. This distinction is no longer valid and may even harm the integrity of a model.

Issue Number: N.A.

### What is the new behavior?

Simplify the use of events for creation of model elements and diagram items. They should behave the same.

`DiagramItemCreated` and `DiagramItemDeleted` have been replaced by `ElementCreated` and `ElementDeleted`.

This change allows us to store diagram items (Presentation) in the ElementFactory, alongside the rest of the model.

### Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
