### PR TITLE
Display guard conditions in square brackets

### DIFF
--- a/gaphor/UML/actions/flow.py
+++ b/gaphor/UML/actions/flow.py
@@ -33,7 +33,12 @@ class FlowItem(LinePresentation, Named):
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
 
-        self.shape_middle = Text(text=lambda: self.subject and self.subject.guard or "")
+        self.shape_middle = Text(
+            text=lambda: self.subject
+            and self.subject.guard
+            and f"[{self.subject.guard}]"
+            or ""
+        )
 
         self.watch("subject[ControlFlow].guard")
         self.watch("subject[ObjectFlow].guard")

--- a/gaphor/UML/actions/tests/test_flow.py
+++ b/gaphor/UML/actions/tests/test_flow.py
@@ -30,7 +30,7 @@ class TestFlow:
         assert "" == guard.text()
 
         flow.subject.guard = "GuardMe"
-        assert "GuardMe" == guard.text()
+        assert "[GuardMe]" == guard.text()
 
         flow.subject = None
         assert "" == guard.text()

--- a/gaphor/UML/states/tests/test_transition.py
+++ b/gaphor/UML/states/tests/test_transition.py
@@ -19,10 +19,10 @@ class TestTransition:
 
         item.subject.guard = c
         assert item.subject.guard is c
-        assert guard.text() == "blah", guard.text()
+        assert guard.text() == "[blah]", guard.text()
 
         del c.specification
         assert guard.text() == "", guard.text()
 
         c.specification = "foo"
-        assert guard.text() == "foo", item._guard.text()
+        assert guard.text() == "[foo]", guard.text()

--- a/gaphor/UML/states/transition.py
+++ b/gaphor/UML/states/transition.py
@@ -28,6 +28,7 @@ class TransitionItem(LinePresentation[UML.Transition], Named):
             text=lambda: self.subject
             and self.subject.guard
             and self.subject.guard.specification
+            and f"[{self.subject.guard.specification}]"
             or ""
         )
 


### PR DESCRIPTION

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The guard field for object and state transitions, is pretty much a free text field.

Issue Number: #978

### What is the new behavior?

The guard is actuallt displayed between square brackets.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Fixes #978.
