### PR TITLE
Update to latest gvsbuild, switch to wingtk repo

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -179,9 +179,9 @@ jobs:
     timeout-minutes: 45
     env:
       # Git revision of gvsbuild we use for to build GTK and the other dependencies
-      gvsbuildref: ce4c9de92dc3487d15b8f5ecc200705f951b6ae8
+      gvsbuildref: b62737ea717bd717b1111934d4904eda0e6eea5a
       # Bump this number if you want to force a rebuild of gvsbuild with the same revision
-      gvsbuildupdate: 2
+      gvsbuildupdate: 1
     outputs:
       cachekey: ${{ steps.output.outputs.cachekey }}
     steps:
@@ -197,7 +197,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v2.4.0
         with:
-          repository: gaphor/gvsbuild
+          repository: wingtk/gvsbuild
           ref: ${{ env.gvsbuildref }}
           path: gvsbuild
       - name: Set up Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,9 +118,9 @@ jobs:
     timeout-minutes: 45
     env:
       # Git revision of gvsbuild we use for to build GTK and the other dependencies
-      gvsbuildref: ce4c9de92dc3487d15b8f5ecc200705f951b6ae8
+      gvsbuildref: b62737ea717bd717b1111934d4904eda0e6eea5a
       # Bump this number if you want to force a rebuild of gvsbuild with the same revision
-      gvsbuildupdate: 2
+      gvsbuildupdate: 1
     outputs:
       cachekey: ${{ steps.output.outputs.cachekey }}
     steps:
@@ -136,7 +136,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v2.4.0
         with:
-          repository: gaphor/gvsbuild
+          repository: wingtk/gvsbuild
           ref: ${{ env.gvsbuildref }}
           path: gvsbuild
       - name: Set up Python

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -60,16 +60,13 @@ Download and install the latest version of Python:
 1. Restart your PowerShell terminal as a normal user and check that `python --version` is correct.
 
 #### Install gvsbuild
-We have forked gvsbuild for now because gaphor has slightly newer dependency
-requirements than the upstream project. If we can get our changes upstream,
-then we'll switch back to using that version directly.
 
 Open a new regular user PowerShell terminal and execute:
 
 ```PowerShell
 mkdir C:\gtk-build\github
 cd C:\gtk-build\github
-git clone https://github.com/gaphor/gvsbuild.git
+git clone https://github.com/wingtk/gvsbuild.git
 
 ```
 


### PR DESCRIPTION
This PR updates to the latest gvsbuild which includes updates to harfbuzz, librsvg, and openssl. It also switches to using the official wingtk repo instead of a separate fork, since I am have the commit bit now and both repositories are identical now.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No