### PR TITLE
Use symbolic close icon for notebook tabs

### DIFF
--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -338,14 +338,14 @@ def tab_label(title, widget, event_manager):
     if Gtk.get_major_version() == 3:
         tab_box.pack_start(child=label, expand=True, fill=True, padding=0)
         close_image = Gtk.Image.new_from_icon_name(
-            icon_name="window-close", size=Gtk.IconSize.BUTTON
+            icon_name="window-close-symbolic", size=Gtk.IconSize.BUTTON
         )
         button.add(close_image)
         tab_box.pack_start(child=button, expand=False, fill=False, padding=0)
         tab_box.show_all()
     else:
         tab_box.append(label)
-        close_image = Gtk.Image.new_from_icon_name("window-close")
+        close_image = Gtk.Image.new_from_icon_name("window-close-symbolic")
         button.set_child(close_image)
         tab_box.append(button)
         tab_box.show()


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [x] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Gaphor uses a legacy, fullcolor close icon for notebook tabs.

### What is the new behavior?

Gaphor uses a symbolic close icon for notebook tabs.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/issues/136