### PR TITLE
Store toolbox settings per modeling language

### DIFF
--- a/gaphor/services/modelinglanguage.py
+++ b/gaphor/services/modelinglanguage.py
@@ -42,8 +42,9 @@ class ModelingLanguageService(Service, ActionProvider, ModelingLanguage):
                 yield id, provider.name
 
     @property
-    def active_modeling_language(self):
-        modeling_language = self.properties.get(
+    def active_modeling_language(self) -> str:
+        """The identifier for the currently active modeling language."""
+        modeling_language: str = self.properties.get(
             "modeling-language", self.DEFAULT_LANGUAGE
         )
         if modeling_language not in self._modeling_languages:
@@ -51,20 +52,13 @@ class ModelingLanguageService(Service, ActionProvider, ModelingLanguage):
         return modeling_language
 
     @property
-    def active_modeling_language_name(self):
-        return self._modeling_languages[self.active_modeling_language].name
-
-    @property
-    def _modeling_language(self):
-        return self._modeling_languages[self.active_modeling_language]
-
-    @property
-    def name(self):
-        return self._modeling_language.name
+    def name(self) -> str:
+        """Localized name of the active modeling language."""
+        return self._modeling_language().name
 
     @property
     def toolbox_definition(self):
-        return self._modeling_language.toolbox_definition
+        return self._modeling_language().toolbox_definition
 
     def lookup_element(self, name):
         return next(
@@ -82,9 +76,12 @@ class ModelingLanguageService(Service, ActionProvider, ModelingLanguage):
         name="select-modeling-language",
         state=lambda self: self.active_modeling_language,
     )
-    def action_select_modeling_language(self, modeling_language: str):
+    def select_modeling_language(self, modeling_language: str):
         self.properties.set("modeling-language", modeling_language)
         self.event_manager.handle(ModelingLanguageChanged(modeling_language))
+
+    def _modeling_language(self) -> ModelingLanguage:
+        return self._modeling_languages[self.active_modeling_language]
 
     @event_handler(PropertyChanged)
     def on_property_changed(self, event: PropertyChanged):

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -300,9 +300,7 @@ class MainWindow(Service, ActionProvider):
     def _on_modeling_language_selection_changed(self, event=None):
         if self.modeling_language_name:
             self.modeling_language_name.set_label(
-                gettext("Profile: {}").format(
-                    self.modeling_language.active_modeling_language_name
-                )
+                gettext("Profile: {}").format(self.modeling_language.name)
             )
 
     def _on_window_active(self, window, prop):

--- a/gaphor/ui/tests/test_toolbox.py
+++ b/gaphor/ui/tests/test_toolbox.py
@@ -1,12 +1,12 @@
 import pytest
 
+from gaphor.services.modelinglanguage import ModelingLanguageService
 from gaphor.ui.toolbox import Toolbox
-from gaphor.UML.modelinglanguage import UMLModelingLanguage
 
 
 @pytest.fixture
-def modeling_language():
-    return UMLModelingLanguage()
+def modeling_language(event_manager):
+    return ModelingLanguageService(event_manager)
 
 
 @pytest.fixture

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -13,7 +13,10 @@ from gaphor.core import action
 from gaphor.core.eventmanager import EventManager, event_handler
 from gaphor.diagram.diagramtoolbox import ToolDef
 from gaphor.diagram.event import DiagramItemPlaced
-from gaphor.services.modelinglanguage import ModelingLanguage, ModelingLanguageChanged
+from gaphor.services.modelinglanguage import (
+    ModelingLanguageChanged,
+    ModelingLanguageService,
+)
 from gaphor.services.properties import Properties
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.actiongroup import create_action_group, from_variant
@@ -39,7 +42,7 @@ class Toolbox(UIComponent):
         self,
         event_manager: EventManager,
         properties: Properties,
-        modeling_language: ModelingLanguage,
+        modeling_language: ModelingLanguageService,
     ):
         self.event_manager = event_manager
         self.properties = properties
@@ -129,11 +132,14 @@ class Toolbox(UIComponent):
         toolbox.set_name("toolbox")
         toolbox.connect("destroy", self._on_toolbox_destroyed)
         toolbox.insert_action_group("toolbox", self._action_group)
-        collapsed = self.properties.get("toolbox-collapsed", {})
+        collapsed_property = (
+            f"toolbox-{self.modeling_language.active_modeling_language}-collapsed"
+        )
+        collapsed = self.properties.get(collapsed_property, {})
 
         def on_expanded(widget, prop, index):
             collapsed[index] = not widget.get_property("expanded")
-            self.properties.set("toolbox-collapsed", collapsed)
+            self.properties.set(collapsed_property, collapsed)
 
         for index, (title, items) in enumerate(toolbox_actions):
             expander = Gtk.Expander.new(title)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Toolbox settings - which sections are expanded/collapsed - is defined once. The settings were used for all modeling languages.

Issue Number: #973 

### What is the new behavior?

Toolbox settings are stored per modeling language.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Also did a bit of cleanup in the `ModelingLanguageService`.

This is a first step towards diagram type support.
