### PR TITLE
Fix splitting of lines

### DIFF
--- a/gaphor/diagram/tools/tests/test_txtool.py
+++ b/gaphor/diagram/tools/tests/test_txtool.py
@@ -1,12 +1,7 @@
 import pytest
 from gi.repository import Gtk
 
-from gaphor.diagram.tools.txtool import (
-    TxData,
-    on_end,
-    on_sequence_claimed,
-    transactional_tool,
-)
+from gaphor.diagram.tools.txtool import TxData, on_begin, on_end, transactional_tool
 from gaphor.transaction import TransactionBegin
 
 
@@ -32,7 +27,7 @@ class MockEventManager:
         self.events.append(event)
 
 
-def test_start_tx_on_sequence_claimed(view):
+def test_start_tx_on_begin(view):
     event_manager = MockEventManager()
     tx_data = TxData(event_manager)
     if Gtk.get_major_version() == 3:
@@ -40,7 +35,7 @@ def test_start_tx_on_sequence_claimed(view):
     else:
         (tool,) = transactional_tool(Gtk.GestureDrag.new(), event_manager=event_manager)  # type: ignore[arg-type]
 
-    on_sequence_claimed(tool, None, Gtk.EventSequenceState.CLAIMED, tx_data)
+    on_begin(tool, None, tx_data)
     assert tx_data.txs
 
     on_end(tool, None, tx_data)

--- a/gaphor/diagram/tools/txtool.py
+++ b/gaphor/diagram/tools/txtool.py
@@ -15,8 +15,7 @@ class TxData:
         self.txs.append(Transaction(self.event_manager))
 
     def commit(self):
-        if not self.txs:
-            return
+        assert self.txs
         tx = self.txs.pop()
         tx.commit()
 
@@ -26,14 +25,13 @@ def transactional_tool(
 ) -> Iterable[Gtk.Gesture]:
     tx_data = TxData(event_manager)
     for tool in tools:
-        tool.connect("sequence-state-changed", on_sequence_claimed, tx_data)
+        tool.connect("begin", on_begin, tx_data)
         tool.connect_after("end", on_end, tx_data)
     return tools
 
 
-def on_sequence_claimed(gesture, _sequence, state, tx_data):
-    if state == Gtk.EventSequenceState.CLAIMED:
-        tx_data.begin()
+def on_begin(gesture, _sequence, tx_data):
+    tx_data.begin()
 
 
 def on_end(gesture, _sequence, tx_data):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

It's no possble to split a line in two segments.

Issue Number: #1312

### What is the new behavior?

Start a transaction on `drag-begin`, So handle creation happens within a transaction.

Reverts d55585903ef6ac9ab7ad119f4b167f22f564b0c9 (except for one line).

Fixes #1312.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

