### PR TITLE
Allow allocation of structural types to swimlane partitions

### DIFF
--- a/gaphor/UML/actions/partition.py
+++ b/gaphor/UML/actions/partition.py
@@ -6,8 +6,9 @@ from gaphor import UML
 from gaphor.core.modeling import DrawContext
 from gaphor.core.modeling.properties import association
 from gaphor.core.styling import VerticalAlign
+from gaphor.core.styling.properties import TextAlign
 from gaphor.diagram.presentation import ElementPresentation
-from gaphor.diagram.shapes import Box, cairo_state, stroke
+from gaphor.diagram.shapes import Box, stroke
 from gaphor.diagram.support import represents
 from gaphor.diagram.text import Layout
 
@@ -23,7 +24,7 @@ class PartitionItem(ElementPresentation):
         self.shape = Box(
             style={
                 "line-width": 2.4,
-                "padding": (2, 2, 2, 2),
+                "padding": (4, 12, 4, 12),
                 "vertical-align": VerticalAlign.TOP,
             },
             draw=self.draw_swimlanes,
@@ -56,32 +57,21 @@ class PartitionItem(ElementPresentation):
         """
         cr = context.cairo
         cr.set_line_width(context.style["line-width"])
-        self.draw_outline(bounding_box, context)
-        self.draw_partitions(bounding_box, context)
-        stroke(context)
-        self.draw_hover(bounding_box, context)
+        partitions = self.partition
 
-    def draw_hover(self, bounding_box: Rectangle, context: DrawContext) -> None:
-        """Add dashed line on bottom of swimlanes when hovered."""
-        if context.hovered or context.dropzone:
-            cr = context.cairo
-            with cairo_state(cr):
-                cr.set_dash((1.0, 5.0), 0)
-                cr.set_line_width(1.0)
-                cr.rectangle(0, 0, bounding_box.width, bounding_box.height)
-                cr.stroke()
-
-    def draw_partitions(self, bounding_box: Rectangle, context: DrawContext) -> None:
-        """Draw partition separators and add the name."""
-        cr = context.cairo
-        if self.partition:
-            partition_width = bounding_box.width / len(self.partition)
+        if partitions:
+            partition_width = bounding_box.width / len(partitions)
         else:
             partition_width = bounding_box.width / 2
+
         layout = Layout()
+        padding_top, padding_right, padding_bottom, padding_left = context.style[
+            "padding"
+        ]
+        layout.set_width(partition_width - padding_left - padding_right)
         style = context.style
-        padding_top = context.style["padding"][0]
-        for num, partition in enumerate(self.partition):
+        header_height = 0.0
+        for num, partition in enumerate(partitions):
             cr.move_to(partition_width * num, 0)
             cr.line_to(partition_width * num, bounding_box.height)
             layout.set(
@@ -89,22 +79,21 @@ class PartitionItem(ElementPresentation):
                 if isinstance(partition.represents, UML.NamedElement)
                 else partition.name,
                 font=style,
+                text_align=TextAlign.CENTER,
             )
-            cr.move_to(partition_width * num, padding_top * 3)
+            cr.move_to(partition_width * num + padding_left, padding_top)
             layout.show_layout(
                 cr,
-                partition_width,
-                default_size=(partition_width, HEADER_HEIGHT),
             )
+            _, h = layout.size()
+            header_height = max(h, header_height)
 
-    def draw_outline(self, bounding_box: Rectangle, context: DrawContext) -> None:
-        """Draw the outline and header of the swimlanes."""
-        cr = context.cairo
-        cr.move_to(0, bounding_box.height)
-        cr.line_to(0, 0)
-        cr.line_to(bounding_box.width, 0)
+        cr.move_to(bounding_box.width, 0)
         cr.line_to(bounding_box.width, bounding_box.height)
-        cr.move_to(0, bounding_box.height)
-        cr.line_to(0, HEADER_HEIGHT)
-        cr.line_to(0 + bounding_box.width, HEADER_HEIGHT)
-        cr.line_to(0 + bounding_box.width, bounding_box.height)
+
+        header_height += padding_top + padding_bottom
+        cr.move_to(0, 0)
+        cr.line_to(0 + bounding_box.width, 0)
+        cr.move_to(0, header_height)
+        cr.line_to(0 + bounding_box.width, header_height)
+        stroke(context)

--- a/gaphor/UML/actions/partition.py
+++ b/gaphor/UML/actions/partition.py
@@ -6,7 +6,6 @@ from gaphor import UML
 from gaphor.core.modeling import DrawContext
 from gaphor.core.modeling.properties import association
 from gaphor.core.styling import VerticalAlign
-from gaphor.core.styling.properties import TextAlign
 from gaphor.diagram.presentation import ElementPresentation
 from gaphor.diagram.shapes import Box, stroke
 from gaphor.diagram.support import represents
@@ -64,12 +63,13 @@ class PartitionItem(ElementPresentation):
         else:
             partition_width = bounding_box.width / 2
 
-        layout = Layout()
         padding_top, padding_right, padding_bottom, padding_left = context.style[
             "padding"
         ]
-        layout.set_width(partition_width - padding_left - padding_right)
-        style = context.style
+        layout = Layout(
+            font=context.style,
+            width=partition_width - padding_left - padding_right,
+        )
         header_height = 0.0
         for num, partition in enumerate(partitions):
             cr.move_to(partition_width * num, 0)
@@ -77,14 +77,10 @@ class PartitionItem(ElementPresentation):
             layout.set(
                 text=f"{partition.name}: {partition.represents.name}"
                 if isinstance(partition.represents, UML.NamedElement)
-                else partition.name,
-                font=style,
-                text_align=TextAlign.CENTER,
+                else partition.name
             )
             cr.move_to(partition_width * num + padding_left, padding_top)
-            layout.show_layout(
-                cr,
-            )
+            layout.show_layout(cr)
             _, h = layout.size()
             header_height = max(h, header_height)
 

--- a/gaphor/UML/actions/partition.py
+++ b/gaphor/UML/actions/partition.py
@@ -30,8 +30,9 @@ class PartitionItem(ElementPresentation):
         )
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
-        self.watch("partition.name")
         self.watch("partition", self.update_partition)
+        self.watch("partition.name")
+        self.watch("partition[ActivityPartition].represents[NamedElement].name")
 
     partition = association("partition", UML.ActivityPartition, composite=True)
 
@@ -83,7 +84,12 @@ class PartitionItem(ElementPresentation):
         for num, partition in enumerate(self.partition):
             cr.move_to(partition_width * num, 0)
             cr.line_to(partition_width * num, bounding_box.height)
-            layout.set(text=partition.name, font=style)
+            layout.set(
+                text=f"{partition.name}: {partition.represents.name}"
+                if isinstance(partition.represents, UML.NamedElement)
+                else partition.name,
+                font=style,
+            )
             cr.move_to(partition_width * num, padding_top * 3)
             layout.show_layout(
                 cr,

--- a/gaphor/UML/actions/partitionpage.py
+++ b/gaphor/UML/actions/partitionpage.py
@@ -1,5 +1,7 @@
 """Activity partition property page."""
 
+from gi.repository import Gtk
+
 from gaphor import UML
 from gaphor.core import gettext, transactional
 from gaphor.diagram.propertypages import (
@@ -30,7 +32,44 @@ class PartitionPropertyPage(PropertyPageBase):
             signals={"partitions-changed": (self._on_num_partitions_changed,)},
         )
 
+        num_partitions = builder.get_object("num-partitions")
+        num_partitions.set_value(len(self.item.partition))
+
+        self.partitions = builder.get_object("partitions")
+        for partition in self.item.partition:
+            self.partitions.pack_start(
+                self.construct_partition(partition), expand=False, fill=False, padding=0
+            )
+
         return builder.get_object("partition-editor")
+
+    def construct_partition(self, partition):
+        builder = new_builder(
+            "partition",
+            signals={
+                "partition-name-changed": (self._on_partition_name_changed, partition),
+                "partition-type-changed": (self._on_partition_type_changed, partition),
+            },
+        )
+
+        builder.get_object("partition-name").set_text(partition.name or "")
+
+        combo = builder.get_object("partition-type")
+        for c in self.item.model.select(UML.Classifier):
+            if c.name:
+                combo.append(c.id, c.name)
+
+        completion = Gtk.EntryCompletion()
+        completion.set_model(combo.get_model())
+        completion.set_minimum_key_length(1)
+        completion.set_text_column(0)
+
+        entry = combo.get_child()
+        entry.set_completion(completion)
+        if partition.represents:
+            combo.set_active_id(partition.represents.id)
+
+        return builder.get_object("partition")
 
     @transactional
     def _on_num_partitions_changed(self, spin_button):
@@ -39,9 +78,19 @@ class PartitionPropertyPage(PropertyPageBase):
         self.update_partitions(num_partitions)
 
     @transactional
-    def _on_partition_name_changed(self, widget, path, text):
+    def _on_partition_name_changed(self, entry, partition):
         """Event handler for editing partition names."""
-        self.item.partition[int(path)].name = text
+        partition.name = entry.get_text()
+
+    @transactional
+    def _on_partition_type_changed(self, combo, partition):
+        """Event handler for editing partition names."""
+        id = combo.get_active_id()
+        if id:
+            element = self.item.model.lookup(id)
+            partition.represents = element
+        else:
+            del partition.represents
 
     def update_partitions(self, num_partitions) -> None:
         """Add and remove partitions.
@@ -52,11 +101,21 @@ class PartitionPropertyPage(PropertyPageBase):
         """
         if not self.item.subject:
             return
-        if num_partitions > len(self.item.partition):
+
+        while num_partitions > len(self.item.partition):
             partition = self.item.subject.model.create(UML.ActivityPartition)
             partition.name = gettext("New Swimlane")
             partition.activity = self.item.subject.activity
             self.item.partition.append(partition)
-        elif num_partitions < len(self.item.partition):
+
+            self.partitions.pack_start(
+                self.construct_partition(partition), expand=False, fill=False, padding=0
+            )
+
+        while num_partitions < len(self.item.partition):
             partition = self.item.partition[-1]
             partition.unlink()
+
+            last_child = self.partitions.get_children()[-1]
+            self.partitions.remove(last_child)
+            last_child.destroy()

--- a/gaphor/UML/actions/partitionpage.py
+++ b/gaphor/UML/actions/partitionpage.py
@@ -55,7 +55,7 @@ class PartitionPropertyPage(PropertyPageBase):
         builder.get_object("partition-name").set_text(partition.name or "")
 
         combo = builder.get_object("partition-type")
-        for c in self.item.model.select(UML.Classifier):
+        for c in self.item.model.select(UML.Class):
             if c.name:
                 combo.append(c.id, c.name)
 

--- a/gaphor/UML/actions/partitionpage.py
+++ b/gaphor/UML/actions/partitionpage.py
@@ -55,8 +55,8 @@ class PartitionPropertyPage(PropertyPageBase):
         builder.get_object("partition-name").set_text(partition.name or "")
 
         combo = builder.get_object("partition-type")
-        for c in self.item.model.select(UML.Class):
-            if c.name:
+        for c in self.item.model.select(UML.Classifier):
+            if c.name and not isinstance(c, UML.Behavior):
                 combo.append(c.id, c.name)
 
         completion = Gtk.EntryCompletion()

--- a/gaphor/UML/actions/propertypages.glade
+++ b/gaphor/UML/actions/propertypages.glade
@@ -208,6 +208,7 @@ renderers and such.</property>
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
+        <property name="spacing">12</property>
         <child>
           <placeholder/>
         </child>
@@ -311,15 +312,13 @@ renderers and such.</property>
   <object class="GtkBox" id="partition">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
-    <property name="margin-top">6</property>
-    <property name="orientation">vertical</property>
+    <property name="margin-start">6</property>
     <property name="spacing">6</property>
     <child>
-      <object class="GtkLabel">
+      <object class="GtkSeparator">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="label" translatable="yes">Name</property>
-        <property name="xalign">0</property>
+        <property name="orientation">vertical</property>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -328,58 +327,67 @@ renderers and such.</property>
       </packing>
     </child>
     <child>
-      <object class="GtkEntry" id="partition-name">
-        <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <signal name="changed" handler="partition-name-changed" swapped="no"/>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel">
+      <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="label" translatable="yes">Type</property>
-        <property name="xalign">0</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkComboBoxText" id="partition-type">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="has-entry">True</property>
-        <signal name="changed" handler="partition-type-changed" swapped="no"/>
-        <child internal-child="entry">
-          <object class="GtkEntry">
-            <property name="can-focus">True</property>
-            <property name="text" translatable="yes">Named Element</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Name</property>
+            <property name="xalign">0</property>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="partition-name">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <signal name="changed" handler="partition-name-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Type</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="partition-type">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="has-entry">True</property>
+            <signal name="changed" handler="partition-type-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
         </child>
       </object>
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
-        <property name="position">3</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkSeparator">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">4</property>
+        <property name="position">1</property>
       </packing>
     </child>
   </object>

--- a/gaphor/UML/actions/propertypages.glade
+++ b/gaphor/UML/actions/propertypages.glade
@@ -361,7 +361,7 @@ renderers and such.</property>
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="label" translatable="yes">Type</property>
+            <property name="label" translatable="yes">Allocated Type</property>
             <property name="xalign">0</property>
           </object>
           <packing>

--- a/gaphor/UML/actions/propertypages.glade
+++ b/gaphor/UML/actions/propertypages.glade
@@ -136,6 +136,89 @@ renderers and such.</property>
       </packing>
     </child>
   </object>
+  <object class="GtkAdjustment" id="num-partitions-adjustment">
+    <property name="lower">1</property>
+    <property name="upper">10</property>
+    <property name="value">2</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">5</property>
+  </object>
+  <object class="GtkBox" id="partition-editor">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="margin-top">6</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">6</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">Swimlanes</property>
+        <property name="xalign">0</property>
+        <attributes>
+          <attribute name="weight" value="bold"/>
+        </attributes>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Partitions</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="num-partitions">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="adjustment">num-partitions-adjustment</property>
+            <property name="numeric">True</property>
+            <signal name="value-changed" handler="partitions-changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack-type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="partitions">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+  </object>
   <object class="GtkBox" id="object-node-editor">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -225,42 +308,18 @@ renderers and such.</property>
       </packing>
     </child>
   </object>
-  <object class="GtkBox" id="partition-editor">
+  <object class="GtkBox" id="partition">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
     <child>
-      <object class="GtkBox">
+      <object class="GtkLabel">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="label" translatable="yes">Partitions</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="num-partitions">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="numeric">True</property>
-            <signal name="value-changed" handler="partitions-changed" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="pack-type">end</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
+        <property name="label" translatable="yes">Name</property>
+        <property name="xalign">0</property>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -269,14 +328,10 @@ renderers and such.</property>
       </packing>
     </child>
     <child>
-      <object class="GtkLabel">
+      <object class="GtkEntry" id="partition-name">
         <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="label" translatable="yes">Partition Names</property>
-        <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"/>
-        </attributes>
+        <property name="can-focus">True</property>
+        <signal name="changed" handler="partition-name-changed" swapped="no"/>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -285,17 +340,46 @@ renderers and such.</property>
       </packing>
     </child>
     <child>
-      <object class="GtkTreeView" id="partition-treeview">
+      <object class="GtkLabel">
         <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <child internal-child="selection">
-          <object class="GtkTreeSelection"/>
-        </child>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">Type</property>
+        <property name="xalign">0</property>
       </object>
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
         <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkComboBoxText" id="partition-type">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="has-entry">True</property>
+        <signal name="changed" handler="partition-type-changed" swapped="no"/>
+        <child internal-child="entry">
+          <object class="GtkEntry">
+            <property name="can-focus">True</property>
+            <property name="text" translatable="yes">Named Element</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSeparator">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">4</property>
       </packing>
     </child>
   </object>

--- a/gaphor/UML/actions/tests/test_partitionpage.py
+++ b/gaphor/UML/actions/tests/test_partitionpage.py
@@ -12,6 +12,40 @@ def test_partition_page(diagram, element_factory):
     widget = property_page.construct()
 
     num_partitions = find(widget, "num-partitions")
-    num_partitions.set_value(2)
+    num_partitions.set_value(4)
 
-    assert len(item.partition) == 2
+    assert len(item.partition) == 4
+
+
+def test_partition_name(diagram, element_factory):
+    item = diagram.create(
+        UML.actions.PartitionItem, subject=element_factory.create(UML.ActivityPartition)
+    )
+    property_page = PartitionPropertyPage(item)
+    property_page.construct()
+    property_page.update_partitions(1)
+
+    widget = property_page.construct_partition(item.partition[0])
+
+    name = find(widget, "partition-name")
+    name.set_text("Name")
+
+    assert item.partition[0].name == "Name"
+
+
+def test_partition_type(diagram, element_factory):
+    class_ = element_factory.create(UML.Class)
+    class_.name = "Foobar"
+    item = diagram.create(
+        UML.actions.PartitionItem, subject=element_factory.create(UML.ActivityPartition)
+    )
+    property_page = PartitionPropertyPage(item)
+    property_page.construct()
+    property_page.update_partitions(1)
+
+    widget = property_page.construct_partition(item.partition[0])
+
+    combo = find(widget, "partition-type")
+    combo.set_active_id(class_.id)
+
+    assert item.partition[0].represents is class_

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -13,6 +13,7 @@ class Layout:
         self,
         text: str = "",
         font: Style | None = None,
+        width: int | None = None,
         text_align: TextAlign = TextAlign.CENTER,
         default_size: tuple[int, int] = (0, 0),
     ):
@@ -25,10 +26,12 @@ class Layout:
         self.width = -1
         self.default_size = default_size
 
-        if font:
-            self.set_font(font)
         if text:
             self.set_text(text)
+        if width is not None:
+            self.set_width(width)
+        if font:
+            self.set_font(font)
         self.set_alignment(text_align)
 
     def set(self, text=None, font=None, width=None, text_align=None):

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -170,30 +170,19 @@ def _text_point_at_line_end(size, p1, p2):
 
     name_w, name_h = size
 
-    if dy == 0:
-        rc = 1000.0  # quite a lot...
-    else:
-        rc = dx / dy
+    rc = 1000.0 if dy == 0 else dx / dy
     abs_rc = abs(rc)
     h = dx > 0  # right side of the box
     v = dy > 0  # bottom side
 
     if abs_rc > 6:
         # horizontal line
-        if h:
-            name_dx = ofs
-            name_dy = -ofs - name_h
-        else:
-            name_dx = -ofs - name_w
-            name_dy = -ofs - name_h
+        name_dx = ofs if h else -ofs - name_w
+        name_dy = -ofs - name_h
     elif 0 <= abs_rc <= 0.2:
+        name_dx = -ofs - name_w
         # vertical line
-        if v:
-            name_dx = -ofs - name_w
-            name_dy = ofs
-        else:
-            name_dx = -ofs - name_w
-            name_dy = -ofs - name_h
+        name_dy = ofs if v else -ofs - name_h
     else:
         # Should both items be placed on the same side of the line?
         r = abs_rc < 1.0
@@ -201,14 +190,8 @@ def _text_point_at_line_end(size, p1, p2):
         # Find out alignment of text (depends on the direction of the line)
         align_left = h ^ r
         align_bottom = v ^ r
-        if align_left:
-            name_dx = ofs
-        else:
-            name_dx = -ofs - name_w
-        if align_bottom:
-            name_dy = -ofs - name_h
-        else:
-            name_dy = ofs
+        name_dx = ofs if align_left else -ofs - name_w
+        name_dy = -ofs - name_h if align_bottom else ofs
     return p1[0] + name_dx, p1[1] + name_dy
 
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Swimlanes can only have a name.

Issue Number: #426 

### What is the new behavior?

Swimlanes can be assigned a type, via a drop-down in the property editor. Swimlane types are restructed to UML Classifiers (Classes, Interfaces, SysML Blocks, etc..

![image](https://user-images.githubusercontent.com/96249/146601776-cbc53dc2-b265-4947-a194-91483a1a4d9e.png)

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

I'll leave out the option to DnD a block on a swimlane for now.