### PR TITLE
Fix Sequence diagram loading when message is close to lifeline body

### DIFF
--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -2,6 +2,9 @@
 
 from typing import Optional
 
+from gaphas.connector import ConnectionSink, ItemConnectionSink
+from gaphas.types import Pos, SupportsFloatPos
+
 from gaphor import UML
 from gaphor.core.modeling import Element, Presentation
 from gaphor.diagram.connectors import BaseConnector, Connector
@@ -306,3 +309,25 @@ class ExecutionSpecificationExecutionSpecificationConnect(BaseConnector):
 
         for cinfo in self.diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).disconnect(cinfo.handle)
+
+
+@ConnectionSink.register(LifelineItem)
+class LifelineConnectionSink(ItemConnectionSink):
+    def glue(
+        self, pos: SupportsFloatPos, secondary_pos: Optional[SupportsFloatPos] = None
+    ) -> Optional[Pos]:
+        """Glue a line to the lifeline item, have a preference for the lifetime
+        line."""
+        assert isinstance(self.item, LifelineItem)
+        glue_pos = super().glue(pos, secondary_pos)
+
+        lifetime = self.item.lifetime
+        if lifetime.visible and self.port is not lifetime.port:  # type: ignore[has-type]
+            g, d = lifetime.port.glue(pos)
+            if d < self.distance:
+                self.port = lifetime.port
+                glue_pos = g
+
+            return glue_pos
+
+        return glue_pos

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -115,7 +115,6 @@ class LifetimeItem:
         self.top.visible = False
 
         self.port = BetweenPort(self.top.pos, self.bottom.pos)
-        self.visible = False
 
         self._c_min_length = None  # to be set by lifeline item
 
@@ -143,7 +142,7 @@ class LifetimeItem:
     def _set_visible(self, visible):
         """Set lifetime visibility."""
         if visible:
-            self.bottom.pos.y = self.top.pos.y + 3 * self.MIN_LENGTH
+            self.bottom.pos.y = self.top.pos.y + self.MIN_LENGTH_VISIBLE
         else:
             self.bottom.pos.y = self.top.pos.y + self.MIN_LENGTH
 

--- a/gaphor/UML/interactions/tests/test_message.py
+++ b/gaphor/UML/interactions/tests/test_message.py
@@ -1,9 +1,13 @@
 """Test messages."""
 
+from gaphas.item import SE
+
 from gaphor import UML
 from gaphor.core.modeling import Diagram
 from gaphor.diagram.grouping import Group
+from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML.interactions.interaction import InteractionItem
+from gaphor.UML.interactions.lifeline import LifelineItem
 from gaphor.UML.interactions.message import MessageItem
 
 
@@ -39,3 +43,32 @@ def test_group_message_item_with_subject(diagram, element_factory):
 
     assert message.subject
     assert message.subject.interaction is interaction.subject
+
+
+def test_message_connected_to_lifeline(diagram, element_factory, saver, loader):
+    lifeline = diagram.create(
+        LifelineItem, subject=element_factory.create(UML.Lifeline)
+    )
+    lifeline.lifetime.length = 100
+    message = diagram.create(MessageItem, subject=element_factory.create(UML.Message))
+    diagram.update_now({lifeline, message})
+    message.head.pos.x = lifeline.handles()[SE].pos.x
+    message.head.pos.y = lifeline.handles()[-1].pos.y
+
+    connect(message, message.head, lifeline)
+    assert lifeline.lifetime.visible
+    assert (
+        diagram.connections.get_connection(message.head).port is lifeline.lifetime.port
+    )
+
+    data = saver()
+    loader(data)
+
+    new_diagram = next(element_factory.select(Diagram))
+    new_lifeline = next(new_diagram.select(LifelineItem))
+    new_message = next(new_diagram.select(MessageItem))
+    new_port = new_diagram.connections.get_connection(new_message.head).port
+
+    assert new_lifeline.lifetime.visible
+    assert new_lifeline.lifetime.length == 100
+    assert new_port is new_lifeline.lifetime.port


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Issue Number: #1285

### What is the new behavior?

Connecting to the lifetime (line) takes preference over connecting
to the lifeline body. But only if the lifeline is visible, of course.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
