### PR TITLE
Add extra rules to avoid cyclic references

### DIFF
--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -797,32 +797,29 @@ class derivedunion(derived[T]):
                     new_value = next(iter(values))
             # Only one subset element, so pass the values on
             self.handle(DerivedSet(event.element, self, old_value, new_value))
+        elif isinstance(event, AssociationSet):
+            old_value, new_value = event.old_value, event.new_value
+            if old_value and old_value not in values:
+                self.handle(DerivedDeleted(event.element, self, old_value))
+            if new_value and new_value not in values:
+                self.handle(DerivedAdded(event.element, self, new_value))
+
+        elif isinstance(event, AssociationAdded):
+            new_value = event.new_value
+            if new_value not in values:
+                self.handle(DerivedAdded(event.element, self, new_value))
+
+        elif isinstance(event, AssociationDeleted):
+            old_value = event.old_value
+            if old_value not in values:
+                self.handle(DerivedDeleted(event.element, self, old_value))
+
+        elif isinstance(event, AssociationUpdated):
+            self.handle(DerivedUpdated(event.element, self))
         else:
-            if isinstance(event, AssociationSet):
-                old_value, new_value = event.old_value, event.new_value
-                if old_value and old_value not in values:
-                    self.handle(DerivedDeleted(event.element, self, old_value))
-                if new_value and new_value not in values:
-                    self.handle(DerivedAdded(event.element, self, new_value))
-
-            elif isinstance(event, AssociationAdded):
-                new_value = event.new_value
-                if new_value not in values:
-                    self.handle(DerivedAdded(event.element, self, new_value))
-
-            elif isinstance(event, AssociationDeleted):
-                old_value = event.old_value
-                if old_value not in values:
-                    self.handle(DerivedDeleted(event.element, self, old_value))
-
-            elif isinstance(event, AssociationUpdated):
-                self.handle(DerivedUpdated(event.element, self))
-            else:
-                log.error(
-                    "Don't know how to handle event "
-                    + str(event)
-                    + " for derived union"
-                )
+            log.error(
+                "Don't know how to handle event " + str(event) + " for derived union"
+            )
 
 
 class redefine(umlproperty):

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -374,6 +374,9 @@ class association(umlproperty):
 
         This method is called from the opposite association property.
         """
+        if obj is value:
+            raise AttributeError(f"Can not set {obj}.{self.name} to itself")
+
         if self.upper == 1:
             self._set_one(obj, value, from_opposite)
         else:

--- a/gaphor/core/modeling/tests/test_properties.py
+++ b/gaphor/core/modeling/tests/test_properties.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from gaphor.core import event_handler
 from gaphor.core.modeling import Element
 from gaphor.core.modeling.collection import collectionlist
@@ -95,12 +97,11 @@ def test_association_1_1():
     assert b.two is None
 
     c = C()
-    try:
+
+    with pytest.raises(AttributeError):
         a.one = c
-    except Exception:
-        pass
-    else:
-        assert a.one is not c
+
+    assert a.one is not c
 
     del a.one
     assert a.one is None
@@ -340,6 +341,18 @@ def test_association_unlink_2():
     assert a1 in b2.two
 
 
+def test_can_not_set_association_to_owner(element_factory, event_manager):
+    class A(Element):
+        pass
+
+    A.a = association("a", A, upper=1)
+
+    a = element_factory.create(A)
+
+    with pytest.raises(AttributeError):
+        a.a = a
+
+
 def test_attributes():
     class A(Element):
         a: attribute[str]
@@ -352,12 +365,9 @@ def test_attributes():
     assert a.a == "bar", a.a
     del a.a
     assert a.a == "default"
-    try:
+
+    with pytest.raises(AttributeError):
         a.a = 1
-    except AttributeError:
-        pass  # ok
-    else:
-        assert 0, "should not set integer"
 
 
 def test_enumerations():
@@ -371,12 +381,12 @@ def test_enumerations():
     assert a.a == "two"
     a.a = "three"
     assert a.a == "three"
-    try:
+
+    with pytest.raises(AttributeError):
         a.a = "four"
-    except AttributeError:
-        assert a.a == "three"
-    else:
-        assert 0, "a.a could not be four"
+
+    assert a.a == "three"
+
     del a.a
     assert a.a == "one"
 

--- a/gaphor/services/tests/test_undomanager.py
+++ b/gaphor/services/tests/test_undomanager.py
@@ -305,9 +305,10 @@ def test_set_association_outside_transaction(
 
     with Transaction(event_manager):
         a = element_factory.create(A)
+        b = element_factory.create(A)
 
     with pytest.raises(NotInTransactionException):
-        a.a = a
+        a.a = b
 
     assert not a.b
     assert a.a is None
@@ -324,9 +325,10 @@ def test_set_multi_association_outside_transaction(
 
     with Transaction(event_manager):
         a = element_factory.create(A)
+        b = element_factory.create(A)
 
     with pytest.raises(NotInTransactionException):
-        a.b = a
+        a.b = b
 
     assert not a.b
     assert a.a is None
@@ -343,14 +345,15 @@ def test_update_association_outside_transaction(
 
     with Transaction(event_manager):
         a = element_factory.create(A)
-        a.a = a
+        b = element_factory.create(A)
+        a.a = b
         other = element_factory.create(A)
 
     with pytest.raises(NotInTransactionException):
         a.a = other
 
-    assert a in a.b
-    assert a.a is a
+    assert a in b.b
+    assert a.a is b
 
 
 def test_set_derived_union_outside_transaction(
@@ -366,12 +369,13 @@ def test_set_derived_union_outside_transaction(
 
     with Transaction(event_manager):
         a = element_factory.create(A)
+        b = element_factory.create(A)
 
     with pytest.raises(NotInTransactionException):
-        a.a = a
+        a.a = b
 
     with pytest.raises(NotInTransactionException):
-        a.b = a
+        a.b = b
 
     assert not a.b
     assert not a.a


### PR DESCRIPTION
This should avoid errors such as #894.

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

It is possible to construct a model in such a way that, for a `ClassItem` and `InterfactItem`, where `obj.parent is obj`.

Issue Number: #894

### What is the new behavior?

An exception is raised if `obj.parent` is set to `obj`. This rule is universal for associations, so it can be checked for at model level.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

This is possibly no a solution to the root cause for #894, but at least it will not create an error in model.