### PR TITLE
Fork node loading

### DIFF
--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -6,6 +6,7 @@ import math
 from gaphas.constraint import constraint
 from gaphas.geometry import Rectangle, distance_line_point
 from gaphas.item import Handle, LinePort
+from gaphas.matrix import Matrix
 from gaphas.util import path_ellipse
 
 from gaphor import UML
@@ -256,8 +257,10 @@ class ForkNodeItem(Presentation[UML.ForkNode], HandlePositionUpdate, Named):
         return self._ports
 
     def save(self, save_func):
-        save_func("matrix", tuple(self.matrix))
-        save_func("height", float(self._handles[1].pos.y))
+        m = Matrix(*self.matrix)
+        m.translate(0, self._handles[0].pos.y)
+        save_func("matrix", tuple(m))
+        save_func("height", float(self._handles[1].pos.y - self._handles[0].pos.y))
         super().save(save_func)
 
     def load(self, name, value):

--- a/gaphor/UML/actions/tests/test_flow.py
+++ b/gaphor/UML/actions/tests/test_flow.py
@@ -6,44 +6,46 @@ from gaphor.core.modeling.diagram import FALLBACK_STYLE
 from gaphor.UML.actions.flow import FlowItem
 
 
-class TestFlow:
-    def test_flow(self, case):
-        case.create(FlowItem, UML.ControlFlow)
+def test_flow(case):
+    case.create(FlowItem, UML.ControlFlow)
 
-    def test_name(self, case):
-        """Test updating of flow name text."""
-        flow = case.create(FlowItem, UML.ControlFlow)
-        name = flow.shape_tail.children[1]
 
-        flow.subject.name = "Blah"
+def test_name(case):
+    """Test updating of flow name text."""
+    flow = case.create(FlowItem, UML.ControlFlow)
+    name = flow.shape_tail.children[1]
 
-        assert "Blah" == name.text()
+    flow.subject.name = "Blah"
 
-        flow.subject = None
+    assert "Blah" == name.text()
 
-        assert "" == name.text()
+    flow.subject = None
 
-    def test_guard_text_update(self, case):
-        flow = case.create(FlowItem, UML.ControlFlow)
-        guard = flow.shape_middle
+    assert "" == name.text()
 
-        assert "" == guard.text()
 
-        flow.subject.guard = "GuardMe"
-        assert "[GuardMe]" == guard.text()
+def test_guard_text_update(case):
+    flow = case.create(FlowItem, UML.ControlFlow)
+    guard = flow.shape_middle
 
-        flow.subject = None
-        assert "" == guard.text()
+    assert "" == guard.text()
 
-    def test_draw(self, case):
-        flow = case.create(FlowItem, UML.ControlFlow)
-        context = DrawContext(
-            cairo=instant_cairo_context(),
-            style=FALLBACK_STYLE,
-            hovered=True,
-            focused=True,
-            selected=True,
-            dropzone=False,
-        )
-        case.diagram.update_now((flow,))
-        flow.draw(context)
+    flow.subject.guard = "GuardMe"
+    assert "[GuardMe]" == guard.text()
+
+    flow.subject = None
+    assert "" == guard.text()
+
+
+def test_draw(case):
+    flow = case.create(FlowItem, UML.ControlFlow)
+    context = DrawContext(
+        cairo=instant_cairo_context(),
+        style=FALLBACK_STYLE,
+        hovered=True,
+        focused=True,
+        selected=True,
+        dropzone=False,
+    )
+    case.diagram.update_now((flow,))
+    flow.draw(context)

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -16,258 +16,258 @@ from gaphor.UML.actions.flow import FlowItem
 from gaphor.UML.actions.objectnode import ObjectNodeItem
 
 
-class TestFlowItemBasicNodesConnection:
-    """Tests for flow item connecting to basic activity nodes."""
+def test_initial_node_glue(case):
+    """Test flow item gluing to initial node item."""
 
-    def test_initial_node_glue(self, case):
-        """Test flow item gluing to initial node item."""
+    flow = case.create(FlowItem)
+    node = case.create(InitialNodeItem, UML.InitialNode)
 
-        flow = case.create(FlowItem)
-        node = case.create(InitialNodeItem, UML.InitialNode)
+    # tail may not connect to initial node item
+    allowed = case.allow(flow, flow.tail, node)
+    assert not allowed
 
-        # tail may not connect to initial node item
-        allowed = case.allow(flow, flow.tail, node)
-        assert not allowed
-
-        allowed = case.allow(flow, flow.head, node)
-        assert allowed
-
-    def test_flow_final_node_glue(self, case):
-        """Test flow item gluing to flow final node item."""
-
-        flow = case.create(FlowItem)
-        node = case.create(FlowFinalNodeItem, UML.FlowFinalNode)
-
-        # head may not connect to flow final node item
-        allowed = case.allow(flow, flow.head, node)
-        assert not allowed
-
-        allowed = case.allow(flow, flow.tail, node)
-        assert allowed
-
-    def test_activity_final_node_glue(self, case):
-        """Test flow item gluing to activity final node item."""
-        flow = case.create(FlowItem)
-        node = case.create(ActivityFinalNodeItem, UML.ActivityFinalNode)
-
-        # head may not connect to activity final node item
-        glued = case.allow(flow, flow.head, node)
-        assert not glued
-
-        glued = case.allow(flow, flow.tail, node)
-        assert glued
+    allowed = case.allow(flow, flow.head, node)
+    assert allowed
 
 
-class TestFlowItemObjectNode:
-    """Flow item connecting to object node item tests."""
+def test_flow_final_node_glue(case):
+    """Test flow item gluing to flow final node item."""
 
-    def test_glue_to_object_node(self, case):
-        flow = case.create(FlowItem)
-        onode = case.create(ObjectNodeItem, UML.ObjectNode)
-        glued = case.allow(flow, flow.head, onode)
-        assert glued
+    flow = case.create(FlowItem)
+    node = case.create(FlowFinalNodeItem, UML.FlowFinalNode)
 
-    def test_connect_to_object_node(self, case):
-        flow = case.create(FlowItem)
-        anode = case.create(ActionItem, UML.Action)
-        onode = case.create(ObjectNodeItem, UML.ObjectNode)
+    # head may not connect to flow final node item
+    allowed = case.allow(flow, flow.head, node)
+    assert not allowed
 
-        case.connect(flow, flow.head, anode)
-        case.connect(flow, flow.tail, onode)
-        assert flow.subject
-        assert isinstance(flow.subject, UML.ObjectFlow)
-
-        case.disconnect(flow, flow.head)
-        case.disconnect(flow, flow.tail)
-
-        # opposite connection
-        case.connect(flow, flow.head, onode)
-        case.connect(flow, flow.tail, anode)
-        assert flow.subject
-        assert isinstance(flow.subject, UML.ObjectFlow)
-
-    def test_object_flow_reconnect(self, case):
-        flow = case.create(FlowItem)
-        a1 = case.create(ActionItem, UML.Action)
-        o1 = case.create(ObjectNodeItem, UML.ObjectNode)
-        o2 = case.create(ObjectNodeItem, UML.ObjectNode)
-
-        # connect: a1 -> o1
-        case.connect(flow, flow.head, a1)
-        case.connect(flow, flow.tail, o1)
-
-        f = flow.subject
-        f.name = "tname"
-        f.guard = "tguard"
-
-        # reconnect: a1 -> o2
-        case.connect(flow, flow.tail, o2)
-
-        assert len(a1.subject.incoming) == 0
-        assert len(a1.subject.outgoing) == 1
-        # no connections to o1
-        assert len(o1.subject.incoming) == 0
-        assert len(o1.subject.outgoing) == 0
-        # connections to o2 instead
-        assert len(o2.subject.incoming) == 1
-        assert len(o2.subject.outgoing) == 0
-
-        assert len(case.kindof(UML.ObjectFlow)) == 1
-        # one guard
-        assert flow.subject.name == "tname"
-        assert flow.subject.guard == "tguard"
-
-    def test_control_flow_reconnection(self, case):
-        """Test control flow becoming object flow due to reconnection."""
-        flow = case.create(FlowItem)
-        a1 = case.create(ActionItem, UML.Action)
-        a2 = case.create(ActionItem, UML.Action)
-        o1 = case.create(ObjectNodeItem, UML.ObjectNode)
-
-        # connect with control flow: a1 -> a2
-        case.connect(flow, flow.head, a1)
-        case.connect(flow, flow.tail, a2)
-
-        f = flow.subject
-        f.name = "tname"
-        f.guard = "tguard"
-
-        # reconnect with object flow: a1 -> o1
-        case.connect(flow, flow.tail, o1)
-
-        assert len(a1.subject.incoming) == 0
-        assert len(a1.subject.outgoing) == 1
-        # no connections to a2
-        assert len(a2.subject.incoming) == 0
-        assert len(a2.subject.outgoing) == 0
-        # connections to o1 instead
-        assert len(o1.subject.incoming) == 1
-        assert len(o1.subject.outgoing) == 0
-
-        assert len(case.kindof(UML.ControlFlow)) == 0
-        assert len(case.kindof(UML.ObjectFlow)) == 1
-        # one guard, not changed
-        assert flow.subject.name == "tname"
-        assert flow.subject.guard == "tguard"
+    allowed = case.allow(flow, flow.tail, node)
+    assert allowed
 
 
-class TestFlowItemAction:
-    """Flow item connecting to action item tests."""
+def test_activity_final_node_glue(case):
+    """Test flow item gluing to activity final node item."""
+    flow = case.create(FlowItem)
+    node = case.create(ActivityFinalNodeItem, UML.ActivityFinalNode)
 
-    def test_glue(self, case):
-        """Test flow item gluing to action items."""
+    # head may not connect to activity final node item
+    glued = case.allow(flow, flow.head, node)
+    assert not glued
 
-        flow = case.create(FlowItem)
-        a1 = case.create(ActionItem, UML.Action)
-        a2 = case.create(ActionItem, UML.Action)
+    glued = case.allow(flow, flow.tail, node)
+    assert glued
 
-        glued = case.allow(flow, flow.head, a1)
-        assert glued
 
-        case.connect(flow, flow.head, a1)
+def test_glue_to_object_node(case):
+    flow = case.create(FlowItem)
+    onode = case.create(ObjectNodeItem, UML.ObjectNode)
+    glued = case.allow(flow, flow.head, onode)
+    assert glued
 
-        glued = case.allow(flow, flow.tail, a2)
-        assert glued
 
-    def test_connect_to_action_item(self, case):
-        flow = case.create(FlowItem)
-        a1 = case.create(ActionItem, UML.Action)
-        a2 = case.create(ActionItem, UML.Action)
+def test_connect_to_object_node(case):
+    flow = case.create(FlowItem)
+    anode = case.create(ActionItem, UML.Action)
+    onode = case.create(ObjectNodeItem, UML.ObjectNode)
 
-        case.connect(flow, flow.head, a1)
-        case.connect(flow, flow.tail, a2)
+    case.connect(flow, flow.head, anode)
+    case.connect(flow, flow.tail, onode)
+    assert flow.subject
+    assert isinstance(flow.subject, UML.ObjectFlow)
 
-        assert isinstance(flow.subject, UML.ControlFlow)
+    case.disconnect(flow, flow.head)
+    case.disconnect(flow, flow.tail)
 
-        assert len(a1.subject.incoming) == 0
-        assert len(a2.subject.incoming) == 1
-        assert len(a1.subject.outgoing) == 1
-        assert len(a2.subject.outgoing) == 0
+    # opposite connection
+    case.connect(flow, flow.head, onode)
+    case.connect(flow, flow.tail, anode)
+    assert flow.subject
+    assert isinstance(flow.subject, UML.ObjectFlow)
 
-        assert flow.subject in a1.subject.outgoing
-        assert flow.subject.source is a1.subject
-        assert flow.subject in a2.subject.incoming
-        assert flow.subject.target is a2.subject
 
-    def test_disconnect_from_action_item(self, case):
-        """Test flow item disconnection from action items."""
-        flow = case.create(FlowItem)
-        a1 = case.create(ActionItem, UML.Action)
-        a2 = case.create(ActionItem, UML.Action)
+def test_object_flow_reconnect(case):
+    flow = case.create(FlowItem)
+    a1 = case.create(ActionItem, UML.Action)
+    o1 = case.create(ObjectNodeItem, UML.ObjectNode)
+    o2 = case.create(ObjectNodeItem, UML.ObjectNode)
 
-        case.connect(flow, flow.head, a1)
-        case.connect(flow, flow.tail, a2)
+    # connect: a1 -> o1
+    case.connect(flow, flow.head, a1)
+    case.connect(flow, flow.tail, o1)
 
-        case.disconnect(flow, flow.head)
-        assert flow.subject is None
-        assert len(a1.subject.incoming) == 0
-        assert len(a2.subject.incoming) == 0
-        assert len(a1.subject.outgoing) == 0
-        assert len(a2.subject.outgoing) == 0
+    f = flow.subject
+    f.name = "tname"
+    f.guard = "tguard"
 
-    def test_reconnect(self, case):
-        """Test flow item reconnection."""
-        flow = case.create(FlowItem)
-        a1 = case.create(ActionItem, UML.Action)
-        a2 = case.create(ActionItem, UML.Action)
-        a3 = case.create(ActionItem, UML.Action)
+    # reconnect: a1 -> o2
+    case.connect(flow, flow.tail, o2)
 
-        # a1 -> a2
-        case.connect(flow, flow.head, a1)
-        case.connect(flow, flow.tail, a2)
-        f = flow.subject
-        f.name = "tname"
-        f.guard = "tguard"
+    assert len(a1.subject.incoming) == 0
+    assert len(a1.subject.outgoing) == 1
+    # no connections to o1
+    assert len(o1.subject.incoming) == 0
+    assert len(o1.subject.outgoing) == 0
+    # connections to o2 instead
+    assert len(o2.subject.incoming) == 1
+    assert len(o2.subject.outgoing) == 0
 
-        # reconnect: a1 -> a3
-        case.connect(flow, flow.tail, a3)
+    assert len(case.kindof(UML.ObjectFlow)) == 1
+    # one guard
+    assert flow.subject.name == "tname"
+    assert flow.subject.guard == "tguard"
 
-        assert len(a1.subject.incoming) == 0
-        assert len(a1.subject.outgoing) == 1
-        # no connections to a2
-        assert len(a2.subject.incoming) == 0
-        assert len(a2.subject.outgoing) == 0
-        # connections to a3 instead
-        assert len(a3.subject.incoming) == 1
-        assert len(a3.subject.outgoing) == 0
 
-        assert len(case.kindof(UML.ControlFlow)) == 1
-        # one guard
-        assert flow.subject.name == "tname"
-        assert flow.subject.guard == "tguard"
+def test_control_flow_reconnection(case):
+    """Test control flow becoming object flow due to reconnection."""
+    flow = case.create(FlowItem)
+    a1 = case.create(ActionItem, UML.Action)
+    a2 = case.create(ActionItem, UML.Action)
+    o1 = case.create(ObjectNodeItem, UML.ObjectNode)
 
-    def test_object_flow_reconnection(self, case):
-        """Test object flow becoming control flow due to reconnection."""
-        flow = case.create(FlowItem)
-        a1 = case.create(ActionItem, UML.Action)
-        a2 = case.create(ActionItem, UML.Action)
-        o1 = case.create(ObjectNodeItem, UML.ObjectNode)
+    # connect with control flow: a1 -> a2
+    case.connect(flow, flow.head, a1)
+    case.connect(flow, flow.tail, a2)
 
-        # connect with control flow: a1 -> o1
-        case.connect(flow, flow.head, a1)
-        case.connect(flow, flow.tail, o1)
+    f = flow.subject
+    f.name = "tname"
+    f.guard = "tguard"
 
-        f = flow.subject
-        f.name = "tname"
-        f.guard = "tguard"
+    # reconnect with object flow: a1 -> o1
+    case.connect(flow, flow.tail, o1)
 
-        # reconnect with object flow: a1 -> a2
-        case.connect(flow, flow.tail, a2)
+    assert len(a1.subject.incoming) == 0
+    assert len(a1.subject.outgoing) == 1
+    # no connections to a2
+    assert len(a2.subject.incoming) == 0
+    assert len(a2.subject.outgoing) == 0
+    # connections to o1 instead
+    assert len(o1.subject.incoming) == 1
+    assert len(o1.subject.outgoing) == 0
 
-        assert len(a1.subject.incoming) == 0
-        assert len(a1.subject.outgoing) == 1
-        # no connections to o1
-        assert len(o1.subject.incoming) == 0
-        assert len(o1.subject.outgoing) == 0
-        # connections to a2 instead
-        assert len(a2.subject.incoming) == 1
-        assert len(a2.subject.outgoing) == 0
+    assert len(case.kindof(UML.ControlFlow)) == 0
+    assert len(case.kindof(UML.ObjectFlow)) == 1
+    # one guard, not changed
+    assert flow.subject.name == "tname"
+    assert flow.subject.guard == "tguard"
 
-        assert len(case.kindof(UML.ControlFlow)) == 1
-        assert len(case.kindof(UML.ObjectFlow)) == 0
-        # one guard, not changed
-        assert flow.subject.name == "tname"
-        assert flow.subject.guard == "tguard"
+
+def test_glue(case):
+    """Test flow item gluing to action items."""
+
+    flow = case.create(FlowItem)
+    a1 = case.create(ActionItem, UML.Action)
+    a2 = case.create(ActionItem, UML.Action)
+
+    glued = case.allow(flow, flow.head, a1)
+    assert glued
+
+    case.connect(flow, flow.head, a1)
+
+    glued = case.allow(flow, flow.tail, a2)
+    assert glued
+
+
+def test_connect_to_action_item(case):
+    flow = case.create(FlowItem)
+    a1 = case.create(ActionItem, UML.Action)
+    a2 = case.create(ActionItem, UML.Action)
+
+    case.connect(flow, flow.head, a1)
+    case.connect(flow, flow.tail, a2)
+
+    assert isinstance(flow.subject, UML.ControlFlow)
+
+    assert len(a1.subject.incoming) == 0
+    assert len(a2.subject.incoming) == 1
+    assert len(a1.subject.outgoing) == 1
+    assert len(a2.subject.outgoing) == 0
+
+    assert flow.subject in a1.subject.outgoing
+    assert flow.subject.source is a1.subject
+    assert flow.subject in a2.subject.incoming
+    assert flow.subject.target is a2.subject
+
+
+def test_disconnect_from_action_item(case):
+    """Test flow item disconnection from action items."""
+    flow = case.create(FlowItem)
+    a1 = case.create(ActionItem, UML.Action)
+    a2 = case.create(ActionItem, UML.Action)
+
+    case.connect(flow, flow.head, a1)
+    case.connect(flow, flow.tail, a2)
+
+    case.disconnect(flow, flow.head)
+    assert flow.subject is None
+    assert len(a1.subject.incoming) == 0
+    assert len(a2.subject.incoming) == 0
+    assert len(a1.subject.outgoing) == 0
+    assert len(a2.subject.outgoing) == 0
+
+
+def test_reconnect(case):
+    """Test flow item reconnection."""
+    flow = case.create(FlowItem)
+    a1 = case.create(ActionItem, UML.Action)
+    a2 = case.create(ActionItem, UML.Action)
+    a3 = case.create(ActionItem, UML.Action)
+
+    # a1 -> a2
+    case.connect(flow, flow.head, a1)
+    case.connect(flow, flow.tail, a2)
+    f = flow.subject
+    f.name = "tname"
+    f.guard = "tguard"
+
+    # reconnect: a1 -> a3
+    case.connect(flow, flow.tail, a3)
+
+    assert len(a1.subject.incoming) == 0
+    assert len(a1.subject.outgoing) == 1
+    # no connections to a2
+    assert len(a2.subject.incoming) == 0
+    assert len(a2.subject.outgoing) == 0
+    # connections to a3 instead
+    assert len(a3.subject.incoming) == 1
+    assert len(a3.subject.outgoing) == 0
+
+    assert len(case.kindof(UML.ControlFlow)) == 1
+    # one guard
+    assert flow.subject.name == "tname"
+    assert flow.subject.guard == "tguard"
+
+
+def test_object_flow_reconnection(case):
+    """Test object flow becoming control flow due to reconnection."""
+    flow = case.create(FlowItem)
+    a1 = case.create(ActionItem, UML.Action)
+    a2 = case.create(ActionItem, UML.Action)
+    o1 = case.create(ObjectNodeItem, UML.ObjectNode)
+
+    # connect with control flow: a1 -> o1
+    case.connect(flow, flow.head, a1)
+    case.connect(flow, flow.tail, o1)
+
+    f = flow.subject
+    f.name = "tname"
+    f.guard = "tguard"
+
+    # reconnect with object flow: a1 -> a2
+    case.connect(flow, flow.tail, a2)
+
+    assert len(a1.subject.incoming) == 0
+    assert len(a1.subject.outgoing) == 1
+    # no connections to o1
+    assert len(o1.subject.incoming) == 0
+    assert len(o1.subject.outgoing) == 0
+    # connections to a2 instead
+    assert len(a2.subject.incoming) == 1
+    assert len(a2.subject.outgoing) == 0
+
+    assert len(case.kindof(UML.ControlFlow)) == 1
+    assert len(case.kindof(UML.ObjectFlow)) == 0
+    # one guard, not changed
+    assert flow.subject.name == "tname"
+    assert flow.subject.guard == "tguard"
 
 
 class FlowItemDecisionAndForkNodes:

--- a/gaphor/UML/actions/tests/test_forknode.py
+++ b/gaphor/UML/actions/tests/test_forknode.py
@@ -1,0 +1,49 @@
+import pytest
+
+from gaphor.UML.actions.activitynodes import ForkNodeItem
+
+
+class Saver:
+    def __call__(self, name, val):
+        setattr(self, name, val)
+
+
+@pytest.fixture
+def saver():
+    return Saver()
+
+
+def test_forknode_save_default_height(diagram, saver):
+    fork: ForkNodeItem = diagram.create(ForkNodeItem)
+    diagram.update_now({fork})
+
+    fork.save(saver)
+
+    assert saver.height == 30
+    assert saver.matrix[5] == 0
+
+
+def test_forknode_save_height_0(diagram, saver):
+    fork: ForkNodeItem = diagram.create(ForkNodeItem)
+
+    fork.handles()[0].pos.y = -100
+    fork.handles()[1].pos.y = 0
+    diagram.update_now({fork})
+
+    fork.save(saver)
+
+    assert saver.height == 100
+    assert saver.matrix[5] == -100
+
+
+def test_forknode_save_height_1(diagram, saver):
+    fork: ForkNodeItem = diagram.create(ForkNodeItem)
+
+    fork.handles()[0].pos.y = 0
+    fork.handles()[1].pos.y = 100
+    diagram.update_now({fork})
+
+    fork.save(saver)
+
+    assert saver.height == 100
+    assert saver.matrix[5] == 0

--- a/gaphor/UML/actions/tests/test_grouping.py
+++ b/gaphor/UML/actions/tests/test_grouping.py
@@ -4,67 +4,69 @@ from gaphor import UML
 from gaphor.UML.actions import ActionItem, PartitionItem
 
 
-class TestPartitionGroup:
-    def test_no_subpartition_when_nodes_in(self, case):
-        """Test adding subpartition when nodes added."""
-        p = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
-        a1 = case.create(ActionItem, UML.Action)
-        p1 = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
-        p2 = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
+def test_no_subpartition_when_nodes_in(case):
+    """Test adding subpartition when nodes added."""
+    p = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
+    a1 = case.create(ActionItem, UML.Action)
+    p1 = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
+    p2 = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
 
-        case.group(p, p1)
-        case.group(p1, a1)
-        assert not case.can_group(p1, p2)
+    case.group(p, p1)
+    case.group(p1, a1)
+    assert not case.can_group(p1, p2)
 
-    def test_action_grouping(self, case):
-        """Test adding action to partition."""
-        p1 = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
-        p2 = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
-        a1 = case.create(ActionItem, UML.Action)
-        a2 = case.create(ActionItem, UML.Action)
 
-        assert case.can_group(p1, a1)
-        case.group(p1, a1)
-        assert len(p1.subject.node) == 1
+def test_action_grouping(case):
+    """Test adding action to partition."""
+    p1 = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
+    p2 = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
+    a1 = case.create(ActionItem, UML.Action)
+    a2 = case.create(ActionItem, UML.Action)
 
-        case.group(p1, p2)
-        case.group(p2, a1)
+    assert case.can_group(p1, a1)
+    case.group(p1, a1)
+    assert len(p1.subject.node) == 1
 
-        assert case.can_group(p2, a1)
-        assert len(p2.subject.node) == 1
-        case.group(p2, a2)
-        assert len(p2.subject.node) == 2
+    case.group(p1, p2)
+    case.group(p2, a1)
 
-    def test_ungrouping(self, case):
-        """Test action and partition removal."""
-        p = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
-        a1 = case.create(ActionItem, UML.Action)
-        a2 = case.create(ActionItem, UML.Action)
+    assert case.can_group(p2, a1)
+    assert len(p2.subject.node) == 1
+    case.group(p2, a2)
+    assert len(p2.subject.node) == 2
 
-        case.group(p, a1)
-        case.group(p, a2)
 
-        case.ungroup(p, a1)
-        assert len(p.subject.node) == 1
-        case.ungroup(p, a2)
-        assert len(p.subject.node) == 0
+def test_ungrouping(case):
+    """Test action and partition removal."""
+    p = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
+    a1 = case.create(ActionItem, UML.Action)
+    a2 = case.create(ActionItem, UML.Action)
 
-    def test_ungrouping_with_actions(self, case):
-        """Test partition with actions removal."""
-        p = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
-        a1 = case.create(ActionItem, UML.Action)
-        a2 = case.create(ActionItem, UML.Action)
+    case.group(p, a1)
+    case.group(p, a2)
 
-        case.group(p, a1)
-        case.group(p, a2)
+    case.ungroup(p, a1)
+    assert len(p.subject.node) == 1
+    case.ungroup(p, a2)
+    assert len(p.subject.node) == 0
 
-        partition = p.subject
-        assert len(partition.node) == 2, partition.node
-        assert len(p.children) == 2, p.children
 
-        case.ungroup(p, a1)
-        case.ungroup(p, a2)
+def test_ungrouping_with_actions(case):
+    """Test partition with actions removal."""
+    p = case.create(PartitionItem, subject_cls=UML.ActivityPartition)
+    a1 = case.create(ActionItem, UML.Action)
+    a2 = case.create(ActionItem, UML.Action)
 
-        assert 0 == len(partition.node)
-        assert len(p.children) == 0
-        assert len(partition.node) == 0
+    case.group(p, a1)
+    case.group(p, a2)
+
+    partition = p.subject
+    assert len(partition.node) == 2, partition.node
+    assert len(p.children) == 2, p.children
+
+    case.ungroup(p, a1)
+    case.ungroup(p, a2)
+
+    assert 0 == len(partition.node)
+    assert len(p.children) == 0
+    assert len(partition.node) == 0

--- a/gaphor/UML/actions/tests/test_objectnode.py
+++ b/gaphor/UML/actions/tests/test_objectnode.py
@@ -2,25 +2,26 @@ from gaphor import UML
 from gaphor.UML.actions.objectnode import ObjectNodeItem
 
 
-class TestObjectNode:
-    def test_object_node(self, case):
-        case.create(ObjectNodeItem, UML.ObjectNode)
+def test_object_node(case):
+    case.create(ObjectNodeItem, UML.ObjectNode)
 
-    def test_name(self, case):
-        """Test updating of object node name."""
-        node = case.create(ObjectNodeItem, UML.ObjectNode)
-        name = node.shape.icon.children[1]
 
-        node.subject.name = "Blah"
+def test_name(case):
+    """Test updating of object node name."""
+    node = case.create(ObjectNodeItem, UML.ObjectNode)
+    name = node.shape.icon.children[1]
 
-        assert "Blah" == name.text()
+    node.subject.name = "Blah"
 
-    def test_ordering(self, case):
-        """Test updating of ObjectNodeItem.ordering."""
-        node = case.create(ObjectNodeItem, UML.ObjectNode)
-        ordering = node.shape.children[1]
+    assert "Blah" == name.text()
 
-        node.subject.ordering = "unordered"
-        node.show_ordering = True
 
-        assert "{ ordering = unordered }" == ordering.text()
+def test_ordering(case):
+    """Test updating of ObjectNodeItem.ordering."""
+    node = case.create(ObjectNodeItem, UML.ObjectNode)
+    ordering = node.shape.children[1]
+
+    node.subject.ordering = "unordered"
+    node.show_ordering = True
+
+    assert "{ ordering = unordered }" == ordering.text()


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?


Issue Number: #1246

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

This is a regression: at some point during the Gaphas 3.0 migration, positions were no longer "normalized" (`handle[0]` was reset to `(0, 0)` and the item `matrix` was updated accordingly).

This fixes the regression, without breaking backwards compatibility. 
A nicer approach may be to implement it like [ExecutionSpecification](https://github.com/gaphor/gaphor/blob/master/gaphor/UML/interactions/executionspecification.py#L116).

NB. `ForkNodeItem` does not save the lines connected to itself.