### PR TITLE
Fix Python 3.10 warnings

### DIFF
--- a/gaphor/codegen/codegen.py
+++ b/gaphor/codegen/codegen.py
@@ -6,8 +6,8 @@ Provides the CLI for the code generator which transforms a Gaphor models
 """
 
 import argparse
-from distutils.util import byte_compile
 from pathlib import Path
+from py_compile import compile
 
 from gaphor.codegen import profile_coder, uml_coder
 
@@ -34,7 +34,7 @@ def main() -> None:
         )
     else:
         uml_coder.generate(args.modelfile, args.outfile, args.overrides)
-    byte_compile([str(args.outfile)])
+    compile(args.outfile)
 
 
 if __name__ == "__main__":

--- a/gaphor/entrypoint.py
+++ b/gaphor/entrypoint.py
@@ -15,7 +15,11 @@ def initialize(scope, services=None, **known_services: T) -> Dict[str, T]:
 
 @functools.lru_cache(maxsize=4)
 def list_entry_points(scope):
-    return importlib.metadata.entry_points()[scope]
+    eps = importlib.metadata.entry_points()
+    if hasattr(eps, "select"):
+        # Python 3.10+:
+        return eps.select(group=scope)  # type: ignore[attr-defined]
+    return eps[scope]
 
 
 def load_entry_points(scope, services=None) -> Dict[str, Type[T]]:


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Pytest gives warnings with Python 3.10:

```
=================================================================================== warnings summary ===================================================================================
gaphor/codegen/codegen.py:9
  /home/arjan/Development/gaphor/gaphor/codegen/codegen.py:9: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils.util import byte_compile

gaphor/UML/actions/tests/test_action.py::test_action
gaphor/UML/actions/tests/test_action.py::test_action
gaphor/tests/test_application.py::test_service_load
  /home/arjan/Development/gaphor/gaphor/entrypoint.py:18: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    return importlib.metadata.entry_points()[scope]

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================================================================== 1123 passed, 4 warnings in 14.86s ===========================================================================
```

### What is the new behavior?

Updated code so warnings do no longer appear.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

