### PR TITLE
Update Style Sheet Editor to be a Code Editor

### DIFF
--- a/.github/actions/linux_dependencies/action.yml
+++ b/.github/actions/linux_dependencies/action.yml
@@ -7,4 +7,5 @@ runs:
         sudo apt-get update -q && sudo apt-get install
         --no-install-recommends -y xvfb python3-dev python3-gi upx
         python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev
+        libgtksourceview-4-dev
       shell: bash

--- a/.github/actions/macos_dependencies/action.yml
+++ b/.github/actions/macos_dependencies/action.yml
@@ -3,5 +3,5 @@ description: 'Installs macOS GTK and Python Dependencies'
 runs:
   using: composite
   steps:
-    - run: brew install gobject-introspection gtk+3 gtk4 adwaita-icon-theme gtk-mac-integration create-dmg upx
+    - run: brew install gobject-introspection gtk+3 gtk4 gtksourceview4 gtksourceview5 adwaita-icon-theme gtk-mac-integration create-dmg upx
       shell: bash

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -29,7 +29,7 @@ execute:
 
 ```bash
 $ sudo apt-get install -y python3-dev python3-gi python3-gi-cairo
-gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev
+gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev libgtksourceview-4-0-dev
 ```
 
 Install Poetry (you may want to consider [alternative methods](https://python-poetry.org/docs/#alternative-installation-methods-not-recommended)):

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -29,7 +29,7 @@ execute:
 
 ```bash
 $ sudo apt-get install -y python3-dev python3-gi python3-gi-cairo
-gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev libgtksourceview-4-0-dev
+gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev libgtksourceview-4-dev
 ```
 
 Install Poetry (you may want to consider [alternative methods](https://python-poetry.org/docs/#alternative-installation-methods-not-recommended)):

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -6,7 +6,7 @@ To setup a development environment with macOS:
 1. Install [homebrew](https://brew.sh)
 1. Open a terminal and execute:
 ```bash
-$ brew install python3 gobject-introspection gtk+3 adwaita-icon-theme gtk-mac-integration
+$ brew install python3 gobject-introspection gtk+3 gtksourceview4 adwaita-icon-theme gtk-mac-integration
 ```
 Install Poetry (you may want to consider installing poetry via [pipx](https://pypi.org/project/pipx/), instead of pip):
 ```bash

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -129,6 +129,7 @@ heavily patched to be built this way and often breaks.
 $ pacman -Suy
 $ pacman -S mingw-w64-x86_64-gcc \
     mingw-w64-x86_64-gtk3 \
+    mingw-w64-x86_64-gtksourceview4 \
     mingw-w64-x86_64-pkgconf \
     mingw-w64-x86_64-cairo \
     mingw-w64-x86_64-gobject-introspection \

--- a/gaphor/__init__.py
+++ b/gaphor/__init__.py
@@ -5,7 +5,9 @@ import os
 import gi
 
 gtk_version = "4.0" if os.getenv("GAPHOR_USE_GTK") == "4" else "3.0"
+gtk_source_version = "5" if os.getenv("GAPHOR_USE_GTK") == "4" else "4"
 
 gi.require_version("PangoCairo", "1.0")
 gi.require_version("Gtk", gtk_version)
 gi.require_version("Gdk", gtk_version)
+gi.require_version("GtkSource", gtk_source_version)

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtksourceview" version="4.0"/>
   <object class="GtkBox" id="no-item-selected">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -90,7 +91,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
       </packing>
     </child>
   </object>
-  <object class="GtkTextBuffer" id="style-sheet-buffer"/>
+  <object class="GtkSourceBuffer" id="style-sheet-buffer"/>
   <object class="GtkRevealer" id="elementeditor">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -407,11 +408,14 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                     <property name="can_focus">True</property>
                     <property name="shadow_type">in</property>
                     <child>
-                      <object class="GtkTextView" id="style-sheet-view">
+                      <object class="GtkSourceView" id="style-sheet-view">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="buffer">style-sheet-buffer</property>
                         <property name="monospace">True</property>
+                        <property name="auto_indent">True</property>
+                        <property name="tab_width">2</property>
+                        <property name="insert_spaces_instead_of_tabs">True</property>
                       </object>
                     </child>
                   </object>

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Optional
 
-from gi.repository import GLib, Gtk
+from gi.repository import GLib, Gtk, GtkSource
 
 from gaphor.abc import ActionProvider
 from gaphor.core import Transaction, action, event_handler
@@ -247,6 +247,7 @@ class SettingsStack:
     def __init__(self, event_manager, element_factory):
         self.event_manager = event_manager
         self.element_factory = element_factory
+        self.lang_manager = GtkSource.LanguageManager.get_default()
 
         def tx_update_style_sheet(style_sheet, text):
             self._in_update = 1
@@ -259,6 +260,7 @@ class SettingsStack:
 
     def open(self, builder):
         self.style_sheet_buffer = builder.get_object("style-sheet-buffer")
+        self.style_sheet_buffer.set_language(self.lang_manager.get_language("css"))
         self.style_sheet_view = builder.get_object("style-sheet-view")
 
         self.event_manager.subscribe(self._model_ready)

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -240,7 +240,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                       <object class="GtkScrolledWindow">
                         <property name="vexpand">1</property>
                         <property name="child">
-                          <object class="GtkTextView" id="style-sheet-view">
+                          <object class="GtkSourceView" id="style-sheet-view">
                             <property name="buffer">style-sheet-buffer</property>
                             <property name="monospace">1</property>
                           </object>

--- a/packaging/gaphor.spec
+++ b/packaging/gaphor.spec
@@ -42,7 +42,7 @@ a = Analysis(
     + copy_metadata("gaphor")
     + copy_metadata("gaphas"),
     hiddenimports=[],
-    hookspath=[],
+    hookspath=["hooks"],
     runtime_hooks=[],
     excludes=["lib2to3", "tcl", "tk", "_tkinter", "tkinter", "Tkinter"],
     win_no_prefer_redirects=False,

--- a/packaging/hooks/hook-gi.repository.GtkSource.py
+++ b/packaging/hooks/hook-gi.repository.GtkSource.py
@@ -1,0 +1,7 @@
+"""Import hook for PyGObject https://wiki.gnome.org/PyGObject."""
+
+from PyInstaller.utils.hooks.gi import collect_glib_share_files, get_gi_typelibs
+
+binaries, datas, hiddenimports = get_gi_typelibs("GtkSource", "4")
+
+datas += collect_glib_share_files("gtksourceview-4")

--- a/packaging/windows/msys2-install.sh
+++ b/packaging/windows/msys2-install.sh
@@ -12,6 +12,7 @@ pacman --noconfirm -S --needed \
     mingw-w64-x86_64-make \
     mingw-w64-x86_64-gcc \
     mingw-w64-x86_64-gtk3 \
+    mingw-w64-x86_64-gtksourceview4 \
     mingw-w64-x86_64-pkgconf \
     mingw-w64-x86_64-nsis \
     mingw-w64-x86_64-cairo \


### PR DESCRIPTION
Uses GtkSourceView to add CSS syntax highlighting, auto indent, and use spaces instead of tabs.

This PR replaces #928 in order to change the branch used so that the full build is done to test the packaging.

- [X] Linux support
- [X] macOS support
- [ ] Windows support

Signed-off-by: Dan Yeaw <dan@yeaw.me>

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
The style sheet editor is a basic text editor with no code editing features.

Issue Number: #804 

### What is the new behavior?
Code editor features are now supported.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
