### PR TITLE
Core as a separate ModelingLanguage

### DIFF
--- a/gaphor/C4Model/tests/conftest.py
+++ b/gaphor/C4Model/tests/conftest.py
@@ -1,28 +1,18 @@
 import pytest
 
 from gaphor.C4Model.modelinglanguage import C4ModelLanguage
-from gaphor.core.modeling import ElementFactory
-from gaphor.core.modeling.elementdispatcher import ElementDispatcher
-from gaphor.diagram.tests.fixtures import diagram, event_manager
+from gaphor.core.modeling.modelinglanguage import CoreModelingLanguage
+from gaphor.diagram.tests.fixtures import (
+    MockModelingLanguage,
+    diagram,
+    element_factory,
+    event_manager,
+)
 from gaphor.UML.modelinglanguage import UMLModelingLanguage
 
 
-class MockModelingLanguage:
-    def __init__(self):
-        self._modeling_languages = [UMLModelingLanguage(), C4ModelLanguage()]
-
-    def lookup_element(self, name):
-        return self.first(lambda provider: provider.lookup_element(name))
-
-    def first(self, predicate):
-        for provider in self._modeling_languages:
-            type = predicate(provider)
-            if type:
-                return type
-
-
 @pytest.fixture
-def element_factory(event_manager):  # noqa: F811
-    return ElementFactory(
-        event_manager, ElementDispatcher(event_manager, MockModelingLanguage())
+def modeling_language():
+    return MockModelingLanguage(
+        CoreModelingLanguage(), UMLModelingLanguage(), C4ModelLanguage()
     )

--- a/gaphor/SysML/blocks/tests/conftest.py
+++ b/gaphor/SysML/blocks/tests/conftest.py
@@ -1,1 +1,2 @@
-from gaphor.SysML.tests.fixtures import diagram, element_factory, event_manager
+from gaphor.diagram.tests.fixtures import diagram, element_factory, event_manager
+from gaphor.SysML.tests.fixtures import modeling_language

--- a/gaphor/SysML/requirements/tests/conftest.py
+++ b/gaphor/SysML/requirements/tests/conftest.py
@@ -1,2 +1,7 @@
-from gaphor.diagram.tests.fixtures import create
-from gaphor.SysML.tests.fixtures import diagram, element_factory, event_manager
+from gaphor.diagram.tests.fixtures import (
+    create,
+    diagram,
+    element_factory,
+    event_manager,
+)
+from gaphor.SysML.tests.fixtures import modeling_language

--- a/gaphor/SysML/tests/conftest.py
+++ b/gaphor/SysML/tests/conftest.py
@@ -1,1 +1,2 @@
-from gaphor.SysML.tests.fixtures import diagram, element_factory, event_manager
+from gaphor.diagram.tests.fixtures import diagram, element_factory, event_manager
+from gaphor.SysML.tests.fixtures import modeling_language

--- a/gaphor/SysML/tests/fixtures.py
+++ b/gaphor/SysML/tests/fixtures.py
@@ -1,28 +1,13 @@
 import pytest
 
-from gaphor.core.modeling import ElementFactory
-from gaphor.core.modeling.elementdispatcher import ElementDispatcher
-from gaphor.diagram.tests.fixtures import diagram, event_manager  # noqa F401
+from gaphor.core.modeling.modelinglanguage import CoreModelingLanguage
+from gaphor.diagram.tests.fixtures import MockModelingLanguage
 from gaphor.SysML.modelinglanguage import SysMLModelingLanguage
 from gaphor.UML.modelinglanguage import UMLModelingLanguage
 
 
-class MockModelingLanguage:
-    def __init__(self):
-        self._modeling_languages = [UMLModelingLanguage(), SysMLModelingLanguage()]
-
-    def lookup_element(self, name):
-        return self.first(lambda provider: provider.lookup_element(name))
-
-    def first(self, predicate):
-        for provider in self._modeling_languages:
-            type = predicate(provider)
-            if type:
-                return type
-
-
 @pytest.fixture
-def element_factory(event_manager):  # noqa: F811
-    return ElementFactory(
-        event_manager, ElementDispatcher(event_manager, MockModelingLanguage())
+def modeling_language():
+    return MockModelingLanguage(
+        CoreModelingLanguage(), UMLModelingLanguage(), SysMLModelingLanguage()
     )

--- a/gaphor/UML/actions/tests/test_activitynodes.py
+++ b/gaphor/UML/actions/tests/test_activitynodes.py
@@ -1,6 +1,7 @@
 from gaphas.item import Item
 
 from gaphor import UML
+from gaphor.core.modeling import Diagram
 from gaphor.UML.actions.activitynodes import DecisionNodeItem, ForkNodeItem
 
 
@@ -17,7 +18,7 @@ def test_decision_node_persistence(diagram, element_factory, saver, loader):
 
     data = saver()
     loader(data)
-    new_diagram = next(element_factory.select(UML.Diagram))
+    new_diagram = next(element_factory.select(Diagram))
     item = next(new_diagram.select(DecisionNodeItem))
 
     assert item.combined is None, item.combined
@@ -32,7 +33,7 @@ def test_combined_decision_node_persistence(diagram, element_factory, saver, loa
 
     data = saver()
     loader(data)
-    new_diagram = next(element_factory.select(UML.Diagram))
+    new_diagram = next(element_factory.select(Diagram))
     item = next(new_diagram.select(DecisionNodeItem))
 
     assert item.combined is not None, item.combined
@@ -45,7 +46,7 @@ def test_fork_node_persistence(diagram, element_factory, saver, loader):
     data = saver()
     loader(data)
 
-    new_diagram = next(element_factory.select(UML.Diagram))
+    new_diagram = next(element_factory.select(Diagram))
     item = next(new_diagram.select(ForkNodeItem))
     assert item.combined is None, item.combined
 
@@ -58,7 +59,7 @@ def test_combined_fork_node_persistence(diagram, element_factory, saver, loader)
 
     data = saver()
     loader(data)
-    new_diagram = next(element_factory.select(UML.Diagram))
+    new_diagram = next(element_factory.select(Diagram))
     item = next(new_diagram.select(ForkNodeItem))
 
     assert item.combined is not None, item.combined

--- a/gaphor/UML/classes/containmentconnect.py
+++ b/gaphor/UML/classes/containmentconnect.py
@@ -1,6 +1,7 @@
 """Containment connection adapters."""
 
 from gaphor import UML
+from gaphor.core.modeling import Diagram
 from gaphor.diagram.connectors import BaseConnector, Connector
 from gaphor.diagram.presentation import ElementPresentation
 from gaphor.UML.classes.containment import ContainmentItem
@@ -55,7 +56,7 @@ class ContainmentConnect(BaseConnector):
         ):
             contained.package = container
             return True
-        if isinstance(container, UML.Package) and isinstance(contained, (UML.Diagram)):
+        if isinstance(container, UML.Package) and isinstance(contained, (Diagram)):
             contained.element = container
             return True
         elif isinstance(container, UML.Class) and isinstance(contained, UML.Classifier):

--- a/gaphor/UML/classes/tests/test_class.py
+++ b/gaphor/UML/classes/tests/test_class.py
@@ -2,7 +2,7 @@
 
 from gaphor import UML
 from gaphor.core.modeling import UpdateContext
-from gaphor.core.modeling.diagram import FALLBACK_STYLE
+from gaphor.core.modeling.diagram import FALLBACK_STYLE, Diagram
 from gaphor.UML.classes.klass import ClassItem
 
 
@@ -17,7 +17,7 @@ def context():
 def test_compartments(case):
     """Test creation of classes and working of compartments."""
     element_factory = case.element_factory
-    diagram = element_factory.create(UML.Diagram)
+    diagram = element_factory.create(Diagram)
     klass = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
     assert 2 == len(compartments(klass))
@@ -54,7 +54,7 @@ def test_compartments(case):
 def test_attribute_removal(case):
 
     element_factory = case.element_factory
-    diagram = element_factory.create(UML.Diagram)
+    diagram = element_factory.create(Diagram)
     klass = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
     diagram.update_now((klass,))
 
@@ -79,7 +79,7 @@ def test_attribute_removal(case):
 
 def test_compartment_resizing(case):
     element_factory = case.element_factory
-    diagram = element_factory.create(UML.Diagram)
+    diagram = element_factory.create(Diagram)
     klass = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
     klass.subject.name = "Class1"
 

--- a/gaphor/UML/classes/tests/test_classconnect.py
+++ b/gaphor/UML/classes/tests/test_classconnect.py
@@ -1,6 +1,7 @@
 """Classes related adapter connection tests."""
 
 from gaphor import UML
+from gaphor.core.modeling import Diagram
 from gaphor.diagram.tests.fixtures import allow, connect, disconnect, get_connected
 from gaphor.UML.classes.dependency import DependencyItem
 from gaphor.UML.classes.interface import InterfaceItem
@@ -131,7 +132,7 @@ def test_multiple_dependencies(create, element_factory):
 
     # Do the same thing, but now on a new diagram:
 
-    diagram2 = element_factory.create(UML.Diagram)
+    diagram2 = element_factory.create(Diagram)
     actoritem3 = diagram2.create(ActorItem, subject=actor1)
     actoritem4 = diagram2.create(ActorItem, subject=actor2)
     dep2 = diagram2.create(DependencyItem)

--- a/gaphor/UML/classes/tests/test_generalizationconnect.py
+++ b/gaphor/UML/classes/tests/test_generalizationconnect.py
@@ -92,7 +92,7 @@ def test_generalization_reconnection(create, element_factory):
     assert gen.subject.specific is c2.subject
 
     # Now do the same on a new diagram:
-    diagram2 = element_factory.create(UML.Diagram)
+    diagram2 = element_factory.create(Diagram)
     c3 = diagram2.create(ClassItem, subject=c1.subject)
     c4 = diagram2.create(ClassItem, subject=c2.subject)
     gen2 = diagram2.create(GeneralizationItem)

--- a/gaphor/UML/interactions/tests/test_message.py
+++ b/gaphor/UML/interactions/tests/test_message.py
@@ -1,6 +1,7 @@
 """Test messages."""
 
 from gaphor import UML
+from gaphor.core.modeling import Diagram
 from gaphor.diagram.grouping import Group
 from gaphor.UML.interactions.interaction import InteractionItem
 from gaphor.UML.interactions.message import MessageItem
@@ -11,7 +12,7 @@ def test_message_persistence(diagram, element_factory, saver, loader):
 
     data = saver()
     loader(data)
-    new_diagram = next(element_factory.select(UML.Diagram))
+    new_diagram = next(element_factory.select(Diagram))
     item = next(new_diagram.select(MessageItem))
 
     assert item

--- a/gaphor/UML/modelinglanguage.py
+++ b/gaphor/UML/modelinglanguage.py
@@ -3,12 +3,15 @@ assets."""
 
 from gaphor.abc import ModelingLanguage
 from gaphor.core import gettext
+from gaphor.core.modeling.modelinglanguage import CoreModelingLanguage
 from gaphor.diagram.diagramtoolbox import ToolboxDefinition
 from gaphor.UML import diagramitems, uml
 from gaphor.UML.toolbox import uml_toolbox_actions
 
 
 class UMLModelingLanguage(ModelingLanguage):
+    core = CoreModelingLanguage()
+
     @property
     def name(self) -> str:
         return gettext("UML")
@@ -18,6 +21,9 @@ class UMLModelingLanguage(ModelingLanguage):
         return uml_toolbox_actions
 
     def lookup_element(self, name):
+        element_type = self.core.lookup_element(name)
+        if element_type:
+            return element_type
         element_type = getattr(uml, name, None)
         if not element_type:
             element_type = getattr(diagramitems, name, None)

--- a/gaphor/UML/modelinglanguage.py
+++ b/gaphor/UML/modelinglanguage.py
@@ -3,15 +3,12 @@ assets."""
 
 from gaphor.abc import ModelingLanguage
 from gaphor.core import gettext
-from gaphor.core.modeling.modelinglanguage import CoreModelingLanguage
 from gaphor.diagram.diagramtoolbox import ToolboxDefinition
 from gaphor.UML import diagramitems, uml
 from gaphor.UML.toolbox import uml_toolbox_actions
 
 
 class UMLModelingLanguage(ModelingLanguage):
-    core = CoreModelingLanguage()
-
     @property
     def name(self) -> str:
         return gettext("UML")
@@ -21,9 +18,6 @@ class UMLModelingLanguage(ModelingLanguage):
         return uml_toolbox_actions
 
     def lookup_element(self, name):
-        element_type = self.core.lookup_element(name)
-        if element_type:
-            return element_type
         element_type = getattr(uml, name, None)
         if not element_type:
             element_type = getattr(diagramitems, name, None)

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -1,6 +1,7 @@
 import pytest
 
 from gaphor import UML
+from gaphor.core.modeling import Comment
 from gaphor.diagram.general import CommentItem, CommentLineItem
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML.classes import ClassItem, GeneralizationItem
@@ -31,7 +32,7 @@ def create_item(element_factory, diagram):
 
 
 def test_connect_element_with_comments(create_item, diagram):
-    comment = create_item(CommentItem, UML.Comment)
+    comment = create_item(CommentItem, Comment)
     line = create_item(CommentLineItem)
     gi = create_item(GeneralizationItem)
     clazz1 = create_item(ClassItem, UML.Class)
@@ -183,7 +184,7 @@ def test_stereotype_deletion(element_factory):
 
 def test_diagram_move(element_factory, mocker):
     diagram = element_factory.create(UML.Diagram)
-    diagram.create(CommentItem, subject=element_factory.create(UML.Comment))
+    diagram.create(CommentItem, subject=element_factory.create(Comment))
     mocked_func = mocker.patch.object(diagram, "request_update")
 
     package = element_factory.create(UML.Package)

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -1,7 +1,7 @@
 import pytest
 
 from gaphor import UML
-from gaphor.core.modeling import Comment
+from gaphor.core.modeling import Comment, Diagram
 from gaphor.diagram.general import CommentItem, CommentLineItem
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML.classes import ClassItem, GeneralizationItem
@@ -183,7 +183,7 @@ def test_stereotype_deletion(element_factory):
 
 
 def test_diagram_move(element_factory, mocker):
-    diagram = element_factory.create(UML.Diagram)
+    diagram = element_factory.create(Diagram)
     diagram.create(CommentItem, subject=element_factory.create(Comment))
     mocked_func = mocker.patch.object(diagram, "request_update")
 

--- a/gaphor/UML/tests/test_uml2.py
+++ b/gaphor/UML/tests/test_uml2.py
@@ -3,7 +3,7 @@ import pytest
 from gaphor import UML
 from gaphor.core.eventmanager import EventManager
 from gaphor.core.format import parse
-from gaphor.core.modeling import ElementFactory
+from gaphor.core.modeling import Comment, ElementFactory
 
 
 @pytest.fixture
@@ -80,7 +80,7 @@ def test_class(factory):
 
 def test_comment(factory):
     """Testing Comment elements in the meta-model."""
-    element = factory.create(UML.Comment)
+    element = factory.create(Comment)
     element.body = "Comment body"
     annotatedElement = factory.create(UML.Class)
     element.annotatedElement = annotatedElement

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -19,8 +19,6 @@ from gaphor.core.modeling.properties import (
 
 from typing import Callable
 
-from gaphor.core.modeling.coremodel import Comment, Diagram, StyleSheet
-
 
 from gaphor.core.modeling.coremodel import Element
 class NamedElement(Element):
@@ -758,10 +756,10 @@ class InformationFlow(DirectedRelationship, PackageableElement):
     realizingMessage: relation_many[Message]
 
 
-# 88: override Lifeline.parse: Callable[[Lifeline, str], None]
+# 86: override Lifeline.parse: Callable[[Lifeline, str], None]
 # defined in umloverrides.py
 
-# 91: override Lifeline.render: Callable[[Lifeline], str]
+# 89: override Lifeline.render: Callable[[Lifeline], str]
 # defined in umloverrides.py
 
 
@@ -772,7 +770,7 @@ Element.relationship.add(Element.directedRelationship)  # type: ignore[attr-defi
 NamedElement.supplierDependency = association("supplierDependency", Dependency, opposite="supplier")
 NamedElement.clientDependency = association("clientDependency", Dependency, composite=True, opposite="client")
 NamedElement.namespace = derivedunion("namespace", Namespace, upper=1)
-# 70: override NamedElement.qualifiedName: derived[list[str]]
+# 68: override NamedElement.qualifiedName: derived[list[str]]
 
 from gaphor.core.modeling.diagram import qualifiedName
 
@@ -816,7 +814,7 @@ Element.owner.add(PackageMerge.mergingPackage)  # type: ignore[attr-defined]
 DirectedRelationship.target.add(PackageMerge.mergedPackage)  # type: ignore[attr-defined]
 RedefinableElement.redefinedElement = derivedunion("redefinedElement", RedefinableElement)
 RedefinableElement.redefinitionContext = derivedunion("redefinitionContext", Classifier)
-# 58: override Namespace.importedMember: derivedunion[PackageableElement]
+# 56: override Namespace.importedMember: derivedunion[PackageableElement]
 Namespace.importedMember = derivedunion('importedMember', PackageableElement, 0, '*')
 
 Namespace.ownedMember = derivedunion("ownedMember", NamedElement)
@@ -834,12 +832,12 @@ PackageableElement.owningPackage.add(Type.package)  # type: ignore[attr-defined]
 Classifier.generalization = association("generalization", Generalization, composite=True, opposite="specific")
 Classifier.ownedUseCase = association("ownedUseCase", UseCase, composite=True)
 Classifier.redefinedClassifier = association("redefinedClassifier", Classifier)
-# 49: override Classifier.inheritedMember: derivedunion[NamedElement]
+# 47: override Classifier.inheritedMember: derivedunion[NamedElement]
 Classifier.inheritedMember = derivedunion('inheritedMember', NamedElement, 0, '*')
 
 Classifier.feature = derivedunion("feature", Feature)
 Classifier.attribute = derivedunion("attribute", Property)
-# 52: override Classifier.general(Generalization.general): derived[Classifier]
+# 50: override Classifier.general(Generalization.general): derived[Classifier]
 Classifier.general = derived('general', Classifier, 0, '*', lambda self: [g.general for g in self.generalization])
 
 Classifier.useCase = association("useCase", UseCase, opposite="subject")
@@ -854,7 +852,7 @@ Classifier.feature.add(Classifier.attribute)  # type: ignore[attr-defined]
 NamedElement.namespace.add(Classifier.nestingClass)  # type: ignore[attr-defined]
 RedefinableElement.redefinitionContext.add(Classifier.nestingClass)  # type: ignore[attr-defined]
 Element.directedRelationship.add(Classifier.specialization)  # type: ignore[attr-defined]
-# 26: override Association.endType(Association.memberEnd, Property.type): derived[Type]
+# 24: override Association.endType(Association.memberEnd, Property.type): derived[Type]
 
 # References the classifiers that are used as types of the ends of the
 # association.
@@ -868,7 +866,7 @@ Association.navigableOwnedEnd = association("navigableOwnedEnd", Property)
 Classifier.feature.add(Association.ownedEnd)  # type: ignore[attr-defined]
 Namespace.ownedMember.add(Association.ownedEnd)  # type: ignore[attr-defined]
 Namespace.member.add(Association.memberEnd)  # type: ignore[attr-defined]
-# 46: override Extension.metaclass(Extension.ownedEnd, Association.memberEnd): property
+# 44: override Extension.metaclass(Extension.ownedEnd, Association.memberEnd): property
 # defined in umloverrides.py
 
 Extension.ownedEnd = association("ownedEnd", ExtensionEnd, upper=1, composite=True)
@@ -896,10 +894,10 @@ Element.owner.add(Dependency.client)  # type: ignore[attr-defined]
 DirectedRelationship.target.add(Dependency.client)  # type: ignore[attr-defined]
 TypedElement.type = association("type", Type, upper=1)
 ObjectNode.selection = association("selection", Behavior, upper=1)
-# 20: override MultiplicityElement.lower(MultiplicityElement.lowerValue): _attribute[str]
+# 18: override MultiplicityElement.lower(MultiplicityElement.lowerValue): _attribute[str]
 MultiplicityElement.lower = MultiplicityElement.lowerValue
 
-# 23: override MultiplicityElement.upper(MultiplicityElement.upperValue): _attribute[str]
+# 21: override MultiplicityElement.upper(MultiplicityElement.upperValue): _attribute[str]
 MultiplicityElement.upper = MultiplicityElement.upperValue
 
 Generalization.specific = association("specific", Classifier, upper=1, opposite="generalization")
@@ -909,7 +907,7 @@ Element.owner.add(Generalization.specific)  # type: ignore[attr-defined]
 DirectedRelationship.target.add(Generalization.general)  # type: ignore[attr-defined]
 StructuredClassifier.role = derivedunion("role", ConnectableElement)
 StructuredClassifier.ownedAttribute = association("ownedAttribute", Property, composite=True)
-# 103: override StructuredClassifier.part: property
+# 101: override StructuredClassifier.part: property
 StructuredClassifier.part = property(lambda self: tuple(a for a in self.ownedAttribute if a.isComposite), doc="""
     Properties owned by a classifier by composition.
 """)
@@ -924,7 +922,7 @@ Classifier.feature.add(StructuredClassifier.ownedConnector)  # type: ignore[attr
 EncapsulatedClassifer.ownedPort = association("ownedPort", Port, composite=True, opposite="encapsulatedClassifier")
 Class.ownedAttribute = association("ownedAttribute", Property, composite=True, opposite="class_")
 Class.ownedOperation = association("ownedOperation", Operation, composite=True, opposite="class_")
-# 34: override Class.extension(Extension.metaclass): property
+# 32: override Class.extension(Extension.metaclass): property
 # See https://www.omg.org/spec/UML/2.5/PDF, section 11.8.3.6, page 219
 # It defines `Extension.allInstances()`, which basically means we have to query the element factory.
 
@@ -936,7 +934,7 @@ Class.extension = property(lambda self: self.model.lselect(lambda e: e.isKindOf(
 metaclass. The property is derived from the extensions whose memberEnds
 are typed by the Class.""")
 
-# 55: override Class.superClass: derived[Classifier]
+# 53: override Class.superClass: derived[Classifier]
 Class.superClass = Classifier.general
 
 Class.nestedClassifier = association("nestedClassifier", Classifier, composite=True, opposite="nestingClass")
@@ -959,11 +957,11 @@ Element.directedRelationship.add(UseCase.include)  # type: ignore[attr-defined]
 Namespace.ownedMember.add(UseCase.include)  # type: ignore[attr-defined]
 Manifestation.artifact = association("artifact", Artifact, upper=1, opposite="manifestation")
 Element.owner.add(Manifestation.artifact)  # type: ignore[attr-defined]
-# 94: override Component.provided: property
+# 92: override Component.provided: property
 # defined in umloverrides.py
 
 Component.packagedElement = association("packagedElement", PackageableElement, composite=True, opposite="component")
-# 97: override Component.required: property
+# 95: override Component.required: property
 # defined in umloverrides.py
 
 Component.realization = redefine(Component, "realization", ComponentRealization, NamedElement.supplierDependency)
@@ -999,14 +997,14 @@ Property.subsettedProperty = association("subsettedProperty", Property)
 Property.association = association("association", Association, upper=1, opposite="memberEnd")
 Property.owningAssociation = association("owningAssociation", Association, upper=1, opposite="ownedEnd")
 Property.classifier = association("classifier", Classifier, upper=1, opposite="attribute")
-# 64: override Property.isComposite(Property.aggregation): derived[bool]
+# 62: override Property.isComposite(Property.aggregation): derived[bool]
 Property.isComposite = derived('isComposite', bool, 0, 1, lambda obj: [obj.aggregation == 'composite'])
 
 Property.datatype = association("datatype", DataType, upper=1, opposite="ownedAttribute")
-# 61: override Property.opposite(Property.association, Association.memberEnd): relation_one[Property | None]
+# 59: override Property.opposite(Property.association, Association.memberEnd): relation_one[Property | None]
 # defined in umloverrides.py
 
-# 82: override Property.navigability(Property.opposite, Property.association): derived[bool | None]
+# 80: override Property.navigability(Property.opposite, Property.association): derived[bool | None]
 # defined in umloverrides.py
 
 Property.artifact = association("artifact", Artifact, upper=1, opposite="ownedAttribute")
@@ -1092,7 +1090,7 @@ Operation.redefinedOperation = association("redefinedOperation", Operation)
 Operation.raisedException = association("raisedException", Type)
 Operation.bodyCondition = association("bodyCondition", Constraint, upper=1, composite=True)
 Operation.datatype = association("datatype", DataType, upper=1, opposite="ownedOperation")
-# 85: override Operation.type: derivedunion[DataType]
+# 83: override Operation.type: derivedunion[DataType]
 Operation.type = derivedunion('type', DataType, 0, 1)
 
 Operation.interface_ = association("interface_", Interface, upper=1, opposite="ownedOperation")
@@ -1167,7 +1165,7 @@ Element.ownedElement.add(StateInvariant.invariant)  # type: ignore[attr-defined]
 Lifeline.coveredBy = association("coveredBy", InteractionFragment, opposite="covered")
 Lifeline.interaction = association("interaction", Interaction, upper=1, opposite="lifeline")
 NamedElement.namespace.add(Lifeline.interaction)  # type: ignore[attr-defined]
-# 100: override Message.messageKind: property
+# 98: override Message.messageKind: property
 # defined in umloverrides.py
 
 Message.sendEvent = association("sendEvent", MessageEnd, upper=1, composite=True, opposite="sendMessage")
@@ -1259,11 +1257,11 @@ Collaboration.collaborationRole = association("collaborationRole", ConnectableEl
 StructuredClassifier.role.add(Collaboration.collaborationRole)  # type: ignore[attr-defined]
 Trigger.event = association("event", Event, upper=1)
 Trigger.port = association("port", Port)
-# 112: override ExecutionSpecification.finish(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
+# 110: override ExecutionSpecification.finish(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
 ExecutionSpecification.finish = derived('finish', OccurrenceSpecification, 0, 1,
     lambda obj: [eos for i, eos in enumerate(obj.executionOccurrenceSpecification) if i == 1])
 
-# 108: override ExecutionSpecification.start(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
+# 106: override ExecutionSpecification.start(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
 ExecutionSpecification.start = derived('start', OccurrenceSpecification, 0, 1,
     lambda obj: [eos for i, eos in enumerate(obj.executionOccurrenceSpecification) if i == 0])
 

--- a/gaphor/codegen/coder.py
+++ b/gaphor/codegen/coder.py
@@ -29,6 +29,10 @@ from typing import Iterable
 from gaphor import UML
 from gaphor.codegen.override import Overrides
 from gaphor.core.modeling import ElementFactory
+from gaphor.core.modeling.modelinglanguage import (
+    CoreModelingLanguage,
+    MockModelingLanguage,
+)
 from gaphor.storage import storage
 from gaphor.UML.modelinglanguage import UMLModelingLanguage
 
@@ -397,7 +401,9 @@ def in_super_model(
 
 def load_model(modelfile: str) -> ElementFactory:
     element_factory = ElementFactory()
-    uml_modeling_language = UMLModelingLanguage()
+    uml_modeling_language = MockModelingLanguage(
+        CoreModelingLanguage(), UMLModelingLanguage()
+    )
     storage.load(
         modelfile,
         element_factory,

--- a/gaphor/codegen/tests/test_coder.py
+++ b/gaphor/codegen/tests/test_coder.py
@@ -19,6 +19,12 @@ from gaphor.core.format import parse
 from gaphor.core.modeling import ElementFactory
 
 
+@pytest.fixture(scope="session")
+def uml_metamodel():
+    element_factory = load_model("models/UML.gaphor")
+    return element_factory
+
+
 def test_coder_write_class():
     class_ = UML.Class()
     class_.name = "TestClass"
@@ -144,12 +150,6 @@ def test_in_toplevel_package():
 
     assert is_in_toplevel_package(class_, "Foo")
     assert not is_in_toplevel_package(class_, "Bar")
-
-
-@pytest.fixture(scope="session")
-def uml_metamodel(modeling_language):
-    element_factory = load_model("models/UML.gaphor")
-    return element_factory
 
 
 def by_name(name):

--- a/gaphor/conftest.py
+++ b/gaphor/conftest.py
@@ -25,6 +25,7 @@ from gaphas.view import GtkView
 # For DiagramItemConnector aspect:
 import gaphor.diagram.tools
 from gaphor import UML
+from gaphor.core.modeling import Diagram
 from gaphor.application import Session
 from gaphor.diagram.connectors import Connector
 from gaphor.diagram.grouping import Group
@@ -56,7 +57,7 @@ class Case:
         assert not list(self.element_factory.select()), list(
             self.element_factory.select()
         )
-        self.diagram = self.element_factory.create(UML.Diagram)
+        self.diagram = self.element_factory.create(Diagram)
 
         # We need to hook up a view for now, so updates are done instantly
         self.view = GtkView(self.diagram, selection=Selection())
@@ -175,7 +176,7 @@ class Case:
         )
         f.close()
 
-        self.diagram = self.element_factory.lselect(UML.Diagram)[0]
+        self.diagram = self.element_factory.lselect(Diagram)[0]
 
     def shutdown(self):
         self.element_factory.shutdown()

--- a/gaphor/core/modeling/elementdispatcher.py
+++ b/gaphor/core/modeling/elementdispatcher.py
@@ -154,9 +154,9 @@ class ElementDispatcher(Service):
 
             if cname:
                 c = self.modeling_language.lookup_element(cname)
-                assert issubclass(c, prop.type), "{} should be a subclass of {}".format(
+                assert c and issubclass(
                     c, prop.type
-                )
+                ), "{} should be a subclass of {}".format(c, prop.type)
             else:
                 c = prop.type
         return tuple(tpath)

--- a/gaphor/core/modeling/modelinglanguage.py
+++ b/gaphor/core/modeling/modelinglanguage.py
@@ -15,3 +15,27 @@ class CoreModelingLanguage(ModelingLanguage):
 
     def lookup_element(self, name):
         return getattr(coremodel, name, None)
+
+
+class MockModelingLanguage(ModelingLanguage):
+    """This class can be used to instantly combine modeling languages."""
+
+    def __init__(self, *modeling_languages):
+        self._modeling_languages = modeling_languages
+
+    @property
+    def name(self) -> str:
+        return "Mock"
+
+    @property
+    def toolbox_definition(self):
+        raise ValueError("No toolbox for the mock model")
+
+    def lookup_element(self, name):
+        return self.first(lambda provider: provider.lookup_element(name))
+
+    def first(self, predicate):
+        for provider in self._modeling_languages:
+            type = predicate(provider)
+            if type:
+                return type

--- a/gaphor/core/modeling/modelinglanguage.py
+++ b/gaphor/core/modeling/modelinglanguage.py
@@ -1,0 +1,17 @@
+"""C4 Model Language entrypoint."""
+
+from gaphor.abc import ModelingLanguage
+from gaphor.core.modeling import coremodel
+
+
+class CoreModelingLanguage(ModelingLanguage):
+    @property
+    def name(self) -> str:
+        return ""
+
+    @property
+    def toolbox_definition(self):
+        raise ValueError("No toolbox for the core model")
+
+    def lookup_element(self, name):
+        return getattr(coremodel, name, None)

--- a/gaphor/core/modeling/modelinglanguage.py
+++ b/gaphor/core/modeling/modelinglanguage.py
@@ -20,7 +20,7 @@ class CoreModelingLanguage(ModelingLanguage):
 class MockModelingLanguage(ModelingLanguage):
     """This class can be used to instantly combine modeling languages."""
 
-    def __init__(self, *modeling_languages):
+    def __init__(self, *modeling_languages: ModelingLanguage):
         self._modeling_languages = modeling_languages
 
     @property
@@ -32,10 +32,13 @@ class MockModelingLanguage(ModelingLanguage):
         raise ValueError("No toolbox for the mock model")
 
     def lookup_element(self, name):
-        return self.first(lambda provider: provider.lookup_element(name))
-
-    def first(self, predicate):
-        for provider in self._modeling_languages:
-            type = predicate(provider)
-            if type:
-                return type
+        return next(
+            filter(
+                None,
+                map(
+                    lambda provider: provider.lookup_element(name),
+                    self._modeling_languages,
+                ),
+            ),
+            None,
+        )

--- a/gaphor/core/modeling/tests/test_modelinglanguage.py
+++ b/gaphor/core/modeling/tests/test_modelinglanguage.py
@@ -1,0 +1,27 @@
+import pytest
+
+from gaphor.core.modeling.modelinglanguage import CoreModelingLanguage
+
+
+def test_name():
+    modeling_language = CoreModelingLanguage()
+
+    assert modeling_language.name == ""
+
+
+def test_lookup_element():
+    modeling_language = CoreModelingLanguage()
+
+    assert modeling_language.lookup_element("Diagram")
+    assert modeling_language.lookup_element("Element")
+    assert modeling_language.lookup_element("Comment")
+    assert modeling_language.lookup_element("Presentation")
+    assert modeling_language.lookup_element("StyleSheet")
+    assert not modeling_language.lookup_element("NonExistant")
+
+
+def test_toolbox():
+    modeling_language = CoreModelingLanguage()
+
+    with pytest.raises(ValueError):
+        modeling_language.toolbox_definition

--- a/gaphor/diagram/diagramtoolbox.py
+++ b/gaphor/diagram/diagramtoolbox.py
@@ -9,9 +9,8 @@ from typing import Callable, NamedTuple, Optional, Sequence, Tuple
 
 from gaphas.item import SE
 
-from gaphor import UML
 from gaphor.core import gettext
-from gaphor.core.modeling import Diagram, Presentation
+from gaphor.core.modeling import Comment, Diagram, Presentation
 from gaphor.diagram import general
 from gaphor.diagram.tools import new_item_factory
 from gaphor.UML.modelfactory import owner_package
@@ -91,7 +90,7 @@ general_tools = ToolSection(
             gettext("Comment"),
             "gaphor-comment-symbolic",
             "k",
-            new_item_factory(general.CommentItem, UML.Comment),
+            new_item_factory(general.CommentItem, Comment),
             handle_index=SE,
         ),
         ToolDef(

--- a/gaphor/diagram/general/tests/test_generalpropertypages.py
+++ b/gaphor/diagram/general/tests/test_generalpropertypages.py
@@ -1,10 +1,10 @@
-from gaphor import UML
+from gaphor.core.modeling import Comment
 from gaphor.diagram.general.generalpropertypages import CommentPropertyPage
 from gaphor.diagram.tests.fixtures import find
 
 
 def test_comment_property_page_body(element_factory):
-    subject = element_factory.create(UML.Comment)
+    subject = element_factory.create(Comment)
     property_page = CommentPropertyPage(subject)
 
     widget = property_page.construct()
@@ -15,7 +15,7 @@ def test_comment_property_page_body(element_factory):
 
 
 def test_comment_property_page_update_text(element_factory):
-    subject = element_factory.create(UML.Comment)
+    subject = element_factory.create(Comment)
     property_page = CommentPropertyPage(subject)
 
     widget = property_page.construct()

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -9,6 +9,10 @@ from gaphor.core import Transaction
 from gaphor.core.eventmanager import EventManager
 from gaphor.core.modeling import Diagram, ElementFactory
 from gaphor.core.modeling.elementdispatcher import ElementDispatcher
+from gaphor.core.modeling.modelinglanguage import (
+    CoreModelingLanguage,
+    MockModelingLanguage,
+)
 from gaphor.diagram.connectors import Connector
 from gaphor.diagram.copypaste import copy, paste
 from gaphor.storage import storage
@@ -30,9 +34,9 @@ def element_factory(event_manager, modeling_language):
     element_factory.shutdown()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def modeling_language():
-    return UMLModelingLanguage()
+    return MockModelingLanguage(CoreModelingLanguage(), UMLModelingLanguage())
 
 
 @pytest.fixture

--- a/gaphor/services/modelinglanguage.py
+++ b/gaphor/services/modelinglanguage.py
@@ -67,13 +67,16 @@ class ModelingLanguageService(Service, ActionProvider, ModelingLanguage):
         return self._modeling_language.toolbox_definition
 
     def lookup_element(self, name):
-        return self.first(lambda provider: provider.lookup_element(name))
-
-    def first(self, predicate):
-        for _, provider in self._modeling_languages.items():
-            type = predicate(provider)
-            if type:
-                return type
+        return next(
+            filter(
+                None,
+                map(
+                    lambda provider: provider.lookup_element(name),
+                    self._modeling_languages.values(),
+                ),
+            ),
+            None,
+        )
 
     @action(
         name="select-modeling-language",

--- a/gaphor/services/modelinglanguage.py
+++ b/gaphor/services/modelinglanguage.py
@@ -38,7 +38,8 @@ class ModelingLanguageService(Service, ActionProvider, ModelingLanguage):
     def modeling_languages(self):
         """A Generator, returns tuples (id, localized name)."""
         for id, provider in self._modeling_languages.items():
-            yield id, provider.name
+            if provider.name:
+                yield id, provider.name
 
     @property
     def active_modeling_language(self):

--- a/gaphor/services/tests/test_copyservice.py
+++ b/gaphor/services/tests/test_copyservice.py
@@ -1,7 +1,6 @@
 import pytest
 
-from gaphor import UML
-from gaphor.core.modeling import Comment
+from gaphor.core.modeling import Comment, Diagram
 from gaphor.diagram.general import CommentItem
 from gaphor.services.copyservice import CopyService
 
@@ -22,7 +21,7 @@ def copy_service(event_manager, element_factory, diagrams):
 
 
 def test_copy(copy_service, element_factory):
-    diagram = element_factory.create(UML.Diagram)
+    diagram = element_factory.create(Diagram)
     ci = diagram.create(CommentItem, subject=element_factory.create(Comment))
 
     copy_service.copy({ci})

--- a/gaphor/services/tests/test_copyservice.py
+++ b/gaphor/services/tests/test_copyservice.py
@@ -1,6 +1,7 @@
 import pytest
 
 from gaphor import UML
+from gaphor.core.modeling import Comment
 from gaphor.diagram.general import CommentItem
 from gaphor.services.copyservice import CopyService
 
@@ -22,7 +23,7 @@ def copy_service(event_manager, element_factory, diagrams):
 
 def test_copy(copy_service, element_factory):
     diagram = element_factory.create(UML.Diagram)
-    ci = diagram.create(CommentItem, subject=element_factory.create(UML.Comment))
+    ci = diagram.create(CommentItem, subject=element_factory.create(Comment))
 
     copy_service.copy({ci})
     assert list(diagram.get_all_items()) == [ci]

--- a/gaphor/services/tests/test_modelinglanguage.py
+++ b/gaphor/services/tests/test_modelinglanguage.py
@@ -1,9 +1,25 @@
+import pytest
+
 from gaphor.services.modelinglanguage import ModelingLanguageService
 
 
-def test_loading_of_modeling_languages(event_manager):
-    modeling_language = ModelingLanguageService(
-        event_manager=event_manager, properties={}
-    )
+@pytest.fixture
+def modeling_language(event_manager):
+    return ModelingLanguageService(event_manager=event_manager, properties={})
+
+
+def test_loading_of_modeling_languages(modeling_language):
     ids = [id for id, name in modeling_language.modeling_languages]
     assert "UML" in ids
+
+
+def test_lookup_uml_element(modeling_language):
+    assert modeling_language.lookup_element("Class")
+
+
+def test_lookup_sysml_element(modeling_language):
+    assert modeling_language.lookup_element("Block")
+
+
+def test_lookup_c4model_element(modeling_language):
+    assert modeling_language.lookup_element("C4Database")

--- a/gaphor/services/tests/test_undo_diagram.py
+++ b/gaphor/services/tests/test_undo_diagram.py
@@ -1,5 +1,6 @@
 from gaphor import UML
 from gaphor.core import Transaction
+from gaphor.core.modeling import Diagram
 from gaphor.UML.classes import ClassItem
 
 
@@ -16,7 +17,7 @@ def test_undo_should_remove_shown_item_on_diagram(
     event_manager, element_factory, undo_manager
 ):
     with Transaction(event_manager):
-        diagram = element_factory.create(UML.Diagram)
+        diagram = element_factory.create(Diagram)
 
     view = ViewMock(diagram)
 
@@ -32,7 +33,7 @@ def test_undo_should_remove_shown_item_on_diagram(
 
 def test_redo_should_show_item_on_diagram(event_manager, element_factory, undo_manager):
     with Transaction(event_manager):
-        diagram = element_factory.create(UML.Diagram)
+        diagram = element_factory.create(Diagram)
 
     view = ViewMock(diagram)
 

--- a/gaphor/storage/tests/conftest.py
+++ b/gaphor/storage/tests/conftest.py
@@ -9,7 +9,6 @@ from gaphor.diagram.tests.fixtures import (
     modeling_language,
 )
 from gaphor.storage import storage
-from gaphor.UML.modelinglanguage import UMLModelingLanguage
 
 
 @pytest.fixture

--- a/gaphor/storage/tests/test_storage.py
+++ b/gaphor/storage/tests/test_storage.py
@@ -6,7 +6,7 @@ from io import StringIO
 import pytest
 
 from gaphor import UML
-from gaphor.core.modeling import StyleSheet
+from gaphor.core.modeling import Comment, Diagram, StyleSheet
 from gaphor.diagram.general import CommentItem
 from gaphor.storage import storage
 from gaphor.storage.xmlwriter import XMLWriter
@@ -44,8 +44,8 @@ class TestStorage:
     def test_save_uml(self, case):
         """Saving gaphor.UML model elements."""
         case.element_factory.create(UML.Package)
-        case.element_factory.create(UML.Diagram)
-        case.element_factory.create(UML.Comment)
+        case.element_factory.create(Diagram)
+        case.element_factory.create(Comment)
         case.element_factory.create(UML.Class)
 
         out = PseudoFile()
@@ -59,8 +59,8 @@ class TestStorage:
 
     def test_save_item(self, case):
         """Save a diagram item too."""
-        diagram = case.element_factory.create(UML.Diagram)
-        diagram.create(CommentItem, subject=case.element_factory.create(UML.Comment))
+        diagram = case.element_factory.create(Diagram)
+        diagram.create(CommentItem, subject=case.element_factory.create(Comment))
 
         out = PseudoFile()
         storage.save(XMLWriter(out), factory=case.element_factory)
@@ -75,7 +75,7 @@ class TestStorage:
         """Test loading of a freshly saved model."""
         case.element_factory.create(UML.Package)
         # diagram is created in case's init
-        case.element_factory.create(UML.Comment)
+        case.element_factory.create(Comment)
         case.element_factory.create(UML.Class)
 
         data = case.save()
@@ -84,15 +84,15 @@ class TestStorage:
         assert len(case.element_factory.lselect()) == 5
         assert len(case.element_factory.lselect(UML.Package)) == 1
         # diagram is created in case's init
-        assert len(case.element_factory.lselect(UML.Diagram)) == 1
-        assert len(case.element_factory.lselect(UML.Comment)) == 1
+        assert len(case.element_factory.lselect(Diagram)) == 1
+        assert len(case.element_factory.lselect(Comment)) == 1
         assert len(case.element_factory.lselect(UML.Class)) == 1
         assert len(case.element_factory.lselect(StyleSheet)) == 1
 
     def test_load_uml_2(self, case):
         """Test loading of a freshly saved model."""
         case.element_factory.create(UML.Package)
-        case.create(CommentItem, UML.Comment)
+        case.create(CommentItem, Comment)
         case.create(ClassItem, UML.Class)
         iface = case.create(InterfaceItem, UML.Interface)
         iface.subject.name = "Circus"
@@ -103,9 +103,9 @@ class TestStorage:
 
         assert len(case.element_factory.lselect()) == 9
         assert len(case.element_factory.lselect(UML.Package)) == 1
-        assert len(case.element_factory.lselect(UML.Diagram)) == 1
-        d = case.element_factory.lselect(UML.Diagram)[0]
-        assert len(case.element_factory.lselect(UML.Comment)) == 1
+        assert len(case.element_factory.lselect(Diagram)) == 1
+        d = case.element_factory.lselect(Diagram)[0]
+        assert len(case.element_factory.lselect(Comment)) == 1
         assert len(case.element_factory.lselect(UML.Class)) == 1
         assert len(case.element_factory.lselect(UML.Interface)) == 1
 
@@ -139,7 +139,7 @@ class TestStorage:
 
     def test_save_and_load_model_with_relationships(self, case):
         case.element_factory.create(UML.Package)
-        case.create(CommentItem, UML.Comment)
+        case.create(CommentItem, Comment)
         case.create(ClassItem, UML.Class)
 
         a = case.diagram.create(AssociationItem)
@@ -154,9 +154,9 @@ class TestStorage:
 
         assert len(case.element_factory.lselect()) == 8
         assert len(case.element_factory.lselect(UML.Package)) == 1
-        assert len(case.element_factory.lselect(UML.Diagram)) == 1
-        d = case.element_factory.lselect(UML.Diagram)[0]
-        assert len(case.element_factory.lselect(UML.Comment)) == 1
+        assert len(case.element_factory.lselect(Diagram)) == 1
+        d = case.element_factory.lselect(Diagram)[0]
+        assert len(case.element_factory.lselect(Comment)) == 1
         assert len(case.element_factory.lselect(UML.Class)) == 1
         assert len(case.element_factory.lselect(UML.Association)) == 0
 
@@ -206,7 +206,7 @@ class TestStorage:
         )
         fd.close()
 
-        diagrams = list(case.kindof(UML.Diagram))
+        diagrams = list(case.kindof(Diagram))
         assert len(diagrams) == 1
         d = diagrams[0]
         a = next(d.select(lambda e: isinstance(e, AssociationItem)))

--- a/gaphor/storage/tests/test_storage_message_item_upgrade.py
+++ b/gaphor/storage/tests/test_storage_message_item_upgrade.py
@@ -1,4 +1,5 @@
 from gaphor import UML
+from gaphor.core.modeling import Diagram
 from gaphor.storage.storage import load
 from gaphor.UML import diagramitems
 
@@ -8,7 +9,7 @@ def test_message_item_upgrade(element_factory, modeling_language, test_models):
 
     load(path, element_factory, modeling_language)
 
-    diagram = element_factory.lselect(UML.Diagram)[0]
+    diagram = element_factory.lselect(Diagram)[0]
     items = [e for e in diagram.get_all_items() if not e.parent]
     message_items = [i for i in items if isinstance(i, diagramitems.MessageItem)]
     subjects = [m.subject for m in message_items]

--- a/gaphor/storage/tests/test_verify.py
+++ b/gaphor/storage/tests/test_verify.py
@@ -1,6 +1,6 @@
 from gaphor import UML
 from gaphor.core.eventmanager import EventManager
-from gaphor.core.modeling import ElementFactory
+from gaphor.core.modeling import Comment, ElementFactory
 from gaphor.storage.verify import orphan_references
 
 
@@ -14,7 +14,7 @@ def test_verifier():
 
     # Now create a separate item, not part of the factory:
 
-    m = UML.Comment(id="acd123")
+    m = Comment(id="acd123")
     m.annotatedElement = c
     assert m in c.comment
 

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -9,7 +9,7 @@ from gi.repository import GLib, Gtk
 from gaphor import UML
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import action, event_handler, gettext
-from gaphor.core.modeling.stylesheet import StyleSheet
+from gaphor.core.modeling import Diagram, StyleSheet
 from gaphor.event import (
     ModelLoaded,
     ModelSaved,
@@ -54,7 +54,7 @@ def load_default_model(element_factory):
         element_factory.create(StyleSheet)
         model = element_factory.create(UML.Package)
         model.name = gettext("New model")
-        diagram = element_factory.create(UML.Diagram)
+        diagram = element_factory.create(Diagram)
         diagram.element = model
         diagram.name = gettext("main")
     element_factory.model_ready()

--- a/gaphor/ui/namespacemodel.py
+++ b/gaphor/ui/namespacemodel.py
@@ -198,7 +198,7 @@ class NamespaceModel(Gtk.TreeStore):
         if (
             event.property is UML.Classifier.isAbstract
             or event.property is UML.BehavioralFeature.isAbstract
-            or event.property is UML.Diagram.name
+            or event.property is Diagram.name
             or event.property is UML.NamedElement.name
         ):
             element = event.element

--- a/gaphor/ui/tests/test_diagrampage.py
+++ b/gaphor/ui/tests/test_diagrampage.py
@@ -7,13 +7,12 @@ from gaphor.core.modeling import Comment, Diagram
 from gaphor.diagram.general import Box
 from gaphor.diagram.general.comment import CommentItem
 from gaphor.ui.diagrampage import DiagramPage, get_placement_cursor, placement_icon_base
-from gaphor.UML.modelinglanguage import UMLModelingLanguage
 
 
 @pytest.fixture
-def page(diagram, event_manager, element_factory, properties):
+def page(diagram, event_manager, element_factory, modeling_language, properties):
     page = DiagramPage(
-        diagram, event_manager, element_factory, properties, UMLModelingLanguage()
+        diagram, event_manager, element_factory, properties, modeling_language
     )
     page.construct()
     assert page.diagram == diagram

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -15,13 +15,11 @@ from gaphor.diagram.tools.connector import PresentationConnector
 from gaphor.ui.diagrams import Diagrams
 from gaphor.ui.event import DiagramOpened
 from gaphor.ui.toolbox import Toolbox
-from gaphor.UML.modelinglanguage import UMLModelingLanguage
 from gaphor.UML.usecases.actor import ActorItem
 
 
 @pytest.fixture
-def diagrams(event_manager, element_factory, properties):
-    modeling_language = UMLModelingLanguage()
+def diagrams(event_manager, element_factory, modeling_language, properties):
     toolbox = Toolbox(event_manager, properties, modeling_language)
     diagrams = Diagrams(
         event_manager, element_factory, properties, modeling_language, toolbox

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -7,6 +7,7 @@ from gaphas.aspect.handlemove import HandleMove
 from gi.repository import GLib, Gtk
 
 from gaphor import UML
+from gaphor.core.modeling import Comment
 from gaphor.diagram.connectors import Connector
 from gaphor.diagram.general.comment import CommentItem
 from gaphor.diagram.general.commentline import CommentLineItem
@@ -48,7 +49,7 @@ def connections(diagram):
 
 @pytest.fixture
 def comment(element_factory, diagram):
-    return diagram.create(CommentItem, subject=element_factory.create(UML.Comment))
+    return diagram.create(CommentItem, subject=element_factory.create(Comment))
 
 
 @pytest.fixture
@@ -99,7 +100,7 @@ def test_iconnect(event_manager, element_factory, diagrams):
     items."""
     diagram = element_factory.create(UML.Diagram)
     event_manager.handle(DiagramOpened(diagram))
-    comment = diagram.create(CommentItem, subject=element_factory.create(UML.Comment))
+    comment = diagram.create(CommentItem, subject=element_factory.create(Comment))
 
     line = diagram.create(CommentLineItem)
 
@@ -130,7 +131,7 @@ def test_connect_comment_and_actor(event_manager, element_factory, diagrams):
     """Test connect/disconnect on comment and actor using comment-line."""
     diagram = element_factory.create(UML.Diagram)
     event_manager.handle(DiagramOpened(diagram))
-    comment = diagram.create(CommentItem, subject=element_factory.create(UML.Comment))
+    comment = diagram.create(CommentItem, subject=element_factory.create(Comment))
 
     line = diagram.create(CommentLineItem)
 

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -7,7 +7,7 @@ from gaphas.aspect.handlemove import HandleMove
 from gi.repository import GLib, Gtk
 
 from gaphor import UML
-from gaphor.core.modeling import Comment
+from gaphor.core.modeling import Comment, Diagram
 from gaphor.diagram.connectors import Connector
 from gaphor.diagram.general.comment import CommentItem
 from gaphor.diagram.general.commentline import CommentLineItem
@@ -98,7 +98,7 @@ def current_diagram_view(diagrams):
 def test_iconnect(event_manager, element_factory, diagrams):
     """Test basic glue functionality using CommentItem and CommentLine
     items."""
-    diagram = element_factory.create(UML.Diagram)
+    diagram = element_factory.create(Diagram)
     event_manager.handle(DiagramOpened(diagram))
     comment = diagram.create(CommentItem, subject=element_factory.create(Comment))
 
@@ -129,7 +129,7 @@ def test_iconnect(event_manager, element_factory, diagrams):
 
 def test_connect_comment_and_actor(event_manager, element_factory, diagrams):
     """Test connect/disconnect on comment and actor using comment-line."""
-    diagram = element_factory.create(UML.Diagram)
+    diagram = element_factory.create(Diagram)
     event_manager.handle(DiagramOpened(diagram))
     comment = diagram.create(CommentItem, subject=element_factory.create(Comment))
 

--- a/gaphor/ui/tests/test_toolbox.py
+++ b/gaphor/ui/tests/test_toolbox.py
@@ -1,6 +1,12 @@
 import pytest
 
 from gaphor.ui.toolbox import Toolbox
+from gaphor.UML.modelinglanguage import UMLModelingLanguage
+
+
+@pytest.fixture
+def modeling_language():
+    return UMLModelingLanguage()
 
 
 @pytest.fixture

--- a/models/UML.override
+++ b/models/UML.override
@@ -14,8 +14,6 @@ comment
 header
 from typing import Callable
 
-from gaphor.core.modeling.coremodel import Comment, Diagram, StyleSheet
-
 %%
 override MultiplicityElement.lower(MultiplicityElement.lowerValue): _attribute[str]
 MultiplicityElement.lower = MultiplicityElement.lowerValue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ type = "virtualenv"
 "help" = "gaphor.services.helpservice:HelpService"
 
 [tool.poetry.plugins."gaphor.modelinglanguages"]
+"Core" = "gaphor.core.modeling.modelinglanguage:CoreModelingLanguage"
 "UML" = "gaphor.UML.modelinglanguage:UMLModelingLanguage"
 "SysML" = "gaphor.SysML.modelinglanguage:SysMLModelingLanguage"
 "C4Model" = "gaphor.C4Model.modelinglanguage:C4ModelLanguage"

--- a/tests/test_action_issue.py
+++ b/tests/test_action_issue.py
@@ -1,4 +1,5 @@
 from gaphor import UML
+from gaphor.core.modeling import Diagram
 from gaphor.storage import storage
 from gaphor.UML.actions import ActionItem, FlowItem
 
@@ -22,7 +23,7 @@ class TestActionIssue:
 
         # Okay, so far the data model is saved correctly. Now, how do the
         # handles behave?
-        diagrams = ef.lselect(UML.Diagram)
+        diagrams = ef.lselect(Diagram)
         assert 1 == len(diagrams)
 
         diagram = diagrams[0]

--- a/tests/test_comment_line_placement.py
+++ b/tests/test_comment_line_placement.py
@@ -13,7 +13,6 @@ from gaphor.diagram.tools.placement import (
 )
 from gaphor.ui.diagrampage import DiagramPage
 from gaphor.ui.filemanager import load_default_model
-from gaphor.UML.modelinglanguage import UMLModelingLanguage
 
 
 @pytest.fixture
@@ -36,16 +35,19 @@ def element_factory(session):
 
 
 @pytest.fixture
+def modeling_language(session):
+    return session.get_service("modeling_language")
+
+
+@pytest.fixture
 def diagram(element_factory, event_manager):
     with Transaction(event_manager):
         return element_factory.create(Diagram)
 
 
 @pytest.fixture
-def view(diagram, event_manager, element_factory):
-    page = DiagramPage(
-        diagram, event_manager, element_factory, {}, UMLModelingLanguage()
-    )
+def view(diagram, event_manager, element_factory, modeling_language):
+    page = DiagramPage(diagram, event_manager, element_factory, {}, modeling_language)
     page.construct()
     return page.view
 

--- a/tests/test_elements_have_owner.py
+++ b/tests/test_elements_have_owner.py
@@ -13,7 +13,7 @@ import pytest
 import gaphor.SysML.diagramitems
 import gaphor.UML.diagramitems
 from gaphor import UML
-from gaphor.core.modeling import Element
+from gaphor.core.modeling import Comment, Element
 from gaphor.core.modeling.properties import derived
 from gaphor.diagram.support import get_model_element
 
@@ -31,7 +31,7 @@ def all_presented_elements(module):
         get_model_element(getattr(module, name))
         for name in dir(module)
         if not name.startswith("_")
-        and get_model_element(getattr(module, name) not in (None, UML.Comment))
+        and get_model_element(getattr(module, name) not in (None, Comment))
     )
 
 

--- a/tests/test_multiple_associations.py
+++ b/tests/test_multiple_associations.py
@@ -19,6 +19,7 @@ import pytest
 from gaphor import UML
 from gaphor.application import Session
 from gaphor.core import Transaction
+from gaphor.core.modeling import Diagram
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML import diagramitems
 from gaphor.UML.modelfactory import set_navigability
@@ -49,7 +50,7 @@ def copy(session):
 @pytest.fixture
 def diagram(event_manager, element_factory):
     with Transaction(event_manager):
-        return element_factory.create(UML.Diagram)
+        return element_factory.create(Diagram)
 
 
 @pytest.fixture
@@ -66,7 +67,7 @@ def class_and_association_with_copy(diagram, event_manager, element_factory, cop
         set_navigability(a.subject, a.subject.memberEnd[0], True)
 
         copy.copy({a, c})
-        new_diagram = element_factory.create(UML.Diagram)
+        new_diagram = element_factory.create(Diagram)
         pasted_items = copy.paste(new_diagram)
 
     aa = pasted_items.pop()

--- a/tests/test_package_removal.py
+++ b/tests/test_package_removal.py
@@ -3,6 +3,7 @@ import pytest
 from gaphor import UML
 from gaphor.application import Session
 from gaphor.core import Transaction
+from gaphor.core.modeling import Diagram
 from gaphor.storage.storage import load
 
 
@@ -50,13 +51,13 @@ def test_package_removal(session, event_manager, element_factory):
     # Check if the link is really removed:
     assert not classes[0].appliedStereotype
     assert not element_factory.lselect(UML.InstanceSpecification)
-    assert len(element_factory.lselect(UML.Diagram)) == 3
+    assert len(element_factory.lselect(Diagram)) == 3
 
 
 def test_package_removal_by_removing_the_diagram(event_manager, element_factory):
 
     diagram = element_factory.lselect(
-        lambda e: e.isKindOf(UML.Diagram) and e.name == "Stereotypes diagram"
+        lambda e: e.isKindOf(Diagram) and e.name == "Stereotypes diagram"
     )[0]
 
     assert diagram
@@ -72,4 +73,4 @@ def test_package_removal_by_removing_the_diagram(event_manager, element_factory)
     # Check if the link is really removed:
     assert not classes[0].appliedStereotype
     assert not element_factory.lselect(UML.InstanceSpecification)
-    assert len(element_factory.lselect(UML.Diagram)) == 2
+    assert len(element_factory.lselect(Diagram)) == 2

--- a/tests/test_placement_tools.py
+++ b/tests/test_placement_tools.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 from gaphor import UML
 from gaphor.C4Model.toolbox import c4model_toolbox_actions
 from gaphor.core.eventmanager import EventManager
-from gaphor.core.modeling.elementfactory import ElementFactory
+from gaphor.core.modeling import Diagram, ElementFactory
 from gaphor.diagram.tools.placement import PlacementState, on_drag_begin
 from gaphor.RAAML.toolbox import raaml_toolbox_actions
 from gaphor.SysML.toolbox import sysml_toolbox_actions
@@ -34,7 +34,7 @@ def properties():
 
 @pytest.fixture
 def tab(event_manager, element_factory, properties):
-    diagram = element_factory.create(UML.Diagram)
+    diagram = element_factory.create(Diagram)
     tab = DiagramPage(
         diagram, event_manager, element_factory, properties, UMLModelingLanguage()
     )

--- a/tests/test_unioncache_in_derived_response.py
+++ b/tests/test_unioncache_in_derived_response.py
@@ -11,6 +11,7 @@ import pytest
 from gaphor import UML
 from gaphor.application import Session
 from gaphor.core import Transaction
+from gaphor.core.modeling import Diagram
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML import diagramitems
 
@@ -35,7 +36,7 @@ def element_factory(session):
 @pytest.fixture
 def diagram(element_factory, event_manager):
     with Transaction(event_manager):
-        return element_factory.create(UML.Diagram)
+        return element_factory.create(Diagram)
 
 
 def test_unioncache_in_derived_union(diagram, event_manager, element_factory):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Currently the Core modeling language is accessed via the UML modeling language. (e.g. for loading a model)

### What is the new behavior?

The Core Modeling Language has its own `ModelingLanguage`, to obtain types like `Diagram` and `Presentation`.
No extra imports need to be done in `gaphor/UML/uml.py`.

All imports for `Comment`, `Diagram`, `Presentation`, and `StyleSheet` have to be done on the core model. Hence the many updated test cases.

We do not want to show the Core language in the dropdown menu, so I made a workaround by proving an empty name (`""`).

Previously, for most tests we could get away with loading the UML language. Now we need a combined Core+UML language. Hence the new `MockModelingLanguage` class. I'm not sure it's the right name, though.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

### Other information

I like the idea that Core is a standalone language now. It's no longer dependent on UML, which it was for historical reasons.

On the other hand, it was convenient to know that everything we need is in the UML model. and the workaround with the Core ML name is not ideal.
