### PR TITLE
Fix lifeline ordering when not all items are linked in a diagram

### DIFF
--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -57,7 +57,7 @@ def order_lifeline_covered_by(lifeline):
 
     if lifeline.subject:
         keys = {o: y for y, o in y_and_occurence(lifeline)}
-        lifeline.subject.coveredBy.order(keys.get)
+        lifeline.subject.coveredBy.order(lambda key: keys.get(key, 0.0))
 
 
 def owner_for_message(line, lifeline):

--- a/gaphor/UML/interactions/tests/test_ordering.py
+++ b/gaphor/UML/interactions/tests/test_ordering.py
@@ -1,3 +1,5 @@
+import pytest
+
 from gaphor import UML
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML.interactions.executionspecification import ExecutionSpecificationItem
@@ -6,25 +8,28 @@ from gaphor.UML.interactions.lifeline import LifelineItem
 from gaphor.UML.interactions.message import MessageItem
 
 
-def test_ordering(diagram, element_factory):
+@pytest.fixture
+def lifeline(diagram, element_factory):
     lifeline = diagram.create(
         LifelineItem, subject=element_factory.create(UML.Lifeline)
     )
     lifeline.lifetime.visible = True
     lifeline.lifetime.bottom.pos.y = 1000
-    lifetime_top = lifeline.lifetime.top.pos
+    return lifeline
 
+
+def test_ordering(lifeline, diagram):
     exec_spec = diagram.create(ExecutionSpecificationItem)
     message1 = diagram.create(MessageItem)
     message2 = diagram.create(MessageItem)
     message3 = diagram.create(MessageItem)
 
+    lifetime_top = lifeline.lifetime.top.pos
     message1.head.pos.y = message1.tail.pos.y = lifetime_top.y + 300
     exec_spec.top.pos.y = lifetime_top.y + 400
     message2.head.pos.y = message2.tail.pos.y = lifetime_top.y + 500
     exec_spec.bottom.pos.y = lifetime_top.y + 600
     message3.head.pos.y = message3.tail.pos.y = lifetime_top.y + 700
-
     diagram.connections.solve()
 
     # Add in "random" order
@@ -39,6 +44,31 @@ def test_ordering(diagram, element_factory):
         message2.subject.sendEvent,
         exec_spec.subject.finish,
         message3.subject.receiveEvent,
+    ]
+
+    order_lifeline_covered_by(lifeline)
+
+    assert list(lifeline.subject.coveredBy) == occurrences
+
+
+def test_ordering_with_connection_missing_in_diagram(
+    lifeline, diagram, element_factory
+):
+    # This can happen during loading of the model
+
+    message1 = diagram.create(MessageItem)
+    lifetime_top = lifeline.lifetime.top.pos
+    message1.head.pos.y = message1.tail.pos.y = lifetime_top.y + 300
+    diagram.connections.solve()
+
+    connect(message1, message1.head, lifeline)
+    lonely_exec_spec = lifeline.subject.coveredBy = element_factory.create(
+        UML.MessageOccurrenceSpecification
+    )
+
+    occurrences = [
+        lonely_exec_spec,
+        message1.subject.sendEvent,
     ]
 
     order_lifeline_covered_by(lifeline)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

This commit fixes an isue that can occur when loading a model. Lifelines are ordered based on their position on the diagram. The re-ordering is triggered when items are connected. However, relations on model level are already connected at that point. The ordering is dependent on the connections in the diagram as well as the connections on model level.

This change makes the code more resilient during loading.

Fixes #1152

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

This issue can only be fixed in code, so it requires a new release.