### PR TITLE
Remove unneeded linux CI build dependencies

### DIFF
--- a/.github/actions/linux_dependencies/action.yml
+++ b/.github/actions/linux_dependencies/action.yml
@@ -3,8 +3,7 @@ description: 'Installs Ubuntu GTK and Python Dependencies'
 runs:
   using: composite
   steps:
-    - run: >
-        sudo apt-get update -q && sudo apt-get install
-        --no-install-recommends -y xvfb python3-dev python3-gi upx
-        python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev
+    - run: |
+        sudo apt update -qq
+        sudo apt install -qq --no-install-recommends gir1.2-gtk-3.0 libgirepository1.0-dev upx
       shell: bash


### PR DESCRIPTION
While working on getting PyGObject tests as part of the PyInstaller CI in https://github.com/pyinstaller/pyinstaller/pull/6300, I realized that we have a lot of extra build dependencies that aren't required. The Python that ships with Ubuntu is not used for CI, instead the setup-python GH Action is used. Installing development libraries for that Python is not needed.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Python dependencies are installed that aren't used because of the GitHub Actions setup-python action.

Issue Number: N/A

### What is the new behavior?
Extra dependencies are removed.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
