### PR TITLE
Use flat buttons in the header bar

### DIFF
--- a/gaphor/ui/mainwindow.glade
+++ b/gaphor/ui/mainwindow.glade
@@ -188,6 +188,9 @@
                 <property name="icon_size">1</property>
               </object>
             </child>
+            <style>
+              <class name="flat"/>
+            </style>
           </object>
           <packing>
             <property name="position">1</property>
@@ -206,6 +209,9 @@
                 <property name="icon-name">open-menu-symbolic</property>
               </object>
             </child>
+            <style>
+              <class name="flat"/>
+            </style>
           </object>
           <packing>
             <property name="pack-type">end</property>
@@ -227,6 +233,9 @@
                 <property name="icon-name">gaphor-view-editor-symbolic</property>
               </object>
             </child>
+            <style>
+              <class name="flat"/>
+            </style>
           </object>
           <packing>
             <property name="pack-type">end</property>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

We have some buttons in the header.

The GTK4 (new libawaita) look will make those buttons flat. I wondered what it would look like for Gaphor.

Issue Number: N/A

### What is the new behavior?

The items in the header are flat. This does indeed make the header less cluttered:

![image](https://user-images.githubusercontent.com/96249/133509466-5da62092-8cec-4f5b-90a8-83d2aabd312a.png)

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

https://blogs.gnome.org/alexm/2021/09/10/cleaning-up-header-bars/

Not sure if we should actually merge this though? Will it look okay and is it intuitive on Windows and macOS?