### PR TITLE
Enable pyupgrade and use Python 3.9 in Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,17 +123,26 @@ jobs:
         run: ./packaging/windows/msys2-install.sh
       - name: Install Poetry
         run: |
+          python3.9 -m venv .venv
+          source .venv/bin/activate
           pip install poetry==$POETRY_VERSION
           poetry config virtualenvs.create false
       - name: Collect Project Data
         id: meta
-        run: .github/scripts/metadata.sh
+        run: |
+          source .venv/bin/activate
+          .github/scripts/metadata.sh
       - name: Install Python Dependencies
-        run: mingw32-make install
+        run: |
+          source .venv/bin/activate
+          mingw32-make install
       - name: Test with PyTest
-        run: mingw32-make test-all
+        run: |
+          source .venv/bin/activate
+          mingw32-make test-all
       - name: Create Windows Installers
         run: |
+          source .venv/bin/activate
           mingw32-make dist
           cd packaging
           mingw32-make all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,11 +121,11 @@ jobs:
           restore-keys: ${{ runner.os }}-poetry-
       - name: Install Dependencies
         run: ./packaging/windows/msys2-install.sh
-      - name: Install Poetry
+      - name: Install Poetry and Wheel
         run: |
           python3.9 -m venv .venv
           source .venv/bin/activate
-          pip install poetry==$POETRY_VERSION
+          pip install poetry==$POETRY_VERSION wheel
           poetry config virtualenvs.create false
       - name: Collect Project Data
         id: meta

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,7 @@ repos:
   rev: v0.7.2.1
   hooks:
   - id: shellcheck
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.19.4
+  hooks:
+  - id: pyupgrade

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -24,7 +24,7 @@ class NamedElement(Element):
     visibility: enumeration
     clientDependency: relation_many[Dependency]
     supplierDependency: relation_many[Dependency]
-    qualifiedName: derived[List[str]]
+    qualifiedName: derived[list[str]]
     namespace: relation_one[Namespace]
     memberNamespace: relation_many[Namespace]
 
@@ -322,8 +322,8 @@ class Property(StructuralFeature, ConnectableElement):
     owningAssociation: relation_one[Association]
     artifact: relation_one[Artifact]
     isComposite: derived[bool]
-    navigability: derived[Optional[bool]]
-    opposite: relation_one[Optional[Property]]
+    navigability: derived[bool | None]
+    opposite: relation_one[Property | None]
 
 
 class ExtensionEnd(Property):
@@ -1311,7 +1311,7 @@ Artifact.ownedOperation = association(
 # 82: override NamedElement.qualifiedName(NamedElement.namespace): derived[List[str]]
 
 
-def _namedelement_qualifiedname(self) -> List[str]:
+def _namedelement_qualifiedname(self) -> list[str]:
     """Returns the qualified name of the element as a tuple."""
     if self.namespace:
         return _namedelement_qualifiedname(self.namespace) + [self.name]

--- a/gaphor/UML/umloverrides.py
+++ b/gaphor/UML/umloverrides.py
@@ -8,7 +8,6 @@ normal properties.
 from __future__ import annotations
 
 import itertools
-from typing import List, Optional
 
 from gaphor.core.modeling.properties import derived
 from gaphor.UML import uml, umllex
@@ -33,7 +32,7 @@ def extension_metaclass(self):
 uml.Extension.metaclass = property(extension_metaclass, doc=extension_metaclass.__doc__)
 
 
-def property_opposite(self: uml.Property) -> List[Optional[uml.Property]]:
+def property_opposite(self: uml.Property) -> list[uml.Property | None]:
     """In the case where the property is one navigable end of a binary
     association with both ends navigable, this gives the other end.
 
@@ -52,7 +51,7 @@ def property_opposite(self: uml.Property) -> List[Optional[uml.Property]]:
 uml.Property.opposite = derived("opposite", uml.Property, 0, 1, property_opposite)
 
 
-def property_navigability(self: uml.Property) -> List[Optional[bool]]:
+def property_navigability(self: uml.Property) -> list[bool | None]:
     """Get navigability of an association end.
 
     If no association is related to the property, then unknown
@@ -103,7 +102,7 @@ def _pr_rc_interface_deps(component, dep_type):
     )
 
 
-def component_provided(self) -> List[uml.Realization]:
+def component_provided(self) -> list[uml.Realization]:
     """Interfaces provided to component environment."""
     implementations = (
         impl.contract[0]
@@ -122,7 +121,7 @@ def component_provided(self) -> List[uml.Realization]:
 uml.Component.provided = property(component_provided, doc=component_provided.__doc__)
 
 
-def component_required(self) -> List[uml.Usage]:
+def component_required(self) -> list[uml.Usage]:
     """Interfaces required by component."""
     usages = _pr_interface_deps(self, uml.Usage)
 

--- a/gaphor/abc.py
+++ b/gaphor/abc.py
@@ -4,8 +4,6 @@ import abc
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Optional, Type
-
     from gaphor.core.modeling import Element
     from gaphor.diagram.diagramtoolbox import ToolboxDefinition
 
@@ -36,5 +34,5 @@ class ModelingLanguage(metaclass=abc.ABCMeta):
         """Get structure for the toolbox."""
 
     @abc.abstractmethod
-    def lookup_element(self, name: str) -> Optional[Type[Element]]:
+    def lookup_element(self, name: str) -> type[Element] | None:
         """Look up a model element type (class) by name."""

--- a/gaphor/application.py
+++ b/gaphor/application.py
@@ -7,7 +7,7 @@ session is represented as a window in which a diagram can be edited.
 from __future__ import annotations
 
 import logging
-from typing import Dict, Iterator, Optional, Set, Tuple, Type, TypeVar, cast
+from typing import Iterator, TypeVar, cast
 
 import importlib_metadata
 
@@ -56,8 +56,8 @@ class Application(Service, ActionProvider):
     """
 
     def __init__(self):
-        self._active_session: Optional[Session] = None
-        self._sessions: Set[Session] = set()
+        self._active_session: Session | None = None
+        self._sessions: set[Session] = set()
 
         self._services_by_name = initialize("gaphor.appservices", application=self)
 
@@ -170,7 +170,7 @@ class Application(Service, ActionProvider):
         self.shutdown()
         return True
 
-    def all(self, base: Type[T]) -> Iterator[Tuple[str, T]]:
+    def all(self, base: type[T]) -> Iterator[tuple[str, T]]:
         return (
             (n, c) for n, c in self._services_by_name.items() if isinstance(c, base)
         )
@@ -186,7 +186,7 @@ class Session(Service):
 
     def __init__(self, services=None):
         """Initialize the application."""
-        services_by_name: Dict[str, Service] = initialize("gaphor.services", services)
+        services_by_name: dict[str, Service] = initialize("gaphor.services", services)
         self._filename = None
 
         self.event_manager: EventManager = cast(

--- a/gaphor/codegen/uml_coder.py
+++ b/gaphor/codegen/uml_coder.py
@@ -321,7 +321,7 @@ def generate(filename, outfile=None, overridesfile=None):  # noqa: C901
             ):
                 assert not derivedunions.get(
                     e1.name
-                ), "%s.%s is already in derived union set in class %s" % (
+                ), "{}.{} is already in derived union set in class {}".format(
                     e1.class_name,
                     e1.name,
                     derivedunions.get(e1.name).class_name,  # type: ignore[union-attr]

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 import uuid
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Callable, Iterator, Optional, Type, TypeVar, overload
+from typing import TYPE_CHECKING, Callable, Iterator, TypeVar, overload
 
 from typing_extensions import Protocol
 
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 class UnlinkEvent:
     """Used to tell event handlers this element should be unlinked."""
 
-    def __init__(self, element: Element, diagram: Optional[Diagram] = None):
+    def __init__(self, element: Element, diagram: Diagram | None = None):
         self.element = element
         self.diagram = diagram
 
@@ -52,9 +52,7 @@ class Element:
     relationship: relation_many[Presentation]
     ownedDiagram: relation_many[Diagram]
 
-    def __init__(
-        self, id: Optional[Id] = None, model: Optional[RepositoryProtocol] = None
-    ):
+    def __init__(self, id: Id | None = None, model: RepositoryProtocol | None = None):
         """Create an element. As optional parameters an id and model can be
         given.
 
@@ -153,7 +151,7 @@ class Element:
         else:
             return DummyEventWatcher()
 
-    def isKindOf(self, class_: Type[Element]) -> bool:
+    def isKindOf(self, class_: type[Element]) -> bool:
         """Returns true if the object is an instance of `class_`."""
         return isinstance(self, class_)
 
@@ -163,7 +161,7 @@ class Element:
 
 
 class DummyEventWatcher:
-    def watch(self, path: str, handler: Optional[Handler] = None) -> DummyEventWatcher:
+    def watch(self, path: str, handler: Handler | None = None) -> DummyEventWatcher:
         return self
 
     def unsubscribe_all(self) -> None:
@@ -176,10 +174,10 @@ Handler = Callable[[ElementUpdated], None]
 
 
 class RepositoryProtocol(Protocol):
-    def create(self, type: Type[T]) -> T:
+    def create(self, type: type[T]) -> T:
         ...
 
-    def create_as(self, type: Type[T], id: str) -> T:
+    def create_as(self, type: type[T], id: str) -> T:
         ...
 
     @overload
@@ -187,18 +185,18 @@ class RepositoryProtocol(Protocol):
         ...
 
     @overload
-    def select(self, expression: Type[T]) -> Iterator[T]:
+    def select(self, expression: type[T]) -> Iterator[T]:
         ...
 
     @overload
     def select(self, expression: None) -> Iterator[Element]:
         ...
 
-    def lookup(self, id: str) -> Optional[Element]:
+    def lookup(self, id: str) -> Element | None:
         ...
 
     def watcher(
-        self, element: Element, default_handler: Optional[Handler] = None
+        self, element: Element, default_handler: Handler | None = None
     ) -> EventWatcherProtocol:
         ...
 
@@ -211,9 +209,7 @@ class RepositoryProtocol(Protocol):
 
 
 class EventWatcherProtocol(Protocol):
-    def watch(
-        self, path: str, handler: Optional[Handler] = None
-    ) -> EventWatcherProtocol:
+    def watch(self, path: str, handler: Handler | None = None) -> EventWatcherProtocol:
         ...
 
     def unsubscribe_all(self) -> None:

--- a/gaphor/core/modeling/elementdispatcher.py
+++ b/gaphor/core/modeling/elementdispatcher.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Set, Tuple
 
 from gaphor.abc import Service
 from gaphor.core import event_handler
@@ -26,15 +25,15 @@ class EventWatcher:
     def __init__(
         self,
         element: Element,
-        element_dispatcher: Optional[ElementDispatcher],
-        default_handler: Optional[Handler] = None,
+        element_dispatcher: ElementDispatcher | None,
+        default_handler: Handler | None = None,
     ):
         self.element = element
         self.element_dispatcher = element_dispatcher
-        self.default_handler: Optional[Handler] = default_handler
-        self._watched_paths: Dict[str, Handler] = dict()
+        self.default_handler: Handler | None = default_handler
+        self._watched_paths: dict[str, Handler] = dict()
 
-    def watch(self, path: str, handler: Optional[Handler] = None) -> EventWatcher:
+    def watch(self, path: str, handler: Handler | None = None) -> EventWatcher:
         """Watch a certain path of elements starting with the DiagramItem. The
         handler is optional and will default the default provided at
         construction time.
@@ -102,11 +101,11 @@ class ElementDispatcher(Service):
 
         # Table used to fire events:
         # (event.element, event.property): { handler: set(path, ..), ..}
-        self._handlers: Dict[Tuple[Element, umlproperty], Dict[Handler, Set]] = dict()
+        self._handlers: dict[tuple[Element, umlproperty], dict[Handler, set]] = dict()
 
         # Fast resolution when handlers are disconnected
         # handler: [(element, property), ..]
-        self._reverse: Dict[Handler, List[Tuple[Element, umlproperty]]] = dict()
+        self._reverse: dict[Handler, list[tuple[Element, umlproperty]]] = dict()
 
         self.event_manager.subscribe(self.on_model_loaded)
         self.event_manager.subscribe(self.on_element_change_event)

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -5,18 +5,7 @@ from __future__ import annotations
 import uuid
 from collections import OrderedDict
 from contextlib import contextmanager
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, Callable, Iterator, TypeVar, overload
 
 from gaphor.abc import Service
 from gaphor.core.modeling.diagram import Diagram
@@ -52,22 +41,22 @@ class ElementFactory(Service):
 
     def __init__(
         self,
-        event_manager: Optional[EventManager] = None,
-        element_dispatcher: Optional[ElementDispatcher] = None,
+        event_manager: EventManager | None = None,
+        element_dispatcher: ElementDispatcher | None = None,
     ):
         self.event_manager = event_manager
         self.element_dispatcher = element_dispatcher
-        self._elements: Dict[str, Element] = OrderedDict()
+        self._elements: dict[str, Element] = OrderedDict()
         self._block_events = 0
 
     def shutdown(self):
         self.flush()
 
-    def create(self, type: Type[T]) -> T:
+    def create(self, type: type[T]) -> T:
         """Create a new model element of type ``type``."""
         return self.create_as(type, str(uuid.uuid1()))
 
-    def create_as(self, type: Type[T], id: str, diagram: Diagram = None) -> T:
+    def create_as(self, type: type[T], id: str, diagram: Diagram = None) -> T:
         """Create a new model element of type 'type' with 'id' as its ID.
 
         This method should only be used when loading models, since it
@@ -99,7 +88,7 @@ class ElementFactory(Service):
         """Return the amount of elements currently in the factory."""
         return len(self._elements)
 
-    def lookup(self, id: str) -> Optional[Element]:
+    def lookup(self, id: str) -> Element | None:
         """Find element with a specific id."""
         return self._elements.get(id)
 
@@ -114,7 +103,7 @@ class ElementFactory(Service):
         ...
 
     @overload
-    def select(self, expression: Type[T]) -> Iterator[T]:
+    def select(self, expression: type[T]) -> Iterator[T]:
         ...
 
     @overload
@@ -131,8 +120,8 @@ class ElementFactory(Service):
             yield from (e for e in self._elements.values() if expression(e))
 
     def lselect(
-        self, expression: Union[Callable[[Element], bool], Type[T], None] = None
-    ) -> List[Element]:
+        self, expression: Callable[[Element], bool] | type[T] | None = None
+    ) -> list[Element]:
         """Get a list of elements that comply with expression.
 
         The expression can be one of:

--- a/gaphor/core/modeling/tests/test_properties.py
+++ b/gaphor/core/modeling/tests/test_properties.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List, Optional
-
 from gaphor.core import event_handler
 from gaphor.core.modeling import Element
 from gaphor.core.modeling.collection import collectionlist
@@ -22,7 +20,7 @@ def test_association_1_x():
     # 1:-
     #
     class A(Element):
-        one: relation_one[Optional[B]]
+        one: relation_one[B | None]
 
     class B(Element):
         two: relation_one[A]
@@ -257,7 +255,7 @@ def test_association_swap():
     assert a.one[0] is b1
     assert a.one[1] is b2
 
-    events: List[object] = []
+    events: list[object] = []
 
     @event_handler(AssociationUpdated)
     def handler(event, events=events):

--- a/gaphor/core/styling/__init__.py
+++ b/gaphor/core/styling/__init__.py
@@ -29,7 +29,7 @@ class StyleNode(Protocol):
     def name(self) -> str:
         ...
 
-    def parent(self) -> Optional[StyleNode]:
+    def parent(self) -> StyleNode | None:
         ...
 
     def children(self) -> Iterator[StyleNode]:
@@ -63,7 +63,7 @@ def merge_styles(*styles: Style) -> Style:
     if "opacity" in style:
         opacity = style["opacity"]
         for color_prop in ("color", "background-color", "text-color"):
-            color: Optional[Color] = style.get(color_prop)  # type: ignore[assignment]
+            color: Color | None = style.get(color_prop)  # type: ignore[assignment]
             if color and color[3] > 0.0:
                 style[color_prop] = color[:3] + (color[3] * opacity,)  # type: ignore[misc]
 

--- a/gaphor/core/styling/parser.py
+++ b/gaphor/core/styling/parser.py
@@ -272,7 +272,7 @@ class CombinedSelector(object):
         return a1 + a2, b1 + b2, c1 + c2
 
     def __repr__(self):
-        return "%r%s%r" % (self.left, self.combinator, self.right)
+        return "{!r}{}{!r}".format(self.left, self.combinator, self.right)
 
 
 class CompoundSelector(object):
@@ -355,7 +355,7 @@ class AttributeSelector(object):
 
     def __repr__(self):
         namespace = "*|" if self.namespace is None else "{%s}" % self.namespace
-        return "[%s%s%s%r]" % (namespace, self.name, self.operator, self.value)
+        return "[{}{}{}{!r}]".format(namespace, self.name, self.operator, self.value)
 
 
 class PseudoClassSelector:
@@ -386,4 +386,4 @@ class FunctionalPseudoClassSelector(object):
         self.arguments = arguments
 
     def __repr__(self):
-        return ":%s%r" % (self.name, tuple(self.arguments))
+        return ":{}{!r}".format(self.name, tuple(self.arguments))

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -6,7 +6,7 @@ gaphor.adapter package.
 
 from __future__ import annotations
 
-from typing import List, Optional, Type, TypeVar, Union
+from typing import TypeVar
 
 from gaphas.connections import Connection
 from gaphas.connector import Handle, Port
@@ -72,11 +72,11 @@ class BaseConnector:
         self.line = line
         self.diagram: Diagram = element.diagram
 
-    def get_connection(self, handle: Handle) -> Optional[Connection]:
+    def get_connection(self, handle: Handle) -> Connection | None:
         """Get connection information."""
         return self.diagram.connections.get_connection(handle)
 
-    def get_connected(self, handle: Handle) -> Optional[Presentation[Element]]:
+    def get_connected(self, handle: Handle) -> Presentation[Element] | None:
         """Get item connected to a handle."""
         cinfo = self.diagram.connections.get_connection(handle)
         if cinfo:
@@ -123,7 +123,7 @@ class NoConnector:
 
 # Work around issue https://github.com/python/mypy/issues/3135 (Class decorators are not type checked)
 # This definition, along with the the ignore below, seems to fix the behaviour for mypy at least.
-Connector: FunctionDispatcher[Type[ConnectorProtocol]] = multidispatch(object, object)(
+Connector: FunctionDispatcher[type[ConnectorProtocol]] = multidispatch(object, object)(
     NoConnector
 )
 
@@ -143,8 +143,8 @@ class UnaryRelationshipConnect(BaseConnector):
     line: LinePresentation[Element]
 
     def relationship(
-        self, required_type: Type[Element], head: relation, tail: relation
-    ) -> Optional[Element]:
+        self, required_type: type[Element], head: relation, tail: relation
+    ) -> Element | None:
         """Find an existing relationship in the model that meets the required
         type and is connected to the same model element the head and tail of
         the line are connected to.
@@ -193,7 +193,7 @@ class UnaryRelationshipConnect(BaseConnector):
                     continue
 
             # Check for this entry on line.diagram
-            item: Union[ElementPresentation, LinePresentation]
+            item: ElementPresentation | LinePresentation
             for item in gen.presentation:
                 # Allow line to be returned. Avoids strange
                 # behaviour during loading
@@ -203,7 +203,7 @@ class UnaryRelationshipConnect(BaseConnector):
                 return gen
         return None
 
-    def relationship_or_new(self, type: Type[T], head: relation, tail: relation) -> T:
+    def relationship_or_new(self, type: type[T], head: relation, tail: relation) -> T:
         """Like relation(), but create a new instance if none was found."""
         relation = self.relationship(type, head, tail)
         if not relation:
@@ -260,7 +260,7 @@ class UnaryRelationshipConnect(BaseConnector):
             )
             adapter.connect(cinfo.handle, cinfo.port)
 
-    def disconnect_connected_items(self) -> List[Connection]:
+    def disconnect_connected_items(self) -> list[Connection]:
         """Cause items connected to @line to be disconnected. This is necessary
         if the subject of the @line is to be removed.
 

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -14,17 +14,7 @@ from __future__ import annotations
 
 import itertools
 from functools import singledispatch
-from typing import (
-    Callable,
-    Dict,
-    Iterator,
-    NamedTuple,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Callable, Iterator, NamedTuple
 
 import gaphas
 
@@ -38,7 +28,7 @@ Opaque = object
 
 
 @singledispatch
-def copy(obj: Element) -> Iterator[Tuple[Id, Opaque]]:
+def copy(obj: Element) -> Iterator[tuple[Id, Opaque]]:
     """Create a copy of an element (or list of elements).
 
     The returned type should be distinct, so the `paste()` function can
@@ -82,9 +72,9 @@ def deserialize(ser, lookup):
 
 
 class ElementCopy(NamedTuple):
-    cls: Type[Element]
-    id: Union[str, bool]
-    data: Dict[str, Tuple[str, str]]
+    cls: type[Element]
+    id: str | bool
+    data: dict[str, tuple[str, str]]
 
 
 def copy_element(element: Element) -> ElementCopy:
@@ -100,7 +90,7 @@ def copy_element(element: Element) -> ElementCopy:
 
 
 @copy.register
-def _copy_element(element: Element) -> Iterator[Tuple[Id, ElementCopy]]:
+def _copy_element(element: Element) -> Iterator[tuple[Id, ElementCopy]]:
     yield element.id, copy_element(element)
 
 
@@ -129,7 +119,7 @@ def copy_named_element(element: NamedElement) -> NamedElementCopy:
 
 
 @copy.register
-def _copy_named_element(element: NamedElement) -> Iterator[Tuple[Id, NamedElementCopy]]:
+def _copy_named_element(element: NamedElement) -> Iterator[tuple[Id, NamedElementCopy]]:
     yield element.id, copy_named_element(element)
 
 
@@ -146,9 +136,9 @@ paste.register(NamedElementCopy, paste_named_element)
 
 
 class PresentationCopy(NamedTuple):
-    cls: Type[Element]
-    data: Dict[str, Tuple[str, str]]
-    parent: Optional[str]
+    cls: type[Element]
+    data: dict[str, tuple[str, str]]
+    parent: str | None
 
 
 def copy_presentation(item: Presentation) -> PresentationCopy:
@@ -171,7 +161,7 @@ def copy_presentation(item: Presentation) -> PresentationCopy:
 
 
 @copy.register
-def _copy_presentation(item: Presentation) -> Iterator[Tuple[Id, object]]:
+def _copy_presentation(item: Presentation) -> Iterator[tuple[Id, object]]:
     yield item.id, copy_presentation(item)
     if item.subject:
         yield from copy(item.subject)
@@ -194,7 +184,7 @@ def paste_presentation(copy_data: PresentationCopy, diagram, lookup):
 
 
 class CopyData(NamedTuple):
-    elements: Dict[str, object]
+    elements: dict[str, object]
 
 
 @copy.register
@@ -204,8 +194,8 @@ def _copy_all(items: set) -> CopyData:
 
 
 @paste.register
-def _paste_all(copy_data: CopyData, diagram, lookup) -> Set[Presentation]:
-    new_elements: Dict[str, Optional[Presentation]] = {}
+def _paste_all(copy_data: CopyData, diagram, lookup) -> set[Presentation]:
+    new_elements: dict[str, Presentation | None] = {}
 
     def element_lookup(ref: str):
         if ref in new_elements:
@@ -234,4 +224,4 @@ def _paste_all(copy_data: CopyData, diagram, lookup) -> Set[Presentation]:
         assert element
         element.postload()
 
-    return set(e for e in new_elements.values() if isinstance(e, Presentation))
+    return {e for e in new_elements.values() if isinstance(e, Presentation)}

--- a/gaphor/diagram/grouping.py
+++ b/gaphor/diagram/grouping.py
@@ -17,7 +17,6 @@ to be aware `AbstractGroup.item` can be null.
 from __future__ import annotations
 
 import abc
-from typing import Type
 
 from generic.multidispatch import FunctionDispatcher, multidispatch
 
@@ -68,7 +67,7 @@ class NoGrouping(AbstractGroup):
         pass
 
 
-Group: FunctionDispatcher[Type[AbstractGroup]] = multidispatch(object, object)(
+Group: FunctionDispatcher[type[AbstractGroup]] = multidispatch(object, object)(
     NoGrouping
 )
 

--- a/gaphor/diagram/inlineeditors.py
+++ b/gaphor/diagram/inlineeditors.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import singledispatch
-from typing import Optional, Tuple
 
 from gaphas import Item
 from gaphas.geometry import Rectangle
@@ -12,7 +11,7 @@ from gaphor.diagram.presentation import LinePresentation, Named
 
 
 @singledispatch
-def InlineEditor(item: Item, view, pos: Optional[Tuple[int, int]] = None) -> bool:
+def InlineEditor(item: Item, view, pos: tuple[int, int] | None = None) -> bool:
     """Show a small editor popup in the diagram. Makes for easy editing without
     resorting to the Element editor.
 

--- a/gaphor/diagram/painter.py
+++ b/gaphor/diagram/painter.py
@@ -8,8 +8,6 @@ and handles).
 
 from __future__ import annotations
 
-from typing import Optional
-
 from cairo import LINE_JOIN_ROUND
 
 from gaphor.core.modeling.diagram import DrawContext, StyledItem
@@ -21,7 +19,7 @@ TOLERANCE = 0.8
 
 
 class ItemPainter:
-    def __init__(self, selection: Optional[Selection] = None):
+    def __init__(self, selection: Selection | None = None):
         self.selection: Selection = selection or Selection()
 
     def paint_item(self, item, cairo):

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from math import pi
-from typing import Callable, List, Optional, Tuple
+from typing import Callable
 
 from gaphas.geometry import Rectangle
 
@@ -93,10 +93,10 @@ class Box:
         self,
         *children,
         style: Style = {},
-        draw: Optional[Callable[[Box, DrawContext, Rectangle], None]] = None,
+        draw: Callable[[Box, DrawContext, Rectangle], None] | None = None,
     ):
         self.children = children
-        self.sizes: List[Tuple[int, int]] = []
+        self.sizes: list[tuple[int, int]] = []
         self._inline_style = style
         self._draw_border = draw
 
@@ -170,7 +170,7 @@ class IconBox:
     def __init__(self, icon, *children, style: Style = {}):
         self.icon = icon
         self.children = children
-        self.sizes: List[Tuple[int, int]] = []
+        self.sizes: list[tuple[int, int]] = []
         self._inline_style = style
 
     def size(self, context: UpdateContext):

--- a/gaphor/storage/parser.py
+++ b/gaphor/storage/parser.py
@@ -25,7 +25,7 @@ import io
 import logging
 import os
 from collections import OrderedDict
-from typing import IO, Dict, List, Optional, Tuple, Union
+from typing import IO
 from xml.sax import handler
 
 from gaphor.storage.upgrade_canvasitem import upgrade_canvasitem
@@ -39,8 +39,8 @@ class base:
     """Simple base class for element, and canvas."""
 
     def __init__(self):
-        self.values: Dict[str, str] = {}
-        self.references: Dict[str, Union[str, List[str]]] = {}
+        self.values: dict[str, str] = {}
+        self.references: dict[str, str | list[str]] = {}
 
     def __getattr__(self, key):
         try:
@@ -62,7 +62,7 @@ class base:
 
 
 class element(base):
-    def __init__(self, id: str, type: str, canvas: Optional[canvas] = None):
+    def __init__(self, id: str, type: str, canvas: canvas | None = None):
         base.__init__(self)
         self.id = id
         self.type = type
@@ -139,8 +139,8 @@ class GaphorLoader(handler.ContentHandler):
         """Start of document: all our attributes are initialized."""
         self.version = None
         self.gaphor_version = None
-        self.elements: Dict[str, Union[element]] = OrderedDict()
-        self._stack: List[Tuple[Union[element, canvas], State]] = []
+        self.elements: dict[str, element] = OrderedDict()
+        self._stack: list[tuple[element | canvas, State]] = []
         self.text = ""
         self._start_element_handlers = (
             self.start_element,
@@ -289,7 +289,7 @@ class GaphorLoader(handler.ContentHandler):
         self.text = self.text + content
 
 
-def parse(filename) -> Dict[str, element]:
+def parse(filename) -> dict[str, element]:
     """Parse a file and return a dictionary ID:element."""
     loader = GaphorLoader()
 
@@ -371,7 +371,7 @@ def parse_file(filename, parser):
     is_fd = True
 
     if isinstance(filename, io.IOBase):
-        file_obj: Union[IO, io.IOBase] = filename
+        file_obj: IO | io.IOBase = filename
     else:
         is_fd = False
         file_obj = open(filename, "r")

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -280,7 +280,7 @@ class DiagramPage:
         self.diagram_css.load_from_data(
             f"diagramview {{ background-color: rgba({int(255*bg[0])}, {int(255*bg[1])}, {int(255*bg[2])}, {bg[3]}); }}".encode()
             if bg
-            else "".encode()
+            else b""
         )
 
         view = self.view

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -8,7 +8,7 @@ classifiers are shown here.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional, Set
+from typing import TYPE_CHECKING
 
 from gi.repository import Gdk, Gio, GLib, Gtk
 
@@ -80,10 +80,10 @@ class Namespace(UIComponent, ActionProvider):
         self.event_manager = event_manager
         self.element_factory = element_factory
 
-        self.model: Optional[NamespaceModel] = None
-        self.view: Optional[Gtk.TreeView] = None
-        self.scrolled_window: Optional[Gtk.ScrolledWindow] = None
-        self.ctrl: Set[Gtk.EventController] = set()
+        self.model: NamespaceModel | None = None
+        self.view: Gtk.TreeView | None = None
+        self.scrolled_window: Gtk.ScrolledWindow | None = None
+        self.ctrl: set[Gtk.EventController] = set()
 
     def open(self):
         self.model = NamespaceModel(self.event_manager, self.element_factory)
@@ -247,7 +247,7 @@ class Namespace(UIComponent, ActionProvider):
         self.view.scroll_to_cell(path, None, False, 0, 0)
         self._on_view_cursor_changed(self.view)
 
-    def get_selected_element(self) -> Optional[Element]:
+    def get_selected_element(self) -> Element | None:
         assert self.view
         selection = self.view.get_selection()
         model, iter = selection.get_selected()

--- a/packaging/windows/msys2-install.sh
+++ b/packaging/windows/msys2-install.sh
@@ -21,4 +21,4 @@ pacman --noconfirm -S --needed \
     mingw-w64-x86_64-python \
     mingw-w64-x86_64-python-pip \
     mingw-w64-x86_64-python-setuptools \
-    mingw-w64-x86_64-python-wheel \
+    mingw-w64-x86_64-python3.9


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

This PR enables pyupgrade to modernize some code, and adds a pre-commit hook to keep things current. Most of the changes currently are simplifications to typing for [PEP 604](https://www.python.org/dev/peps/pep-0604/).

Because there was a typing error while running pytest in Windows with these changes, also upgraded Windows to use Python 3.9. PR #873 will update the docs to match.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
No pyupgrade.

Issue Number: N/A

### What is the new behavior?
pyupgrade enabled :robot: 

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
