### PR TITLE
Improve inline editor undo/redo behavior

### DIFF
--- a/docs/modeling_language.md
+++ b/docs/modeling_language.md
@@ -81,7 +81,7 @@ When you double click on an item in a diagram, a popup can show up so you can ea
 By default this works for any named element. You can register your own inline editor function if you need to.
 
 ```{eval-rst}
-.. function:: gaphor.diagram.inlineeditors.InlineEditor(item: Item, view, pos: Optional[Tuple[int, int]] = None) -> bool
+.. function:: gaphor.diagram.inlineeditors.InlineEditor(item: Item, view, event_manager, pos: Optional[Tuple[int, int]] = None) -> bool
 
    Show a small editor popup in the diagram. Makes for
    easy editing without resorting to the Element editor.

--- a/gaphor/UML/actions/actionseditors.py
+++ b/gaphor/UML/actions/actionseditors.py
@@ -1,20 +1,24 @@
 from gaphor.core import transactional
 from gaphor.diagram.inlineeditors import InlineEditor, popup_entry, show_popover
+from gaphor.transaction import Transaction
 from gaphor.UML.actions.activitynodes import ForkNodeItem
 
 
 @InlineEditor.register(ForkNodeItem)
 def fork_node_item_inline_editor(item, view, event_manager, pos=None) -> bool:
     """Text edit support for Named items."""
+    commit = True
 
-    @transactional
     def update_text(text):
-        item.subject.joinSpec = text
-        return True
+        if not commit:
+            return
+        with Transaction(event_manager):
+            item.subject.joinSpec = text
 
     @transactional
     def escape():
-        item.subject.joinSpec = join_spec
+        nonlocal commit
+        commit = False
 
     subject = item.subject
     if not subject:

--- a/gaphor/UML/actions/actionseditors.py
+++ b/gaphor/UML/actions/actionseditors.py
@@ -1,4 +1,3 @@
-from gaphor.core import transactional
 from gaphor.diagram.inlineeditors import InlineEditor, popup_entry, show_popover
 from gaphor.transaction import Transaction
 from gaphor.UML.actions.activitynodes import ForkNodeItem
@@ -7,18 +6,6 @@ from gaphor.UML.actions.activitynodes import ForkNodeItem
 @InlineEditor.register(ForkNodeItem)
 def fork_node_item_inline_editor(item, view, event_manager, pos=None) -> bool:
     """Text edit support for Named items."""
-    commit = True
-
-    def update_text(text):
-        if not commit:
-            return
-        with Transaction(event_manager):
-            item.subject.joinSpec = text
-
-    @transactional
-    def escape():
-        nonlocal commit
-        commit = False
 
     subject = item.subject
     if not subject:
@@ -26,6 +13,11 @@ def fork_node_item_inline_editor(item, view, event_manager, pos=None) -> bool:
 
     join_spec = subject.joinSpec or ""
     box = view.get_item_bounding_box(view.selection.hovered_item)
-    entry = popup_entry(join_spec, update_text)
-    show_popover(entry, view, box, escape)
+    entry = popup_entry(join_spec)
+
+    def update_text():
+        with Transaction(event_manager):
+            item.subject.joinSpec = entry.get_buffer().get_text()
+
+    show_popover(entry, view, box, update_text)
     return True

--- a/gaphor/UML/actions/actionseditors.py
+++ b/gaphor/UML/actions/actionseditors.py
@@ -4,7 +4,7 @@ from gaphor.UML.actions.activitynodes import ForkNodeItem
 
 
 @InlineEditor.register(ForkNodeItem)
-def fork_node_item_inline_editor(item, view, pos=None) -> bool:
+def fork_node_item_inline_editor(item, view, event_manager, pos=None) -> bool:
     """Text edit support for Named items."""
 
     @transactional

--- a/gaphor/UML/classes/classeseditors.py
+++ b/gaphor/UML/classes/classeseditors.py
@@ -7,7 +7,7 @@ from gaphor.UML.classes.association import AssociationItem
 
 
 @InlineEditor.register(AssociationItem)
-def association_item_inline_editor(item, view, pos=None) -> bool:
+def association_item_inline_editor(item, view, event_manager, pos=None) -> bool:
     """Text edit support for Named items."""
 
     @transactional

--- a/gaphor/diagram/diagramtools/__init__.py
+++ b/gaphor/diagram/diagramtools/__init__.py
@@ -28,7 +28,7 @@ def apply_default_tool_set(view, modeling_language, event_manager, rubberband_st
             segment_tool(view), item_tool(view), event_manager=event_manager
         )
     )
-    view.add_controller(*text_edit_tools(view))
+    view.add_controller(*text_edit_tools(view, event_manager))
     view.add_controller(rubberband_tool(view, rubberband_state))
     view.add_controller(*scroll_tools(view))
     view.add_controller(zoom_tool(view))

--- a/gaphor/diagram/diagramtools/textedit.py
+++ b/gaphor/diagram/diagramtools/textedit.py
@@ -3,7 +3,7 @@ from gi.repository import Gdk, Gtk
 from gaphor.diagram.inlineeditors import InlineEditor
 
 
-def text_edit_tools(view):
+def text_edit_tools(view, event_manager):
     if Gtk.get_major_version() == 3:
         key_tool = Gtk.EventControllerKey.new(view)
         click_tool = Gtk.GestureMultiPress.new(view)
@@ -11,21 +11,21 @@ def text_edit_tools(view):
         key_tool = Gtk.EventControllerKey.new()
         click_tool = Gtk.GestureClick.new()
 
-    key_tool.connect("key-pressed", on_key_pressed)
-    click_tool.connect("released", on_double_click)
+    key_tool.connect("key-pressed", on_key_pressed, event_manager)
+    click_tool.connect("released", on_double_click, event_manager)
     return key_tool, click_tool
 
 
-def on_key_pressed(controller, keyval, keycode, state):
+def on_key_pressed(controller, keyval, keycode, state, event_manager):
     view = controller.get_widget()
     item = view.selection.hovered_item
     if item and keyval == Gdk.KEY_F2:
-        return InlineEditor(item, view)
+        return InlineEditor(item, view, event_manager)
 
 
-def on_double_click(gesture, n_press, x, y):
+def on_double_click(gesture, n_press, x, y, event_manager):
     view = gesture.get_widget()
     item = view.selection.hovered_item
     if item and n_press == 2:
         ix, iy = view.get_matrix_v2i(item).transform_point(x, y)
-        return InlineEditor(item, view, (ix, iy))
+        return InlineEditor(item, view, event_manager, (ix, iy))

--- a/gaphor/diagram/general/generaleditors.py
+++ b/gaphor/diagram/general/generaleditors.py
@@ -1,23 +1,26 @@
 from gi.repository import Gtk
 
-from gaphor.core import transactional
 from gaphor.diagram.general.comment import CommentItem
 from gaphor.diagram.inlineeditors import InlineEditor, show_popover
+from gaphor.transaction import Transaction
 
 
 @InlineEditor.register(CommentItem)
 def CommentItemInlineEditor(item, view, event_manager, pos=None) -> bool:
-    @transactional
+    commit = True
+
     def update_text():
+        if not commit:
+            return
         text = buffer.get_text(
             buffer.get_start_iter(), buffer.get_end_iter(), include_hidden_chars=True
         )
-        item.subject.body = text
-        return True
+        with Transaction(event_manager):
+            item.subject.body = text
 
-    @transactional
     def escape():
-        subject.body = body
+        nonlocal commit
+        commit = False
 
     subject = item.subject
     if not subject:
@@ -30,7 +33,6 @@ def CommentItemInlineEditor(item, view, event_manager, pos=None) -> bool:
     startiter, enditer = buffer.get_bounds()
     buffer.move_mark_by_name("selection_bound", startiter)
     buffer.move_mark_by_name("insert", enditer)
-    buffer.connect("changed", lambda _: update_text())
 
     text_view = Gtk.TextView.new_with_buffer(buffer)
     box = view.get_item_bounding_box(view.selection.hovered_item)
@@ -41,5 +43,7 @@ def CommentItemInlineEditor(item, view, event_manager, pos=None) -> bool:
     text_view.show()
     frame.show()
 
-    show_popover(frame, view, box, escape)
+    popover = show_popover(frame, view, box, escape)
+    popover.connect("closed", lambda _: update_text())
+
     return True

--- a/gaphor/diagram/general/generaleditors.py
+++ b/gaphor/diagram/general/generaleditors.py
@@ -7,20 +7,12 @@ from gaphor.transaction import Transaction
 
 @InlineEditor.register(CommentItem)
 def CommentItemInlineEditor(item, view, event_manager, pos=None) -> bool:
-    commit = True
-
     def update_text():
-        if not commit:
-            return
         text = buffer.get_text(
             buffer.get_start_iter(), buffer.get_end_iter(), include_hidden_chars=True
         )
         with Transaction(event_manager):
             item.subject.body = text
-
-    def escape():
-        nonlocal commit
-        commit = False
 
     subject = item.subject
     if not subject:
@@ -43,7 +35,6 @@ def CommentItemInlineEditor(item, view, event_manager, pos=None) -> bool:
     text_view.show()
     frame.show()
 
-    popover = show_popover(frame, view, box, escape)
-    popover.connect("closed", lambda _: update_text())
+    show_popover(frame, view, box, update_text)
 
     return True

--- a/gaphor/diagram/general/generaleditors.py
+++ b/gaphor/diagram/general/generaleditors.py
@@ -6,7 +6,7 @@ from gaphor.diagram.inlineeditors import InlineEditor, show_popover
 
 
 @InlineEditor.register(CommentItem)
-def CommentItemInlineEditor(item, view, pos=None) -> bool:
+def CommentItemInlineEditor(item, view, event_manager, pos=None) -> bool:
     @transactional
     def update_text():
         text = buffer.get_text(

--- a/gaphor/diagram/general/generalpropertypages.py
+++ b/gaphor/diagram/general/generalpropertypages.py
@@ -32,7 +32,7 @@ class CommentPropertyPage(PropertyPageBase):
         def handler(event):
             if not text_view.props.has_focus:
                 buffer.handler_block(changed_id)
-                buffer.set_text(event.new_value)
+                buffer.set_text(event.new_value or "")
                 buffer.handler_unblock(changed_id)
 
         self.watcher.watch("body", handler)

--- a/gaphor/diagram/inlineeditors.py
+++ b/gaphor/diagram/inlineeditors.py
@@ -11,7 +11,9 @@ from gaphor.diagram.presentation import LinePresentation, Named
 
 
 @singledispatch
-def InlineEditor(item: Item, view, pos: tuple[int, int] | None = None) -> bool:
+def InlineEditor(
+    item: Item, view, event_manager, pos: tuple[int, int] | None = None
+) -> bool:
     """Show a small editor popup in the diagram. Makes for easy editing without
     resorting to the Element editor.
 
@@ -22,7 +24,7 @@ def InlineEditor(item: Item, view, pos: tuple[int, int] | None = None) -> bool:
 
 
 @InlineEditor.register(Named)
-def named_item_inline_editor(item, view, pos=None) -> bool:
+def named_item_inline_editor(item, view, event_manager, pos=None) -> bool:
     """Text edit support for Named items."""
 
     @transactional

--- a/gaphor/diagram/tests/test_inlineeditors.py
+++ b/gaphor/diagram/tests/test_inlineeditors.py
@@ -18,28 +18,34 @@ def view(diagram):
     return view
 
 
-def test_named_item_inline_editor_with_element(diagram, element_factory, view):
+def test_named_item_inline_editor_with_element(
+    diagram, element_factory, view, event_manager
+):
     item = diagram.create(
         UML.classes.ClassItem, subject=element_factory.create(UML.Class)
     )
     view.selection.hovered_item = item
-    result = named_item_inline_editor(item, view)
+    result = named_item_inline_editor(item, view, event_manager)
 
     assert result is True
 
 
-def test_named_item_inline_editor_with_line(diagram, element_factory, view):
+def test_named_item_inline_editor_with_line(
+    diagram, element_factory, view, event_manager
+):
     item = diagram.create(
         UML.classes.DependencyItem, subject=element_factory.create(UML.Dependency)
     )
     view.selection.hovered_item = item
-    result = named_item_inline_editor(item, view)
+    result = named_item_inline_editor(item, view, event_manager)
 
     assert result is True
 
 
-def test_named_item_inline_editor_without_item(diagram, element_factory, view):
+def test_named_item_inline_editor_without_item(
+    diagram, element_factory, view, event_manager
+):
     item = diagram.create(UML.classes.DependencyItem)
-    result = named_item_inline_editor(item, view)
+    result = named_item_inline_editor(item, view, event_manager)
 
     assert result is False


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When editing, for each character changed a new undo transaction is created. This makes undo/redo behave in an unexpected way.

Issue Number: N/A

### What is the new behavior?

Only set name once, after editng
### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
