### PR TITLE
Notification when model elements are automatically removed

### DIFF
--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -8,6 +8,8 @@ from gaphor.core import event_handler
 from gaphor.core.modeling import Diagram, Element, Presentation
 from gaphor.core.modeling.event import AssociationDeleted, AssociationSet, DerivedSet
 from gaphor.diagram.general import CommentLineItem
+from gaphor.event import Notification
+from gaphor.i18n import gettext
 
 
 def undo_guard(func):
@@ -58,6 +60,14 @@ class SanitizerService(Service):
             old_subject = event.old_value
             if old_subject and not old_subject.presentation:
                 old_subject.unlink()
+
+                self.event_manager.handle(
+                    Notification(
+                        gettext(
+                            "Model element(s) have been removed: they're not shown in a diagram anymore."
+                        )
+                    )
+                )
 
     @event_handler(AssociationSet)
     @undo_guard

--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -70,7 +70,7 @@ class SanitizerService(Service):
             self.event_manager.handle(
                 Notification(
                     gettext(
-                        "Dangling model element(s) have been removed: they're not shown in a diagram anymore."
+                        "Removed unused elements from the model: they are not used in any other diagram."
                     )
                 )
             )

--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -30,8 +30,9 @@ class SanitizerService(Service):
     """Does some background cleanup jobs, such as removing elements from the
     model that have no presentations (and should have some)."""
 
-    def __init__(self, event_manager, undo_manager=None):
+    def __init__(self, event_manager, undo_manager=None, properties=None):
         self.event_manager = event_manager
+        self.properties = properties or {}
         self.undo_manager = undo_manager
 
         event_manager.subscribe(self._unlink_on_subject_delete)
@@ -56,18 +57,23 @@ class SanitizerService(Service):
         """Unlink the model element if no more presentations link to the
         `item`'s subject or the deleted item was the only item currently
         linked."""
-        if event.property is Presentation.subject:  # type: ignore[misc]
-            old_subject = event.old_value
-            if old_subject and not old_subject.presentation:
-                old_subject.unlink()
+        if (
+            not self.properties.get("remove-dangling-elements", True)
+            or event.property is not Presentation.subject  # type: ignore[misc]
+        ):
+            return
 
-                self.event_manager.handle(
-                    Notification(
-                        gettext(
-                            "Model element(s) have been removed: they're not shown in a diagram anymore."
-                        )
+        old_subject = event.old_value
+        if old_subject and not old_subject.presentation:
+            old_subject.unlink()
+
+            self.event_manager.handle(
+                Notification(
+                    gettext(
+                        "Dangling model element(s) have been removed: they're not shown in a diagram anymore."
                     )
                 )
+            )
 
     @event_handler(AssociationSet)
     @undo_guard

--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -58,7 +58,7 @@ class SanitizerService(Service):
         `item`'s subject or the deleted item was the only item currently
         linked."""
         if (
-            not self.properties.get("remove-dangling-elements", True)
+            not self.properties.get("remove-unused-elements", True)
             or event.property is not Presentation.subject  # type: ignore[misc]
         ):
             return

--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -98,3 +98,10 @@ class ActionEnabled:
             action_name.split(".", 2) if "." in action_name else ("win", action_name)
         )
         self.enabled = bool(enabled)
+
+
+class Notification:
+    """Inform the user about important events."""
+
+    def __init__(self, message):
+        self.message = message

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -21,8 +21,9 @@ from gaphor.diagram.selection import Selection
 from gaphor.diagram.support import get_diagram_item
 from gaphor.diagram.tools import apply_default_tool_set, apply_placement_tool_set
 from gaphor.diagram.tools.placement import create_item, open_editor
+from gaphor.event import Notification
 from gaphor.transaction import Transaction
-from gaphor.ui.event import DiagramSelectionChanged, Notification, ToolSelected
+from gaphor.ui.event import DiagramSelectionChanged, ToolSelected
 
 log = logging.getLogger(__name__)
 

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -354,6 +354,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
@@ -387,6 +388,43 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Remove dangling elements</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="action-name">win.remove-dangling-elements</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -400,7 +438,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
@@ -423,7 +461,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="position">4</property>
                   </packing>
                 </child>
                 <child>
@@ -439,7 +477,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">4</property>
+                    <property name="position">5</property>
                   </packing>
                 </child>
               </object>

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -359,7 +359,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Reset tool automatically</property>
+                        <property name="label" translatable="yes">Reset Tool Automatically</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -396,7 +396,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Remove unused elements</property>
+                        <property name="label" translatable="yes">Remove Unused Elements</property>
                         <property name="tooltip-text" translatable="yes">Automatically remove elements no longer in use in any diagram.</property>
                         <property name="xalign">0</property>
                       </object>
@@ -431,7 +431,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="margin-top">6</property>
-                    <property name="label" translatable="yes">Style sheet</property>
+                    <property name="label" translatable="yes">Style Sheet</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>

--- a/gaphor/ui/elementeditor.glade
+++ b/gaphor/ui/elementeditor.glade
@@ -396,7 +396,8 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Remove dangling elements</property>
+                        <property name="label" translatable="yes">Remove unused elements</property>
+                        <property name="tooltip-text" translatable="yes">Automatically remove elements no longer in use in any diagram.</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -409,7 +410,8 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                       <object class="GtkSwitch">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
-                        <property name="action-name">win.remove-dangling-elements</property>
+                        <property name="action-name">win.remove-unused-elements</property>
+                        <property name="tooltip-text" translatable="yes">Automatically remove elements no longer in use in any diagram.</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -104,6 +104,13 @@ class ElementEditor(UIComponent, ActionProvider):
     def reset_tool_after_create(self, active):
         self.properties.set("reset-tool-after-create", active)
 
+    @action(
+        name="remove-dangling-elements",
+        state=lambda self: self.properties.get("remove-dangling-elements", True),
+    )
+    def remove_dangling_elements(self, active):
+        self.properties.set("remove-dangling-elements", active)
+
 
 class EditorStack:
     def __init__(self, event_manager, diagrams, properties):

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -105,11 +105,11 @@ class ElementEditor(UIComponent, ActionProvider):
         self.properties.set("reset-tool-after-create", active)
 
     @action(
-        name="remove-dangling-elements",
-        state=lambda self: self.properties.get("remove-dangling-elements", True),
+        name="remove-unused-elements",
+        state=lambda self: self.properties.get("remove-unused-elements", True),
     )
-    def remove_dangling_elements(self, active):
-        self.properties.set("remove-dangling-elements", active)
+    def remove_unused_elements(self, active):
+        self.properties.set("remove-unused-elements", active)
 
 
 class EditorStack:

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -233,14 +233,16 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                         <child>
                           <object class="GtkLabel">
                             <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Remove dangling elements</property>
+                            <property name="label" translatable="yes">Remove unused elements</property>
                             <property name="xalign">0</property>
+                            <property name="tooltip-text" translatable="yes">Automatically remove elements no longer in use in any diagram.</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSwitch">
                             <property name="halign">center</property>
-                            <property name="action_name">win.remove-dangling-elements</property>
+                            <property name="action_name">win.remove-unused-elements</property>
+                            <property name="tooltip-text" translatable="yes">Automatically remove elements no longer in use in any diagram.</property>
                           </object>
                         </child>
                       </object>

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -215,7 +215,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                         <child>
                           <object class="GtkLabel">
                             <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Reset tool automatically</property>
+                            <property name="label" translatable="yes">Reset Tool Automatically</property>
                             <property name="xalign">0</property>
                           </object>
                         </child>
@@ -233,7 +233,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                         <child>
                           <object class="GtkLabel">
                             <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Remove unused elements</property>
+                            <property name="label" translatable="yes">Remove Unused Elements</property>
                             <property name="xalign">0</property>
                             <property name="tooltip-text" translatable="yes">Automatically remove elements no longer in use in any diagram.</property>
                           </object>
@@ -250,7 +250,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                     <child>
                       <object class="GtkLabel">
                         <property name="margin_top">6</property>
-                        <property name="label" translatable="yes">Style sheet</property>
+                        <property name="label" translatable="yes">Style Sheet</property>
                         <property name="xalign">0</property>
                         <attributes>
                           <attribute name="weight" value="bold"></attribute>

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -211,6 +211,7 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                     </child>
                     <child>
                       <object class="GtkBox">
+                        <property name="spacing">6</property>
                         <child>
                           <object class="GtkLabel">
                             <property name="hexpand">1</property>
@@ -222,6 +223,24 @@ Tool selection only works from the diagram. If a tool does not get selected, cli
                           <object class="GtkSwitch">
                             <property name="halign">center</property>
                             <property name="action_name">win.reset-tool-after-create</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Remove dangling elements</property>
+                            <property name="xalign">0</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch">
+                            <property name="halign">center</property>
+                            <property name="action_name">win.remove-dangling-elements</property>
                           </object>
                         </child>
                       </object>

--- a/gaphor/ui/event.py
+++ b/gaphor/ui/event.py
@@ -21,8 +21,3 @@ class DiagramSelectionChanged:
 class ToolSelected:
     def __init__(self, tool_name):
         self.tool_name = tool_name
-
-
-class Notification:
-    def __init__(self, message):
-        self.message = message

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -330,27 +330,6 @@ class Namespace(UIComponent, ActionProvider):
     @action(name="tree-view.delete")
     def tree_view_delete(self):
         element = self.get_selected_element()
-        if isinstance(element, Diagram):
-            m = Gtk.MessageDialog(
-                None,
-                Gtk.DialogFlags.MODAL,
-                Gtk.MessageType.QUESTION,
-                Gtk.ButtonsType.YES_NO,
-                gettext(
-                    "Do you really want to delete diagram {name}?\n\n"
-                    "This will possibly delete diagram items\n"
-                    "that are not shown in other diagrams."
-                ).format(name=element.name or gettext("<None>")),
-            )
-            if m.run() == Gtk.ResponseType.YES:
-                with Transaction(self.event_manager):
-                    for i in reversed(list(element.get_all_items())):
-                        s = i.subject
-                        if s and len(s.presentation) == 1:
-                            s.unlink()
-                        i.unlink()
-                    element.unlink()
-            m.destroy()
-        elif element:
+        if element:
             with Transaction(self.event_manager):
                 element.unlink()

--- a/gaphor/ui/namespacemodel.py
+++ b/gaphor/ui/namespacemodel.py
@@ -18,7 +18,7 @@ from gaphor.core.modeling import (
     ModelFlushed,
     ModelReady,
 )
-from gaphor.ui.event import Notification
+from gaphor.event import Notification
 
 if TYPE_CHECKING:
     from gaphor.core.eventmanager import EventManager

--- a/gaphor/ui/notification.py
+++ b/gaphor/ui/notification.py
@@ -1,7 +1,7 @@
 from gi.repository import GLib
 
 from gaphor.core import event_handler
-from gaphor.ui.event import Notification
+from gaphor.event import Notification
 
 DELAY = 5_000
 

--- a/gaphor/ui/tests/test_notifier.py
+++ b/gaphor/ui/tests/test_notifier.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gaphor.ui.event import Notification
+from gaphor.event import Notification
 from gaphor.ui.mainwindow import new_builder
 from gaphor.ui.notification import InAppNotifier
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When you remove a diagram with diagram items, model elements that are no longer presented in any diagram will be removed. A dialog is shown (somewhere on screen) with a message.

Fixes #971.

### What is the new behavior?

Instead of a dialog, an in-app notification is shown. An option has been added to the Preferences pane to toggle automatic deletion of no longer presented model elements.

When a diagram is deleted with items, a notification is shown. The notification is also shown if an item is removed on a diagram.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

This solution leverages the solutions already present in Gaphor: in-app notifications and our simple preferences pane.
If items are deleted by accident, they can simply be undone.

Note that the message does not tell *which* items have been removed. This is partly due to where the message is constructed and partly because it's likely to break localization.