### PR TITLE
Empty square bracket notation

### DIFF
--- a/gaphor/UML/tests/test_umllex.py
+++ b/gaphor/UML/tests/test_umllex.py
@@ -253,11 +253,20 @@ def test_parse_operation_with_note(factory):
 
 
 def test_parse_operation_with_square_brackets(factory):
-    """Test parsing simple operation."""
     o: UML.Operation = factory.create(UML.Operation)
     parse(o, "myfunc(args: string[])")
     p = o.ownedParameter[0]
     assert "args" == p.name
+    assert "string" == p.typeValue
+    assert "*" == p.upperValue
+    assert None is p.lowerValue
+
+
+def test_parse_operation_return_with_square_brackets(factory):
+    o: UML.Operation = factory.create(UML.Operation)
+    parse(o, "myfunc(): string[]")
+    p = o.ownedParameter[0]
+    assert "return" == p.direction
     assert "string" == p.typeValue
     assert "*" == p.upperValue
     assert None is p.lowerValue

--- a/gaphor/UML/tests/test_umllex.py
+++ b/gaphor/UML/tests/test_umllex.py
@@ -90,6 +90,15 @@ def test_parse_property_with_default_value_and_note(factory):
     assert "note" == a.note
 
 
+def test_parse_property_with_square_brackets(factory):
+    a = factory.create(UML.Property)
+    parse(a, "attr[]")
+
+    assert "attr" == a.name
+    assert "*" == a.upperValue
+    assert None is a.lowerValue
+
+
 def test_parse_property_invalid(factory):
     """Test parsing property with invalid syntax."""
     a = factory.create(UML.Property)
@@ -180,6 +189,17 @@ def test_parse_association_end_with_note(factory):
     parse(p, "end # some note")
     assert "end" == p.name
     assert "some note" == p.note
+
+
+def test_parse_association_end_with_square_brackets(factory):
+    a = factory.create(UML.Association)
+    p = factory.create(UML.Property)
+    p.association = a
+
+    parse(p, "end[]")
+    assert "end" == p.name
+    assert "*" == p.upperValue
+    assert None is p.lowerValue
 
 
 def test_parse_operation(factory):

--- a/gaphor/UML/tests/test_umllex.py
+++ b/gaphor/UML/tests/test_umllex.py
@@ -250,3 +250,14 @@ def test_parse_operation_with_note(factory):
     parse(o, "myfunc() # and a note")
     assert "myfunc" == o.name
     assert "and a note" == o.note
+
+
+def test_parse_operation_with_square_brackets(factory):
+    """Test parsing simple operation."""
+    o: UML.Operation = factory.create(UML.Operation)
+    parse(o, "myfunc(args: string[])")
+    p = o.ownedParameter[0]
+    assert "args" == p.name
+    assert "string" == p.typeValue
+    assert "*" == p.upperValue
+    assert None is p.lowerValue

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -23,7 +23,7 @@ derived_subpat = r"\s*(?P<derived>/)?"
 name_subpat = r"\s*(?P<name>[a-zA-Z_]\w*( +\w+)*)"
 
 # Multiplicity ::= '[' [mult_l ..] mult_u ']'
-mult_subpat = r"\s*(\[\s*((?P<mult_l>[0-9]+)\s*\.\.)?\s*(?P<mult_u>([0-9]+|\*))\s*\])?"
+mult_subpat = r"\s*(?P<has_mult>\[\s*((?P<mult_l>[0-9]+)\s*\.\.)?\s*(?P<mult_u>([0-9]+|\*))?\s*\])?"
 multa_subpat = r"\s*(\[?((?P<mult_l>[0-9]+)\s*\.\.)?\s*(?P<mult_u>([0-9]+|\*))\]?)?"
 
 # Type and multiplicity (optional) ::= ':' type
@@ -277,6 +277,8 @@ def parse_operation(el: uml.Operation, s: str) -> None:
             p.typeValue = g("type")
             p.lowerValue = g("mult_l")
             p.upperValue = g("mult_u")
+            if g("has_mult") and not g("mult_u"):
+                p.upperValue = "*"
             p.defaultValue = g("default")
             el.ownedParameter = p
             defined_params.add(p)

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -167,6 +167,8 @@ def parse_attribute(el: uml.Property, s: str) -> None:
         el.typeValue = g("type")
         el.lowerValue = g("mult_l")
         el.upperValue = g("mult_u")
+        if g("has_mult") and not g("mult_u"):
+            el.upperValue = "*"
         el.defaultValue = g("default")
         el.note = g("note")
 
@@ -215,6 +217,8 @@ def parse_association_end(el: uml.Property, s: str) -> None:
                 if not g("mult_l"):
                     el.lowerValue = None
                 el.upperValue = g("mult_u")
+            elif g("has_mult") and not g("mult_u"):
+                el.upperValue = "*"
 
 
 @parse.register(uml.Property)

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -257,6 +257,8 @@ def parse_operation(el: uml.Operation, s: str) -> None:
             p.typeValue = g("type")
             p.lowerValue = g("mult_l")
             p.upperValue = g("mult_u")
+            if g("has_mult") and not g("mult_u"):
+                p.upperValue = "*"
             defined_params.add(p)
 
         pindex = 0


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

For an attribute or parameters, it's not possible to have an undefined multiplicity: `attr[]`, `myfunc(arg: string[]): result[]`. The brackets `[]` are not parsed.

However, `[]` is a common construct in programming languages to define an unbounded array. We can simply help the user here by interpreting `[]` as `[*]`.

Issue Number: #1185

### What is the new behavior?

Attributes and parameters with undefined multiplicity are treated as if it has a `*` multiplicity. `attr[]` will parse and render as `attr[*]`.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


### Other information
