### PR TITLE
Fix model element ownership

### DIFF
--- a/gaphor/SysML/blocks/connectors.py
+++ b/gaphor/SysML/blocks/connectors.py
@@ -77,5 +77,6 @@ class PropertyConnectorConnector(UnaryRelationshipConnect):
         if c1 and c2 and not line.subject:
             assert isinstance(c1.subject, UML.ConnectableElement)
             assert isinstance(c2.subject, UML.ConnectableElement)
-            relation = UML.recipes.create_connector(c1.subject, c2.subject)
-            line.subject = relation
+            connector = UML.recipes.create_connector(c1.subject, c2.subject)
+            line.subject = connector
+            connector.structuredClassifier = c1.subject.owner or c2.subject.owner

--- a/gaphor/SysML/blocks/connectors.py
+++ b/gaphor/SysML/blocks/connectors.py
@@ -34,7 +34,7 @@ class BlockProperyProxyPortConnector:
         proxy_port = self.proxy_port
         if not proxy_port.subject:
             proxy_port.subject = proxy_port.model.create(sysml.ProxyPort)
-        if isinstance(self.block.subject, UML.EncapsulatedClassifer):
+        if isinstance(self.block.subject, UML.EncapsulatedClassifier):
             proxy_port.subject.encapsulatedClassifier = self.block.subject
 
         # This raises the item in the item hierarchy

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -298,6 +298,9 @@ DirectedRelationshipPropertyPath.targetContext = association("targetContext", Cl
 DirectedRelationshipPropertyPath.sourceContext = association("sourceContext", Classifier, upper=1)
 DirectedRelationshipPropertyPath.sourcePropertyPath = association("sourcePropertyPath", Property)
 DirectedRelationshipPropertyPath.targetPropertyPath = association("targetPropertyPath", Property)
+Property.itemFlow = association("itemFlow", ItemFlow, upper=1, opposite="itemProperty")
+from gaphor.UML.uml import Element
+Element.owner.add(Property.itemFlow)  # type: ignore[attr-defined]
 ConnectorProperty.connector = association("connector", Connector, upper=1, composite=True)
 ParticipantProperty.end_ = association("end_", Property, upper=1, composite=True)
 ValueType.unit = association("unit", InstanceSpecification, upper=1)
@@ -318,4 +321,5 @@ Stakeholder.concernList = association("concernList", Comment, composite=True)
 ElementGroup.member = derivedunion("member", Element)
 ElementGroup.orderedMember = association("orderedMember", Element, composite=True)
 Rate.rate = association("rate", InstanceSpecification, composite=True)
-ItemFlow.itemProperty = association("itemProperty", Property, upper=1, composite=True)
+ItemFlow.itemProperty = association("itemProperty", Property, upper=1, composite=True, opposite="itemFlow")
+Element.ownedElement.add(ItemFlow.itemProperty)  # type: ignore[attr-defined]

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -226,11 +226,11 @@ class StructuredClassifier(Classifier):
     role: relation_many[ConnectableElement]
 
 
-class EncapsulatedClassifer(StructuredClassifier):
+class EncapsulatedClassifier(StructuredClassifier):
     ownedPort: relation_many[Port]
 
 
-class Class(BehavioredClassifier, EncapsulatedClassifer):
+class Class(BehavioredClassifier, EncapsulatedClassifier):
     extension: property
     isActive: _attribute[int] = _attribute("isActive", int, default=False)
     nestedClassifier: relation_many[Classifier]
@@ -629,7 +629,7 @@ class FinalState(State):
 
 
 class Port(Property):
-    encapsulatedClassifier: relation_one[EncapsulatedClassifer]
+    encapsulatedClassifier: relation_one[EncapsulatedClassifier]
     isBehavior: _attribute[int] = _attribute("isBehavior", int)
     isService: _attribute[int] = _attribute("isService", int)
 
@@ -919,7 +919,7 @@ Classifier.attribute.add(StructuredClassifier.ownedAttribute)  # type: ignore[at
 Namespace.ownedMember.add(StructuredClassifier.ownedAttribute)  # type: ignore[attr-defined]
 Namespace.ownedMember.add(StructuredClassifier.ownedConnector)  # type: ignore[attr-defined]
 Classifier.feature.add(StructuredClassifier.ownedConnector)  # type: ignore[attr-defined]
-EncapsulatedClassifer.ownedPort = association("ownedPort", Port, composite=True, opposite="encapsulatedClassifier")
+EncapsulatedClassifier.ownedPort = association("ownedPort", Port, composite=True, opposite="encapsulatedClassifier")
 Class.ownedAttribute = association("ownedAttribute", Property, composite=True, opposite="class_")
 Class.ownedOperation = association("ownedOperation", Operation, composite=True, opposite="class_")
 # 32: override Class.extension(Extension.metaclass): property
@@ -1235,7 +1235,7 @@ Element.ownedElement.add(State.entry)  # type: ignore[attr-defined]
 Element.ownedElement.add(State.exit)  # type: ignore[attr-defined]
 Element.ownedElement.add(State.doActivity)  # type: ignore[attr-defined]
 Element.ownedElement.add(State.statevariant)  # type: ignore[attr-defined]
-Port.encapsulatedClassifier = association("encapsulatedClassifier", EncapsulatedClassifer, upper=1, opposite="ownedPort")
+Port.encapsulatedClassifier = association("encapsulatedClassifier", EncapsulatedClassifier, upper=1, opposite="ownedPort")
 RedefinableElement.redefinitionContext.add(Port.encapsulatedClassifier)  # type: ignore[attr-defined]
 Deployment.location = association("location", DeploymentTarget, upper=1, opposite="deployment")
 Deployment.deployedArtifact = association("deployedArtifact", DeployedArtifact)

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -906,20 +906,23 @@ DirectedRelationship.source.add(Generalization.specific)  # type: ignore[attr-de
 Element.owner.add(Generalization.specific)  # type: ignore[attr-defined]
 DirectedRelationship.target.add(Generalization.general)  # type: ignore[attr-defined]
 StructuredClassifier.role = derivedunion("role", ConnectableElement)
-StructuredClassifier.ownedAttribute = association("ownedAttribute", Property, composite=True)
 # 101: override StructuredClassifier.part: property
 StructuredClassifier.part = property(lambda self: tuple(a for a in self.ownedAttribute if a.isComposite), doc="""
     Properties owned by a classifier by composition.
 """)
 
 StructuredClassifier.ownedConnector = association("ownedConnector", Connector, composite=True, opposite="structuredClassifier")
+StructuredClassifier.ownedAttribute = association("ownedAttribute", Property, composite=True)
 Namespace.member.add(StructuredClassifier.role)  # type: ignore[attr-defined]
+Namespace.ownedMember.add(StructuredClassifier.ownedConnector)  # type: ignore[attr-defined]
+Classifier.feature.add(StructuredClassifier.ownedConnector)  # type: ignore[attr-defined]
 StructuredClassifier.role.add(StructuredClassifier.ownedAttribute)  # type: ignore[attr-defined]
 Classifier.attribute.add(StructuredClassifier.ownedAttribute)  # type: ignore[attr-defined]
 Namespace.ownedMember.add(StructuredClassifier.ownedAttribute)  # type: ignore[attr-defined]
-Namespace.ownedMember.add(StructuredClassifier.ownedConnector)  # type: ignore[attr-defined]
-Classifier.feature.add(StructuredClassifier.ownedConnector)  # type: ignore[attr-defined]
 EncapsulatedClassifier.ownedPort = association("ownedPort", Port, composite=True, opposite="encapsulatedClassifier")
+StructuredClassifier.role.add(EncapsulatedClassifier.ownedPort)  # type: ignore[attr-defined]
+Classifier.attribute.add(EncapsulatedClassifier.ownedPort)  # type: ignore[attr-defined]
+Namespace.ownedMember.add(EncapsulatedClassifier.ownedPort)  # type: ignore[attr-defined]
 Class.ownedAttribute = association("ownedAttribute", Property, composite=True, opposite="class_")
 Class.ownedOperation = association("ownedOperation", Operation, composite=True, opposite="class_")
 # 32: override Class.extension(Extension.metaclass): property
@@ -1236,7 +1239,7 @@ Element.ownedElement.add(State.exit)  # type: ignore[attr-defined]
 Element.ownedElement.add(State.doActivity)  # type: ignore[attr-defined]
 Element.ownedElement.add(State.statevariant)  # type: ignore[attr-defined]
 Port.encapsulatedClassifier = association("encapsulatedClassifier", EncapsulatedClassifier, upper=1, opposite="ownedPort")
-RedefinableElement.redefinitionContext.add(Port.encapsulatedClassifier)  # type: ignore[attr-defined]
+NamedElement.namespace.add(Port.encapsulatedClassifier)  # type: ignore[attr-defined]
 Deployment.location = association("location", DeploymentTarget, upper=1, opposite="deployment")
 Deployment.deployedArtifact = association("deployedArtifact", DeployedArtifact)
 Element.owner.add(Deployment.location)  # type: ignore[attr-defined]

--- a/gaphor/ui/icons/Makefile
+++ b/gaphor/ui/icons/Makefile
@@ -71,6 +71,7 @@ ICONS=diagram \
 	stereotype \
 	extension \
 	property \
+	item-flow \
 	requirement \
 	satisfy \
 	derive \

--- a/gaphor/ui/icons/hicolor/scalable/actions/gaphor-item-flow-symbolic.svg
+++ b/gaphor/ui/icons/hicolor/scalable/actions/gaphor-item-flow-symbolic.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="15.998601"
+   height="15.998601"
+   viewBox="0 0 4.2329631 4.2329633"
+   version="1.1"
+   id="svg4268"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4262" />
+  <metadata
+     id="metadata4265">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="item-flow"
+     transform="translate(-69.849827,-24.342015)">
+    <path
+       style="color:#000000;fill:#000000;stroke-linecap:round;-inkscape-stroke:none"
+       d="m 73.630859,24.419922 -3.703125,3.703125 a 0.26458335,0.26458335 0 0 0 0,0.375 0.26458335,0.26458335 0 0 0 0.373047,0 l 3.705078,-3.705078 a 0.26458335,0.26458335 0 0 0 0,-0.373047 0.26458335,0.26458335 0 0 0 -0.375,0 z"
+       id="path1749" />
+    <g
+       id="path1817">
+      <path
+         style="color:#000000;fill:#000000;stroke-width:0.529167;stroke-linejoin:round;-inkscape-stroke:none"
+         d="m 71.437499,25.929166 h 1.058333 V 26.9875 Z"
+         id="path1968" />
+      <path
+         style="color:#000000;fill:#000000;stroke-linejoin:round;-inkscape-stroke:none"
+         d="M 71.4375,25.664062 A 0.26460981,0.26460981 0 0 0 71.25,26.117187 l 1.058594,1.056641 a 0.26460981,0.26460981 0 0 0 0.451172,-0.185547 v -1.058594 a 0.26460981,0.26460981 0 0 0 -0.263672,-0.265625 z m 0.638672,0.529297 h 0.154297 v 0.154297 z"
+         id="path1970" />
+    </g>
+  </g>
+</svg>

--- a/gaphor/ui/icons/stensil.svg
+++ b/gaphor/ui/icons/stensil.svg
@@ -59,11 +59,11 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="15.566408"
-     inkscape:cx="173.2577"
-     inkscape:cy="196.32018"
+     inkscape:zoom="11.313708"
+     inkscape:cx="274.53421"
+     inkscape:cy="82.024387"
      inkscape:document-units="px"
-     inkscape:current-layer="magnet"
+     inkscape:current-layer="item-flow"
      showgrid="true"
      units="px"
      inkscape:window-width="1920"
@@ -2608,6 +2608,26 @@
        style="color:#000000;fill:#000000;-inkscape-stroke:none"
        d="m 38.179687,-4.2324219 v 3.1738282 h 0.369141 v -3.1738282 z"
        id="path1046-6" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="item-flow"
+     inkscape:label="item-flow">
+    <path
+       style="color:#000000;fill:#000000;stroke-linecap:round;-inkscape-stroke:none"
+       d="m 73.630859,24.419922 -3.703125,3.703125 a 0.26458335,0.26458335 0 0 0 0,0.375 0.26458335,0.26458335 0 0 0 0.373047,0 l 3.705078,-3.705078 a 0.26458335,0.26458335 0 0 0 0,-0.373047 0.26458335,0.26458335 0 0 0 -0.375,0 z"
+       id="path1749" />
+    <g
+       id="path1817">
+      <path
+         style="color:#000000;fill:#000000;stroke-width:0.529167;stroke-linejoin:round;-inkscape-stroke:none"
+         d="m 71.437499,25.929166 h 1.058333 V 26.9875 Z"
+         id="path1968" />
+      <path
+         style="color:#000000;fill:#000000;stroke-linejoin:round;-inkscape-stroke:none"
+         d="M 71.4375,25.664062 A 0.26460981,0.26460981 0 0 0 71.25,26.117187 l 1.058594,1.056641 a 0.26460981,0.26460981 0 0 0 0.451172,-0.185547 v -1.058594 a 0.26460981,0.26460981 0 0 0 -0.263672,-0.265625 z m 0.638672,0.529297 h 0.154297 v 0.154297 z"
+         id="path1970" />
+    </g>
   </g>
   <g
      inkscape:groupmode="layer"

--- a/models/SysML.gaphor
+++ b/models/SysML.gaphor
@@ -305,6 +305,7 @@
 <ref refid="cc3943a6-4bc2-11ec-8e7f-0456e5e540ed"/>
 <ref refid="91156aa4-5921-11ec-befa-0456e5e540ed"/>
 <ref refid="996a85fe-5921-11ec-befa-0456e5e540ed"/>
+<ref refid="5a9cebd2-633a-11ec-ad85-0456e5e540ed"/>
 </reflist>
 </ownedType>
 <package>
@@ -1961,6 +1962,7 @@
 <ref refid="30de57e4-4bc1-11ec-8e7f-0456e5e540ed"/>
 <ref refid="b6fe160c-4bc1-11ec-8e7f-0456e5e540ed"/>
 <ref refid="c358adb2-4bc2-11ec-8e7f-0456e5e540ed"/>
+<ref refid="5a9d9b5e-633a-11ec-ad85-0456e5e540ed"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -1974,6 +1976,7 @@
 <ref refid="8237c456-210f-11ea-ab0b-c72c0738acd2"/>
 <ref refid="019476b0-2357-11ea-ab0b-c72c0738acd2"/>
 <ref refid="2c1dab98-85ce-11ea-9e67-15eb92d7f2b9"/>
+<ref refid="54929b88-633a-11ec-ad85-0456e5e540ed"/>
 </reflist>
 </presentation>
 </Class>
@@ -10578,6 +10581,12 @@
 <name>
 <val>subsets</val>
 </name>
+<slot>
+<reflist>
+<ref refid="d5720734-633a-11ec-ad85-0456e5e540ed"/>
+<ref refid="ea91bbfa-633a-11ec-ad85-0456e5e540ed"/>
+</reflist>
+</slot>
 <typeValue>
 <val>str</val>
 </typeValue>
@@ -12110,7 +12119,9 @@ diagram {
 <reflist>
 <ref refid="888205fa-5921-11ec-befa-0456e5e540ed"/>
 <ref refid="91157b2a-5921-11ec-befa-0456e5e540ed"/>
+<ref refid="54929b88-633a-11ec-ad85-0456e5e540ed"/>
 <ref refid="98958548-5921-11ec-befa-0456e5e540ed"/>
+<ref refid="5a9d1986-633a-11ec-ad85-0456e5e540ed"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
@@ -12162,7 +12173,7 @@ diagram {
 <ownedAttribute>
 <reflist>
 <ref refid="996aa85e-5921-11ec-befa-0456e5e540ed"/>
-<ref refid="e6c1cfc4-5921-11ec-befa-0456e5e540ed"/>
+<ref refid="5a9dacc0-633a-11ec-ad85-0456e5e540ed"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -12261,7 +12272,111 @@ diagram {
 <ref refid="91156aa4-5921-11ec-befa-0456e5e540ed"/>
 </type>
 </ExtensionEnd>
-<Property id="e6c1cfc4-5921-11ec-befa-0456e5e540ed">
+<ClassItem id="54929b88-633a-11ec-ad85-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 271.0, 576.0)</val>
+</matrix>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>71.0</val>
+</height>
+<diagram>
+<ref refid="7a0704c6-5921-11ec-befa-0456e5e540ed"/>
+</diagram>
+<subject>
+<ref refid="1178a6b2-2101-11ea-ab0b-c72c0738acd2"/>
+</subject>
+</ClassItem>
+<Association id="5a9cebd2-633a-11ec-ad85-0456e5e540ed">
+<memberEnd>
+<reflist>
+<ref refid="5a9d9b5e-633a-11ec-ad85-0456e5e540ed"/>
+<ref refid="5a9dacc0-633a-11ec-ad85-0456e5e540ed"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="5e99006a-20e1-11ea-9209-e76c3117c943"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="5a9d1986-633a-11ec-ad85-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Association>
+<AssociationItem id="5a9d1986-633a-11ec-ad85-0456e5e540ed">
+<diagram>
+<ref refid="7a0704c6-5921-11ec-befa-0456e5e540ed"/>
+</diagram>
+<head_subject>
+<ref refid="5a9d9b5e-633a-11ec-ad85-0456e5e540ed"/>
+</head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="5a9cebd2-633a-11ec-ad85-0456e5e540ed"/>
+</subject>
+<tail_subject>
+<ref refid="5a9dacc0-633a-11ec-ad85-0456e5e540ed"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 319.0, 436.0)</val>
+</matrix>
+<points>
+<val>[(2.0, 20.0), (2.0, 140.0)]</val>
+</points>
+<head-connection>
+<ref refid="91157b2a-5921-11ec-befa-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="54929b88-633a-11ec-ad85-0456e5e540ed"/>
+</tail-connection>
+</AssociationItem>
+<Property id="5a9d9b5e-633a-11ec-ad85-0456e5e540ed">
+<appliedStereotype>
+<reflist>
+<ref refid="7f0d0fec-633a-11ec-ad85-0456e5e540ed"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="5a9cebd2-633a-11ec-ad85-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="1178a6b2-2101-11ea-ab0b-c72c0738acd2"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>itemFlow</val>
+</name>
+<type>
+<ref refid="91156aa4-5921-11ec-befa-0456e5e540ed"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<Property id="5a9dacc0-633a-11ec-ad85-0456e5e540ed">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<appliedStereotype>
+<reflist>
+<ref refid="e31c7a9a-633a-11ec-ad85-0456e5e540ed"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="5a9cebd2-633a-11ec-ad85-0456e5e540ed"/>
+</association>
 <class_>
 <ref refid="91156aa4-5921-11ec-befa-0456e5e540ed"/>
 </class_>
@@ -12274,9 +12389,9 @@ diagram {
 <name>
 <val>itemProperty</val>
 </name>
-<typeValue>
-<val>Property</val>
-</typeValue>
+<type>
+<ref refid="1178a6b2-2101-11ea-ab0b-c72c0738acd2"/>
+</type>
 <upperValue>
 <val>1</val>
 </upperValue>
@@ -12284,4 +12399,60 @@ diagram {
 <val>1</val>
 </upperValue>
 </Property>
+<InstanceSpecification id="7f0d0fec-633a-11ec-ad85-0456e5e540ed">
+<classifier>
+<reflist>
+<ref refid="03bf0cd4-2357-11ea-ab0b-c72c0738acd2"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="5a9d9b5e-633a-11ec-ad85-0456e5e540ed"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="d5720734-633a-11ec-ad85-0456e5e540ed"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="d5720734-633a-11ec-ad85-0456e5e540ed">
+<definingFeature>
+<ref refid="5b050d0c-2359-11ea-ab0b-c72c0738acd2"/>
+</definingFeature>
+<owningInstance>
+<ref refid="7f0d0fec-633a-11ec-ad85-0456e5e540ed"/>
+</owningInstance>
+<value>
+<val>owner</val>
+</value>
+</Slot>
+<InstanceSpecification id="e31c7a9a-633a-11ec-ad85-0456e5e540ed">
+<classifier>
+<reflist>
+<ref refid="03bf0cd4-2357-11ea-ab0b-c72c0738acd2"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="5a9dacc0-633a-11ec-ad85-0456e5e540ed"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="ea91bbfa-633a-11ec-ad85-0456e5e540ed"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="ea91bbfa-633a-11ec-ad85-0456e5e540ed">
+<definingFeature>
+<ref refid="5b050d0c-2359-11ea-ab0b-c72c0738acd2"/>
+</definingFeature>
+<owningInstance>
+<ref refid="e31c7a9a-633a-11ec-ad85-0456e5e540ed"/>
+</owningInstance>
+<value>
+<val>ownedElement</val>
+</value>
+</Slot>
 </gaphor>

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -23459,7 +23459,7 @@ specially for Gaphor</val>
 <val>(1.0, 0.0, 0.0, 1.0, 1028.5, 1036.5185185185187)</val>
 </matrix>
 <points>
-<val>[(-2.0, 1.1368683772161603e-13), (-2.0, 91.0)]</val>
+<val>[(-2.0, 0.0), (-2.0, 91.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:A70E26A6-4695-11D7-B567-379CA7034986"/>
@@ -31170,9 +31170,9 @@ directly in a model.</val>
 <ownedAttribute>
 <reflist>
 <ref refid="DCE:D56902FA-5FD6-11D9-89DE-0050040A5923"/>
-<ref refid="DCE:0CA69B9C-3509-11DA-8668-000D936B094A"/>
 <ref refid="DCE:10D3F714-3509-11DA-8668-000D936B094A"/>
 <ref refid="DCE:03A91174-5FD7-11D9-89DE-0050040A5923"/>
+<ref refid="DCE:0CA69B9C-3509-11DA-8668-000D936B094A"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -44326,7 +44326,7 @@ swimlanes</val>
 <ref refid="179563ca-fa90-11de-bd51-00224128e79d"/>
 </owningInstance>
 <value>
-<val>redefinitionContext</val>
+<val>classifier, namespace</val>
 </value>
 </Slot>
 <InstanceSpecification id="17960afa-fa90-11de-bd51-00224128e79d">
@@ -44354,7 +44354,7 @@ swimlanes</val>
 <ref refid="17960afa-fa90-11de-bd51-00224128e79d"/>
 </owningInstance>
 <value>
-<val>ownedAttribute</val>
+<val>role, attribute, ownedMember</val>
 </value>
 </Slot>
 <InstanceSpecification id="1796bae0-fa90-11de-bd51-00224128e79d">

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -35720,7 +35720,7 @@ directly in a model.</val>
 </reflist>
 </generalization>
 <name>
-<val>EncapsulatedClassifer</val>
+<val>EncapsulatedClassifier</val>
 </name>
 <ownedAttribute>
 <reflist>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Connector and itemProperty end up in the root of the model.

Issue Number: #841

### What is the new behavior?

* The SysML model has been adjusted to make itemProperty an owned property of ItemFlow
* Connector has been changed to be owned by the owner of the property it's connecting to
* ProxyPort is now properly owned by a classifier

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

To make the lookup for "owner" work from the SysML model, I had to make a tweak to the coder to recurse multiple models if needed.
