### PR TITLE
Python 3.9 is now default in MSYS2

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -141,8 +141,7 @@ $ pacman -S mingw-w64-x86_64-gcc \
     mingw-w64-x86_64-gobject-introspection \
     mingw-w64-x86_64-python \
     mingw-w64-x86_64-python-pip \
-    mingw-w64-x86_64-python-setuptools \
-    mingw-w64-x86_64-python3.9
+    mingw-w64-x86_64-python-setuptools
 $ echo 'export PATH="/c/Program Files/Git/bin:$PATH"' >> ~/.bash_profile
 ```
 

--- a/packaging/windows/msys2-install.sh
+++ b/packaging/windows/msys2-install.sh
@@ -16,5 +16,4 @@ pacman --noconfirm -S --needed \
     mingw-w64-x86_64-gobject-introspection \
     mingw-w64-x86_64-python \
     mingw-w64-x86_64-python-pip \
-    mingw-w64-x86_64-python-setuptools \
-    mingw-w64-x86_64-python3.9
+    mingw-w64-x86_64-python-setuptools


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->

Reverts back to using the MSYS2 python package since Python 3.9 is now default.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
