### PR TITLE
Fix positions of nested items during undo

### DIFF
--- a/gaphor/SysML/blocks/connectors.py
+++ b/gaphor/SysML/blocks/connectors.py
@@ -39,7 +39,7 @@ class BlockProperyProxyPortConnector:
 
         # This raises the item in the item hierarchy
         assert proxy_port.diagram
-        proxy_port.parent = self.block
+        proxy_port.change_parent(self.block)
 
         return True
 
@@ -48,7 +48,7 @@ class BlockProperyProxyPortConnector:
         if proxy_port.subject and proxy_port.diagram:
             subject = proxy_port.subject
             del proxy_port.subject
-            proxy_port.parent = None
+            proxy_port.change_parent(None)
             subject.unlink()
 
 

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -254,7 +254,7 @@ class LifelineExecutionSpecificationConnect(BaseConnector):
 
         diagram = self.diagram
         if self.line.parent is not self.element:
-            self.line.parent = self.element
+            self.line.change_parent(self.element)
 
         for cinfo in diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).connect(cinfo.handle, cinfo.port)
@@ -270,7 +270,7 @@ class LifelineExecutionSpecificationConnect(BaseConnector):
 
         if self.line.parent is self.element:
             new_parent = self.element.parent
-            self.line.parent = new_parent
+            self.line.change_parent(new_parent)
 
         for cinfo in diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).disconnect(cinfo.handle)
@@ -294,7 +294,7 @@ class ExecutionSpecificationExecutionSpecificationConnect(BaseConnector):
         assert connected_item
         Connector(connected_item, self.line).connect(handle, None)
 
-        self.line.parent = self.element
+        self.line.change_parent(self.element)
 
         return True
 

--- a/gaphor/UML/interactions/interactionsgrouping.py
+++ b/gaphor/UML/interactions/interactionsgrouping.py
@@ -11,7 +11,7 @@ class InteractionLifelineGroup(AbstractGroup):
     def group(self):
         assert self.parent.diagram
         self.parent.subject.lifeline = self.item.subject
-        self.item.parent = self.parent
+        self.item.change_parent(self.parent)
 
     def ungroup(self):
         """Lifelines are not ungrouped on purpose.
@@ -29,7 +29,7 @@ class InteractionMessageGroup(AbstractGroup):
             return
         assert self.parent.diagram
         self.parent.subject.message = self.item.subject
-        self.item.parent = self.parent
+        self.item.change_parent(self.parent)
 
     def ungroup(self):
         """Messages are not ungrouped on purpose.

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -62,6 +62,20 @@ class Presentation(Matrices, Element, Generic[S]):
         self._watcher.watch(path, handler)
         return self
 
+    def change_parent(self, new_parent):
+        """Change the parent and update the item's matrix so the item visualy
+        remains in the same place."""
+        old_parent = self.parent
+        self.parent = new_parent
+
+        if old_parent:
+            m = old_parent.matrix_i2c
+            self.matrix.set(*self.matrix.multiply(m))
+
+        if new_parent:
+            m = new_parent.matrix_i2c.inverse()
+            self.matrix.set(*self.matrix.multiply(m))
+
     def load(self, name, value):
         if name == "matrix":
             self.matrix.set(*ast.literal_eval(value))
@@ -101,14 +115,12 @@ class Presentation(Matrices, Element, Generic[S]):
         old_parent = event.old_value
         if old_parent:
             old_parent.matrix_i2c.remove_handler(self._on_matrix_changed)
-            m = old_parent.matrix_i2c
-            self.matrix.set(*self.matrix.multiply(m))
 
         new_parent = event.new_value
         if new_parent:
             new_parent.matrix_i2c.add_handler(self._on_matrix_changed)
-            m = new_parent.matrix_i2c.inverse()
-            self.matrix.set(*self.matrix.multiply(m))
+
+        self._on_matrix_changed(self.matrix, self.matrix.tuple())
 
     def _on_matrix_changed(self, matrix, old_value):
         if self.parent:

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -66,15 +66,16 @@ class Presentation(Matrices, Element, Generic[S]):
         """Change the parent and update the item's matrix so the item visualy
         remains in the same place."""
         old_parent = self.parent
+        if new_parent is old_parent:
+            return
+
         self.parent = new_parent
-
+        m = self.matrix
         if old_parent:
-            m = old_parent.matrix_i2c
-            self.matrix.set(*self.matrix.multiply(m))
-
+            m = m * old_parent.matrix_i2c
         if new_parent:
-            m = new_parent.matrix_i2c.inverse()
-            self.matrix.set(*self.matrix.multiply(m))
+            m = m * new_parent.matrix_i2c.inverse()
+        self.matrix.set(*m)
 
     def load(self, name, value):
         if name == "matrix":
@@ -120,7 +121,7 @@ class Presentation(Matrices, Element, Generic[S]):
         if new_parent:
             new_parent.matrix_i2c.add_handler(self._on_matrix_changed)
 
-        self._on_matrix_changed(self.matrix, self.matrix.tuple())
+        self._on_matrix_changed(None, ())
 
     def _on_matrix_changed(self, matrix, old_value):
         if self.parent:

--- a/gaphor/core/modeling/tests/test_presentation.py
+++ b/gaphor/core/modeling/tests/test_presentation.py
@@ -62,7 +62,7 @@ def test_parent_matrix_updates(diagram):
     parent = diagram.create(Example)
     presentation = diagram.create(Example)
 
-    presentation.parent = parent
+    presentation.change_parent(parent)
     parent.matrix.scale(2, 2)
 
     assert tuple(presentation.matrix_i2c) == (2, 0, 0, 2, 0, 0)
@@ -73,7 +73,7 @@ def test_set_parent_updates_matrix_i2c(diagram):
     presentation = diagram.create(Example)
 
     parent.matrix.scale(2, 2)
-    presentation.parent = parent
+    presentation.change_parent(parent)
 
     assert tuple(presentation.matrix_i2c) == (1, 0, 0, 1, 0, 0)
 
@@ -83,8 +83,8 @@ def test_unset_parent_updates_matrix_i2c(diagram):
     presentation = diagram.create(Example)
 
     parent.matrix.scale(2, 2)
-    presentation.parent = parent
-    presentation.parent = None
+    presentation.change_parent(parent)
+    presentation.change_parent(None)
 
     assert tuple(presentation.matrix_i2c) == (1, 0, 0, 1, 0, 0)
 
@@ -96,7 +96,7 @@ def test_change_parent_updates_matrix_i2c_and_keeps_coordinates(diagram):
 
     parent.matrix.scale(2, 2)
     new_parent.matrix.translate(2, 2)
-    presentation.parent = parent
-    presentation.parent = new_parent
+    presentation.change_parent(parent)
+    presentation.change_parent(new_parent)
 
     assert tuple(presentation.matrix_i2c) == (1, 0, 0, 1, 0, 0)

--- a/gaphor/diagram/diagramtoolbox.py
+++ b/gaphor/diagram/diagramtoolbox.py
@@ -96,7 +96,7 @@ def new_item_factory(
 
         adapter = Group(parent, item)
         if parent and adapter.can_contain():
-            item.parent = parent
+            item.change_parent(parent)
             adapter.group()
 
         if config_func:

--- a/gaphor/diagram/tests/test_copypaste_grouping.py
+++ b/gaphor/diagram/tests/test_copypaste_grouping.py
@@ -15,7 +15,7 @@ def node_with_component(diagram, element_factory):
     comp_item = diagram.create(ComponentItem, subject=comp)
 
     Group(node_item, comp_item).group()
-    comp_item.parent = node_item
+    comp_item.change_parent(node_item)
 
     assert comp_item.parent is node_item
 

--- a/gaphor/diagram/tools/dropzone.py
+++ b/gaphor/diagram/tools/dropzone.py
@@ -112,7 +112,7 @@ class DropZoneMove(GuidedItemMove):
                 return
 
             if old_parent:
-                item.parent = None
+                item.change_parent(None)
 
                 adapter = Group(old_parent, item)
                 if adapter:
@@ -122,7 +122,7 @@ class DropZoneMove(GuidedItemMove):
 
             if new_parent:
                 grow_parent(new_parent, item)
-                item.parent = new_parent
+                item.change_parent(new_parent)
 
                 adapter = Group(new_parent, item)
                 if adapter and adapter.can_contain():

--- a/gaphor/diagram/tools/placement.py
+++ b/gaphor/diagram/tools/placement.py
@@ -79,7 +79,7 @@ def maybe_group(parent, item):
     adapter = Group(parent, item)
     if parent and adapter.can_contain():
         grow_parent(parent, item)
-        item.parent = parent
+        item.change_parent(parent)
         adapter.group()
 
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When undo-ing a nested item, it's positioned wrongly.

Issue Number: #1264

### What is the new behavior?

The nested item appears exactly where it was when it was removed.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

To change the parent of an item and keep it visually at the same place, a new method `change_parent()` was introduced.

### Other information
