### PR TITLE
Add "values" compartment to Block item

### DIFF
--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -16,7 +16,7 @@ from gaphor.diagram.shapes import (
 from gaphor.diagram.support import represents
 from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
-from gaphor.SysML.sysml import Block
+from gaphor.SysML.sysml import Block, ValueType
 from gaphor.UML.classes.klass import (
     attribute_watches,
     stereotype_compartments,
@@ -38,6 +38,8 @@ class BlockItem(ElementPresentation[Block], Classified):
         self.watch("show_stereotypes", self.update_shapes).watch(
             "show_parts", self.update_shapes
         ).watch("show_references", self.update_shapes).watch(
+            "show_values", self.update_shapes
+        ).watch(
             "subject[NamedElement].name"
         ).watch(
             "subject[NamedElement].namespace.name"
@@ -54,6 +56,8 @@ class BlockItem(ElementPresentation[Block], Classified):
     show_parts: attribute[int] = attribute("show_parts", int, default=False)
 
     show_references: attribute[int] = attribute("show_references", int, default=False)
+
+    show_values: attribute[int] = attribute("show_values", int, default=False)
 
     def additional_stereotypes(self):
         if isinstance(self.subject, raaml.Situation):
@@ -95,7 +99,7 @@ class BlockItem(ElementPresentation[Block], Classified):
                 and [
                     self.block_compartment(
                         gettext("parts"),
-                        lambda a: a.aggregation == "composite",
+                        lambda a: not a.association and a.aggregation == "composite",
                     )
                 ]
                 or []
@@ -106,7 +110,19 @@ class BlockItem(ElementPresentation[Block], Classified):
                 and [
                     self.block_compartment(
                         gettext("references"),
-                        lambda a: a.aggregation != "composite",
+                        lambda a: not a.association and a.aggregation != "composite",
+                    )
+                ]
+                or []
+            ),
+            *(
+                self.show_values
+                and self.subject
+                and [
+                    self.block_compartment(
+                        gettext("values"),
+                        lambda a: isinstance(a.type, ValueType)
+                        and a.aggregation == "composite",
                     )
                 ]
                 or []

--- a/gaphor/SysML/propertypages.glade
+++ b/gaphor/SysML/propertypages.glade
@@ -208,6 +208,42 @@ renderers and such.</property>
             <property name="position">1</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Show Values</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="show-values">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <signal name="notify::active" handler="show-values-changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack-type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
       </object>
     </child>
     <child type="label">

--- a/gaphor/SysML/propertypages.glade
+++ b/gaphor/SysML/propertypages.glade
@@ -124,7 +124,7 @@ renderers and such.</property>
       </packing>
     </child>
   </object>
-  <object class="GtkExpander" id="parts-and-references-editor">
+  <object class="GtkExpander" id="compartment-editor">
     <property name="visible">True</property>
     <property name="can-focus">True</property>
     <property name="margin-top">12</property>
@@ -180,7 +180,7 @@ renderers and such.</property>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Show references</property>
+                <property name="label" translatable="yes">Show References</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -214,7 +214,7 @@ renderers and such.</property>
       <object class="GtkLabel">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="label" translatable="yes">Parts and References</property>
+        <property name="label" translatable="yes">Compartments</property>
         <attributes>
           <attribute name="weight" value="bold"/>
         </attributes>

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -72,7 +72,7 @@ PropertyPages.register(RequirementItem)(OperationsPage)
 
 
 @PropertyPages.register(BlockItem)
-class PartsAndReferencesPage(PropertyPageBase):
+class CompartmentPage(PropertyPageBase):
     """An editor for Block items."""
 
     order = 30
@@ -87,7 +87,7 @@ class PartsAndReferencesPage(PropertyPageBase):
             return
 
         builder = new_builder(
-            "parts-and-references-editor",
+            "compartment-editor",
             signals={
                 "show-parts-changed": (self._on_show_parts_change,),
                 "show-references-changed": (self._on_show_references_change,),
@@ -100,7 +100,7 @@ class PartsAndReferencesPage(PropertyPageBase):
         show_references = builder.get_object("show-references")
         show_references.set_active(self.item.show_references)
 
-        return builder.get_object("parts-and-references-editor")
+        return builder.get_object("compartment-editor")
 
     @transactional
     def _on_show_parts_change(self, button, gparam):

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -91,6 +91,7 @@ class CompartmentPage(PropertyPageBase):
             signals={
                 "show-parts-changed": (self._on_show_parts_change,),
                 "show-references-changed": (self._on_show_references_change,),
+                "show-values-changed": (self._on_show_values_change,),
             },
         )
 
@@ -105,12 +106,14 @@ class CompartmentPage(PropertyPageBase):
     @transactional
     def _on_show_parts_change(self, button, gparam):
         self.item.show_parts = button.get_active()
-        self.item.request_update()
 
     @transactional
     def _on_show_references_change(self, button, gparam):
         self.item.show_references = button.get_active()
-        self.item.request_update()
+
+    @transactional
+    def _on_show_values_change(self, button, gparam):
+        self.item.show_values = button.get_active()
 
 
 @PropertyPages.register(sysml.Property)

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -64,7 +64,7 @@ renderers and such.</property>
       </object>
     </child>
   </object>
-  <object class="GtkExpander" id="parts-and-references-editor">
+  <object class="GtkExpander" id="compartment-editor">
     <property name="margin_top">12</property>
     <property name="expanded">1</property>
     <child>
@@ -89,7 +89,7 @@ renderers and such.</property>
           <object class="GtkBox">
             <child>
               <object class="GtkLabel">
-                <property name="label" translatable="yes">Show references</property>
+                <property name="label" translatable="yes">Show References</property>
               </object>
             </child>
             <child>
@@ -104,7 +104,7 @@ renderers and such.</property>
     </child>
     <child type="label">
       <object class="GtkLabel">
-        <property name="label" translatable="yes">Parts and References</property>
+        <property name="label" translatable="yes">Compartments</property>
         <attributes>
           <attribute name="weight" value="bold"></attribute>
         </attributes>

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -100,6 +100,21 @@ renderers and such.</property>
             </child>
           </object>
         </child>
+        <child>
+          <object class="GtkBox">
+            <child>
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Show Values</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="show-values">
+                <property name="halign">center</property>
+                <signal name="notify::active" handler="show-values-changed" swapped="no"/>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
     <child type="label">

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -71,6 +71,19 @@ def test_compartment_property_page_show_references(diagram, element_factory):
     assert item.show_references
 
 
+def test_compartment_property_page_show_values(diagram, element_factory):
+    item = diagram.create(
+        SysML.blocks.BlockItem, subject=element_factory.create(SysML.sysml.Block)
+    )
+    property_page = CompartmentPage(item)
+
+    widget = property_page.construct()
+    show_references = find(widget, "show-values")
+    show_references.set_active(True)
+
+    assert item.show_values
+
+
 def test_property_property_page(element_factory):
     subject = element_factory.create(SysML.sysml.Property)
     property_page = PropertyPropertyPage(subject)

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -4,8 +4,8 @@ from gaphor import UML, SysML
 from gaphor.diagram.propertypages import PropertyPages
 from gaphor.diagram.tests.fixtures import find
 from gaphor.SysML.propertypages import (
+    CompartmentPage,
     ItemFlowPropertyPage,
-    PartsAndReferencesPage,
     PropertyPropertyPage,
     RequirementPropertyPage,
 )
@@ -45,11 +45,11 @@ def test_requirement_property_page_text(diagram, element_factory):
     assert subject.text == "test"
 
 
-def test_part_and_reference_property_page_show_parts(diagram, element_factory):
+def test_compartment_property_page_show_parts(diagram, element_factory):
     item = diagram.create(
         SysML.blocks.BlockItem, subject=element_factory.create(SysML.sysml.Block)
     )
-    property_page = PartsAndReferencesPage(item)
+    property_page = CompartmentPage(item)
 
     widget = property_page.construct()
     show_parts = find(widget, "show-parts")
@@ -58,11 +58,11 @@ def test_part_and_reference_property_page_show_parts(diagram, element_factory):
     assert item.show_parts
 
 
-def test_part_and_reference_property_page_show_references(diagram, element_factory):
+def test_compartment_property_page_show_references(diagram, element_factory):
     item = diagram.create(
         SysML.blocks.BlockItem, subject=element_factory.create(SysML.sysml.Block)
     )
-    property_page = PartsAndReferencesPage(item)
+    property_page = CompartmentPage(item)
 
     widget = property_page.construct()
     show_references = find(widget, "show-references")

--- a/gaphor/UML/classes/tests/test_datatype_connect.py
+++ b/gaphor/UML/classes/tests/test_datatype_connect.py
@@ -1,0 +1,22 @@
+from gaphor import UML
+from gaphor.diagram.tests.fixtures import connect
+from gaphor.UML.classes.association import AssociationItem
+from gaphor.UML.classes.datatype import DataTypeItem
+from gaphor.UML.classes.klass import ClassItem
+from gaphor.UML.modelfactory import set_navigability
+
+
+def test_connect_value_type_to_block(diagram, element_factory):
+    b = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    v = diagram.create(DataTypeItem, subject=element_factory.create(UML.DataType))
+    a = diagram.create(AssociationItem)
+
+    connect(a, a.head, b)
+    connect(a, a.tail, v)
+    set_navigability(a.subject, a.head_end.subject, True)
+    set_navigability(a.subject, a.tail_end.subject, True)
+    a.tail_end.subject.aggregation = "composite"
+
+    assert a.head_end.subject.type is b.subject
+    assert a.tail_end.subject.type is v.subject
+    assert a.tail_end.subject in b.subject.ownedAttribute

--- a/gaphor/UML/modelfactory.py
+++ b/gaphor/UML/modelfactory.py
@@ -17,6 +17,7 @@ from gaphor.UML.uml import (
     ConnectableElement,
     Connector,
     ConnectorEnd,
+    DataType,
     Dependency,
     Element,
     Extension,
@@ -311,7 +312,7 @@ def set_navigability(assoc, end, nav):
     When an end is non-navigable, then it is just member of an association.
     """
     # remove "navigable" and "unspecified" navigation indicators first
-    if isinstance(end.type, (Class, Interface)):
+    if isinstance(end.type, (Class, DataType, Interface)):
         owner = end.opposite.type
         if owner and end in owner.ownedAttribute:
             owner.ownedAttribute.remove(end)
@@ -324,7 +325,7 @@ def set_navigability(assoc, end, nav):
     assert end not in assoc.navigableOwnedEnd
 
     if nav is True:
-        if isinstance(end.type, (Class, Interface)):
+        if isinstance(end.type, (Class, DataType, Interface)):
             owner = end.opposite.type
             owner.ownedAttribute = end
         else:

--- a/gaphor/UML/umloverrides.py
+++ b/gaphor/UML/umloverrides.py
@@ -62,8 +62,8 @@ def property_navigability(self: uml.Property) -> list[bool | None]:
         return [None]  # assume unknown
     owner = self.opposite.type
     if (
-        isinstance(owner, (uml.Class, uml.Interface))
-        and isinstance(self.type, (uml.Class, uml.Interface))
+        isinstance(owner, (uml.Class, uml.DataType, uml.Interface))
+        and isinstance(self.type, (uml.Class, uml.DataType, uml.Interface))
         and (self in owner.ownedAttribute)
         or self in assoc.navigableOwnedEnd
     ):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Value types can not be shown in Block as a compartment.

Issue Number: #701

### What is the new behavior?

* A fix is done so DataType's connect with (composite) associations similar to Classes and Interfaces
* The "Parts and References" property page has been renamed to "Compartments" and "values" have been added as an option.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


### Other information

![image](https://user-images.githubusercontent.com/96249/145710814-971b8896-b5f2-4854-b949-f1007bf45895.png)
