### PR TITLE
Fix TypeError for Protocols cannot be instantiated

### DIFF
--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -62,7 +62,6 @@ class Element:
 
         A model can be provided to refer to the model this element belongs to.
         """
-        super().__init__()
         self._id: Id = id or str(uuid.uuid1())
         # The model this element belongs to.
         self._model = model


### PR DESCRIPTION
This PR fixes a TypeError I was getting in 11 of the tests with Python 3.9.7 locally, although I haven't seen the errors on CI.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
```
diagram = <gaphor.core.modeling.diagram.Diagram element 565e76b2-0e80-11ec-a48f-18cf5efc6bb9>

    def test_unset_parent_updates_matrix_i2c(diagram):
>       parent = diagram.create(Example)

gaphor/core/modeling/tests/test_presentation.py:111: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
gaphor/core/modeling/diagram.py:256: in create
    return self.create_as(type, str(uuid.uuid1()), parent, subject)
gaphor/core/modeling/diagram.py:260: in create_as
    item = self.model.create_as(type, id, diagram=self)
gaphor/core/modeling/elementfactory.py:73: in create_as
    item = type(diagram=diagram, id=id)
gaphor/core/modeling/presentation.py:36: in __init__
    super().__init__(id=id, model=diagram.model)
.venv/lib/python3.9/site-packages/gaphas/item.py:76: in __init__
    super().__init__(**kwargs)  # type: ignore[call-arg]
gaphor/core/modeling/element.py:65: in __init__
    super().__init__()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <[AttributeError("'Example' object has no attribute '_id'") raised in repr()] Example object at 0x7f7670405460>
args = (), kwargs = {}

    def _no_init(self, *args, **kwargs):
>       raise TypeError('Protocols cannot be instantiated')
E       TypeError: Protocols cannot be instantiated

../../.pyenv/versions/3.9.7/lib/python3.9/typing.py:1083: TypeError
_________ test_change_parent_updates_matrix_i2c_and_keeps_coordinates _________
```

Issue Number: N/A

### What is the new behavior?
No TypeErrors

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
Linux with Python 3.9.7