### PR TITLE
Full Copy/Paste of model elements

### DIFF
--- a/gaphor/UML/actions/tests/test_partition.py
+++ b/gaphor/UML/actions/tests/test_partition.py
@@ -2,7 +2,7 @@ import pytest
 
 from gaphor import UML
 from gaphor.diagram.diagramtoolbox import new_item_factory
-from gaphor.diagram.tests.fixtures import copy_and_paste, copy_clear_and_paste
+from gaphor.diagram.tests.fixtures import copy_and_paste_link, copy_clear_and_paste_link
 from gaphor.UML.actions.actionstoolbox import partition_config
 from gaphor.UML.actions.partition import PartitionItem
 
@@ -28,7 +28,7 @@ def test_partition_placement_adds_two_partitions(partition_item: PartitionItem):
 
 
 def test_copy_and_paste_partition_item(partition_item, diagram, element_factory):
-    new_items = copy_and_paste({partition_item}, diagram, element_factory)
+    new_items = copy_and_paste_link({partition_item}, diagram, element_factory)
 
     (new_item,) = new_items
 
@@ -38,7 +38,7 @@ def test_copy_and_paste_partition_item(partition_item, diagram, element_factory)
 
 
 def test_copy_remove_and_paste_partition_item(partition_item, diagram, element_factory):
-    copy_clear_and_paste({partition_item}, diagram, element_factory)
+    copy_clear_and_paste_link({partition_item}, diagram, element_factory)
 
     new_item = diagram.ownedPresentation[0]
 

--- a/gaphor/UML/classes/tests/test_copypaste.py
+++ b/gaphor/UML/classes/tests/test_copypaste.py
@@ -2,7 +2,11 @@ import pytest
 
 from gaphor import UML
 from gaphor.core.format import format, parse
-from gaphor.diagram.tests.fixtures import connect, copy_and_paste, copy_clear_and_paste
+from gaphor.diagram.tests.fixtures import (
+    connect,
+    copy_and_paste_link,
+    copy_clear_and_paste_link,
+)
 from gaphor.UML.classes import (
     AssociationItem,
     ClassItem,
@@ -28,7 +32,7 @@ def test_class_with_attributes(diagram, element_factory, cls_type, item):
 
     cls_item = diagram.create(item, subject=cls)
 
-    new_items = copy_clear_and_paste({cls_item}, diagram, element_factory)
+    new_items = copy_clear_and_paste_link({cls_item}, diagram, element_factory)
     new_cls_item = new_items.pop()
 
     assert isinstance(new_cls_item, item)
@@ -51,7 +55,7 @@ def test_class_with_operation(diagram, element_factory, cls_type, item):
 
     cls_item = diagram.create(item, subject=cls)
 
-    new_items = copy_clear_and_paste({cls_item}, diagram, element_factory)
+    new_items = copy_clear_and_paste_link({cls_item}, diagram, element_factory)
     new_cls_item = new_items.pop()
 
     assert isinstance(new_cls_item, item)
@@ -69,7 +73,7 @@ def test_enumeration_with_literal(diagram, element_factory):
 
     enum_item = diagram.create(EnumerationItem, subject=enum)
 
-    new_items = copy_clear_and_paste({enum_item}, diagram, element_factory)
+    new_items = copy_clear_and_paste_link({enum_item}, diagram, element_factory)
     new_enum_item = new_items.pop()
 
     assert isinstance(new_enum_item, EnumerationItem)
@@ -89,7 +93,7 @@ def test_interface_with_attributes_and_operation(diagram, element_factory):
 
     iface_item = diagram.create(InterfaceItem, subject=iface)
 
-    new_items = copy_clear_and_paste({iface_item}, diagram, element_factory)
+    new_items = copy_clear_and_paste_link({iface_item}, diagram, element_factory)
     new_iface_item = new_items.pop()
 
     assert isinstance(new_iface_item, InterfaceItem)
@@ -134,7 +138,9 @@ def test_copy_paste_items_with_connections(diagram, element_factory):
 
     assoc = assoc_item.subject
 
-    copy_and_paste({gen_cls_item, assoc_item, spc_cls_item}, diagram, element_factory)
+    copy_and_paste_link(
+        {gen_cls_item, assoc_item, spc_cls_item}, diagram, element_factory
+    )
 
     new_assoc_item = assoc.presentation[1]
 
@@ -149,7 +155,7 @@ def test_copy_remove_paste_items_with_connections(diagram, element_factory):
         diagram, element_factory
     )
 
-    new_items = copy_clear_and_paste(
+    new_items = copy_clear_and_paste_link(
         {gen_cls_item, assoc_item, spc_cls_item}, diagram, element_factory
     )
     new_cls1 = next(

--- a/gaphor/UML/components/componentsgrouping.py
+++ b/gaphor/UML/components/componentsgrouping.py
@@ -25,26 +25,26 @@ class NodeComponentGroup(AbstractGroup):
         node = self.parent.subject
         component = self.item.subject
 
-        # node attribute
-        a1 = node.model.create(UML.Property)
-        a1.aggregation = "composite"
-        # component attribute
-        a2 = node.model.create(UML.Property)
+        # attributes
+        node_attr = node.model.create(UML.Property)
+        node_attr.aggregation = "composite"
+        comp_attr = node.model.create(UML.Property)
 
-        e1 = node.model.create(UML.ConnectorEnd)
-        e2 = node.model.create(UML.ConnectorEnd)
+        node_end = node.model.create(UML.ConnectorEnd)
+        comp_end = node.model.create(UML.ConnectorEnd)
 
         # create connection between node and component
-        e1.role = a1
-        e2.role = a2
+        node_end.role = node_attr
+        comp_end.role = comp_attr
+
         connector = node.model.create(UML.Connector)
-        connector.end = e1
-        connector.end = e2
+        connector.end = node_end
+        connector.end = comp_end
 
         # compose component within node
-        node.ownedAttribute = a1
+        node.ownedAttribute = node_attr
         node.ownedConnector = connector
-        component.ownedAttribute = a2
+        component.ownedAttribute = comp_attr
 
     def ungroup(self):
         node = self.parent.subject

--- a/gaphor/UML/components/tests/test_copypaste.py
+++ b/gaphor/UML/components/tests/test_copypaste.py
@@ -5,7 +5,7 @@ from gaphor.core.modeling.modelinglanguage import (
     CoreModelingLanguage,
     MockModelingLanguage,
 )
-from gaphor.diagram.tests.fixtures import connect, copy_clear_and_paste
+from gaphor.diagram.tests.fixtures import connect, copy_clear_and_paste_link
 from gaphor.SysML.modelinglanguage import SysMLModelingLanguage
 from gaphor.UML.classes import InterfaceItem
 from gaphor.UML.components import ComponentItem, ConnectorItem
@@ -30,7 +30,9 @@ def test_connector(diagram, element_factory):
     connect(conn_item, conn_item.handles()[0], comp_item)
     connect(conn_item, conn_item.handles()[1], iface_item)
 
-    copy_clear_and_paste({comp_item, iface_item, conn_item}, diagram, element_factory)
+    copy_clear_and_paste_link(
+        {comp_item, iface_item, conn_item}, diagram, element_factory
+    )
 
     new_conn = element_factory.lselect(UML.Connector)[0]
     new_comp = element_factory.lselect(UML.Component)[0]

--- a/gaphor/UML/interactions/tests/test_copypaste.py
+++ b/gaphor/UML/interactions/tests/test_copypaste.py
@@ -1,5 +1,5 @@
 from gaphor import UML
-from gaphor.diagram.tests.fixtures import connect, copy_clear_and_paste
+from gaphor.diagram.tests.fixtures import connect, copy_clear_and_paste_link
 from gaphor.UML.interactions import LifelineItem, MessageItem
 from gaphor.UML.interactions.tests.test_executionspecification import (
     create_lifeline_with_execution_specification,
@@ -17,7 +17,7 @@ def test_message(diagram, element_factory):
     connect(message_item, message_item.handles()[0], lifeline1_item)
     connect(message_item, message_item.handles()[1], lifeline2_item)
 
-    copy_clear_and_paste(
+    copy_clear_and_paste_link(
         {lifeline1_item, lifeline2_item, message_item}, diagram, element_factory
     )
 
@@ -36,7 +36,7 @@ def test_execution_specification(diagram, element_factory):
         diagram, element_factory
     )
 
-    copy_clear_and_paste({lifeline_item, exec_spec_item}, diagram, element_factory)
+    copy_clear_and_paste_link({lifeline_item, exec_spec_item}, diagram, element_factory)
 
     new_exec_spec: UML.ExecutionSpecification = element_factory.lselect(
         lambda e: isinstance(e, UML.ExecutionSpecification)

--- a/gaphor/UML/profiles/tests/test_copypaste.py
+++ b/gaphor/UML/profiles/tests/test_copypaste.py
@@ -1,5 +1,9 @@
 from gaphor import UML
-from gaphor.diagram.tests.fixtures import connect, copy_and_paste, copy_clear_and_paste
+from gaphor.diagram.tests.fixtures import (
+    connect,
+    copy_and_paste_link,
+    copy_clear_and_paste_link,
+)
 from gaphor.UML.classes import ClassItem
 from gaphor.UML.profiles.extension import ExtensionItem
 
@@ -24,7 +28,7 @@ def test_copy_paste_of_stereotype(diagram, element_factory):
         diagram, element_factory
     )
 
-    copy_and_paste({m_cls_item, ext_item, st_cls_item}, diagram, element_factory)
+    copy_and_paste_link({m_cls_item, ext_item, st_cls_item}, diagram, element_factory)
 
     new_ext_item = ext_item.subject.presentation[1]
 
@@ -37,7 +41,9 @@ def test_cut_paste_of_stereotype(diagram, element_factory):
         diagram, element_factory
     )
 
-    copy_clear_and_paste({m_cls_item, st_cls_item, ext_item}, diagram, element_factory)
+    copy_clear_and_paste_link(
+        {m_cls_item, st_cls_item, ext_item}, diagram, element_factory
+    )
     new_m_cls = next(
         element_factory.select(
             lambda e: isinstance(e, UML.NamedElement) and e.name == "Class"

--- a/gaphor/UML/states/tests/test_copypaste.py
+++ b/gaphor/UML/states/tests/test_copypaste.py
@@ -1,5 +1,5 @@
 from gaphor import UML
-from gaphor.diagram.tests.fixtures import connect, copy_clear_and_paste
+from gaphor.diagram.tests.fixtures import connect, copy_clear_and_paste_link
 from gaphor.UML.states import StateItem, TransitionItem
 
 
@@ -14,7 +14,7 @@ def test_state_with_behaviors(diagram, element_factory):
 
     state_item = diagram.create(StateItem, subject=state)
 
-    new_items = copy_clear_and_paste({state_item}, diagram, element_factory)
+    new_items = copy_clear_and_paste_link({state_item}, diagram, element_factory)
     new_state_item = new_items.pop()
 
     assert isinstance(new_state_item, StateItem)
@@ -32,7 +32,7 @@ def test_connected_transition(diagram, element_factory):
     connect(transition_item, transition_item.tail, state_item_2)
     transition_item.subject.guard.specification = "[test]"
 
-    new_items = copy_clear_and_paste({transition_item}, diagram, element_factory)
+    new_items = copy_clear_and_paste_link({transition_item}, diagram, element_factory)
     new_transition_item = new_items.pop()
 
     assert isinstance(new_transition_item, TransitionItem), new_items

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -116,6 +116,9 @@ class ElementFactory(Service):
 
     __getitem__ = lookup
 
+    def __iter__(self):
+        return iter(self._elements.values())
+
     def __contains__(self, element: Element) -> bool:
         assert isinstance(element.id, str)
         return self.lookup(element.id) is element

--- a/gaphor/core/modeling/tests/test_elementfactory.py
+++ b/gaphor/core/modeling/tests/test_elementfactory.py
@@ -49,7 +49,7 @@ def test_flush(factory):
 
     gc.collect()
 
-    assert len(list(factory.values())) == 0, list(factory.values())
+    assert not list(factory.values()), list(factory.values())
 
 
 def test_without_application(factory):
@@ -73,7 +73,7 @@ def test_unlink(factory):
 
     p.unlink()
 
-    assert len(list(factory.values())) == 0, list(factory.values())
+    assert not list(factory.values()), list(factory.values())
 
     p = factory.create(Parameter)
     p.defaultValue = "l"
@@ -83,7 +83,7 @@ def test_unlink(factory):
     p.unlink()
     del p
 
-    assert len(list(factory.values())) == 0, list(factory.values())
+    assert not list(factory.values()), list(factory.values())
 
 
 # Event handlers are registered as persisting top level handlers, since no

--- a/gaphor/core/modeling/tests/test_elementfactory.py
+++ b/gaphor/core/modeling/tests/test_elementfactory.py
@@ -1,4 +1,5 @@
 import gc
+from collections.abc import Container, Iterable
 
 import pytest
 
@@ -20,6 +21,14 @@ from gaphor.UML import Parameter
 def factory():
     event_manager = EventManager()
     return ElementFactory(event_manager)
+
+
+def test_element_factory_is_an_iterable(factory):
+    assert isinstance(factory, Iterable)
+
+
+def test_element_factory_is_a_container(factory):
+    assert isinstance(factory, Container)
 
 
 def test_create(factory):

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -36,6 +36,14 @@ def copy(obj: Element | set) -> Iterator[tuple[Id, Opaque]]:
     raise ValueError(f"No copier for {obj}")
 
 
+def paste_link(copy_data, diagram, lookup) -> set[Presentation]:
+    return _paste(copy_data, diagram, lookup, full=False)
+
+
+def paste_full(copy_data, diagram, lookup) -> set[Presentation]:
+    return _paste(copy_data, diagram, lookup, full=True)
+
+
 @singledispatch
 def paste(copy_data: Opaque, diagram: Diagram, lookup: Callable[[str], Element]):
     """Paste previously copied data.
@@ -190,14 +198,6 @@ class CopyData(NamedTuple):
 def _copy_all(items: set) -> CopyData:
     elements = itertools.chain.from_iterable(copy(item) for item in items)
     return CopyData(elements=dict(elements))
-
-
-def paste_link(copy_data, diagram, lookup) -> set[Presentation]:
-    return _paste(copy_data, diagram, lookup, full=False)
-
-
-def paste_full(copy_data, diagram, lookup) -> set[Presentation]:
-    return _paste(copy_data, diagram, lookup, full=True)
 
 
 def _paste(copy_data, diagram, lookup, full) -> set[Presentation]:

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -3,11 +3,12 @@
 The `copy()` function will return all values serialized, either as string
 values or reference id's.
 
-The `paste_link()` function will resolve those values. Based on the elements
-that are already in the model,
-`paste_full()` will try copy every element involved.
+The `paste_link()` function will resolve those values and place instances of
+them on the diagram using the same defining element.
+The `paste_full()` function is similar, but it creates new defining elements
+for the elements being pasted.
 
-The copy() function returns only data that has to be part of the copy buffer.
+The `copy()` function returns only data that has to be part of the copy buffer.
 the `paste()` function will load this data in a model.
 """
 

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -3,8 +3,9 @@
 The `copy()` function will return all values serialized, either as string
 values or reference id's.
 
-The `paste()` function will resolve those values. Based on the elements
+The `paste_link()` function will resolve those values. Based on the elements
 that are already in the model,
+`paste_full()` will try copy every element involved.
 
 The copy() function returns only data that has to be part of the copy buffer.
 the `paste()` function will load this data in a model.
@@ -191,8 +192,9 @@ def _copy_all(items: set) -> CopyData:
     return CopyData(elements=dict(elements))
 
 
-@paste.register
-def _paste_all(copy_data: CopyData, diagram, lookup) -> set[Presentation]:
+def paste_link(copy_data, diagram, lookup) -> set[Presentation]:
+    assert isinstance(copy_data, CopyData)
+
     new_elements: dict[str, Presentation | None] = {}
 
     def element_lookup(ref: str):
@@ -213,7 +215,7 @@ def _paste_all(copy_data: CopyData, diagram, lookup) -> set[Presentation]:
         if looked_up:
             return looked_up
 
-    for old_id, data in copy_data.elements.items():
+    for old_id in copy_data.elements.keys():
         if old_id in new_elements:
             continue
         element_lookup(old_id)
@@ -223,3 +225,9 @@ def _paste_all(copy_data: CopyData, diagram, lookup) -> set[Presentation]:
         element.postload()
 
     return {e for e in new_elements.values() if isinstance(e, Presentation)}
+
+
+def paste_full(copy_data, diagram, lookup) -> set[Presentation]:
+    assert isinstance(copy_data, CopyData)
+
+    return set()

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -14,6 +14,7 @@ the `paste()` function will load this data in a model.
 from __future__ import annotations
 
 import itertools
+from collections.abc import Iterable
 from functools import singledispatch
 from typing import Callable, Iterator, NamedTuple
 
@@ -27,7 +28,7 @@ Opaque = object
 
 
 @singledispatch
-def copy(obj: Element | set) -> Iterator[tuple[Id, Opaque]]:
+def copy(obj: Element | Iterable) -> Iterator[tuple[Id, Opaque]]:
     """Create a copy of an element (or list of elements).
 
     The returned type should be distinct, so the `paste()` function can
@@ -195,7 +196,7 @@ class CopyData(NamedTuple):
 
 
 @copy.register  # type: ignore[arg-type]
-def _copy_all(items: set) -> CopyData:
+def _copy_all(items: Iterable) -> CopyData:
     elements = itertools.chain.from_iterable(copy(item) for item in items)
     return CopyData(elements=dict(elements))
 

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -14,7 +14,7 @@ from gaphor.core.modeling.modelinglanguage import (
     MockModelingLanguage,
 )
 from gaphor.diagram.connectors import Connector
-from gaphor.diagram.copypaste import copy, paste
+from gaphor.diagram.copypaste import copy, paste_link
 from gaphor.storage import storage
 from gaphor.storage.xmlwriter import XMLWriter
 from gaphor.UML.modelinglanguage import UMLModelingLanguage
@@ -138,15 +138,15 @@ def clear_model(diagram, element_factory, retain=[]):
         item.unlink()
 
 
-def copy_and_paste(items, diagram, element_factory, retain=[]):
+def copy_and_paste_link(items, diagram, element_factory, retain=[]):
     buffer = copy(items)
-    return paste(buffer, diagram, element_factory.lookup)
+    return paste_link(buffer, diagram, element_factory.lookup)
 
 
-def copy_clear_and_paste(items, diagram, element_factory, retain=[]):
+def copy_clear_and_paste_link(items, diagram, element_factory, retain=[]):
     buffer = copy(items)
     clear_model(diagram, element_factory, retain)
-    return paste(buffer, diagram, element_factory.lookup)
+    return paste_link(buffer, diagram, element_factory.lookup)
 
 
 if Gtk.get_major_version() == 3:

--- a/gaphor/diagram/tests/test_copypaste_full.py
+++ b/gaphor/diagram/tests/test_copypaste_full.py
@@ -1,4 +1,5 @@
 from gaphor import UML
+from gaphor.core.modeling import Diagram, ElementFactory
 from gaphor.diagram.copypaste import copy, paste_full
 from gaphor.diagram.tests.test_copypaste_link import two_classes_and_a_generalization
 from gaphor.UML.classes import ClassItem, GeneralizationItem
@@ -49,3 +50,22 @@ def test_copy_items_with_connections(diagram, element_factory):
 
     assert new_gen.general in {new_cls1, new_cls2}
     assert new_gen.specific in {new_cls1, new_cls2}
+
+
+def test_copy_element_factory(diagram, element_factory):
+    """This case tests the boundaries of the copy/paste functionality:
+
+    it copies a complete element factory, something that's not possible
+    to do from the UI.
+    """
+    two_classes_and_a_generalization(diagram, element_factory)
+
+    buffer = copy(element_factory)
+
+    new_element_factory = ElementFactory()
+    new_diagram = new_element_factory.create(Diagram)
+    paste_full(buffer, new_diagram, new_element_factory.lookup)
+
+    # new element factory has one more diagram:
+    assert len(new_element_factory.lselect(Diagram)) == 2
+    assert element_factory.size() == new_element_factory.size() - 1

--- a/gaphor/diagram/tests/test_copypaste_full.py
+++ b/gaphor/diagram/tests/test_copypaste_full.py
@@ -1,0 +1,51 @@
+from gaphor import UML
+from gaphor.diagram.copypaste import copy, paste_full
+from gaphor.diagram.tests.test_copypaste_link import two_classes_and_a_generalization
+from gaphor.UML.classes import ClassItem, GeneralizationItem
+
+
+def test_copied_item_references_new_model_element(diagram, element_factory):
+    cls = element_factory.create(UML.Class)
+    cls.name = "Name"
+    cls_item = diagram.create(ClassItem, subject=cls)
+
+    buffer = copy({cls_item})
+
+    all(paste_full(buffer, diagram, element_factory.lookup))
+
+    assert len(list(diagram.get_all_items())) == 2
+    item1, item2 = diagram.get_all_items()
+
+    assert item1.subject
+    assert item2.subject
+    assert item1.subject in element_factory
+    assert item2.subject in element_factory
+    assert item1.subject is not item2.subject
+    assert item1.subject.name == item2.subject.name
+
+
+def test_copy_multiple_items(diagram, element_factory):
+    cls = element_factory.create(UML.Class)
+    cls_item1 = diagram.create(ClassItem, subject=cls)
+    cls_item2 = diagram.create(ClassItem, subject=cls)
+
+    buffer = copy({cls_item1, cls_item2})
+
+    paste_full(buffer, diagram, element_factory.lookup)
+
+    assert len(list(diagram.get_all_items())) == 4
+    assert len(element_factory.lselect(UML.Class)) == 2
+
+
+def test_copy_items_with_connections(diagram, element_factory):
+    gen_cls_item, spc_cls_item, gen_item = two_classes_and_a_generalization(
+        diagram, element_factory
+    )
+
+    buffer = copy({gen_cls_item, gen_item, spc_cls_item})
+    new_items = paste_full(buffer, diagram, element_factory.lookup)
+    (new_cls1, new_cls2) = [ci.subject for ci in new_items if isinstance(ci, ClassItem)]
+    (new_gen,) = [gi.subject for gi in new_items if isinstance(gi, GeneralizationItem)]
+
+    assert new_gen.general in {new_cls1, new_cls2}
+    assert new_gen.specific in {new_cls1, new_cls2}

--- a/gaphor/diagram/tests/test_copypaste_grouping.py
+++ b/gaphor/diagram/tests/test_copypaste_grouping.py
@@ -1,9 +1,9 @@
 import pytest
 
 from gaphor import UML
-from gaphor.diagram.copypaste import copy, paste
+from gaphor.diagram.copypaste import copy, paste_link
 from gaphor.diagram.grouping import Group
-from gaphor.diagram.tests.fixtures import copy_clear_and_paste
+from gaphor.diagram.tests.fixtures import copy_clear_and_paste_link
 from gaphor.UML.components import ComponentItem, NodeItem
 
 
@@ -27,7 +27,7 @@ def test_copy_paste_of_nested_item(diagram, element_factory, node_with_component
 
     buffer = copy({comp_item})
 
-    (new_comp_item,) = paste(buffer, diagram, element_factory.lookup)
+    (new_comp_item,) = paste_link(buffer, diagram, element_factory.lookup)
 
     assert new_comp_item.parent is node_item
 
@@ -39,7 +39,7 @@ def test_copy_paste_of_item_with_nested_item(
 
     buffer = copy(set(node_with_component))
 
-    new_items = paste(buffer, diagram, element_factory.lookup)
+    new_items = paste_link(buffer, diagram, element_factory.lookup)
 
     new_node_item = next(i for i in new_items if isinstance(i, NodeItem))
     new_comp_item = next(i for i in new_items if isinstance(i, ComponentItem))
@@ -51,7 +51,9 @@ def test_copy_remove_paste_of_item_with_nested_item(
     diagram, element_factory, node_with_component
 ):
 
-    new_items = copy_clear_and_paste(set(node_with_component), diagram, element_factory)
+    new_items = copy_clear_and_paste_link(
+        set(node_with_component), diagram, element_factory
+    )
 
     new_node_item = next(i for i in new_items if isinstance(i, NodeItem))
     new_comp_item = next(i for i in new_items if isinstance(i, ComponentItem))

--- a/gaphor/diagram/tests/test_copypaste_link.py
+++ b/gaphor/diagram/tests/test_copypaste_link.py
@@ -32,20 +32,6 @@ def test_copied_item_references_same_model_element(diagram, element_factory):
     assert item1.subject is item2.subject
 
 
-def test_copied_item_with_new_model_element(diagram, element_factory):
-    cls = element_factory.create(UML.Class)
-    cls_item = diagram.create(ClassItem, subject=cls)
-
-    _, buffer = next(copy(cls_item))
-
-    all(paste(buffer, diagram, element_factory.lookup))
-
-    assert len(list(diagram.get_all_items())) == 2
-    item1, item2 = diagram.get_all_items()
-
-    assert item1.subject is item2.subject
-
-
 def test_copy_multiple_items(diagram, element_factory):
     cls = element_factory.create(UML.Class)
     cls_item1 = diagram.create(ClassItem, subject=cls)
@@ -135,9 +121,9 @@ def test_copy_item_when_subject_has_been_removed(diagram, element_factory):
 
     paste_link(buffer, diagram, element_factory.lookup)
     new_cls = element_factory.lselect(UML.Class)[0]
-    assert len(list(diagram.get_all_items())) == 1
+    (new_cls_item,) = diagram.get_all_items()
     assert new_cls.package is package
-    assert element_factory.lookup(orig_cls_id) is new_cls
+    assert new_cls_item.subject is new_cls
 
 
 def test_copy_remove_paste_items_with_connections(diagram, element_factory):

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -59,7 +59,7 @@ class CopyService(Service, ActionProvider):
         if items:
             copy_buffer = copy(items)
 
-    def paste(self, diagram):
+    def paste_link(self, diagram):
         """Paste items in the copy-buffer to the diagram."""
         with Transaction(self.event_manager):
             # Create new id's that have to be used to create the items:
@@ -96,8 +96,8 @@ class CopyService(Service, ActionProvider):
                 for i in list(items):
                     i.unlink()
 
-    @action(name="edit-paste", shortcut="<Primary>v")
-    def paste_action(self):
+    @action(name="edit-paste-link", shortcut="<Primary>v")
+    def paste_link_action(self):
         view = self.diagrams.get_current_view()
         diagram = self.diagrams.get_current_diagram()
         if not (view and view.is_focus()):
@@ -106,7 +106,7 @@ class CopyService(Service, ActionProvider):
         if not copy_buffer:
             return
 
-        new_items = self.paste(diagram)
+        new_items = self.paste_link(diagram)
 
         selection = view.selection
         selection.unselect_all()

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -7,7 +7,7 @@ from gi.repository import Gdk, Gtk
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import Transaction, action
 from gaphor.core.modeling import Presentation
-from gaphor.diagram.copypaste import copy, paste
+from gaphor.diagram.copypaste import copy, paste_full, paste_link
 from gaphor.ui.event import DiagramSelectionChanged
 
 copy_buffer: object = None
@@ -63,7 +63,7 @@ class CopyService(Service, ActionProvider):
         """Paste items in the copy-buffer to the diagram."""
         with Transaction(self.event_manager):
             # Create new id's that have to be used to create the items:
-            new_items: Set[Presentation] = paste(
+            new_items: Set[Presentation] = paste_link(
                 copy_buffer, diagram, self.element_factory.lookup
             )
 
@@ -77,7 +77,7 @@ class CopyService(Service, ActionProvider):
     def paste_full(self, diagram):
         with Transaction(self.event_manager):
             # Create new id's that have to be used to create the items:
-            new_items: Set[Presentation] = paste(
+            new_items: Set[Presentation] = paste_full(
                 copy_buffer, diagram, self.element_factory.lookup
             )
 

--- a/gaphor/services/helpservice/shortcuts.ui
+++ b/gaphor/services/helpservice/shortcuts.ui
@@ -152,7 +152,7 @@
               <object class="GtkShortcutsShortcut">
                 <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;v</property>
-                <property name="title" translatable="yes">Paste (link)</property>
+                <property name="title" translatable="yes">Paste (link defining elements)</property>
               </object>
             </child>
 
@@ -160,7 +160,7 @@
               <object class="GtkShortcutsShortcut">
                 <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;v</property>
-                <property name="title" translatable="yes">Paste (full)</property>
+                <property name="title" translatable="yes">Paste (copy defining elements)</property>
               </object>
             </child>
 

--- a/gaphor/services/helpservice/shortcuts.ui
+++ b/gaphor/services/helpservice/shortcuts.ui
@@ -159,6 +159,14 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">1</property>
+                <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;v</property>
+                <property name="title" translatable="yes">Paste (full)</property>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
                 <property name="accelerator">Delete</property>
                 <property name="title" translatable="yes">Delete</property>
               </object>

--- a/gaphor/services/tests/test_copyservice.py
+++ b/gaphor/services/tests/test_copyservice.py
@@ -20,13 +20,13 @@ def copy_service(event_manager, element_factory, diagrams):
     return CopyService(event_manager, element_factory, diagrams)
 
 
-def test_copy(copy_service, element_factory):
+def test_copy_link(copy_service, element_factory):
     diagram = element_factory.create(Diagram)
     ci = diagram.create(CommentItem, subject=element_factory.create(Comment))
 
     copy_service.copy({ci})
     assert list(diagram.get_all_items()) == [ci]
 
-    copy_service.paste(diagram)
+    copy_service.paste_link(diagram)
 
     assert len(list(diagram.get_all_items())) == 2, list(diagram.get_all_items())

--- a/tests/test_multiple_associations.py
+++ b/tests/test_multiple_associations.py
@@ -68,7 +68,7 @@ def class_and_association_with_copy(diagram, event_manager, element_factory, cop
 
         copy.copy({a, c})
         new_diagram = element_factory.create(Diagram)
-        pasted_items = copy.paste(new_diagram)
+        pasted_items = copy.paste_link(new_diagram)
 
     aa = pasted_items.pop()
     if not isinstance(aa, diagramitems.AssociationItem):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Only a shallow (link) type of paste is supported for the diagram items

Issue Number: #791

### What is the new behavior?

A new key binding <key>Ctrl</key>+<key>Shift</key>+<key>p</key> can be used to copy the presentation along with the underlying model elements.

I introduced a `paste_link()` and `paste_full()` function to distinguish between the two types of pasting.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

### Other information

Model elements were already copied, because they were needed for cut/paste functionality.

* A lot of changes have to do with changing the test functions `copy_and_paste` and `copy_clear_and_paste` to `*_link`, to distinguish them from the deep-copy functionality.
* Newly created elements now always get a new id.
* I refactored the copy code a little to get rid of some duplication &mdash; introduced a `blacklist` parameter for `copy_element`.