### PR TITLE
Check for placeholder errors in translations

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -26,6 +26,8 @@ jobs:
           python-version: ${{ env.python_version }}
       - name: Lint with Pre-commit
         uses: pre-commit/action@v2.0.3
+      - name: Check translations
+        run: pip install babel && python po/check-babel.py
 
   linux:
     needs: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
           python-version: ${{ env.python_version }}
       - name: Lint with Pre-commit
         uses: pre-commit/action@v2.0.3
+      - name: Check translations
+        run: pip install babel && python po/check-babel.py
 
   linux:
     needs: lint

--- a/gaphor/babel.py
+++ b/gaphor/babel.py
@@ -43,8 +43,8 @@ def translate_model(fileobj):
     tree = etree.parse(fileobj)
 
     for node in tree.findall(".//g:name/g:val", NS):
-        node.text = gettext(node.text or "")
+        node.text = gettext(node.text) if node.text else ""
     for node in tree.findall(".//g:body/g:val", NS):
-        node.text = gettext(node.text or "")
+        node.text = gettext(node.text) if node.text else ""
 
     return io.StringIO(etree.tostring(tree.getroot(), encoding="unicode", method="xml"))

--- a/gaphor/i18n.py
+++ b/gaphor/i18n.py
@@ -30,6 +30,6 @@ def translated_ui_string(package: str, ui_filename: str) -> str:
     with importlib.resources.path(package, ui_filename) as ui_path:
         ui_xml = etree.parse(ui_path)
     for node in ui_xml.findall(".//*[@translatable='yes']"):
-        node.text = gettext(node.text or "")
+        node.text = gettext(node.text) if node.text else ""
         del node.attrib["translatable"]
     return etree.tostring(ui_xml.getroot(), encoding="unicode", method="xml")

--- a/po/check-babel.py
+++ b/po/check-babel.py
@@ -1,0 +1,38 @@
+import re
+import sys
+from pathlib import Path
+
+import babel.messages.pofile as pofile
+
+
+def invalid(messages):
+    placeholders = re.compile(r"{\w*}")
+    for message in messages:
+        if not message.string or message.fuzzy:
+            continue
+
+        if "%" in message.id:
+            yield message, f"Old %-syntax used '{message.id}'"
+
+        id_formats = placeholders.findall(message.id)
+        str_formats = placeholders.findall(message.string)
+
+        if set(id_formats) != set(str_formats):
+            yield message, f"Invalid placeholders for '{message.id}': '{message.string}'"
+
+
+def check_po_files():
+    po_path: Path = Path(__file__).resolve().parent
+    have_errors = False
+    for path in (path for path in po_path.iterdir() if path.suffix == ".po"):
+        with path.open() as po:
+            messages = pofile.read_po(po)
+
+        for message, error in invalid(messages):
+            have_errors = True
+            print(f"{path.name}:{message.lineno}: {error}.")
+    return have_errors
+
+
+if __name__ == "__main__":
+    sys.exit(check_po_files())

--- a/po/check-babel.py
+++ b/po/check-babel.py
@@ -7,6 +7,8 @@ import babel.messages.pofile as pofile
 
 def invalid(messages):
     placeholders = re.compile(r"{\w*}")
+    html_entity = re.compile(r"&\w+;")
+
     for message in messages:
         if not message.string or message.fuzzy:
             continue
@@ -19,6 +21,9 @@ def invalid(messages):
 
         if set(id_formats) != set(str_formats):
             yield message, f"Invalid placeholders for '{message.id}': '{message.string}'"
+
+        if html_entity.findall(message.string):
+            yield message, f"Translation contains HTML entities: '{message.string}'"
 
 
 def check_po_files():

--- a/po/de.po
+++ b/po/de.po
@@ -2077,7 +2077,7 @@ msgstr ""
 
 #: gaphor/ui/diagrampage.py:129 gaphor/ui/namespaceview.py:143
 msgid "<None>"
-msgstr "&lt;Keine&gt;"
+msgstr "<Keine>"
 
 #: gaphor/ui/diagrampage.py:348
 msgid ""
@@ -2391,7 +2391,7 @@ msgstr "Ein {} kann nicht Teil eines {} sein."
 
 #: gaphor/ui/namespaceview.py:141
 msgid "<Relationships>"
-msgstr "&lt;Beziehung&gt;"
+msgstr "<Beziehung>"
 
 #~ msgid "Parts and References"
 #~ msgstr "Teile und Verweise"

--- a/po/fi.po
+++ b/po/fi.po
@@ -2030,7 +2030,7 @@ msgstr ""
 
 #: gaphor/ui/diagrampage.py:129 gaphor/ui/namespaceview.py:143
 msgid "<None>"
-msgstr "&lt;Ei mitään&gt;"
+msgstr "<Ei mitään>"
 
 #: gaphor/ui/diagrampage.py:348
 msgid ""
@@ -2330,7 +2330,7 @@ msgstr "{} ei voi olla osana {}."
 
 #: gaphor/ui/namespaceview.py:141
 msgid "<Relationships>"
-msgstr "&lt;Suhteet&gt;"
+msgstr "<Suhteet>"
 
 #~ msgid ""
 #~ "To create a fresh model: create a window, create the\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2239,7 +2239,7 @@ msgstr "Chargement du modèle à partir de {filename}"
 
 #: gaphor/ui/filemanager.py:147
 msgid "Unable to open model “{filename}”."
-msgstr "Impossible d'ouvrir le modèle « {nom du fichier} »."
+msgstr "Impossible d'ouvrir le modèle « {filename} »."
 
 #: gaphor/ui/filemanager.py:150
 msgid "This file does not contain a valid Gaphor model."

--- a/po/hr.po
+++ b/po/hr.po
@@ -1284,8 +1284,8 @@ msgid ""
 "Type \"help\" for more information.\n"
 msgstr ""
 "Gaphorova interaktivna Python konzola\n"
-"{verzija)\n"
-"Za daljnje informacije upiši “help\" (pomoć).\n"
+"{version}\n"
+"Za daljnje informacije upiši \"help\" (pomoć).\n"
 
 #: gaphor/plugins/console/consolewindow.py:20
 msgid "Gaphor Console"

--- a/po/hr.po
+++ b/po/hr.po
@@ -2083,7 +2083,7 @@ msgstr ""
 
 #: gaphor/ui/diagrampage.py:129 gaphor/ui/namespaceview.py:143
 msgid "<None>"
-msgstr "&lt;Bez&gt;"
+msgstr "<Bez>"
 
 #: gaphor/ui/diagrampage.py:348
 msgid ""
@@ -2390,7 +2390,7 @@ msgstr "{} ne može biti dio od {}."
 
 #: gaphor/ui/namespaceview.py:141
 msgid "<Relationships>"
-msgstr "&lt;Odnosi&gt;"
+msgstr "<Odnosi>"
 
 #~ msgid "title"
 #~ msgstr "naslov"

--- a/po/hu.po
+++ b/po/hu.po
@@ -2096,7 +2096,7 @@ msgstr ""
 
 #: gaphor/ui/diagrampage.py:129 gaphor/ui/namespaceview.py:143
 msgid "<None>"
-msgstr "&lt;Nincs&gt;"
+msgstr "<Nincs>"
 
 #: gaphor/ui/diagrampage.py:348
 msgid ""
@@ -2395,7 +2395,7 @@ msgstr "A(z) {} nem lehet része a következőnek: {}."
 
 #: gaphor/ui/namespaceview.py:141
 msgid "<Relationships>"
-msgstr "&lt;Kapcsolatok&gt;"
+msgstr "<Kapcsolatok>"
 
 #~ msgid ""
 #~ "To create a fresh model: create a window, create the\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -2360,7 +2360,7 @@ msgstr "Toon in “{diagram}”"
 
 #: gaphor/ui/namespace.py:323
 msgid "{name} package"
-msgstr "Nieuw package"
+msgstr "{name} package"
 
 #: gaphor/ui/namespace.py:342
 msgid "New diagram"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2384,7 +2384,7 @@ msgstr "Um {} não pode fazer parte de um {}."
 
 #: gaphor/ui/namespaceview.py:141
 msgid "<Relationships>"
-msgstr "&lt;Relacionamentos&gt;"
+msgstr "<Relacionamentos>"
 
 #~ msgid ""
 #~ "Opening a new model will flush the currently loaded model.\n"


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Errors can slip in the PO files that cause our app to fail.

We do not check for errors in translations actively.


Issue Number: #1297

### What is the new behavior?

Check if all placeholders are properly used in the translations.

We should only use the `{key}` syntax for placeholders.


### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Output is like:

```
nl.po:2362: Invalid placeholders for '{name} package': 'Nieuw package'
hr.po:1281: Invalid placeholders for 'Gaphor Interactive Python Console
{version}
Type "help" for more information.
': 'Gaphorova interaktivna Python konzola
{verzija)
Za daljnje informacije upiši “help" (pomoć).
'
fr.po:2241: Invalid placeholders for 'Unable to open model “{filename}”.': 'Impossible d'ouvrir le modèle « {nom du fichier} ».'
```