### PR TITLE
Allow messages to move freely on Lifeline and ExecutionSpec

### DIFF
--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -23,7 +23,7 @@ behavior, whereas ActionExecutionSpecification has a [1] relation to action.
 import ast
 
 from gaphas import Handle
-from gaphas.connector import LinePort, Position
+from gaphas.connector import Position
 from gaphas.constraint import constraint
 from gaphas.geometry import Rectangle, distance_rectangle_point
 from gaphas.solver import WEAK
@@ -33,6 +33,7 @@ from gaphor.core.modeling import Presentation
 from gaphor.diagram.presentation import HandlePositionUpdate, postload_connect
 from gaphor.diagram.shapes import Box, draw_border
 from gaphor.diagram.support import represents
+from gaphor.UML.interactions.lifeline import BetweenPort
 
 
 @represents(UML.ExecutionSpecification)
@@ -75,7 +76,7 @@ class ExecutionSpecificationItem(
         ):
             self._connections.add_constraint(self, c)
 
-        self._ports = [LinePort(nw, sw), LinePort(ne, se)]
+        self._ports = [BetweenPort(nw, sw), BetweenPort(ne, se)]
 
         self.shape = Box(
             style={"background-color": (1.0, 1.0, 1.0, 1.0)}, draw=draw_border

--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -26,7 +26,7 @@ from gaphas import Handle
 from gaphas.connector import Position
 from gaphas.constraint import constraint
 from gaphas.geometry import Rectangle, distance_rectangle_point
-from gaphas.solver import WEAK
+from gaphas.solver import STRONG
 
 from gaphor import UML
 from gaphor.core.modeling import Presentation
@@ -49,7 +49,7 @@ class ExecutionSpecificationItem(
 
         self.bar_width = 12
 
-        ht, hb = Handle(), Handle()
+        ht, hb = Handle(strength=STRONG), Handle(strength=STRONG)
         ht.connectable = True
 
         self._handles = [ht, hb]
@@ -59,10 +59,10 @@ class ExecutionSpecificationItem(
         self._connections.add_constraint(self, constraint(vertical=(ht.pos, hb.pos)))
 
         r = self.bar_width / 2
-        nw = Position(-r, 0, strength=WEAK)
-        ne = Position(r, 0, strength=WEAK)
-        se = Position(r, 0, strength=WEAK)
-        sw = Position(-r, 0, strength=WEAK)
+        nw = Position(-r, 0, strength=STRONG)
+        ne = Position(r, 0, strength=STRONG)
+        se = Position(r, 0, strength=STRONG)
+        sw = Position(-r, 0, strength=STRONG)
 
         for c in (
             constraint(horizontal=(nw, ht.pos)),

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -34,6 +34,9 @@ def order_lifeline_covered_by(lifeline):
     def y_and_occurence(connected):
         for conn in diagram.connections.get_connections(connected=connected):
             m = conn.item.matrix_i2c
+            if not conn.item.subject:
+                # Can happen during DnD
+                continue
             if isinstance(conn.item, ExecutionSpecificationItem):
                 yield (
                     m.transform_point(*conn.item.top.pos)[1],

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -24,7 +24,7 @@ from gaphas.constraint import CenterConstraint, EqualsConstraint, LessThanConstr
 from gaphas.geometry import distance_line_point
 from gaphas.item import SE, SW
 from gaphas.position import MatrixProjection, Position
-from gaphas.solver import STRONG, MultiConstraint
+from gaphas.solver import VERY_STRONG, MultiConstraint
 from gaphas.solver.constraint import BaseConstraint
 from gaphas.types import Pos, SupportsFloatPos
 
@@ -48,7 +48,10 @@ class BetweenConstraint(BaseConstraint):
         self.lower = lower
         self.upper = upper
 
-    def solve(self):
+    def solve_for(self, var):
+        if var is not self.v:
+            return
+
         lower = self.lower.value
         upper = self.upper.value
         if lower > upper:
@@ -81,7 +84,7 @@ class BetweenPort(Port):
         end = MatrixProjection(self.end, glue_item.matrix_i2c)
         point = MatrixProjection(handle.pos, item.matrix_i2c)
 
-        cx = BetweenConstraint(point.x, start.x, end.x)
+        cx = EqualsConstraint(point.x, start.x)
         cy = BetweenConstraint(point.y, start.y, end.y)
 
         return MultiConstraint(start, end, point, cx, cy)
@@ -105,8 +108,8 @@ class LifetimeItem:
     def __init__(self):
         super().__init__()
 
-        self.top = Handle(strength=STRONG - 1)
-        self.bottom = Handle(strength=STRONG)
+        self.top = Handle(strength=VERY_STRONG - 1)
+        self.bottom = Handle(strength=VERY_STRONG)
 
         self.top.movable = False
         self.top.visible = False


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Message ends are tied to a specific position on the life line. When the lifeline is grown, the messages ends also move.

Issue Number: #1007

### What is the new behavior?

Messages stay on their place, as long as they are on the lifeline. This allows to freely grow and shrink the lifeline and execution specifications. Also it allows for message to be moved up and down the lifeline.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

