### PR TITLE
Fix FileNotFoundError when running packaged app

### DIFF
--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -43,6 +43,7 @@ a = Analysis(
         ),
         ("../LICENSE.txt", "gaphor"),
         ("../gaphor/locale/*", "gaphor/locale"),
+        ("../gaphor/templates/*.gaphor", "gaphor/templates"),
     ]
     + glade_files
     + ui_files


### PR DESCRIPTION
The gaphor template files weren't included in the packaged apps using PyInstaller. This PR adds the files as extra data to be packaged.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Launch gaphor from a new template using Windows, macOS, or AppImage:
```
Traceback (most recent call last):
  File "gaphor/ui/greeter.py", line 146, in _on_template_activated
  File "gaphor/babel.py", line 43, in translate_model
  File "xml/etree/ElementTree.py", line 1229, in parse
  File "xml/etree/ElementTree.py", line 569, in parse
FileNotFoundError: [Errno 2] No such file or directory: '/home/dan/Projects/gaphor/_packaging/dist/gaphor/gaphor/templates/c4model.gaphor'
Traceback (most recent call last):
  File "gaphor/ui/greeter.py", line 146, in _on_template_activated
  File "gaphor/babel.py", line 43, in translate_model
  File "xml/etree/ElementTree.py", line 1229, in parse
  File "xml/etree/ElementTree.py", line 569, in parse
FileNotFoundError: [Errno 2] No such file or directory: '/home/dan/Projects/gaphor/_packaging/dist/gaphor/gaphor/templates/c4model.gaphor'
```

Issue Number: N/A

### What is the new behavior?
No errors. :+1: 

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
