### PR TITLE
Add Docs for Building GTK for Windows with gvsbuild

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -12,6 +12,10 @@ To install it, open PowerShell as an administrator, then execute:
 Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 ```
 
+To run local scripts in follow-on steps, also execute
+`Set-ExecutionPolicy RemoteSigned`. This allows for local PowerShell scripts
+to run without signing, but still requires signing for remote scripts.
+
 ### Git
 To setup a development environment in Windows first install
 [Git](https://gitforwindows.org) by executing as an adminstrator:
@@ -60,9 +64,9 @@ select Customize installation
 1. Allow the installation to finish
 
 #### Install gvsbuild
-We have forked gvsbuild for now because the upstream project is a little slow at
-accepting our Pull Requests. If we can get our changes upstream, then we'll
-switch back to using that version directly.
+We have forked gvsbuild for now because gaphor has slightly newer dependency
+requirements than the upstream project. If we can get our changes upstream,
+then we'll switch back to using that version directly.
 
 Open a new regular user PowerShell terminal and execute:
 
@@ -121,8 +125,7 @@ Install and configure Poetry
 
 Install PyGObject and pycairo from gvsbuild
 ```PowerShell
-(.venv) PS > pip install C:\gtk-build\build\x64\release\pygobject\dist\PyGObject-*-cp39-cp39-win_amd64.whl
-(.venv) PS > pip install C:\gtk-build\build\x64\release\pycairo\dist\pycairo-*-cp39-cp39-win_amd64.whl
+(.venv) PS > Get-ChildItem C:\gtk-build\build\x64\release\*\dist\*.whl | ForEach-Object -process { pip install $_ }
 ```
 
 Install Gaphor's other dependencies and give it a try

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -2,11 +2,131 @@
 
 ## Development Environment
 
-To setup a development environment in Windows:
-1) Install [Git for Windows](https://gitforwindows.org)
-1) Go to [MSYS2 website](http://www.msys2.org) and download the x86_64 installer
-1) Follow the instructions on the page for setting up the basic environment
-1) Run `C:\msys64\mingw64.exe` - a terminal window should pop up
+### Choco
+We recommend using [Chocolately](https://chocolatey.org/) as a package manager
+in Windows.
+
+To install it, open PowerShell as an administrator, then execute:
+
+```PowerShell
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+```
+
+### Git
+To setup a development environment in Windows first install
+[Git](https://gitforwindows.org) by executing as an adminstrator:
+
+```PowerShell
+choco install git
+```
+
+### MSYS2
+Both of the development environments in the next steps need MSYS2 installed.
+
+Install [MSYS2](http://www.msys2.org/):
+
+Keep PowerShell open as administrator and execute:
+```PowerShell
+choco install msys2
+```
+
+### GTK and Python with gvsbuild (recommended)
+gvsbuild provides a Python script helps you build the GTK library stack for
+Windows using Visual Studio. By compiling GTK with Visual Studio, we can then
+use a standard Python development environment in Windows.
+
+Note: gvsbuild says it requires msys2, but does it for our needs?
+
+First we will install the gvsbuild dependencies:
+1. Visual C++ build tools workload for Visual Studio 2019 Build Tools
+1. Python 3.6 (yes, this version is pretty old)
+
+#### Install Visual Studio 2019
+With your admin PowerShell terminal:
+
+```PowerShell
+choco install visualstudio2019-workload-vctools
+```
+
+#### Install Python 3.6
+
+1. Download [Python 3.6.8](https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64-webinstall.exe)
+1. Launch the installer by double clicking on it
+1. On the first screen of the installation wizard, leave the default options and
+select Customize installation
+1. On the Optional Features screen, select Next to keep the defaults
+1. On the Advanced Options screen, unselect the two selected options
+1. In the Customize install location field enter `C:\Python36` and select Install
+1. Allow the installation to finish
+
+#### Install gvsbuild
+We have forked gvsbuild for now because the upstream project is a little slow at
+accepting our Pull Requests. If we can get our changes upstream, then we'll
+switch back to using that version directly.
+
+Open a new regular user PowerShell terminal and execute:
+
+```PowerShell
+mkdir C:\gtk-build\github
+cd C:\gtk-build\github
+git clone https://github.com/gaphor/gvsbuild.git
+
+```
+
+#### Build GTK
+
+In the same PowerShell terminal, execute:
+
+```PowerShell
+C:\Python36\python.exe .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\tools\msys64 --enable-gi --py-wheel --gtk3-ver=3.24 gobject-introspection gtk3 pycairo pygobject adwaita-icon-theme hicolor-icon-theme
+```
+Grab a coffee, the build will take a few minutes to complete.
+
+#### Install the Latest Python for Gaphor
+
+Download and install the latest version of Python. For this you have a few options:
+
+1. Install from Chocolately with `choco install python` as an admin 
+1. Install from the Windows Store
+1. If you need to test with multiple versions of Python, install
+[pyenv-win](https://github.com/pyenv-win/pyenv-win)
+
+Restart your PowerShell terminal as a normal user and check that `python --version` is correct.
+
+#### Setup Gaphor
+
+In the same PowerShell terminal, clone the repository:
+```PowerShell
+cd (to the location you want to put Gaphor)
+git clone https://github.com/gaphor/gaphor.git
+```
+
+Create and activate a virtual environment in which Gaphor can be installed.
+```PowerShell
+PS > cd gaphor
+PS > python -m venv .venv
+PS > .\.venv\Scripts\activate.ps1
+```
+
+Install and configure Poetry
+```PowerShell
+(.venv) PS > pip install poetry
+(.venv) PS > poetry config virtualenvs.create false
+```
+
+Install Gaphor's dependencies and give it a try:
+```PowerShell
+(.venv) PS > poetry install
+(.venv) PS > gaphor
+```
+
+### GTK and Python with MSYS2 (alternative method)
+MSYS2 provides a bash terminal, with Python and GTK compiled against GCC. This
+is an alternative method to using gvsbuild above. The advantage is that you get
+a full bash environment in Windows, the disadvantage is that Python is very
+heavily patched to be built this way and often breaks.
+
+1) Run `C:\tools\msys64\mingw64.exe` - the MINGW64 terminal window should pop up
 
 ```bash
 $ pacman -Suy
@@ -22,7 +142,7 @@ $ pacman -S mingw-w64-x86_64-gcc \
 $ echo 'export PATH="/c/Program Files/Git/bin:$PATH"' >> ~/.bash_profile
 ```
 
-Restart your terminal.
+Restart the MINGW64 terminal.
 
 [Clone the
 repository](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository).
@@ -56,7 +176,7 @@ script that creates a Windows installer using
 [7-Zip](https://www.7-zip.org).
 
 1. Follow the instructions for settings up a development environment above
-1. Run ``C:\msys64\mingw64.exe`` - a terminal window should pop up
+1. Run ``C:\tools\msys64\mingw64.exe`` - a terminal window should pop up
 ```bash
 $ source .venv/bin/activate
 $ mingw32-make dist

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -43,7 +43,7 @@ Note: gvsbuild says it requires msys2, but does it for our needs?
 
 First we will install the gvsbuild dependencies:
 1. Visual C++ build tools workload for Visual Studio 2019 Build Tools
-1. Python 3.6 (yes, this version is pretty old)
+1. Python
 
 #### Install Visual Studio 2019
 With your admin PowerShell terminal:
@@ -52,16 +52,12 @@ With your admin PowerShell terminal:
 choco install visualstudio2019-workload-vctools
 ```
 
-#### Install Python 3.6
+#### Install the Latest Python
 
-1. Download [Python 3.6.8](https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64-webinstall.exe)
-1. Launch the installer by double clicking on it
-1. On the first screen of the installation wizard, leave the default options and
-select Customize installation
-1. On the Optional Features screen, select Next to keep the defaults
-1. On the Advanced Options screen, unselect the two selected options
-1. In the Customize install location field enter `C:\Python36` and select Install
-1. Allow the installation to finish
+Download and install the latest version of Python:
+
+1. Install from Chocolately with `choco install python` with admin PowerShell
+1. Restart your PowerShell terminal as a normal user and check that `python --version` is correct.
 
 #### Install gvsbuild
 We have forked gvsbuild for now because gaphor has slightly newer dependency
@@ -82,20 +78,10 @@ git clone https://github.com/gaphor/gvsbuild.git
 In the same PowerShell terminal, execute:
 
 ```PowerShell
-C:\Python36\python.exe .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\tools\msys64 --enable-gi --py-wheel --gtk3-ver=3.24 gobject-introspection gtk3 pycairo pygobject adwaita-icon-theme hicolor-icon-theme
+cd C:\gtk-build\github\gvsbuild
+python .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\tools\msys64 --enable-gi --py-wheel --gtk3-ver=3.24 gobject-introspection gtk3 pycairo pygobject adwaita-icon-theme hicolor-icon-theme
 ```
 Grab a coffee, the build will take a few minutes to complete.
-
-#### Install the Latest Python for Gaphor
-
-Download and install the latest version of Python. For this you have a few options:
-
-1. Install from Chocolately with `choco install python` as an admin 
-1. Install from the Windows Store
-1. If you need to test with multiple versions of Python, install
-[pyenv-win](https://github.com/pyenv-win/pyenv-win)
-
-Restart your PowerShell terminal as a normal user and check that `python --version` is correct.
 
 #### Setup Gaphor
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -86,11 +86,6 @@ C:\Python36\python.exe .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\tools\m
 ```
 Grab a coffee, the build will take a few minutes to complete.
 
-Once it is complete, add GTK to your path:
-```PowerShell
-$env:Path = "C:\gtk-build\gtk\x64\release\bin;" + $env:Path
-```
-
 #### Install the Latest Python for Gaphor
 
 Download and install the latest version of Python. For this you have a few options:
@@ -128,9 +123,18 @@ Install PyGObject and pycairo from gvsbuild
 (.venv) PS > Get-ChildItem C:\gtk-build\build\x64\release\*\dist\*.whl | ForEach-Object -process { pip install $_ }
 ```
 
-Install Gaphor's other dependencies and give it a try
+Install Gaphor's other dependencies
 ```PowerShell
 (.venv) PS > poetry install
+```
+
+Add GTK to your path:
+```PowerShell
+$env:Path = "C:\gtk-build\gtk\x64\release\bin;" + $env:Path
+```
+
+Launch Gaphor!
+```PowerShell
 (.venv) PS > gaphor
 ```
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -82,6 +82,11 @@ C:\Python36\python.exe .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\tools\m
 ```
 Grab a coffee, the build will take a few minutes to complete.
 
+Once it is complete, add GTK to your path:
+```PowerShell
+$env:Path = "C:\gtk-build\gtk\x64\release\bin;" + $env:Path
+```
+
 #### Install the Latest Python for Gaphor
 
 Download and install the latest version of Python. For this you have a few options:
@@ -114,7 +119,13 @@ Install and configure Poetry
 (.venv) PS > poetry config virtualenvs.create false
 ```
 
-Install Gaphor's dependencies and give it a try:
+Install PyGObject and pycairo from gvsbuild
+```PowerShell
+(.venv) PS > pip install C:\gtk-build\build\x64\release\pygobject\dist\PyGObject-*-cp39-cp39-win_amd64.whl
+(.venv) PS > pip install C:\gtk-build\build\x64\release\pycairo\dist\pycairo-*-cp39-cp39-win_amd64.whl
+```
+
+Install Gaphor's other dependencies and give it a try
 ```PowerShell
 (.venv) PS > poetry install
 (.venv) PS > gaphor


### PR DESCRIPTION
This PR adds docs for the creation of a development environment in Windows using gvsbuild and the official version of Python for Windows instead of MSYS2.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [X] Documentation content changes

### What is the current behavior?
MSYS2 is only supported

Issue Number: N/A

### What is the new behavior?
gvsbuild and MSYS2 are options.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
