### PR TITLE
Fix AppImage GLIBC Error on Older Distro Versions

### DIFF
--- a/.github/workflows/appimage-docker.yml
+++ b/.github/workflows/appimage-docker.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: AppImage Docker Image Build and Push
 on:
   schedule:
     - cron: '15 1 * * 1' # Weekly at 01:15 UTC
@@ -36,5 +36,5 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           python -m pip install poethepoet
-          poe docker-build
-          poe docker-push
+          poe appimage-docker-build
+          poe appimage-docker-push

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - 'docker/**'
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  python_version: '3.10'
+  registry: ghcr.io
 
 jobs:
   build-and-push-image:
@@ -21,10 +21,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2.3.1
+        with:
+          python-version: ${{ env.python_version }}
+      - name: Lint with Pre-commit
+        uses: pre-commit/action@v2.0.3
       - name: Log in to the Container registry
         uses: docker/login-action@v1.12.0
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Poetry

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -25,21 +25,16 @@ jobs:
         uses: actions/setup-python@v2.3.1
         with:
           python-version: ${{ env.python_version }}
-      - name: Lint with Pre-commit
-        uses: pre-commit/action@v2.0.3
       - name: Log in to the Container registry
         uses: docker/login-action@v1.12.0
         with:
           registry: ${{ env.registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Poetry
-        run: pip install poetry==1.1.12
-      - name: Configure Poetry
-        run: poetry config virtualenvs.in-project true
-      - name: Install Build Dependencies
-        run: poetry install --no-dev --extras poethepoet
       - name: Build and Push
         run: |
-          poetry run poe docker-build
-          poetry run poe docker-push
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install poethepoet
+          poe docker-build
+          poe docker-push

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,39 @@
+name: Docker
+on:
+  schedule:
+    - cron: '15 1 * * 1' # Weekly at 01:15 UTC
+  push:
+    branches:
+      - 'docker/**'
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1.12.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Poetry
+        run: pip install poetry==1.1.12
+      - name: Configure Poetry
+        run: poetry config virtualenvs.in-project true
+      - name: Install Build Dependencies
+        run: poetry install --no-dev --extras poethepoet
+      - name: Build and Push
+        run: |
+          poetry run poe docker-build
+          poetry run poe docker-push

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,66 +1,24 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [master]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
-  schedule:
-    - cron: '0 10 * * 1'
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['python']
-        # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2.4.0
       with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
         fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
     - run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
-
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
+        languages: python
     - name: Autobuild
       uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -30,6 +30,9 @@ jobs:
   linux:
     needs: lint
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: /home/runner
     container:
       image: ghcr.io/gaphor/gaphor-appimage
     timeout-minutes: 30

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -48,12 +48,6 @@ jobs:
         uses: ./.github/actions/setup_and_test
         with:
           xvfb_command: 'xvfb-run'
-      - name: Upload Code Coverage to Code Climate
-        uses: paambaati/codeclimate-action@v3.0.0
-        env:
-          CC_TEST_REPORTER_ID: 05f6288b94a87daa172d3e96a33ec331a4374be7d01eb9a42b3b21c4c550a8ff
-        with:
-          coverageCommand: poetry run coverage xml
       - name: Install Build Dependencies
         run: poetry install --no-dev --extras poethepoet
       - name: Create Source Dist and Wheel

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -38,12 +38,6 @@ jobs:
       - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Install Linux Dependencies
-        uses: ./.github/actions/linux_dependencies
-      - name: Set up Python
-        uses: actions/setup-python@v2.3.1
-        with:
-          python-version: ${{ env.python_version }}
       - name: Use Python Dependency Cache
         uses: actions/cache@v2.1.7
         with:

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -30,6 +30,8 @@ jobs:
   linux:
     needs: lint
     runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/gaphor/gaphor-appimage
     timeout-minutes: 30
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
@@ -46,7 +48,7 @@ jobs:
         uses: actions/cache@v2.1.7
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-20.04
+          key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-container
       - name: Install Dependencies and Test
         id: setup_and_test
         uses: ./.github/actions/setup_and_test

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -85,7 +85,7 @@ jobs:
   macos:
     needs: lint
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     env:
       LDFLAGS: -L/usr/local/opt/python@3.10/lib

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -30,9 +30,6 @@ jobs:
   linux:
     needs: lint
     runs-on: ubuntu-20.04
-    defaults:
-      run:
-        working-directory: /home/runner
     container:
       image: ghcr.io/gaphor/gaphor-appimage
     timeout-minutes: 30

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -6,8 +6,7 @@ ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     PY_VERSION="3.10" \
     FONTCONFIG_VERSION="2.13.1" \
-    DEBIAN_FRONTEND=noninteractive \
-    USER=runner
+    DEBIAN_FRONTEND=noninteractive
 
 # Enable source lists for build-dep
 RUN sed -i -- 's/#deb-src/deb-src/g' /etc/apt/sources.list && \
@@ -100,12 +99,11 @@ RUN dpkg -i *.deb \
 `# Make Deadsnakes Python the default python3` \
  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$PY_VERSION 1
 
-RUN useradd -m -u 1000 $USER
-USER $USER
-ENV CHECKOUT=/home/$USER/jhbuild/checkout \
-    LD_LIBRARY_PATH="/home/$USER/jhbuild/install/lib" \
-    PKG_CONFIG_PATH="/home/$USER/jhbuild/install/lib/pkgconfig" \
-    PATH="/home/$USER/jhbuild/install/bin:/home/$USER/.local/bin:$PATH"
+ENV CHECKOUT=/root/jhbuild/checkout \
+    LD_LIBRARY_PATH="/root/jhbuild/install/lib" \
+    PKG_CONFIG_PATH="/root/jhbuild/install/lib/pkgconfig" \
+    PATH="/root/jhbuild/install/bin:/root/.local/bin:$PATH" \
+    JHBUILD_RUN_AS_ROOT=""
 
 # Install jhbuild
 RUN mkdir -p $CHECKOUT
@@ -115,10 +113,10 @@ WORKDIR $CHECKOUT/jhbuild
 RUN ./autogen.sh --simple-install \
  && make \
  && make install
-WORKDIR /home/$USER
+WORKDIR /
 
 # Configure jhbuild
-COPY --chown=$USER jhbuildrc /home/$USER/.config/jhbuildrc
+COPY jhbuildrc /root/.config/jhbuildrc
 
 # Build GTK, GtkSourceView, and gobject-introspection
-RUN jhbuild build \
+RUN jhbuild build

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     automake \
     autopoint \
     bison \
+    cargo  \
     desktop-file-utils \
     doxygen \
     flex \
@@ -71,6 +72,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ragel \
     shared-mime-info \
     trang \
+    valac \
     xmlto \
     yelp-tools \
 `# Dependency missed by jhbuild sysdeps` \
@@ -89,8 +91,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && apt-get build-dep -y fontconfig \
  && apt-get install -y --no-install-recommends uuid-dev \
  && rm -rf /var/lib/apt/lists/*
- # && jq -r 'to_entries | .[] | .key + "=" + .value' /tmp/dependencies.json | xargs apt-get install -y --no-install-recommends \
- # && rm /tmp/dependencies.json \
 
 # Build updated fontconfig deb files
 RUN wget -q https://www.freedesktop.org/software/fontconfig/release/fontconfig-$FONTCONFIG_VERSION.tar.gz \

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     flex \
     gettext \
     git \
+    libcanberra-gtk3-dev \
     libcups2-dev \
     libdbus-1-dev \
     libegl1-mesa-dev \

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -116,6 +116,10 @@ RUN apt-file update
 # Cleanup
 RUN rm -rf /var/lib/apt/lists/*
 
+# Make Python 3.10 the default python3
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
+
+
 ENV USER gnome
 RUN useradd -m -u 1000 $USER
 
@@ -139,8 +143,13 @@ ENV PATH "/home/$USER/.local/bin:$PATH"
 # Configure jhbuild
 run mkdir -p /home/$USER/.config
 RUN echo "modules = ['gtk+-3', 'gtksourceview-4', 'gobject-introspection']" >> /home/$USER/.config/jhbuildrc
-RUN echo "module_mesonargs['gtksourceview-4'] = '-D vapi=false'" >> /home/$USER/.config/jhbuildrc
+RUN echo "module_mesonargs['gtksourceview-4'] = '-Dvapi=false'" >> /home/$USER/.config/jhbuildrc
+RUN echo "module_mesonargs['gobject-introspection'] = '-Dcairo=enabled'" >> /home/$USER/.config/jhbuildrc
 
 # Build GTK, GtkSourceView, and gobject-introspection
 # RUN jhbuild build
+# 
+ENV LD_LIBRARY_PATH "/home/$USER/jhbuild/install/lib"
+ENV PKG_CONFIG_PATH "/home/$USER/jhbuild/install/lib/pkgconfig"
+ENV PATH "/home/$USER/jhbuild/install/bin:$PATH"
 

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:18.04 AS build
 LABEL maintainer="dan@yeaw.me"
 LABEL org.opencontainers.image.source=https://github.com/gaphor/gaphor
 
+# WORKDIR is not used to be compatible with GitHub Actions:
+# https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#workdir
+
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     PY_VERSION="3.10" \
@@ -9,8 +12,8 @@ ENV LANG=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive
 
 # Enable source lists for build-dep
-RUN sed -i -- 's/#deb-src/deb-src/g' /etc/apt/sources.list && \
-    sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list
+RUN sed -i -- 's/#deb-src/deb-src/g' /etc/apt/sources.list \
+ && sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list
 
 # Add repositories for Python deadsnakes and PowerShell
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -95,13 +98,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN wget -q https://www.freedesktop.org/software/fontconfig/release/fontconfig-$FONTCONFIG_VERSION.tar.gz \
  && apt-get update \
  && apt-get source fontconfig \
- && rm -rf /var/lib/apt/lists*
-WORKDIR /fontconfig-2.12.6
-RUN uupdate ../fontconfig-$FONTCONFIG_VERSION.tar.gz
-WORKDIR /fontconfig-$FONTCONFIG_VERSION
-RUN dpkg-buildpackage --unsigned-source --unsigned-changes --no-pre-clean
-WORKDIR /
-RUN dpkg -i *.deb \
+ && rm -rf /var/lib/apt/lists* \
+ && cd /fontconfig-2.12.6 \
+ && uupdate ../fontconfig-$FONTCONFIG_VERSION.tar.gz \
+ && cd /fontconfig-$FONTCONFIG_VERSION \
+ && dpkg-buildpackage --unsigned-source --unsigned-changes --no-pre-clean \
+ && cd / \
+ && dpkg -i *.deb \
  && rm *.deb \
  && rm -r /fontconfig-* \
 `# Make Deadsnakes Python the default python3` \
@@ -114,14 +117,13 @@ ENV CHECKOUT=/root/jhbuild/checkout \
     JHBUILD_RUN_AS_ROOT=""
 
 # Install jhbuild
-RUN mkdir -p $CHECKOUT
-WORKDIR $CHECKOUT
-RUN git clone --depth=1 https://gitlab.gnome.org/GNOME/jhbuild.git
-WORKDIR $CHECKOUT/jhbuild
-RUN ./autogen.sh --simple-install \
+RUN mkdir -p $CHECKOUT \
+ && cd $CHECKOUT \
+ && git clone --depth=1 https://gitlab.gnome.org/GNOME/jhbuild.git \
+ && cd $CHECKOUT/jhbuild \
+ && ./autogen.sh --simple-install \
  && make \
  && make install
-WORKDIR /
 
 # Configure jhbuild
 COPY jhbuildrc /root/.config/jhbuildrc

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -72,7 +72,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ragel \
     shared-mime-info \
     trang \
-    valac \
     xmlto \
     yelp-tools \
 `# Dependency missed by jhbuild sysdeps` \

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -7,19 +7,52 @@ ENV LC_ALL C.UTF-8
 ENV PYTHON_VERSION "3.10.1"
 ENV PYTHON_VERSION_SHORT "3.10"
 
+# Enable source lists for build-dep
 RUN sed -i -- 's/#deb-src/deb-src/g' /etc/apt/sources.list && \
     sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get build-dep -y \
+# Common dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    sudo \
+    vim \
+    wget
+# Python dependencies
+RUN apt-get install -y \
+    libbz2-dev \
+    libc6-dev \
+    libffi-dev \
+    libgdbm-dev \
+    libgdbm-compat-dev \
+    libncursesw5-dev \
+    libreadline-gplv2-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    tk-dev \
+    zlib1g-dev
+# Python deadsnakes
+RUN apt-get install -y \
+    software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y \
+    python3.10 \
+    python3.10-dev \
+    python3.10-venv \
+    python3.10-distutils
+# fontconfig dependencies
+RUN apt-get build-dep -y \
     fontconfig \
-  && apt install -y \
+    && apt-get install -y \
+    uuid-dev \
+    devscripts
+# jhbuild dependencies
+RUN apt-get install -y \
     apt-file \
     autoconf \
     automake \
     autopoint \
     bison \
-    build-essential \
     desktop-file-utils \
     doxygen \
     flex \
@@ -43,7 +76,6 @@ RUN apt-get update && apt-get build-dep -y \
     libxkbcommon-dev \
     libxkbcommon-x11-dev \
     libxml2-dev \
-    libxrandr-dev \
     libxrender-dev \
     libxslt1-dev \
     libxtst-dev \
@@ -60,39 +92,29 @@ RUN apt-get update && apt-get build-dep -y \
     python3-pytest \
     ragel \
     shared-mime-info \
-    sudo \
     trang \
-    uuid-dev \
-    vim \
-    wget \
     xmlto \
-    yelp-tools \
-  && rm -rf /var/lib/apt/lists/*
+    yelp-tools
+# Dependency missed by jhbuild sysdeps
+RUN apt-get install -y \
+    libxrandr-dev
+
+# Build updated fontconfig deb files
+RUN apt-get source fontconfig
+ENV FONTCONFIG_VERSION 2.13.1
+RUN wget -q https://www.freedesktop.org/software/fontconfig/release/fontconfig-$FONTCONFIG_VERSION.tar.gz
+WORKDIR fontconfig-2.12.6
+RUN uupdate ../fontconfig-$FONTCONFIG_VERSION.tar.gz
+WORKDIR /fontconfig-$FONTCONFIG_VERSION
+RUN dpkg-buildpackage -us -uc -nc
+WORKDIR /
+RUN dpkg -i *.deb
+
+# Build apt-file search index for jhbuild
 RUN apt-file update
 
-RUN mkdir -p /opt
-
-# Install Python
-# WORKDIR /opt
-# RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz
-# RUN tar xvf Python-$PYTHON_VERSION.tgz
-# WORKDIR /opt/Python-$PYTHON_VERSION
-# RUN ./configure --enable-optimizations
-# RUN make
-# RUN make altinstall
-# RUN update-alternatives --install /usr/bin/python python /usr/local/bin/python$PYTHON_VERSION_SHORT 1
-# RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python$PYTHON_VERSION_SHORT 1
-
-# Build Fontconfig
-WORKDIR /opt
-ENV FONTCONFIG_VERSION 2.13.1
-RUN wget https://www.freedesktop.org/software/fontconfig/release/fontconfig-$FONTCONFIG_VERSION.tar.gz
-RUN tar xzvf fontconfig-$FONTCONFIG_VERSION.tar.gz
-WORKDIR fontconfig-$FONTCONFIG_VERSION
-RUN ./configure
-RUN make
-RUN make install
-ENV PKG_CONFIG_PATH=/usr/local/lib:$PKG_CONFIG_PATH
+# Cleanup
+RUN rm -rf /var/lib/apt/lists/*
 
 ENV USER gnome
 RUN useradd -m -u 1000 $USER
@@ -101,15 +123,24 @@ RUN echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/nopasswd
 
 USER $USER
 
-run mkdir -p /home/$USER/.config
-RUN echo "modules = ['gtk+-3', 'gtksourceview-4', 'gobject-introspection']\n" > /home/$USER/.config/jhbuildrc
-
-ENV PATH "/home/$USER/.local/bin:$PATH"
-
-WORKDIR /home/$USER
+# Install jhbuild
+ENV CHECKOUT /home/$USER/jhbuild/checkout
+RUN mkdir -p $CHECKOUT
+WORKDIR $CHECKOUT
 RUN git clone --depth=1 https://gitlab.gnome.org/GNOME/jhbuild.git
-WORKDIR /home/$USER/jhbuild
+WORKDIR $CHECKOUT/jhbuild
 RUN ./autogen.sh --simple-install
 RUN make
 RUN make install
+WORKDIR /home/$USER
+
+ENV PATH "/home/$USER/.local/bin:$PATH"
+
+# Configure jhbuild
+run mkdir -p /home/$USER/.config
+RUN echo "modules = ['gtk+-3', 'gtksourceview-4', 'gobject-introspection']" >> /home/$USER/.config/jhbuildrc
+RUN echo "module_mesonargs['gtksourceview-4'] = '-D vapi=false'" >> /home/$USER/.config/jhbuildrc
+
+# Build GTK, GtkSourceView, and gobject-introspection
+# RUN jhbuild build
 

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -105,7 +105,7 @@ RUN wget -q https://www.freedesktop.org/software/fontconfig/release/fontconfig-$
  && dpkg-buildpackage --unsigned-source --unsigned-changes --no-pre-clean \
  && cd / \
  && dpkg -i *.deb \
- && rm *.deb \
+ && rm *.deb *.ddeb *.tar.xz *.tar.bz2 *.dsc *.buildinfo *.changes \
  && rm -r /fontconfig-* \
 `# Make Deadsnakes Python the default python3` \
  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$PY_VERSION 1
@@ -129,4 +129,9 @@ RUN mkdir -p $CHECKOUT \
 COPY jhbuildrc /root/.config/jhbuildrc
 
 # Build GTK, GtkSourceView, and gobject-introspection
-RUN jhbuild build
+RUN jhbuild build \
+ && rm -r /root/jhbuild/checkout \
+ && rm -r /root/.local \
+ && rm -r /root/.config \
+ && rm -r /root/.cache
+

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -76,6 +76,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
     python$PY_VERSION-venv \
     python$PY_VERSION-distutils \
  && python$PY_VERSION -m ensurepip --upgrade \
+ && python$PY_VERSION -m pip install --upgrade pip \
 `# fontconfig dependencies` \
  && apt-get build-dep -y fontconfig \
  && apt-get install -y --no-install-recommends uuid-dev \
@@ -112,6 +113,7 @@ WORKDIR $CHECKOUT/jhbuild
 RUN ./autogen.sh --simple-install \
  && make \
  && make install
+WORKDIR /home/$USER
 
 # Configure jhbuild
 COPY --chown=$USER jhbuildrc /home/$USER/.config/jhbuildrc
@@ -125,4 +127,3 @@ RUN jhbuild build \
     requests \
     poetry \
  && poetry config virtualenvs.in-project true
-

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -1,0 +1,115 @@
+FROM ubuntu:18.04
+LABEL maintainer="dan@yeaw.me"
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV PYTHON_VERSION "3.10.1"
+ENV PYTHON_VERSION_SHORT "3.10"
+
+RUN sed -i -- 's/#deb-src/deb-src/g' /etc/apt/sources.list && \
+    sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get build-dep -y \
+    fontconfig \
+  && apt install -y \
+    apt-file \
+    autoconf \
+    automake \
+    autopoint \
+    bison \
+    build-essential \
+    desktop-file-utils \
+    doxygen \
+    flex \
+    gettext \
+    git \
+    libcups2-dev \
+    libdbus-1-dev \
+    libegl1-mesa-dev \
+    libffi-dev \
+    libgl1-mesa-dev \
+    libgraphviz-dev \
+    libicu-dev \
+    libjpeg-turbo8-dev \
+    libpcre3-dev \
+    libtool \
+    libx11-dev \
+    libxcursor-dev \
+    libxext-dev \
+    libxft-dev \
+    libxi-dev \
+    libxkbcommon-dev \
+    libxkbcommon-x11-dev \
+    libxml2-dev \
+    libxrandr-dev \
+    libxrender-dev \
+    libxslt1-dev \
+    libxtst-dev \
+    make \
+    ninja-build \
+    patch \
+    pkg-config \
+    python \
+    python-gi-dev \
+    python3 \
+    python3-dbus \
+    python3-dev \
+    python3-flake8 \
+    python3-pytest \
+    ragel \
+    shared-mime-info \
+    sudo \
+    trang \
+    uuid-dev \
+    vim \
+    wget \
+    xmlto \
+    yelp-tools \
+  && rm -rf /var/lib/apt/lists/*
+RUN apt-file update
+
+RUN mkdir -p /opt
+
+# Install Python
+# WORKDIR /opt
+# RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz
+# RUN tar xvf Python-$PYTHON_VERSION.tgz
+# WORKDIR /opt/Python-$PYTHON_VERSION
+# RUN ./configure --enable-optimizations
+# RUN make
+# RUN make altinstall
+# RUN update-alternatives --install /usr/bin/python python /usr/local/bin/python$PYTHON_VERSION_SHORT 1
+# RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python$PYTHON_VERSION_SHORT 1
+
+# Build Fontconfig
+WORKDIR /opt
+ENV FONTCONFIG_VERSION 2.13.1
+RUN wget https://www.freedesktop.org/software/fontconfig/release/fontconfig-$FONTCONFIG_VERSION.tar.gz
+RUN tar xzvf fontconfig-$FONTCONFIG_VERSION.tar.gz
+WORKDIR fontconfig-$FONTCONFIG_VERSION
+RUN ./configure
+RUN make
+RUN make install
+ENV PKG_CONFIG_PATH=/usr/local/lib:$PKG_CONFIG_PATH
+
+ENV USER gnome
+RUN useradd -m -u 1000 $USER
+
+RUN echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/nopasswd
+
+USER $USER
+
+run mkdir -p /home/$USER/.config
+RUN echo "modules = ['gtk+-3', 'gtksourceview-4', 'gobject-introspection']\n" > /home/$USER/.config/jhbuildrc
+
+ENV PATH "/home/$USER/.local/bin:$PATH"
+
+WORKDIR /home/$USER
+RUN git clone --depth=1 https://gitlab.gnome.org/GNOME/jhbuild.git
+WORKDIR /home/$USER/jhbuild
+RUN ./autogen.sh --simple-install
+RUN make
+RUN make install
+

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -1,54 +1,29 @@
 FROM ubuntu:18.04
 LABEL maintainer="dan@yeaw.me"
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-
-ENV PYTHON_VERSION "3.10.1"
-ENV PYTHON_VERSION_SHORT "3.10"
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PY_VERSION="3.10" \
+    FONTCONFIG_VERSION="2.13.1" \
+    DEBIAN_FRONTEND=noninteractive \
+    USER=runner \
+    CHECKOUT=/home/$USER/jhbuild/checkout \
+    LD_LIBRARY_PATH="/home/$USER/jhbuild/install/lib" \
+    PKG_CONFIG_PATH="/home/$USER/jhbuild/install/lib/pkgconfig" \
+    PATH="/home/$USER/jhbuild/install/bin:/home/$USER/.local/bin:$PATH"
 
 # Enable source lists for build-dep
 RUN sed -i -- 's/#deb-src/deb-src/g' /etc/apt/sources.list && \
     sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list
 
-ENV DEBIAN_FRONTEND=noninteractive
-# Common dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    sudo \
-    vim \
-    wget
-# Python dependencies
-RUN apt-get install -y \
-    libbz2-dev \
-    libc6-dev \
-    libffi-dev \
-    libgdbm-dev \
-    libgdbm-compat-dev \
-    libncursesw5-dev \
-    libreadline-gplv2-dev \
-    libsqlite3-dev \
-    libssl-dev \
-    tk-dev \
-    zlib1g-dev
 # Python deadsnakes
-RUN apt-get install -y \
-    software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update && apt-get install -y \
-    python3.10 \
-    python3.10-dev \
-    python3.10-venv \
-    python3.10-distutils
-# fontconfig dependencies
-RUN apt-get build-dep -y \
-    fontconfig \
-    && apt-get install -y \
-    uuid-dev \
-    devscripts
-# jhbuild dependencies
-RUN apt-get install -y \
-    apt-file \
+RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common \
+ && add-apt-repository ppa:deadsnakes/ppa \
+ && apt-get update && apt-get install -y --no-install-recommends \
+`# Common dependencies` \
+    build-essential \
+    wget \
+`# jhbuild dependencies` \
     autoconf \
     automake \
     autopoint \
@@ -94,62 +69,60 @@ RUN apt-get install -y \
     shared-mime-info \
     trang \
     xmlto \
-    yelp-tools
-# Dependency missed by jhbuild sysdeps
-RUN apt-get install -y \
-    libxrandr-dev
+    yelp-tools \
+`# Dependency missed by jhbuild sysdeps` \
+    libxrandr-dev \
+`# Dependency for building a deb package` \
+    devscripts \
+`# Python deadsnakes` \
+    python$PY_VERSION \
+    python$PY_VERSION-dev \
+    python$PY_VERSION-venv \
+    python$PY_VERSION-distutils \
+ && python$PY_VERSION -m ensurepip --upgrade \
+`# fontconfig dependencies` \
+ && apt-get build-dep -y fontconfig \
+ && apt-get install -y --no-install-recommends uuid-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 # Build updated fontconfig deb files
-RUN apt-get source fontconfig
-ENV FONTCONFIG_VERSION 2.13.1
-RUN wget -q https://www.freedesktop.org/software/fontconfig/release/fontconfig-$FONTCONFIG_VERSION.tar.gz
-WORKDIR fontconfig-2.12.6
+RUN wget -q https://www.freedesktop.org/software/fontconfig/release/fontconfig-$FONTCONFIG_VERSION.tar.gz \
+ && apt-get update \
+ && apt-get source fontconfig \
+ && rm -rf /var/lib/apt/lists*
+WORKDIR /fontconfig-2.12.6
 RUN uupdate ../fontconfig-$FONTCONFIG_VERSION.tar.gz
 WORKDIR /fontconfig-$FONTCONFIG_VERSION
-RUN dpkg-buildpackage -us -uc -nc
+RUN dpkg-buildpackage --unsigned-source --unsigned-changes --no-pre-clean
 WORKDIR /
-RUN dpkg -i *.deb
+RUN dpkg -i *.deb \
+ && rm *.deb \
+ && rm -r /fontconfig-* \
+`# Make Deadsnakes Python the default python3` \
+ && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$PY_VERSION 1
 
-# Build apt-file search index for jhbuild
-RUN apt-file update
-
-# Cleanup
-RUN rm -rf /var/lib/apt/lists/*
-
-# Make Python 3.10 the default python3
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
-
-
-ENV USER gnome
 RUN useradd -m -u 1000 $USER
-
-RUN echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/nopasswd
-
 USER $USER
 
 # Install jhbuild
-ENV CHECKOUT /home/$USER/jhbuild/checkout
 RUN mkdir -p $CHECKOUT
 WORKDIR $CHECKOUT
 RUN git clone --depth=1 https://gitlab.gnome.org/GNOME/jhbuild.git
 WORKDIR $CHECKOUT/jhbuild
-RUN ./autogen.sh --simple-install
-RUN make
-RUN make install
-WORKDIR /home/$USER
-
-ENV PATH "/home/$USER/.local/bin:$PATH"
+RUN ./autogen.sh --simple-install \
+ && make \
+ && make install
 
 # Configure jhbuild
-run mkdir -p /home/$USER/.config
-RUN echo "modules = ['gtk+-3', 'gtksourceview-4', 'gobject-introspection']" >> /home/$USER/.config/jhbuildrc
-RUN echo "module_mesonargs['gtksourceview-4'] = '-Dvapi=false'" >> /home/$USER/.config/jhbuildrc
-RUN echo "module_mesonargs['gobject-introspection'] = '-Dcairo=enabled'" >> /home/$USER/.config/jhbuildrc
+COPY --chown=$USER jhbuildrc /home/$USER/.config/jhbuildrc
 
 # Build GTK, GtkSourceView, and gobject-introspection
-# RUN jhbuild build
-# 
-ENV LD_LIBRARY_PATH "/home/$USER/jhbuild/install/lib"
-ENV PKG_CONFIG_PATH "/home/$USER/jhbuild/install/lib/pkgconfig"
-ENV PATH "/home/$USER/jhbuild/install/bin:$PATH"
+RUN jhbuild build \
+`# Setup poetry` \
+ && python$PY_VERSION -m pip install --user --upgrade \
+    pip \
+    urllib3 \
+    requests \
+    poetry \
+ && poetry config virtualenvs.in-project true
 

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.04 AS build
 LABEL maintainer="dan@yeaw.me"
 
 ENV LANG=C.UTF-8 \
@@ -6,11 +6,7 @@ ENV LANG=C.UTF-8 \
     PY_VERSION="3.10" \
     FONTCONFIG_VERSION="2.13.1" \
     DEBIAN_FRONTEND=noninteractive \
-    USER=runner \
-    CHECKOUT=/home/$USER/jhbuild/checkout \
-    LD_LIBRARY_PATH="/home/$USER/jhbuild/install/lib" \
-    PKG_CONFIG_PATH="/home/$USER/jhbuild/install/lib/pkgconfig" \
-    PATH="/home/$USER/jhbuild/install/bin:/home/$USER/.local/bin:$PATH"
+    USER=runner
 
 # Enable source lists for build-dep
 RUN sed -i -- 's/#deb-src/deb-src/g' /etc/apt/sources.list && \
@@ -103,6 +99,10 @@ RUN dpkg -i *.deb \
 
 RUN useradd -m -u 1000 $USER
 USER $USER
+ENV CHECKOUT=/home/$USER/jhbuild/checkout \
+    LD_LIBRARY_PATH="/home/$USER/jhbuild/install/lib" \
+    PKG_CONFIG_PATH="/home/$USER/jhbuild/install/lib/pkgconfig" \
+    PATH="/home/$USER/jhbuild/install/bin:/home/$USER/.local/bin:$PATH"
 
 # Install jhbuild
 RUN mkdir -p $CHECKOUT

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -12,13 +12,20 @@ ENV LANG=C.UTF-8 \
 RUN sed -i -- 's/#deb-src/deb-src/g' /etc/apt/sources.list && \
     sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list
 
-# Python deadsnakes
-RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common \
+# Add repositories for Python deadsnakes and PowerShell
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    software-properties-common \
+    wget \
  && add-apt-repository ppa:deadsnakes/ppa \
+ && wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb \
+ && dpkg -i packages-microsoft-prod.deb \
  && apt-get update && apt-get install -y --no-install-recommends \
 `# Common dependencies` \
     build-essential \
-    wget \
+`# GitHub Actions dependencies` \
+    xvfb \
+    powershell \
 `# jhbuild dependencies` \
     autoconf \
     automake \
@@ -82,6 +89,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
  && apt-get build-dep -y fontconfig \
  && apt-get install -y --no-install-recommends uuid-dev \
  && rm -rf /var/lib/apt/lists/*
+ # && jq -r 'to_entries | .[] | .key + "=" + .value' /tmp/dependencies.json | xargs apt-get install -y --no-install-recommends \
+ # && rm /tmp/dependencies.json \
 
 # Build updated fontconfig deb files
 RUN wget -q https://www.freedesktop.org/software/fontconfig/release/fontconfig-$FONTCONFIG_VERSION.tar.gz \

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -78,6 +78,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
     python$PY_VERSION-distutils \
  && python$PY_VERSION -m ensurepip --upgrade \
  && python$PY_VERSION -m pip install --upgrade pip \
+ && python$PY_VERSION -m pip install --upgrade requests urllib3 \
 `# fontconfig dependencies` \
  && apt-get build-dep -y fontconfig \
  && apt-get install -y --no-install-recommends uuid-dev \
@@ -121,10 +122,3 @@ COPY --chown=$USER jhbuildrc /home/$USER/.config/jhbuildrc
 
 # Build GTK, GtkSourceView, and gobject-introspection
 RUN jhbuild build \
-`# Setup poetry` \
- && python$PY_VERSION -m pip install --user --upgrade \
-    pip \
-    urllib3 \
-    requests \
-    poetry \
- && poetry config virtualenvs.in-project true

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:18.04 AS build
 LABEL maintainer="dan@yeaw.me"
+LABEL org.opencontainers.image.source=https://github.com/gaphor/gaphor
 
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \

--- a/_packaging/appimage/jhbuildrc
+++ b/_packaging/appimage/jhbuildrc
@@ -1,6 +1,13 @@
-modules = ['pycairo', 'pygobject', 'gtk+-3', 'gtksourceview-4', 'gobject-introspection']
+modules = [
+    'pycairo',
+    'pygobject',
+    'gtk+-3',
+    'gtksourceview-4',
+    'gobject-introspection',
+    'adwaita-icon-theme',
+    'hicolor-icon-theme'
+]
 module_mesonargs['gtksourceview-4'] = '-Dvapi=false'
 module_mesonargs['gobject-introspection'] = '-Dcairo=enabled'
 mesonargs = '--buildtype=release'
 autogenargs = '--disable-static --disable-gtk-doc'
-

--- a/_packaging/appimage/jhbuildrc
+++ b/_packaging/appimage/jhbuildrc
@@ -7,7 +7,13 @@ modules = [
     'adwaita-icon-theme',
     'hicolor-icon-theme'
 ]
+
+# Disable Vala API
 module_mesonargs['gtksourceview-4'] = '-Dvapi=false'
+
 module_mesonargs['gobject-introspection'] = '-Dcairo=enabled'
+
+# Minimize and optimize what is downloaded and built
 mesonargs = '--buildtype=release'
 autogenargs = '--disable-static --disable-gtk-doc'
+shallow_clone = True

--- a/_packaging/appimage/jhbuildrc
+++ b/_packaging/appimage/jhbuildrc
@@ -5,7 +5,8 @@ modules = [
     'gtksourceview-4',
     'gobject-introspection',
     'adwaita-icon-theme',
-    'hicolor-icon-theme'
+    'hicolor-icon-theme',
+    'libcanberra-gtk3'
 ]
 
 # Disable Vala

--- a/_packaging/appimage/jhbuildrc
+++ b/_packaging/appimage/jhbuildrc
@@ -1,0 +1,6 @@
+modules = ['pycairo', 'pygobject', 'gtk+-3', 'gtksourceview-4', 'gobject-introspection']
+module_mesonargs['gtksourceview-4'] = '-Dvapi=false'
+module_mesonargs['gobject-introspection'] = '-Dcairo=enabled'
+mesonargs = '--buildtype=release'
+autogenargs = '--disable-static --disable-gtk-doc'
+

--- a/_packaging/appimage/jhbuildrc
+++ b/_packaging/appimage/jhbuildrc
@@ -8,12 +8,13 @@ modules = [
     'hicolor-icon-theme'
 ]
 
-# Disable Vala API
+# Disable Vala
+skip = ['vala']
 module_mesonargs['gtksourceview-4'] = '-Dvapi=false'
+module_autogenargs['librsvg'] = '--enable-vala=no'
 
 module_mesonargs['gobject-introspection'] = '-Dcairo=enabled'
 
 # Minimize and optimize what is downloaded and built
 mesonargs = '--buildtype=release'
-autogenargs = '--disable-static --disable-gtk-doc'
 shallow_clone = True

--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -37,6 +37,10 @@ a = Analysis(
             "../gaphor/ui/icons/hicolor/scalable/apps/*.svg",
             "gaphor/ui/icons/hicolor/scalable/apps",
         ),
+        (
+            "../gaphor/ui/icons/hicolor/scalable/emblems/*.svg",
+            "gaphor/ui/icons/hicolor/scalable/emblems",
+        ),
         ("../LICENSE.txt", "gaphor"),
         ("../gaphor/locale/*", "gaphor/locale"),
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,9 @@ version-file = { "script" = "_packaging.make-script:make_file_version_info" }
 pyinstall = { "script" = "_packaging.make-script:make_pyinstaller" }
 package = ["install-pyinstall", "gaphor-script", "version-file", "pyinstall"]
 win-installer = { "script" = "_packaging.windows.build-win-installer:main" }
+docker-build = "docker build -t ghcr.io/gaphor/gaphor-appimage _packaging/appimage"
+docker-push = "docker push ghcr.io/gaphor/gaphor-appimage:latest"
+docker-run = "docker run --rm -it --volume $PWD:/home/runner/gaphor ghcr.io/gaphor/gaphor-appimage"
 gettext-pot = "pybabel extract -o po/gaphor.pot -F po/babel.ini gaphor"
 gettext-po = { "script" = "po.build-babel:update_po_files" }
 gettext-mo = { "script" = "po.build-babel:compile_mo_files" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ package = ["install-pyinstall", "gaphor-script", "version-file", "pyinstall"]
 win-installer = { "script" = "_packaging.windows.build-win-installer:main" }
 docker-build = "docker build -t ghcr.io/gaphor/gaphor-appimage _packaging/appimage"
 docker-push = "docker push ghcr.io/gaphor/gaphor-appimage:latest"
-docker-run = "docker run --rm -it --volume $PWD:/home/runner/gaphor ghcr.io/gaphor/gaphor-appimage"
+docker-run = "docker run --rm -it --volume $PWD:/gaphor ghcr.io/gaphor/gaphor-appimage"
 gettext-pot = "pybabel extract -o po/gaphor.pot -F po/babel.ini gaphor"
 gettext-po = { "script" = "po.build-babel:update_po_files" }
 gettext-mo = { "script" = "po.build-babel:compile_mo_files" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,9 +122,9 @@ version-file = { "script" = "_packaging.make-script:make_file_version_info" }
 pyinstall = { "script" = "_packaging.make-script:make_pyinstaller" }
 package = ["install-pyinstall", "gaphor-script", "version-file", "pyinstall"]
 win-installer = { "script" = "_packaging.windows.build-win-installer:main" }
-docker-build = "docker build -t ghcr.io/gaphor/gaphor-appimage _packaging/appimage"
-docker-push = "docker push ghcr.io/gaphor/gaphor-appimage:latest"
-docker-run = "docker run --rm -it --volume $PWD:/gaphor ghcr.io/gaphor/gaphor-appimage"
+appimage-docker-build = "docker build -t ghcr.io/gaphor/gaphor-appimage _packaging/appimage"
+appimage-docker-push = "docker push ghcr.io/gaphor/gaphor-appimage:latest"
+appimage-docker-run = "docker run --rm -it --volume $PWD:/gaphor ghcr.io/gaphor/gaphor-appimage"
 gettext-pot = "pybabel extract -o po/gaphor.pot -F po/babel.ini gaphor"
 gettext-po = { "script" = "po.build-babel:update_po_files" }
 gettext-mo = { "script" = "po.build-babel:compile_mo_files" }


### PR DESCRIPTION
This PR uses Docker and [jhbuild](https://gitlab.gnome.org/GNOME/jhbuild) to build GTK and then package Gaphor in an AppImage on Ubuntu-18.04 bionic. I propose that we try to support the [oldest LTS version](https://ubuntu.com/about/release-cycle) that is still getting hardware and security updates, not ones in extended security maintenance.

- [X] Get GTK, GtkSource, and GI building on Ubuntu-18.04
- [x] pycairo and PyGObject successfully build wheels and install
- [x] Update GitHub Actions to use the docker image

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
The Gaphor AppImage runs on distros with GLIBC >= 2.31 like Ubuntu-20.04.

Issue Number: #1023 

### What is the new behavior?
The Gaphor AppImage runs on distros with GLIBC >= 2.29

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
