### PR TITLE
Up typing compliance to 3.9, and remove typing_extensions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,5 +8,4 @@ sphinxcontrib-websupport==1.2.4
 sphinxcontrib-images==0.9.4
 tomli==1.2.1
 generic==1.0.0
-typing_extensions==3.10.0.2
 importlib_metadata==4.8.1

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -8,10 +8,18 @@ import logging
 import uuid
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Callable, Iterable, Iterator, Sequence, TypeVar, overload
+from typing import (
+    Callable,
+    Iterable,
+    Iterator,
+    Protocol,
+    Sequence,
+    TypeVar,
+    overload,
+    runtime_checkable,
+)
 
 import gaphas
-from typing_extensions import Protocol, runtime_checkable
 
 from gaphor.core.modeling.collection import collection
 from gaphor.core.modeling.element import Element, Id, RepositoryProtocol

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 import logging
 import uuid
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Callable, Iterator, TypeVar, overload
-
-from typing_extensions import Protocol
+from typing import TYPE_CHECKING, Callable, Iterator, Protocol, TypeVar, overload
 
 from gaphor.core.modeling.event import ElementUpdated
 from gaphor.core.modeling.properties import (

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -26,9 +26,17 @@ methods:
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Generic, Sequence, TypeVar, Union, overload
-
-from typing_extensions import Literal, Protocol
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Literal,
+    Protocol,
+    Sequence,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from gaphor.core.modeling.collection import collection, collectionlist
 from gaphor.core.modeling.event import (

--- a/gaphor/core/styling/__init__.py
+++ b/gaphor/core/styling/__init__.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import itertools
 import operator
-from typing import Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, Iterator, Literal, Protocol, Sequence, Tuple, Union
 
 import tinycss2
-from typing_extensions import Literal, Protocol
 
 from gaphor.core.styling.declarations import (
     FONT_SIZE_VALUES,

--- a/gaphor/core/styling/properties.py
+++ b/gaphor/core/styling/properties.py
@@ -1,8 +1,6 @@
 """Definitions (types) for style sheets."""
 from enum import Enum
-from typing import Sequence, Tuple, Union
-
-from typing_extensions import TypedDict
+from typing import Sequence, Tuple, TypedDict, Union
 
 Color = Tuple[float, float, float, float]  # RGBA
 Padding = Tuple[float, float, float, float]  # top/right/bottom/left

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -6,12 +6,11 @@ gaphor.adapter package.
 
 from __future__ import annotations
 
-from typing import TypeVar
+from typing import Protocol, TypeVar
 
 from gaphas.connections import Connection
 from gaphas.connector import Handle, Port
 from generic.multidispatch import FunctionDispatcher, multidispatch
-from typing_extensions import Protocol
 
 from gaphor.core.modeling import Diagram, Element, Presentation
 from gaphor.core.modeling.properties import association, redefine, relation

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -24,7 +24,7 @@ icon_theme = (
     else Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
 )
 if sys.version_info >= (3, 9):
-    path: Path = importlib.resources.files("gaphor") / "ui" / "icons"
+    path: Path = importlib.resources.files("gaphor") / "ui" / "icons"  # type: ignore[assignment]
     if Gtk.get_major_version() == 3:
         icon_theme.append_search_path(str(path))
     else:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.9
 warn_return_any = True
 warn_unused_configs = True
 warn_redundant_casts = True

--- a/packaging/windows/build-win-installer.py
+++ b/packaging/windows/build-win-installer.py
@@ -16,7 +16,7 @@ def clean_files(paths: list[Path]) -> None:
         if path.is_dir():
             shutil.rmtree(path, ignore_errors=True)
         elif path.is_file():
-            path.unlink(missing_ok=True)  # type: ignore[call-arg]
+            path.unlink(missing_ok=True)
 
 
 def build_installer(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ pycairo = "^1.18"
 PyGObject = "^3.30"
 gaphas = "^3.1.0"
 importlib_metadata = ">=1.4,<5.0"
-typing_extensions = "^3.7.4"
 generic = "^1.0.0"
 tinycss2 = "^1.0.2"
 pyinstaller = { version = "^4.3", optional = true } 
@@ -188,7 +187,7 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 88
-known_third_party = ["cairo", "gaphas", "generic", "gi", "importlib_metadata", "pytest", "recommonmark", "tinycss2", "tomlkit", "typing_extensions"]
+known_third_party = ["cairo", "gaphas", "generic", "gi", "importlib_metadata", "pytest", "recommonmark", "tinycss2", "tomlkit"]
 skip = "flatpak,.venv,build,dist"
 skip_glob = "gaphor/diagram/general/__init__.py,gaphor/UML/__init__.py,gaphor/UML/*/__init__.py,gaphor/RAAML/stpa/__init__.py"
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Python has all typing features we need. No need anymore for typing_extensions.
