### PR TITLE
Load files directly from macOS Finder

### DIFF
--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -1,5 +1,5 @@
 from pathlib import Path
-
+import time
 import tomli
 from PyInstaller.utils.hooks import copy_metadata
 
@@ -90,4 +90,43 @@ app = BUNDLE(
     icon="macos/gaphor.icns",
     bundle_identifier="org.gaphor.gaphor",
     version=get_version(),
+    info_plist={
+        "CFBundleVersion": get_version(),
+        "NSHumanReadableCopyright": f"Copyright 2001-{time.strftime('%Y')} Gaphor Developers, Apache 2 License.",
+        "LSMinimumSystemVersion": "10.13",
+        "NSHighResolutionCapable": True,
+        "LSApplicationCategoryType": "public.app-category.developer-tools",
+        "NSPrincipalClass": "NSApplication",
+        "CFBundleDocumentTypes": [
+            {
+                "CFBundleTypeExtensions": ["gaphor"],
+                "CFBundleTypeIconFile": "gaphor.icns",
+                "CFBundleTypeMIMETypes": ["application/x-gaphor"],
+                "CFBundleTypeName": "Gaphor Model",
+                "CFBundleTypeOSTypes": ["GAPHOR"],
+                "CFBundleTypeRole": "Editor",
+                "LSIsAppleDefaultForType": True,
+                "LSItemContentTypes": ["org.gaphor.model"],
+            }
+        ],
+        "UTExportedTypeDeclarations": [
+            {
+                "UTTypeIdentifier": "org.gaphor.model",
+                "UTTypeConformsTo": ["gaphor.model"],
+                "UTTypeDescription": "Gaphor Model",
+                "UTTypeIconFile": "gaphor.icns",
+                "UTTypeReferenceURL": "https://gaphor.org",
+                "UTTypeTagSpecification": {
+                    "com.apple.ostype": "GAPHOR",
+                    "public.filename-extension": ["gaphor"],
+                    "public.mime-type": ["application/x-gaphor"],
+                },
+            }
+        ],
+        "NSDesktopFolderUsageDescription": "Gaphor needs your permission to load models from disk.",
+        "NSDocumentsFolderUsageDescription": "Gaphor needs your permission to load models from disk.",
+        "NSDownloadsFolderUsageDescription": "Gaphor needs your permission to load models from disk.",
+        "NSRequiresAquaSystemAppearance": "No",
+        "NSAppleScriptEnabled": False,
+    },
 )

--- a/gaphor/ui/macosshim.py
+++ b/gaphor/ui/macosshim.py
@@ -17,8 +17,7 @@ else:
         if path == __file__:
             return False
 
-        app_file_manager = application.get_service("app_file_manager")
-        app_file_manager.load(path)
+        application.new_session(filename=path)
 
         return True
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

* Gaphor files do not have the proper file icon on macos
* On macOS, files do not load from the command line.

Issue Number: #1280

### What is the new behavior?

Gaphor starts and opens a model when one is double clicked from Finder

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
