### PR TITLE
Fix parameter is incorrect error with ";;" in path

### DIFF
--- a/packaging/make-script.py
+++ b/packaging/make-script.py
@@ -29,6 +29,9 @@ def make_gaphor_script():
         file.write("if os.environ['PATH'][-1] == ';':\n")
         file.write("    os.environ['PATH'] = os.environ['PATH'][:-1]\n")
 
+        # Check for and remove two semicolons in path
+        file.write("os.environ['PATH'] = os.environ['PATH'].replace(';;', ';')\n")
+
         plugins = toml["tool"]["poetry"]["plugins"]
         for cat in plugins.values():
             for entrypoint in cat.values():


### PR DESCRIPTION
This PR fixes parameter incorrect errors when trying to load PyGObject with a double semicolon in the path. PyGObject doesn't check that the path is valid prior to adding the dll directory to it. We may be able to push a fix upstream to resolve this as well.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, for
- [ ] matting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
WinError with parameter is incorrect error for ""

Issue Number: #1001

### What is the new behavior?
No error.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
