### PR TITLE
Add Additional Strings for Translation

### DIFF
--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -3,6 +3,7 @@
 import re
 from typing import Tuple
 
+from gaphor.core import gettext
 from gaphor.core.format import format
 from gaphor.UML import uml as UML
 
@@ -198,19 +199,19 @@ def format_relationship(el):
 
 @format.register(UML.Generalization)
 def format_generalization(el):
-    return f"general: {el.general and el.general.name or ''}"
+    return gettext("general: {}").format(el.general and el.general.name or "")
 
 
 @format.register(UML.Dependency)
 def format_dependency(el):
-    return f"supplier: {el.supplier and el.supplier.name or ''}"
+    return gettext("supplier: {}").format(el.supplier and el.supplier.name or "")
 
 
 @format.register(UML.Extend)
 def format_extend(el):
-    return f"extend: {el.extendedCase and el.extendedCase.name or ''}"
+    return gettext("extend: {}").format(el.extendedCase and el.extendedCase.name or "")
 
 
 @format.register(UML.Include)
 def format_include(el):
-    return f"include: {el.addition and el.addition.name or ''}"
+    return gettext("include: {}").format(el.addition and el.addition.name or "")

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -53,10 +53,11 @@ def format_property(
     if name:
         s.append(name)
 
-    if type and el.typeValue:
-        s.append(f": {el.typeValue}")
-    elif type and el.type and el.type.name:
-        s.append(f": {el.type.name}")
+    if type:
+        if el.typeValue:
+            s.append(f": {el.typeValue}")
+        elif el.type and el.type.name:
+            s.append(f": {el.type.name}")
 
     if multiplicity:
         s.append(format_multiplicity(el))
@@ -64,10 +65,10 @@ def format_property(
     if default and el.defaultValue:
         s.append(f" = {el.defaultValue}")
 
-    if tags:
-        slots = [format(slot) for slot in el.appliedStereotype[:].slot if slot]
-        if slots:
-            s.append(" { %s }" % ", ".join(slots))
+    if tags and (
+        slots := [format(slot) for slot in el.appliedStereotype[:].slot if slot]
+    ):
+        s.append(" { %s }" % ", ".join(slots))
 
     if note and el.note:
         s.append(f" # {el.note}")
@@ -89,8 +90,7 @@ def format_association_end(el) -> Tuple[str, str]:
         name = "".join(n)
 
     m = [format_multiplicity(el, bare=True)]
-    slots = [format(slot) for slot in el.appliedStereotype[:].slot if slot]
-    if slots:
+    if slots := [format(slot) for slot in el.appliedStereotype[:].slot if slot]:
         m.append(" { %s }" % ",\n".join(slots))
     mult = "".join(m)
 
@@ -142,8 +142,7 @@ def format_operation(
     )
     s.append(")")
 
-    rr = next((p for p in el.ownedParameter if p.direction == "return"), None)
-    if rr:
+    if rr := next((p for p in el.ownedParameter if p.direction == "return"), None):
         s.append(format(rr, type=type, multiplicity=multiplicity, default=default))
 
     if note and el.note:

--- a/gaphor/ui/appfilemanager.py
+++ b/gaphor/ui/appfilemanager.py
@@ -36,7 +36,7 @@ class AppFileManager(Service, ActionProvider):
     def action_open(self):
         """This menu action opens the standard model open dialog."""
         filenames = open_file_dialog(
-            gettext("Gaphor - Open Model"),
+            gettext("Open a Model"),
             parent=self.parent_window,
             dirname=self.last_dir,
             filters=FILTERS,

--- a/gaphor/ui/greeter.py
+++ b/gaphor/ui/greeter.py
@@ -160,11 +160,11 @@ class Greeter(Service, ActionProvider):
                 self.back_button.set_visible(True)
             else:
                 self.back_button.set_visible(False)
-            self.greeter.set_title(gettext("Gaphor - Create a New Model"))
+            self.greeter.set_title(gettext("Create a New Model"))
         else:
             self.action_bar.set_visible(True)
             self.back_button.set_visible(False)
-            self.greeter.set_title(gettext("Gaphor - Open a Recent Model"))
+            self.greeter.set_title(gettext("Open a Recent Model"))
 
     def _on_recent_file_activated(self, _listbox, row):
         filename = row.filename

--- a/po/ca.po
+++ b/po/ca.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor 0.15\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2011-03-05 20:26+0100\n"
 "Last-Translator: Jordi Vilalta Prat <jvprat@gmail.com>\n"
 "Language: ca\n"
@@ -580,6 +580,25 @@ msgstr ""
 #, fuzzy
 msgid "New Profile Diagram"
 msgstr "_Diagrama"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "generalització: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "extèn: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "inclou: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/ca.po
+++ b/po/ca.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor 0.15\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2011-03-05 20:26+0100\n"
 "Last-Translator: Jordi Vilalta Prat <jvprat@gmail.com>\n"
 "Language: ca\n"
@@ -1378,7 +1378,7 @@ msgid "About Gaphor"
 msgstr ""
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr ""
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2079,8 +2079,9 @@ msgid "All Gaphor Models"
 msgstr "Anomena i desa el model de Gaphor"
 
 #: gaphor/ui/appfilemanager.py:39
-msgid "Gaphor - Open Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Model"
+msgstr "Anomena i desa el model de Gaphor"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2264,12 +2265,14 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Model nou"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Model nou"
 
 #: gaphor/ui/greeter.ui:88
 #, fuzzy
@@ -2844,4 +2847,16 @@ msgstr ""
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Anomena i desa el model de Gaphor"
+
+#~ msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2022-01-16 13:30+0000\n"
 "Last-Translator: Dan Yeaw <dan@yeaw.me>\n"
 "Language: de\n"
@@ -1352,7 +1352,8 @@ msgid "About Gaphor"
 msgstr "Über Gaphor"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#, fuzzy
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr "Copyright © 2001-2021 Arjan J. Molenaar und Dan Yeaw"
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2064,8 +2065,8 @@ msgstr "Alle Gaphor-Modelle"
 
 #: gaphor/ui/appfilemanager.py:39
 #, fuzzy
-msgid "Gaphor - Open Model"
-msgstr "Gaphor-Konsole"
+msgid "Open a Model"
+msgstr "Öffne Gaphor-Modell"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2285,12 +2286,14 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Neues Modell"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Neues Modell"
 
 #: gaphor/ui/greeter.ui:88
 #, fuzzy
@@ -2597,4 +2600,13 @@ msgstr "<Beziehung>"
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Öffne Gaphor-Modell"
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr "Gaphor-Konsole"
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2022-01-16 13:30+0000\n"
 "Last-Translator: Dan Yeaw <dan@yeaw.me>\n"
 "Language: de\n"
@@ -572,6 +572,25 @@ msgstr ""
 #, fuzzy
 msgid "New Profile Diagram"
 msgstr "Neues Diagramm"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "generalisierung: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr ""
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/es.po
+++ b/po/es.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor 0.8.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2022-01-20 01:07+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@tuta.io>\n"
 "Language: es\n"
@@ -1365,7 +1365,8 @@ msgid "About Gaphor"
 msgstr "Acerca de Gaphor"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#, fuzzy
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr "Copyright © 2001-2021 Arjan J. Molenaar y Dan Yeaw"
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2075,8 +2076,8 @@ msgstr "Todos los modelos Gaphor"
 
 #: gaphor/ui/appfilemanager.py:39
 #, fuzzy
-msgid "Gaphor - Open Model"
-msgstr "Consola de Gaphor"
+msgid "Open a Model"
+msgstr "Abrir un modelo…"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2294,12 +2295,14 @@ msgid "Generic"
 msgstr "Genérico"
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Crear un modelo nuevo…"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Modelo reciente…"
 
 #: gaphor/ui/greeter.ui:88
 msgid "Recent Model…"
@@ -2666,4 +2669,13 @@ msgstr "<Relationships>"
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Abrir un modelo Gaphor"
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr "Consola de Gaphor"
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor 0.8.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2022-01-20 01:07+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@tuta.io>\n"
 "Language: es\n"
@@ -549,6 +549,25 @@ msgstr "Diagrama de comunicación nuevo"
 #: gaphor/UML/toolbox.py:39
 msgid "New Profile Diagram"
 msgstr "Diagrama de perfil nuevo"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "extender: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "incluir: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2022-01-20 01:21+0000\n"
 "Last-Translator: Dan Yeaw <dan@yeaw.me>\n"
 "Language: fi\n"
@@ -556,6 +556,25 @@ msgstr "Uusi kommunikaatiokaavio"
 #: gaphor/UML/toolbox.py:39
 msgid "New Profile Diagram"
 msgstr "Uusi profiilikaavio"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "yleiset: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "laajenna: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "sisällytä: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2022-01-20 01:21+0000\n"
 "Last-Translator: Dan Yeaw <dan@yeaw.me>\n"
 "Language: fi\n"
@@ -1335,7 +1335,8 @@ msgid "About Gaphor"
 msgstr "Tietoja - Gaphor"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#, fuzzy
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr "Tekijänoikeus © 2001-2021 Arjan J. Molenaar ja Dan Yeaw"
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2006,8 +2007,8 @@ msgstr "Kaikki Gaphor-mallit"
 
 #: gaphor/ui/appfilemanager.py:39
 #, fuzzy
-msgid "Gaphor - Open Model"
-msgstr "Gaphorin konsoli"
+msgid "Open a Model"
+msgstr "Avaa malli…"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2219,12 +2220,14 @@ msgid "Generic"
 msgstr "Yleinen"
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Luo uusi malli…"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Äskettäinen malli…"
 
 #: gaphor/ui/greeter.ui:88
 msgid "Recent Model…"
@@ -2638,4 +2641,13 @@ msgstr "<Suhteet>"
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Avaa Gaphor-malli"
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr "Gaphorin konsoli"
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor 0.13.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2021-08-29 19:09+0000\n"
 "Last-Translator: J. Lavoie <j.lavoie@net-c.ca>\n"
 "Language: fr\n"
@@ -589,6 +589,25 @@ msgstr ""
 #, fuzzy
 msgid "New Profile Diagram"
 msgstr "Nouveau _Diagramme"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "général: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "étendre: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "inclure: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/fr.po
+++ b/po/fr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor 0.13.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2021-08-29 19:09+0000\n"
 "Last-Translator: J. Lavoie <j.lavoie@net-c.ca>\n"
 "Language: fr\n"
@@ -1393,7 +1393,7 @@ msgid "About Gaphor"
 msgstr "À _propos de Gaphor"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr ""
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2103,8 +2103,9 @@ msgid "All Gaphor Models"
 msgstr "Modèles Gaphor"
 
 #: gaphor/ui/appfilemanager.py:39
-msgid "Gaphor - Open Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Model"
+msgstr "Ouvrir un modèle Gaphor"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2293,12 +2294,14 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Nouveau modèle"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Nouveau modèle"
 
 #: gaphor/ui/greeter.ui:88
 #, fuzzy
@@ -2866,4 +2869,16 @@ msgstr ""
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Ouvrir un modèle Gaphor"
+
+#~ msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/gaphor.pot
+++ b/po/gaphor.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1322,7 +1322,7 @@ msgid "About Gaphor"
 msgstr ""
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr ""
 
 #: gaphor/services/helpservice/about.ui:11
@@ -1986,7 +1986,7 @@ msgid "All Gaphor Models"
 msgstr ""
 
 #: gaphor/ui/appfilemanager.py:39
-msgid "Gaphor - Open Model"
+msgid "Open a Model"
 msgstr ""
 
 #: gaphor/ui/appfilemanager.py:49
@@ -2162,11 +2162,11 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
+msgid "Create a New Model"
 msgstr ""
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
+msgid "Open a Recent Model"
 msgstr ""
 
 #: gaphor/ui/greeter.ui:88

--- a/po/gaphor.pot
+++ b/po/gaphor.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -548,6 +548,22 @@ msgstr ""
 
 #: gaphor/UML/toolbox.py:39
 msgid "New Profile Diagram"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:202
+msgid "general: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+msgid "extend: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:217
+msgid "include: {}"
 msgstr ""
 
 #: gaphor/UML/actions/actionstoolbox.py:16

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2022-01-03 00:54+0000\n"
 "Last-Translator: Fran Diéguez <fran.dieguez@mabishu.com>\n"
 "Language: gl\n"
@@ -1327,7 +1327,8 @@ msgid "About Gaphor"
 msgstr "Sobre Gaphorr"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#, fuzzy
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr "Copyright © 2001-2021 Arjan J. Molenaar e Dan Yeaw"
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2042,8 +2043,8 @@ msgstr "Todos os modelos Gaphor"
 
 #: gaphor/ui/appfilemanager.py:39
 #, fuzzy
-msgid "Gaphor - Open Model"
-msgstr "Consola de Gaphor"
+msgid "Open a Model"
+msgstr "Abrir un modelo…"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2238,12 +2239,14 @@ msgid "Generic"
 msgstr "Xenérico"
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Crear novo modelo…"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Modelo recente…"
 
 #: gaphor/ui/greeter.ui:88
 msgid "Recent Model…"
@@ -2616,4 +2619,13 @@ msgstr "<relationships></relationships>"
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Abrir un modelo Gaphor"
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr "Consola de Gaphor"
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2022-01-03 00:54+0000\n"
 "Last-Translator: Fran Diéguez <fran.dieguez@mabishu.com>\n"
 "Language: gl\n"
@@ -551,6 +551,25 @@ msgstr "Novo diagrama de comunicación"
 #: gaphor/UML/toolbox.py:39
 msgid "New Profile Diagram"
 msgstr "Novo diagrama de perfíl"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "xeral: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "estender: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "incluír: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/hr.po
+++ b/po/hr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Gaphor\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2021-12-19 14:52+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language: hr\n"
@@ -568,6 +568,25 @@ msgstr ""
 #, fuzzy
 msgid "New Profile Diagram"
 msgstr "Novi dijagram"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "opće: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "proširi: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "uključi: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/hr.po
+++ b/po/hr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Gaphor\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2021-12-19 14:52+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language: hr\n"
@@ -1347,7 +1347,8 @@ msgid "About Gaphor"
 msgstr "O programu Gaphor"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#, fuzzy
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr "Copyright © 2001. – 2021. Arjan J. Molenaar i Dan Yeaw"
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2071,8 +2072,8 @@ msgstr "Svi Gaphor modeli"
 
 #: gaphor/ui/appfilemanager.py:39
 #, fuzzy
-msgid "Gaphor - Open Model"
-msgstr "Gaphor konzola"
+msgid "Open a Model"
+msgstr "Otvori Gaphor model"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2285,12 +2286,14 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Novi model"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Novi model"
 
 #: gaphor/ui/greeter.ui:88
 #, fuzzy
@@ -2810,4 +2813,13 @@ msgstr "<Odnosi>"
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Otvori Gaphor model"
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr "Gaphor konzola"
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2022-01-21 06:55+0000\n"
 "Last-Translator: ovari <ovari123@zoho.com>\n"
 "Language: hu\n"
@@ -553,6 +553,25 @@ msgstr "Új kommunikációs ábra"
 #: gaphor/UML/toolbox.py:39
 msgid "New Profile Diagram"
 msgstr "Új profilábra"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "általános: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "kiterjesztés: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "belefoglalás: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,17 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2022-01-21 06:55+0000\n"
 "Last-Translator: ovari <ovari123@zoho.com>\n"
-"Language-Team: Hungarian <https://hosted.weblate.org/projects/gaphor/gaphor/"
-"hu/>\n"
 "Language: hu\n"
+"Language-Team: Hungarian "
+"<https://hosted.weblate.org/projects/gaphor/gaphor/hu/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.11-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: gaphor/C4Model/modelinglanguage.py:18 gaphor/C4Model/toolbox.py:56
@@ -1377,7 +1376,8 @@ msgid "About Gaphor"
 msgstr "A Gaphor névjegye"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#, fuzzy
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr "Szerzői jog © 2001-2021 Molenaar Arjan J. és Yeaw Dan"
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2083,8 +2083,9 @@ msgid "All Gaphor Models"
 msgstr "Minden Gaphor-modell"
 
 #: gaphor/ui/appfilemanager.py:39
-msgid "Gaphor - Open Model"
-msgstr "Modell megnyitása - Gaphor"
+#, fuzzy
+msgid "Open a Model"
+msgstr "Modell megnyitása…"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2294,11 +2295,13 @@ msgid "Generic"
 msgstr "Általános"
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr "Új modell létrehozása - Gaphor"
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Új modell létrehozása…"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
+#, fuzzy
+msgid "Open a Recent Model"
 msgstr "Legutóbbi modell megnyitása - Gaphor"
 
 #: gaphor/ui/greeter.ui:88
@@ -2739,3 +2742,10 @@ msgstr "<Kapcsolatok>"
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Gaphor-modell megnyitása"
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr "Modell megnyitása - Gaphor"
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr "Új modell létrehozása - Gaphor"
+

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2021-03-21 14:30+0100\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language: it\n"
@@ -598,6 +598,25 @@ msgstr ""
 #, fuzzy
 msgid "New Profile Diagram"
 msgstr "Nuovo_Diagrama"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "generale: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "estendi: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "includi: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2021-03-21 14:30+0100\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language: it\n"
@@ -1402,7 +1402,7 @@ msgid "About Gaphor"
 msgstr "Informazioni su Gaphor"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr ""
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2112,8 +2112,9 @@ msgid "All Gaphor Models"
 msgstr "Modelli Gaphor"
 
 #: gaphor/ui/appfilemanager.py:39
-msgid "Gaphor - Open Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Model"
+msgstr "Apri modello Gaphor"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2296,12 +2297,14 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Nuovo modello"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Nuovo modello"
 
 #: gaphor/ui/greeter.ui:88
 #, fuzzy
@@ -2861,4 +2864,16 @@ msgstr ""
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Apri modello Gaphor"
+
+#~ msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2021-10-21 12:41+0000\n"
 "Last-Translator: Tomo Dote <fu7mu4@gmail.com>\n"
 "Language: ja\n"
@@ -1350,7 +1350,8 @@ msgid "About Gaphor"
 msgstr "Gaphor について"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#, fuzzy
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2058,8 +2059,8 @@ msgstr "全Gaphorモデル"
 
 #: gaphor/ui/appfilemanager.py:39
 #, fuzzy
-msgid "Gaphor - Open Model"
-msgstr "Gaphorコンソール"
+msgid "Open a Model"
+msgstr "Gaphorモデルを開く"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2254,12 +2255,14 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "新モデル"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "新モデル"
 
 #: gaphor/ui/greeter.ui:88
 #, fuzzy
@@ -2658,4 +2661,13 @@ msgstr ""
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Gaphorモデルを開く"
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr "Gaphorコンソール"
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2021-10-21 12:41+0000\n"
 "Last-Translator: Tomo Dote <fu7mu4@gmail.com>\n"
 "Language: ja\n"
@@ -571,6 +571,23 @@ msgstr ""
 #, fuzzy
 msgid "New Profile Diagram"
 msgstr "新ダイアグラム(_D)"
+
+#: gaphor/UML/umlfmt.py:202
+msgid "general: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+msgid "extend: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "プロファイル: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/ko.po
+++ b/po/ko.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor master\n"
 "Report-Msgid-Bugs-To: https://github.com/gaphor/gaphor/issues\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2021-08-31 14:20+0900\n"
 "Last-Translator: Seong-ho Cho <darkcircle.0426@gmail.com>\n"
 "Language: ko\n"
@@ -1381,7 +1381,8 @@ msgid "About Gaphor"
 msgstr "가포 정보"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#, fuzzy
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2092,8 +2093,9 @@ msgid "All Gaphor Models"
 msgstr "모든 가포 모델"
 
 #: gaphor/ui/appfilemanager.py:39
-msgid "Gaphor - Open Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Model"
+msgstr "가포 모델 열기"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2299,12 +2301,14 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "새 모델"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "새 모델"
 
 #: gaphor/ui/greeter.ui:88
 #, fuzzy
@@ -2728,4 +2732,13 @@ msgstr "<Relationships>"
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "가포 모델 열기"
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor master\n"
 "Report-Msgid-Bugs-To: https://github.com/gaphor/gaphor/issues\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2021-08-31 14:20+0900\n"
 "Last-Translator: Seong-ho Cho <darkcircle.0426@gmail.com>\n"
 "Language: ko\n"
@@ -582,6 +582,25 @@ msgstr ""
 #, fuzzy
 msgid "New Profile Diagram"
 msgstr "새 다이어그램(_D)"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "일반: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "확장: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "포함: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.6.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2022-01-09 06:56+0000\n"
 "Last-Translator: Arjan Molenaar <gaphor@gmail.com>\n"
 "Language: nl\n"
@@ -551,6 +551,25 @@ msgstr "Nieuw Communicatie Diagram"
 #: gaphor/UML/toolbox.py:39
 msgid "New Profile Diagram"
 msgstr "Nieuw Profiel Diagram"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "algemeen: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr ""
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.6.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2022-01-09 06:56+0000\n"
 "Last-Translator: Arjan Molenaar <gaphor@gmail.com>\n"
 "Language: nl\n"
@@ -1364,7 +1364,8 @@ msgid "About Gaphor"
 msgstr "Over Gaphor"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#, fuzzy
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2079,8 +2080,8 @@ msgstr "Alle Gaphor modellen"
 
 #: gaphor/ui/appfilemanager.py:39
 #, fuzzy
-msgid "Gaphor - Open Model"
-msgstr "Gaphor Console"
+msgid "Open a Model"
+msgstr "Open een Model…"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2273,12 +2274,14 @@ msgid "Generic"
 msgstr "Generiek"
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Maak Nieuw Model…"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Recente modellen…"
 
 #: gaphor/ui/greeter.ui:88
 msgid "Recent Model…"
@@ -2476,4 +2479,13 @@ msgstr ""
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Open Gaphor Model"
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr "Gaphor Console"
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor 0.14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2022-01-07 16:56+0000\n"
 "Last-Translator: Gabriel Gian <gabrielgian@live.com>\n"
 "Language: pt_BR\n"
@@ -552,6 +552,25 @@ msgstr "Novo Diagrama de Comunicação"
 #: gaphor/UML/toolbox.py:39
 msgid "New Profile Diagram"
 msgstr "Novo Diagrama de Perfil"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "geral: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "estende: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "inclui: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor 0.14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2022-01-07 16:56+0000\n"
 "Last-Translator: Gabriel Gian <gabrielgian@live.com>\n"
 "Language: pt_BR\n"
@@ -1349,7 +1349,8 @@ msgid "About Gaphor"
 msgstr "Sobre Gaphor"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#, fuzzy
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2060,8 +2061,9 @@ msgid "All Gaphor Models"
 msgstr "Todos os modelos Gaphor"
 
 #: gaphor/ui/appfilemanager.py:39
-msgid "Gaphor - Open Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Model"
+msgstr "Abrir Modelo Gaphor"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2274,12 +2276,14 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Novo modelo"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Novo modelo"
 
 #: gaphor/ui/greeter.ui:88
 #, fuzzy
@@ -2859,4 +2863,13 @@ msgstr "<Relacionamentos>"
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Abrir Modelo Gaphor"
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor 0.13.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2011-08-22 22:15+0000\n"
 "Last-Translator: Евгений Лежнин <z_lezhnin@mail2000.ru>\n"
 "Language: ru\n"
@@ -1373,7 +1373,7 @@ msgid "About Gaphor"
 msgstr ""
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr ""
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2075,8 +2075,9 @@ msgid "All Gaphor Models"
 msgstr "Сохранить модель Gaphor как"
 
 #: gaphor/ui/appfilemanager.py:39
-msgid "Gaphor - Open Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Model"
+msgstr "Новая модель"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2258,12 +2259,14 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Новая модель"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Новая модель"
 
 #: gaphor/ui/greeter.ui:88
 #, fuzzy
@@ -2844,4 +2847,16 @@ msgstr ""
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Сохранить модель Gaphor как"
+
+#~ msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gaphor 0.13.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2011-08-22 22:15+0000\n"
 "Last-Translator: Евгений Лежнин <z_lezhnin@mail2000.ru>\n"
 "Language: ru\n"
@@ -581,6 +581,24 @@ msgstr ""
 #, fuzzy
 msgid "New Profile Diagram"
 msgstr "_Новая диаграмма"
+
+#: gaphor/UML/umlfmt.py:202
+msgid "general: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "расширение: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "включение: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/sv.po
+++ b/po/sv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  gaphor\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2006-05-11 16:34+0000\n"
 "Last-Translator: Daniel Nylander <po@danielnylander.se>\n"
 "Language: sv\n"
@@ -1368,7 +1368,7 @@ msgid "About Gaphor"
 msgstr ""
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr ""
 
 #: gaphor/services/helpservice/about.ui:11
@@ -2068,8 +2068,9 @@ msgid "All Gaphor Models"
 msgstr "Spara Gaphor-modell som"
 
 #: gaphor/ui/appfilemanager.py:39
-msgid "Gaphor - Open Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Model"
+msgstr "Spara Gaphor-modell som"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2249,12 +2250,14 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "Ny modell"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "Ny modell"
 
 #: gaphor/ui/greeter.ui:88
 #, fuzzy
@@ -2845,4 +2848,16 @@ msgstr ""
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "Spara Gaphor-modell som"
+
+#~ msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  gaphor\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2006-05-11 16:34+0000\n"
 "Last-Translator: Daniel Nylander <po@danielnylander.se>\n"
 "Language: sv\n"
@@ -574,6 +574,23 @@ msgstr ""
 #, fuzzy
 msgid "New Profile Diagram"
 msgstr "Nytt _Diagram"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "interaktioner: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+msgid "extend: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:217
+msgid "include: {}"
+msgstr ""
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-19 20:35-0500\n"
+"POT-Creation-Date: 2022-01-22 14:42-0500\n"
 "PO-Revision-Date: 2022-01-17 18:34+0000\n"
 "Last-Translator: ZHUOQI LI <zhuoqi06@gmail.com>\n"
 "Language: zh_Hans\n"
@@ -1324,7 +1324,7 @@ msgid "About Gaphor"
 msgstr "关于 Gaphor"
 
 #: gaphor/services/helpservice/about.ui:10
-msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+msgid "Copyright © 2001-2022 Arjan J. Molenaar and Dan Yeaw"
 msgstr ""
 
 #: gaphor/services/helpservice/about.ui:11
@@ -1991,8 +1991,8 @@ msgstr ""
 
 #: gaphor/ui/appfilemanager.py:39
 #, fuzzy
-msgid "Gaphor - Open Model"
-msgstr "Gaphor 控制台"
+msgid "Open a Model"
+msgstr "打开模型 …"
 
 #: gaphor/ui/appfilemanager.py:49
 msgid ""
@@ -2168,12 +2168,14 @@ msgid "Generic"
 msgstr ""
 
 #: gaphor/ui/greeter.py:163
-msgid "Gaphor - Create a New Model"
-msgstr ""
+#, fuzzy
+msgid "Create a New Model"
+msgstr "创建新模型 …"
 
 #: gaphor/ui/greeter.py:167
-msgid "Gaphor - Open a Recent Model"
-msgstr ""
+#, fuzzy
+msgid "Open a Recent Model"
+msgstr "最近打开的模型…"
 
 #: gaphor/ui/greeter.ui:88
 msgid "Recent Model…"
@@ -2429,4 +2431,16 @@ msgstr ""
 
 #~ msgid "Open a Gaphor Model"
 #~ msgstr "打开 Gaphor 模型"
+
+#~ msgid "Copyright © 2001-2021 Arjan J. Molenaar and Dan Yeaw"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open Model"
+#~ msgstr "Gaphor 控制台"
+
+#~ msgid "Gaphor - Create a New Model"
+#~ msgstr ""
+
+#~ msgid "Gaphor - Open a Recent Model"
+#~ msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-22 14:42-0500\n"
+"POT-Creation-Date: 2022-01-22 15:09-0500\n"
 "PO-Revision-Date: 2022-01-17 18:34+0000\n"
 "Last-Translator: ZHUOQI LI <zhuoqi06@gmail.com>\n"
 "Language: zh_Hans\n"
@@ -551,6 +551,25 @@ msgstr "新建通讯图"
 #: gaphor/UML/toolbox.py:39
 msgid "New Profile Diagram"
 msgstr "新建配置图"
+
+#: gaphor/UML/umlfmt.py:202
+#, fuzzy
+msgid "general: {}"
+msgstr "通用: {}"
+
+#: gaphor/UML/umlfmt.py:207
+msgid "supplier: {}"
+msgstr ""
+
+#: gaphor/UML/umlfmt.py:212
+#, fuzzy
+msgid "extend: {}"
+msgstr "扩展: {}"
+
+#: gaphor/UML/umlfmt.py:217
+#, fuzzy
+msgid "include: {}"
+msgstr "包含: {}"
 
 #: gaphor/UML/actions/actionstoolbox.py:16
 #: gaphor/UML/interactions/interactionstoolbox.py:20


### PR DESCRIPTION
This PR adds additional translation strings:

- The updated greeter added the app name to the Greeter and File Manager window titles. This PR removes them, as discussed in #1308. Other GNOME apps don't include the app name in the Window title.
- Adds translation for UML relationship formats like `include: ClassName`

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Window titles say, for example: `Gaphor - Create a New Model`

Issue Number: 1308

### What is the new behavior?
Window titles say, for example: `Create a New Model`

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

### Other information
