### PR TITLE
Improve reconnect for relationships

### DIFF
--- a/docs/connect.gaphor
+++ b/docs/connect.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.7.1">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.8.2">
 <Package id="a26e1ce4-0092-11eb-8f71-7fd0147881a5">
 <name>
 <val>connect</val>
@@ -9,6 +9,11 @@
 <ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
 </reflist>
 </ownedDiagram>
+<ownedType>
+<reflist>
+<ref refid="183251a5-8a7b-11ec-a060-69879bc4f7d4"/>
+</reflist>
+</ownedType>
 </Package>
 <Diagram id="a26e1ce5-0092-11eb-8f71-7fd0147881a5">
 <element>
@@ -24,32 +29,31 @@
 <ref refid="b7ca8dad-0092-11eb-8f71-7fd0147881a5"/>
 <ref refid="dfca3399-0092-11eb-8f71-7fd0147881a5"/>
 <ref refid="3590f245-0093-11eb-8f71-7fd0147881a5"/>
-<ref refid="035d56f9-0094-11eb-8f71-7fd0147881a5"/>
 <ref refid="5337bbe3-0094-11eb-8f71-7fd0147881a5"/>
 <ref refid="a5d7ae62-0094-11eb-8f71-7fd0147881a5"/>
-<ref refid="29b44aa3-0097-11eb-8f71-7fd0147881a5"/>
 <ref refid="4859fda5-0097-11eb-8f71-7fd0147881a5"/>
 <ref refid="737761ea-0097-11eb-8f71-7fd0147881a5"/>
+<ref refid="53ca10f1-8b30-11ec-9c46-3d62bbb2b1b9"/>
+<ref refid="93086bf3-8b30-11ec-a706-3d62bbb2b1b9"/>
 <ref refid="b374785d-0092-11eb-8f71-7fd0147881a5"/>
 <ref refid="f7247d4a-0092-11eb-8f71-7fd0147881a5"/>
 <ref refid="106489cc-0093-11eb-8f71-7fd0147881a5"/>
 <ref refid="44175877-0093-11eb-8f71-7fd0147881a5"/>
 <ref refid="69fcbf89-0093-11eb-8f71-7fd0147881a5"/>
-<ref refid="d82f0d92-0093-11eb-8f71-7fd0147881a5"/>
 <ref refid="f15455e9-0093-11eb-8f71-7fd0147881a5"/>
 <ref refid="175402ac-0094-11eb-8f71-7fd0147881a5"/>
-<ref refid="3d675f9e-0094-11eb-8f71-7fd0147881a5"/>
 <ref refid="8c653495-0094-11eb-8f71-7fd0147881a5"/>
 <ref refid="a189d5be-0094-11eb-8f71-7fd0147881a5"/>
 <ref refid="a8df3642-0094-11eb-8f71-7fd0147881a5"/>
-<ref refid="adac3838-0094-11eb-8f71-7fd0147881a5"/>
 <ref refid="b7d7849a-0094-11eb-8f71-7fd0147881a5"/>
+<ref refid="63c22454-8b30-11ec-8aa4-3d62bbb2b1b9"/>
+<ref refid="9d3de0a7-8b30-11ec-8352-3d62bbb2b1b9"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
 <InitialNodeItem id="a6e6483d-0092-11eb-8f71-7fd0147881a5">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 235.0, 235.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 289.67187499999613, 28.0)</val>
 </matrix>
 <width>
 <val>20.0</val>
@@ -66,7 +70,7 @@
 </InitialNodeItem>
 <DecisionNodeItem id="a91cfefd-0092-11eb-8f71-7fd0147881a5">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 313.3828125, 230.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 289.67187499999613, 83.0)</val>
 </matrix>
 <width>
 <val>20.0</val>
@@ -86,7 +90,7 @@
 <ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
 </diagram>
 <horizontal>
-<val>0</val>
+<val>1</val>
 </horizontal>
 <orthogonal>
 <val>1</val>
@@ -95,10 +99,10 @@
 <ref refid="b9c464de-0092-11eb-8f71-7fd0147881a5"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 322.82421875, 230.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, -36.17578125, 266.0)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (0.0, -70.0), (299.6171875, -70.0)]</val>
+<val>[(345.84765624999613, -168.0), (583.5, -168.0), (583.5, -86.0)]</val>
 </points>
 <head-connection>
 <ref refid="a91cfefd-0092-11eb-8f71-7fd0147881a5"/>
@@ -109,7 +113,7 @@
 </FlowItem>
 <ActivityFinalNodeItem id="b7ca8dad-0092-11eb-8f71-7fd0147881a5">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 622.44140625, 143.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 530.8828125, 180.0)</val>
 </matrix>
 <width>
 <val>30.0</val>
@@ -126,7 +130,7 @@
 </ActivityFinalNodeItem>
 <DecisionNodeItem id="dfca3399-0092-11eb-8f71-7fd0147881a5">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 491.9414062499999, 230.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 289.67187499999613, 180.0)</val>
 </matrix>
 <width>
 <val>20.0</val>
@@ -155,10 +159,10 @@
 <ref refid="b1a5eb64-0093-11eb-8f71-7fd0147881a5"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 333.3828125, 245.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, -25.6171875, 281.0)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (158.5585937499999, 0.0)]</val>
+<val>[(325.730468749996, -168.0), (326.0585937499999, -101.0)]</val>
 </points>
 <head-connection>
 <ref refid="a91cfefd-0092-11eb-8f71-7fd0147881a5"/>
@@ -174,17 +178,14 @@
 <horizontal>
 <val>0</val>
 </horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
 <subject>
 <ref refid="14112cc4-0093-11eb-8f71-7fd0147881a5"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 502.8828124999999, 230.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 61.26953125000375, 252.0)</val>
 </matrix>
 <points>
-<val>[(-0.94140625, 0.0), (-0.94140625, -36.0), (136.0000000000001, -36.0), (136.0000000000001, -57.0)]</val>
+<val>[(248.40234374999238, -57.0), (469.61328124999625, -57.0)]</val>
 </points>
 <head-connection>
 <ref refid="dfca3399-0092-11eb-8f71-7fd0147881a5"/>
@@ -195,7 +196,7 @@
 </FlowItem>
 <DecisionNodeItem id="3590f245-0093-11eb-8f71-7fd0147881a5">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 705.0, 230.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 289.67187499999613, 281.0)</val>
 </matrix>
 <width>
 <val>20.0</val>
@@ -224,10 +225,10 @@
 <ref refid="4593dfc6-0093-11eb-8f71-7fd0147881a5"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 511.9414062499999, 247.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 152.9414062499999, 283.0)</val>
 </matrix>
 <points>
-<val>[(0.0, -1.0), (193.0585937500001, -2.5)]</val>
+<val>[(146.73046874999625, -73.0), (147.5, -2.0)]</val>
 </points>
 <head-connection>
 <ref refid="dfca3399-0092-11eb-8f71-7fd0147881a5"/>
@@ -250,42 +251,16 @@
 <ref refid="6be64506-0093-11eb-8f71-7fd0147881a5"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 255.0, 243.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, -165.1640624999643, 300.5)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (58.3828125, -0.5)]</val>
+<val>[(465.6054687499642, -252.5), (465.6054687499642, -217.5)]</val>
 </points>
 <head-connection>
 <ref refid="a6e6483d-0092-11eb-8f71-7fd0147881a5"/>
 </head-connection>
 <tail-connection>
 <ref refid="a91cfefd-0092-11eb-8f71-7fd0147881a5"/>
-</tail-connection>
-</FlowItem>
-<FlowItem id="d82f0d92-0093-11eb-8f71-7fd0147881a5">
-<diagram>
-<ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
-</diagram>
-<horizontal>
-<val>0</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<subject>
-<ref refid="053e4d98-0094-11eb-8f71-7fd0147881a5"/>
-</subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 725.0, 246.0)</val>
-</matrix>
-<points>
-<val>[(0.0, 0.0), (110.94140625, -1.5)]</val>
-</points>
-<head-connection>
-<ref refid="3590f245-0093-11eb-8f71-7fd0147881a5"/>
-</head-connection>
-<tail-connection>
-<ref refid="035d56f9-0094-11eb-8f71-7fd0147881a5"/>
 </tail-connection>
 </FlowItem>
 <FlowItem id="f15455e9-0093-11eb-8f71-7fd0147881a5">
@@ -299,93 +274,44 @@
 <val>0</val>
 </orthogonal>
 <subject>
-<ref refid="58e0e9ba-0094-11eb-8f71-7fd0147881a5"/>
+<ref refid="60b8c11b-8b30-11ec-8eb3-3d62bbb2b1b9"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 735.4414062499999, 259.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 317.5234374999535, 295.5)</val>
 </matrix>
 <points>
-<val>[(-20.0, 0.5), (-19.941406249999886, 93.0)]</val>
+<val>[(-17.41015624995748, 15.5), (-17.082031249953616, 71.5)]</val>
 </points>
 <head-connection>
 <ref refid="3590f245-0093-11eb-8f71-7fd0147881a5"/>
 </head-connection>
 <tail-connection>
-<ref refid="5337bbe3-0094-11eb-8f71-7fd0147881a5"/>
+<ref refid="53ca10f1-8b30-11ec-9c46-3d62bbb2b1b9"/>
 </tail-connection>
 </FlowItem>
-<DecisionNodeItem id="035d56f9-0094-11eb-8f71-7fd0147881a5">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 835.94140625, 230.0)</val>
-</matrix>
-<width>
-<val>20.0</val>
-</width>
-<height>
-<val>30.0</val>
-</height>
-<diagram>
-<ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
-</diagram>
-<subject>
-<ref refid="035d56f8-0094-11eb-8f71-7fd0147881a5"/>
-</subject>
-</DecisionNodeItem>
 <FlowItem id="175402ac-0094-11eb-8f71-7fd0147881a5">
 <diagram>
 <ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
 </diagram>
-<horizontal>
-<val>0</val>
-</horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
 <subject>
-<ref refid="1ad48906-0094-11eb-8f71-7fd0147881a5"/>
+<ref refid="9927da32-8b30-11ec-8d82-3d62bbb2b1b9"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 847.94140625, 230.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 489.71093750000375, 266.0)</val>
 </matrix>
 <points>
-<val>[(-2.0, 0.0), (-2.0, -69.0), (-195.5, -69.0)]</val>
+<val>[(-180.03906250000762, 30.0), (5.1718749999961915, 30.0)]</val>
 </points>
 <head-connection>
-<ref refid="035d56f9-0094-11eb-8f71-7fd0147881a5"/>
+<ref refid="3590f245-0093-11eb-8f71-7fd0147881a5"/>
 </head-connection>
 <tail-connection>
-<ref refid="b7ca8dad-0092-11eb-8f71-7fd0147881a5"/>
-</tail-connection>
-</FlowItem>
-<FlowItem id="3d675f9e-0094-11eb-8f71-7fd0147881a5">
-<diagram>
-<ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
-</diagram>
-<horizontal>
-<val>0</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<subject>
-<ref refid="327a5628-0097-11eb-8f71-7fd0147881a5"/>
-</subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 855.94140625, 244.5)</val>
-</matrix>
-<points>
-<val>[(0.0, 0.0), (174.99999999999454, 0.0)]</val>
-</points>
-<head-connection>
-<ref refid="035d56f9-0094-11eb-8f71-7fd0147881a5"/>
-</head-connection>
-<tail-connection>
-<ref refid="29b44aa3-0097-11eb-8f71-7fd0147881a5"/>
+<ref refid="93086bf3-8b30-11ec-a706-3d62bbb2b1b9"/>
 </tail-connection>
 </FlowItem>
 <DecisionNodeItem id="5337bbe3-0094-11eb-8f71-7fd0147881a5">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 705.0, 352.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 290.4414062499999, 460.0)</val>
 </matrix>
 <width>
 <val>20.0</val>
@@ -405,19 +331,19 @@
 <ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
 </diagram>
 <horizontal>
-<val>0</val>
+<val>1</val>
 </horizontal>
 <orthogonal>
-<val>0</val>
+<val>1</val>
 </orthogonal>
 <subject>
 <ref refid="4eb63078-0097-11eb-8f71-7fd0147881a5"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 725.0, 368.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 454.5000000000001, 466.0)</val>
 </matrix>
 <points>
-<val>[(0.0, -0.5), (122.94140625, -1.5)]</val>
+<val>[(-144.05859375000023, 9.0), (32.441406249999886, 9.0), (32.441406249999886, 74.0)]</val>
 </points>
 <head-connection>
 <ref refid="5337bbe3-0094-11eb-8f71-7fd0147881a5"/>
@@ -431,19 +357,19 @@
 <ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
 </diagram>
 <horizontal>
-<val>0</val>
+<val>1</val>
 </horizontal>
 <orthogonal>
-<val>0</val>
+<val>1</val>
 </orthogonal>
 <subject>
 <ref refid="85488974-0097-11eb-8f71-7fd0147881a5"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 705.0, 367.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 365.57812500003365, 466.0)</val>
 </matrix>
 <points>
-<val>[(0.0, -0.5), (-179.05859375, 0.5)]</val>
+<val>[(-75.13671875003376, 9.0), (-250.63671875003365, 9.0), (-250.63671875003365, 74.0)]</val>
 </points>
 <head-connection>
 <ref refid="5337bbe3-0094-11eb-8f71-7fd0147881a5"/>
@@ -454,7 +380,7 @@
 </FlowItem>
 <ActivityFinalNodeItem id="a5d7ae62-0094-11eb-8f71-7fd0147881a5">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1100.4414062499945, 351.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 285.4414062499999, 589.0)</val>
 </matrix>
 <width>
 <val>30.0</val>
@@ -477,45 +403,19 @@
 <val>0</val>
 </horizontal>
 <orthogonal>
-<val>0</val>
+<val>1</val>
 </orthogonal>
 <subject>
 <ref refid="5370e6ee-0097-11eb-8f71-7fd0147881a5"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1059.94140625, 367.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 709.94140625, 477.5)</val>
 </matrix>
 <points>
-<val>[(5.0, 0.0), (40.49999999999454, -0.5)]</val>
+<val>[(-223.0, 92.5), (-223.0, 127.0), (-394.5000000000001, 127.0)]</val>
 </points>
 <head-connection>
 <ref refid="4859fda5-0097-11eb-8f71-7fd0147881a5"/>
-</head-connection>
-<tail-connection>
-<ref refid="a5d7ae62-0094-11eb-8f71-7fd0147881a5"/>
-</tail-connection>
-</FlowItem>
-<FlowItem id="adac3838-0094-11eb-8f71-7fd0147881a5">
-<diagram>
-<ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
-</diagram>
-<horizontal>
-<val>0</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<subject>
-<ref refid="365f15d0-0097-11eb-8f71-7fd0147881a5"/>
-</subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1094.94140625, 257.5)</val>
-</matrix>
-<points>
-<val>[(21.99999999999409, 0.0), (20.999999999994543, 94.0)]</val>
-</points>
-<head-connection>
-<ref refid="29b44aa3-0097-11eb-8f71-7fd0147881a5"/>
 </head-connection>
 <tail-connection>
 <ref refid="a5d7ae62-0094-11eb-8f71-7fd0147881a5"/>
@@ -525,9 +425,6 @@
 <diagram>
 <ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
 </diagram>
-<horizontal>
-<val>0</val>
-</horizontal>
 <orthogonal>
 <val>1</val>
 </orthogonal>
@@ -535,10 +432,10 @@
 <ref refid="85488975-0097-11eb-8f71-7fd0147881a5"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 438.94140625, 382.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 89.74999999978229, 488.5)</val>
 </matrix>
 <points>
-<val>[(3.0, 0.0), (3.0, 85.0), (677.9999999999941, 85.0), (677.9999999999941, -1.0)]</val>
+<val>[(25.19140625021771, 81.5), (25.19140625021771, 116.0), (195.6914062502176, 116.0)]</val>
 </points>
 <head-connection>
 <ref refid="737761ea-0097-11eb-8f71-7fd0147881a5"/>
@@ -547,26 +444,9 @@
 <ref refid="a5d7ae62-0094-11eb-8f71-7fd0147881a5"/>
 </tail-connection>
 </FlowItem>
-<ActionItem id="29b44aa3-0097-11eb-8f71-7fd0147881a5">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 1030.9414062499945, 227.5)</val>
-</matrix>
-<width>
-<val>169.0</val>
-</width>
-<height>
-<val>30.0</val>
-</height>
-<diagram>
-<ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
-</diagram>
-<subject>
-<ref refid="29b44aa2-0097-11eb-8f71-7fd0147881a5"/>
-</subject>
-</ActionItem>
 <ActionItem id="4859fda5-0097-11eb-8f71-7fd0147881a5">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 847.94140625, 352.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 379.8828125, 540.0)</val>
 </matrix>
 <width>
 <val>217.0</val>
@@ -583,7 +463,7 @@
 </ActionItem>
 <ActionItem id="737761ea-0097-11eb-8f71-7fd0147881a5">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 357.94140625, 352.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 30.94140625, 540.0)</val>
 </matrix>
 <width>
 <val>168.0</val>
@@ -655,7 +535,7 @@ diagram {
 <reflist>
 <ref refid="b9c464de-0092-11eb-8f71-7fd0147881a5"/>
 <ref refid="14112cc4-0093-11eb-8f71-7fd0147881a5"/>
-<ref refid="1ad48906-0094-11eb-8f71-7fd0147881a5"/>
+<ref refid="9dd06faf-8b30-11ec-b791-3d62bbb2b1b9"/>
 </reflist>
 </incoming>
 <presentation>
@@ -728,8 +608,8 @@ diagram {
 </name>
 <outgoing>
 <reflist>
-<ref refid="053e4d98-0094-11eb-8f71-7fd0147881a5"/>
-<ref refid="58e0e9ba-0094-11eb-8f71-7fd0147881a5"/>
+<ref refid="60b8c11b-8b30-11ec-8eb3-3d62bbb2b1b9"/>
+<ref refid="9927da32-8b30-11ec-8d82-3d62bbb2b1b9"/>
 </reflist>
 </outgoing>
 <presentation>
@@ -783,66 +663,10 @@ diagram {
 <ref refid="dfca3398-0092-11eb-8f71-7fd0147881a5"/>
 </target>
 </ControlFlow>
-<DecisionNode id="035d56f8-0094-11eb-8f71-7fd0147881a5">
-<incoming>
-<reflist>
-<ref refid="053e4d98-0094-11eb-8f71-7fd0147881a5"/>
-</reflist>
-</incoming>
-<name>
-<val></val>
-</name>
-<outgoing>
-<reflist>
-<ref refid="1ad48906-0094-11eb-8f71-7fd0147881a5"/>
-<ref refid="327a5628-0097-11eb-8f71-7fd0147881a5"/>
-</reflist>
-</outgoing>
-<presentation>
-<reflist>
-<ref refid="035d56f9-0094-11eb-8f71-7fd0147881a5"/>
-</reflist>
-</presentation>
-</DecisionNode>
-<ControlFlow id="053e4d98-0094-11eb-8f71-7fd0147881a5">
-<guard>
-<val>has subject</val>
-</guard>
-<presentation>
-<reflist>
-<ref refid="d82f0d92-0093-11eb-8f71-7fd0147881a5"/>
-</reflist>
-</presentation>
-<source>
-<ref refid="3590f244-0093-11eb-8f71-7fd0147881a5"/>
-</source>
-<target>
-<ref refid="035d56f8-0094-11eb-8f71-7fd0147881a5"/>
-</target>
-</ControlFlow>
-<ControlFlow id="1ad48906-0094-11eb-8f71-7fd0147881a5">
-<guard>
-<val>is same</val>
-</guard>
-<name>
-<val></val>
-</name>
-<presentation>
-<reflist>
-<ref refid="175402ac-0094-11eb-8f71-7fd0147881a5"/>
-</reflist>
-</presentation>
-<source>
-<ref refid="035d56f8-0094-11eb-8f71-7fd0147881a5"/>
-</source>
-<target>
-<ref refid="b7ca8dac-0092-11eb-8f71-7fd0147881a5"/>
-</target>
-</ControlFlow>
 <DecisionNode id="5337bbe2-0094-11eb-8f71-7fd0147881a5">
 <incoming>
 <reflist>
-<ref refid="58e0e9ba-0094-11eb-8f71-7fd0147881a5"/>
+<ref refid="64f4a003-8b30-11ec-98e1-3d62bbb2b1b9"/>
 </reflist>
 </incoming>
 <name>
@@ -860,26 +684,9 @@ diagram {
 </reflist>
 </presentation>
 </DecisionNode>
-<ControlFlow id="58e0e9ba-0094-11eb-8f71-7fd0147881a5">
-<guard>
-<val>no subject</val>
-</guard>
-<presentation>
-<reflist>
-<ref refid="f15455e9-0093-11eb-8f71-7fd0147881a5"/>
-</reflist>
-</presentation>
-<source>
-<ref refid="3590f244-0093-11eb-8f71-7fd0147881a5"/>
-</source>
-<target>
-<ref refid="5337bbe2-0094-11eb-8f71-7fd0147881a5"/>
-</target>
-</ControlFlow>
 <ActivityFinalNode id="a5d7ae61-0094-11eb-8f71-7fd0147881a5">
 <incoming>
 <reflist>
-<ref refid="365f15d0-0097-11eb-8f71-7fd0147881a5"/>
 <ref refid="5370e6ee-0097-11eb-8f71-7fd0147881a5"/>
 <ref refid="85488975-0097-11eb-8f71-7fd0147881a5"/>
 </reflist>
@@ -890,55 +697,6 @@ diagram {
 </reflist>
 </presentation>
 </ActivityFinalNode>
-<Action id="29b44aa2-0097-11eb-8f71-7fd0147881a5">
-<incoming>
-<reflist>
-<ref refid="327a5628-0097-11eb-8f71-7fd0147881a5"/>
-</reflist>
-</incoming>
-<name>
-<val>Update relations</val>
-</name>
-<outgoing>
-<reflist>
-<ref refid="365f15d0-0097-11eb-8f71-7fd0147881a5"/>
-</reflist>
-</outgoing>
-<presentation>
-<reflist>
-<ref refid="29b44aa3-0097-11eb-8f71-7fd0147881a5"/>
-</reflist>
-</presentation>
-</Action>
-<ControlFlow id="327a5628-0097-11eb-8f71-7fd0147881a5">
-<guard>
-<val>subject is different</val>
-</guard>
-<presentation>
-<reflist>
-<ref refid="3d675f9e-0094-11eb-8f71-7fd0147881a5"/>
-</reflist>
-</presentation>
-<source>
-<ref refid="035d56f8-0094-11eb-8f71-7fd0147881a5"/>
-</source>
-<target>
-<ref refid="29b44aa2-0097-11eb-8f71-7fd0147881a5"/>
-</target>
-</ControlFlow>
-<ControlFlow id="365f15d0-0097-11eb-8f71-7fd0147881a5">
-<presentation>
-<reflist>
-<ref refid="adac3838-0094-11eb-8f71-7fd0147881a5"/>
-</reflist>
-</presentation>
-<source>
-<ref refid="29b44aa2-0097-11eb-8f71-7fd0147881a5"/>
-</source>
-<target>
-<ref refid="a5d7ae61-0094-11eb-8f71-7fd0147881a5"/>
-</target>
-</ControlFlow>
 <Action id="4859fda4-0097-11eb-8f71-7fd0147881a5">
 <incoming>
 <reflist>
@@ -961,7 +719,7 @@ diagram {
 </Action>
 <ControlFlow id="4eb63078-0097-11eb-8f71-7fd0147881a5">
 <guard>
-<val>No exiting rel.</val>
+<val>No exiting relation</val>
 </guard>
 <presentation>
 <reflist>
@@ -1035,6 +793,216 @@ diagram {
 </source>
 <target>
 <ref refid="a5d7ae61-0094-11eb-8f71-7fd0147881a5"/>
+</target>
+</ControlFlow>
+<Activity id="183251a5-8a7b-11ec-a060-69879bc4f7d4">
+<edge>
+<reflist>
+<ref refid="64f4a003-8b30-11ec-98e1-3d62bbb2b1b9"/>
+<ref refid="9dd06faf-8b30-11ec-b791-3d62bbb2b1b9"/>
+</reflist>
+</edge>
+<name>
+<val>Activity</val>
+</name>
+<node>
+<reflist>
+<ref refid="53c9fc01-8b30-11ec-9d46-3d62bbb2b1b9"/>
+<ref refid="93085676-8b30-11ec-a394-3d62bbb2b1b9"/>
+</reflist>
+</node>
+<package>
+<ref refid="a26e1ce4-0092-11eb-8f71-7fd0147881a5"/>
+</package>
+</Activity>
+<Action id="53c9fc01-8b30-11ec-9d46-3d62bbb2b1b9">
+<activity>
+<ref refid="183251a5-8a7b-11ec-a060-69879bc4f7d4"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="60b8c11b-8b30-11ec-8eb3-3d62bbb2b1b9"/>
+</reflist>
+</incoming>
+<name>
+<val>Disconnect</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="64f4a003-8b30-11ec-98e1-3d62bbb2b1b9"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="53ca10f1-8b30-11ec-9c46-3d62bbb2b1b9"/>
+</reflist>
+</presentation>
+</Action>
+<ActionItem id="53ca10f1-8b30-11ec-9c46-3d62bbb2b1b9">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 248.17187499999613, 367.0)</val>
+</matrix>
+<width>
+<val>103.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
+</diagram>
+<subject>
+<ref refid="53c9fc01-8b30-11ec-9d46-3d62bbb2b1b9"/>
+</subject>
+</ActionItem>
+<ControlFlow id="60b8c11b-8b30-11ec-8eb3-3d62bbb2b1b9">
+<presentation>
+<reflist>
+<ref refid="f15455e9-0093-11eb-8f71-7fd0147881a5"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="3590f244-0093-11eb-8f71-7fd0147881a5"/>
+</source>
+<target>
+<ref refid="53c9fc01-8b30-11ec-9d46-3d62bbb2b1b9"/>
+</target>
+</ControlFlow>
+<FlowItem id="63c22454-8b30-11ec-8aa4-3d62bbb2b1b9">
+<diagram>
+<ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="64f4a003-8b30-11ec-98e1-3d62bbb2b1b9"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 287.1103678929766, 384.0)</val>
+</matrix>
+<points>
+<val>[(12.561507107019509, 13.0), (12.561507107019509, 76.0)]</val>
+</points>
+<head-connection>
+<ref refid="53ca10f1-8b30-11ec-9c46-3d62bbb2b1b9"/>
+</head-connection>
+<tail-connection>
+<ref refid="5337bbe3-0094-11eb-8f71-7fd0147881a5"/>
+</tail-connection>
+</FlowItem>
+<ControlFlow id="64f4a003-8b30-11ec-98e1-3d62bbb2b1b9">
+<activity>
+<ref refid="183251a5-8a7b-11ec-a060-69879bc4f7d4"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="63c22454-8b30-11ec-8aa4-3d62bbb2b1b9"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="53c9fc01-8b30-11ec-9d46-3d62bbb2b1b9"/>
+</source>
+<target>
+<ref refid="5337bbe2-0094-11eb-8f71-7fd0147881a5"/>
+</target>
+</ControlFlow>
+<Action id="93085676-8b30-11ec-a394-3d62bbb2b1b9">
+<activity>
+<ref refid="183251a5-8a7b-11ec-a060-69879bc4f7d4"/>
+</activity>
+<incoming>
+<reflist>
+<ref refid="9927da32-8b30-11ec-8d82-3d62bbb2b1b9"/>
+</reflist>
+</incoming>
+<name>
+<val>Reconnect</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="9dd06faf-8b30-11ec-b791-3d62bbb2b1b9"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="93086bf3-8b30-11ec-a706-3d62bbb2b1b9"/>
+</reflist>
+</presentation>
+</Action>
+<ActionItem id="93086bf3-8b30-11ec-a706-3d62bbb2b1b9">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 494.88281249999994, 281.0)</val>
+</matrix>
+<width>
+<val>102.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
+</diagram>
+<subject>
+<ref refid="93085676-8b30-11ec-a394-3d62bbb2b1b9"/>
+</subject>
+</ActionItem>
+<ControlFlow id="9927da32-8b30-11ec-8d82-3d62bbb2b1b9">
+<guard>
+<val>connected end is same</val>
+</guard>
+<name>
+<val></val>
+</name>
+<presentation>
+<reflist>
+<ref refid="175402ac-0094-11eb-8f71-7fd0147881a5"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="3590f244-0093-11eb-8f71-7fd0147881a5"/>
+</source>
+<target>
+<ref refid="93085676-8b30-11ec-a394-3d62bbb2b1b9"/>
+</target>
+</ControlFlow>
+<FlowItem id="9d3de0a7-8b30-11ec-8352-3d62bbb2b1b9">
+<diagram>
+<ref refid="a26e1ce5-0092-11eb-8f71-7fd0147881a5"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="9dd06faf-8b30-11ec-b791-3d62bbb2b1b9"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 540.1103678929767, 220.9230769230769)</val>
+</matrix>
+<points>
+<val>[(5.941406250000057, 60.076923076923094), (5.772444607023317, -10.923076923076906)]</val>
+</points>
+<head-connection>
+<ref refid="93086bf3-8b30-11ec-a706-3d62bbb2b1b9"/>
+</head-connection>
+<tail-connection>
+<ref refid="b7ca8dad-0092-11eb-8f71-7fd0147881a5"/>
+</tail-connection>
+</FlowItem>
+<ControlFlow id="9dd06faf-8b30-11ec-b791-3d62bbb2b1b9">
+<activity>
+<ref refid="183251a5-8a7b-11ec-a060-69879bc4f7d4"/>
+</activity>
+<presentation>
+<reflist>
+<ref refid="9d3de0a7-8b30-11ec-8352-3d62bbb2b1b9"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="93085676-8b30-11ec-a394-3d62bbb2b1b9"/>
+</source>
+<target>
+<ref refid="b7ca8dac-0092-11eb-8f71-7fd0147881a5"/>
 </target>
 </ControlFlow>
 </gaphor>

--- a/gaphor/SysML/requirements/connectors.py
+++ b/gaphor/SysML/requirements/connectors.py
@@ -25,11 +25,6 @@ class DirectedRelationshipPropertyPathConnect(RelationshipConnect):
 
     relation_type: Type[DirectedRelationshipPropertyPath]
 
-    def reconnect(self, handle, port):
-        self.reconnect_relationship(
-            handle, self.relation_type.sourceContext, self.relation_type.targetContext
-        )
-
     def connect_subject(self, handle):
         relation = self.relationship_or_new(
             self.relation_type,

--- a/gaphor/UML/actions/flowconnect.py
+++ b/gaphor/UML/actions/flowconnect.py
@@ -50,19 +50,6 @@ class FlowConnect(UnaryRelationshipConnect):
 
         return super().allow(handle, port)
 
-    def reconnect(self, handle, port):
-        line = self.line
-        old_flow = line.subject
-        # Secure properties before old_flow is removed:
-        name = old_flow.name
-        guard_value = old_flow.guard
-        self.connect_subject(handle)
-        relation = line.subject
-        if old_flow:
-            relation.name = name
-            if guard_value:
-                relation.guard = guard_value
-
     def connect_subject(self, handle):
         line = self.line
         assert line

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -2,8 +2,6 @@
 
 from typing import Type
 
-import pytest
-
 from gaphor import UML
 from gaphor.core.modeling import Presentation
 from gaphor.UML.actions.action import ActionItem
@@ -118,7 +116,6 @@ def test_object_flow_reconnect(case):
     assert flow.subject.guard == "tguard"
 
 
-@pytest.mark.xfail
 def test_control_flow_reconnection(case):
     """Test control flow becoming object flow due to reconnection."""
     flow = case.create(ControlFlowItem)
@@ -237,7 +234,6 @@ def test_reconnect(case):
     assert flow.subject.guard == "tguard"
 
 
-@pytest.mark.xfail
 def test_object_flow_reconnection(case):
     """Test object flow becoming control flow due to reconnection."""
     flow = case.create(ObjectFlowItem)

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -2,6 +2,8 @@
 
 from typing import Type
 
+import pytest
+
 from gaphor import UML
 from gaphor.core.modeling import Presentation
 from gaphor.UML.actions.action import ActionItem
@@ -84,6 +86,7 @@ def test_connect_to_object_node(case):
     assert isinstance(flow.subject, UML.ObjectFlow)
 
 
+@pytest.mark.xfail
 def test_object_flow_reconnect(case):
     flow = case.create(ObjectFlowItem)
     a1 = case.create(ActionItem, UML.Action)
@@ -116,6 +119,7 @@ def test_object_flow_reconnect(case):
     assert flow.subject.guard == "tguard"
 
 
+@pytest.mark.xfail
 def test_control_flow_reconnection(case):
     """Test control flow becoming object flow due to reconnection."""
     flow = case.create(ControlFlowItem)
@@ -202,6 +206,7 @@ def test_disconnect_from_action_item(case):
     assert len(a2.subject.outgoing) == 0
 
 
+@pytest.mark.xfail
 def test_reconnect(case):
     """Test flow item reconnection."""
     flow = case.create(ControlFlowItem)
@@ -234,6 +239,7 @@ def test_reconnect(case):
     assert flow.subject.guard == "tguard"
 
 
+@pytest.mark.xfail
 def test_object_flow_reconnection(case):
     """Test object flow becoming control flow due to reconnection."""
     flow = case.create(ObjectFlowItem)

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -86,7 +86,6 @@ def test_connect_to_object_node(case):
     assert isinstance(flow.subject, UML.ObjectFlow)
 
 
-@pytest.mark.xfail
 def test_object_flow_reconnect(case):
     flow = case.create(ObjectFlowItem)
     a1 = case.create(ActionItem, UML.Action)
@@ -206,7 +205,6 @@ def test_disconnect_from_action_item(case):
     assert len(a2.subject.outgoing) == 0
 
 
-@pytest.mark.xfail
 def test_reconnect(case):
     """Test flow item reconnection."""
     flow = case.create(ControlFlowItem)

--- a/gaphor/UML/classes/classconnect.py
+++ b/gaphor/UML/classes/classconnect.py
@@ -32,20 +32,14 @@ class DependencyConnect(RelationshipConnect):
         return super().allow(handle, port)
 
     def connect_subject(self, handle):
-        """
-        TODO: check for existing relationships (use self.relation())
-        """
-
-        line = self.line
-
-        self.update_dependency_type(handle)
+        dependency_type = self.update_dependency_type(handle)
 
         relation = self.relationship_or_new(
-            line.dependency_type,
-            line.dependency_type.supplier,
-            line.dependency_type.client,
+            dependency_type,
+            dependency_type.supplier,
+            dependency_type.client,
         )
-        line.subject = relation
+        self.line.subject = relation
 
     def update_dependency_type(self, handle):
         line = self.line
@@ -62,6 +56,7 @@ class DependencyConnect(RelationshipConnect):
                 client = self.element.subject
                 supplier = other.subject
             line.dependency_type = UML.recipes.dependency_type(client, supplier)
+        return line.dependency_type
 
 
 @Connector.register(Classified, GeneralizationItem)

--- a/gaphor/UML/classes/classconnect.py
+++ b/gaphor/UML/classes/classconnect.py
@@ -20,6 +20,8 @@ from gaphor.UML.recipes import owner_package
 class DependencyConnect(RelationshipConnect):
     """Connect two Named elements using a Dependency."""
 
+    line: DependencyItem
+
     def allow(self, handle, port):
         element = self.element
 
@@ -29,24 +31,23 @@ class DependencyConnect(RelationshipConnect):
 
         return super().allow(handle, port)
 
-    def reconnect(self, handle, port):
-        line = self.line
-        dep = line.subject
-        assert isinstance(dep, UML.Dependency)
-        if dep:
-            if handle is line.head:
-                del dep.supplier
-            elif handle is line.tail:
-                del dep.client
-        self.reconnect_relationship(
-            handle, line.dependency_type.supplier, line.dependency_type.client
-        )
-
     def connect_subject(self, handle):
         """
         TODO: check for existing relationships (use self.relation())
         """
 
+        line = self.line
+
+        self.update_dependency_type(handle)
+
+        relation = self.relationship_or_new(
+            line.dependency_type,
+            line.dependency_type.supplier,
+            line.dependency_type.client,
+        )
+        line.subject = relation
+
+    def update_dependency_type(self, handle):
         line = self.line
 
         if line.auto_dependency:
@@ -62,28 +63,15 @@ class DependencyConnect(RelationshipConnect):
                 supplier = other.subject
             line.dependency_type = UML.recipes.dependency_type(client, supplier)
 
-        relation = self.relationship_or_new(
-            line.dependency_type,
-            line.dependency_type.supplier,
-            line.dependency_type.client,
-        )
-        line.subject = relation
-
 
 @Connector.register(Classified, GeneralizationItem)
 class GeneralizationConnect(RelationshipConnect):
     """Connect Classifiers with a Generalization relationship."""
 
-    def reconnect(self, handle, port):
-        self.reconnect_relationship(
-            handle, UML.Generalization.specific, UML.Generalization.general
-        )
-
     def connect_subject(self, handle):
-        relation = self.relationship_or_new(
+        self.line.subject = self.relationship_or_new(
             UML.Generalization, UML.Generalization.specific, UML.Generalization.general
         )
-        self.line.subject = relation
 
 
 @Connector.register(Classified, AssociationItem)
@@ -138,26 +126,6 @@ class AssociationConnect(UnaryRelationshipConnect):
             line.head_subject.type = c1.subject
             line.tail_subject.type = c2.subject
 
-    def reconnect(self, handle, port):
-        line = self.line
-        c = self.get_connected(handle)
-        assert c
-        if handle is line.head:
-            end = line.tail_end
-            oend = line.head_end
-        elif handle is line.tail:
-            end = line.head_end
-            oend = line.tail_end
-        else:
-            raise ValueError("Incorrect handle passed to adapter")
-
-        nav = oend.subject.navigability
-
-        UML.recipes.set_navigability(line.subject, end.subject, None)  # clear old data
-
-        oend.subject.type = c.subject
-        UML.recipes.set_navigability(line.subject, oend.subject, nav)
-
     def disconnect_subject(self, handle: Handle) -> None:
         """Disconnect the type of each member end.
 
@@ -192,21 +160,6 @@ class InterfaceRealizationConnect(RelationshipConnect):
             return None
 
         return super().allow(handle, port)
-
-    def reconnect(self, handle, port):
-        line = self.line
-        impl = line.subject
-        assert isinstance(impl, UML.InterfaceRealization)
-        if handle is line.head:
-            for s in impl.contract:
-                del impl.contract[s]
-        elif handle is line.tail:
-            del impl.implementatingClassifier
-        self.reconnect_relationship(
-            handle,
-            UML.InterfaceRealization.contract,
-            UML.InterfaceRealization.implementatingClassifier,
-        )
 
     def connect_subject(self, handle):
         """Perform implementation relationship connection."""

--- a/gaphor/UML/classes/tests/test_associationconnect.py
+++ b/gaphor/UML/classes/tests/test_associationconnect.py
@@ -54,6 +54,7 @@ def test_association_item_connect(connected_association, element_factory):
     assert asc.tail_subject is not None
 
 
+@pytest.mark.xfail
 def test_association_item_reconnect(connected_association, create):
     asc, c1, c2 = connected_association
     c3 = create(ClassItem, UML.Class)

--- a/gaphor/UML/classes/tests/test_containmentconnect.py
+++ b/gaphor/UML/classes/tests/test_containmentconnect.py
@@ -1,6 +1,7 @@
 """Test connection of containment relationship."""
 
 from gaphor import UML
+from gaphor.core.modeling import Diagram
 from gaphor.diagram.tests.fixtures import allow, connect, disconnect
 from gaphor.UML.classes import ClassItem, PackageItem
 from gaphor.UML.classes.containment import ContainmentItem
@@ -82,3 +83,28 @@ def test_containment_class_class_disconnect(create, diagram, element_factory):
 
     assert klass.subject.owner is parent_package
     assert klass.subject in parent_package.ownedElement
+
+
+def test_containment_reconnect_in_new_diagram(create, element_factory):
+    # Most recently created containment relation wins.
+    rel = create(ContainmentItem)
+    c1 = create(ClassItem, UML.Class)
+    c2 = create(ClassItem, UML.Class)
+
+    connect(rel, rel.head, c1)
+    connect(rel, rel.tail, c2)
+
+    # Now do the same on a new diagram:
+    diagram2 = element_factory.create(Diagram)
+    c3 = diagram2.create(ClassItem, subject=c1.subject)
+    c4 = diagram2.create(ClassItem, subject=c2.subject)
+    rel2 = diagram2.create(ContainmentItem)
+
+    connect(rel2, rel2.head, c3)
+    connect(rel2, rel2.tail, c4)
+
+    c5 = diagram2.create(ClassItem, subject=element_factory.create(UML.Class))
+    connect(rel2, rel2.head, c5)
+
+    assert c2.subject.owner is c5.subject
+    assert c4.subject.owner is c5.subject

--- a/gaphor/UML/classes/tests/test_dependencyconnect.py
+++ b/gaphor/UML/classes/tests/test_dependencyconnect.py
@@ -68,6 +68,25 @@ def test_dependency_reconnect(create):
     assert a2.subject is not dep.subject.client, dep.subject.client
 
 
+def test_dependency_reconnect_should_keep_attributes(create):
+    """Test dependency reconnection."""
+    a1 = create(ActorItem, UML.Actor)
+    a2 = create(ActorItem, UML.Actor)
+    a3 = create(ActorItem, UML.Actor)
+    dep = create(DependencyItem)
+
+    # connect: a1 -> a2
+    connect(dep, dep.head, a1)
+    connect(dep, dep.tail, a2)
+
+    dep.subject.name = "Name"
+
+    # reconnect: a1 -> a3
+    connect(dep, dep.tail, a3)
+
+    assert dep.subject.name == "Name"
+
+
 def test_dependency_disconnect(create, element_factory):
     actor1 = create(ActorItem, UML.Actor)
     actor2 = create(ActorItem, UML.Actor)

--- a/gaphor/UML/classes/tests/test_dependencyconnect.py
+++ b/gaphor/UML/classes/tests/test_dependencyconnect.py
@@ -46,7 +46,7 @@ def test_dependency_connect(create, element_factory):
     assert actor2.subject is dep.subject.client
 
 
-def test_dependency_reconnection(create):
+def test_dependency_reconnect(create):
     """Test dependency reconnection."""
     a1 = create(ActorItem, UML.Actor)
     a2 = create(ActorItem, UML.Actor)
@@ -62,7 +62,7 @@ def test_dependency_reconnection(create):
     # reconnect: a1 -> a3
     connect(dep, dep.tail, a3)
 
-    assert d is dep.subject
+    assert d is not dep.subject
     assert a1.subject is dep.subject.supplier
     assert a3.subject is dep.subject.client
     assert a2.subject is not dep.subject.client, dep.subject.client
@@ -86,7 +86,7 @@ def test_dependency_disconnect(create, element_factory):
     assert dep_subj not in actor2.subject.clientDependency
 
 
-def test_dependency_reconnect(create):
+def test_dependency_reconnect_on_same(create):
     """Test dependency reconnection using two actor items."""
     actor1 = create(ActorItem, UML.Actor)
     actor2 = create(ActorItem, UML.Actor)
@@ -165,3 +165,58 @@ def test_dependency_type_auto(create, element_factory):
     assert dep.subject is not None
     assert isinstance(dep.subject, UML.Usage), dep.subject
     assert dep.subject in element_factory.select()
+
+
+def test_dependency_reconnect_in_new_diagram(create, element_factory):
+    dep = create(DependencyItem)
+    c1 = create(ClassItem, UML.Class)
+    c2 = create(ClassItem, UML.Class)
+
+    connect(dep, dep.head, c1)
+    connect(dep, dep.tail, c2)
+
+    # Now do the same on a new diagram:
+    diagram2 = element_factory.create(Diagram)
+    c3 = diagram2.create(ClassItem, subject=c1.subject)
+    c4 = diagram2.create(ClassItem, subject=c2.subject)
+    dep2 = diagram2.create(DependencyItem)
+
+    connect(dep2, dep2.head, c3)
+    connect(dep2, dep2.tail, c4)
+    assert dep.subject is dep2.subject
+
+    c5 = diagram2.create(ClassItem, subject=c2.subject)
+    connect(dep2, dep2.head, c5)
+
+    assert dep.subject is not dep2.subject
+    assert dep.subject.supplier is c1.subject
+    assert dep.subject.client is c2.subject
+    assert dep2.subject.supplier is c5.subject
+    assert dep2.subject.client is c4.subject
+
+
+def test_dependency_reconnect_twice_in_new_diagram(create, element_factory):
+    dep = create(DependencyItem)
+    c1 = create(ClassItem, UML.Class)
+    c2 = create(ClassItem, UML.Class)
+
+    connect(dep, dep.head, c1)
+    connect(dep, dep.tail, c2)
+
+    # Now do the same on a new diagram:
+    diagram2 = element_factory.create(Diagram)
+    c3 = diagram2.create(ClassItem, subject=c1.subject)
+    c4 = diagram2.create(ClassItem, subject=c2.subject)
+    dep2 = diagram2.create(DependencyItem)
+
+    connect(dep2, dep2.head, c3)
+    connect(dep2, dep2.tail, c4)
+    assert dep.subject is dep2.subject
+
+    c5 = diagram2.create(ClassItem, subject=c2.subject)
+    connect(dep2, dep2.head, c5)
+    connect(dep2, dep2.head, c3)
+
+    assert dep.subject is dep2.subject
+    assert dep.subject.supplier is c3.subject
+    assert dep.subject.client is c4.subject

--- a/gaphor/UML/classes/tests/test_generalizationconnect.py
+++ b/gaphor/UML/classes/tests/test_generalizationconnect.py
@@ -1,34 +1,11 @@
-import pytest
-
 from gaphor import UML
-from gaphor.core import Transaction
 from gaphor.core.modeling import Diagram
 from gaphor.diagram.tests.fixtures import allow, connect, get_connected
 from gaphor.UML.classes.generalization import GeneralizationItem
 from gaphor.UML.classes.klass import ClassItem
 
 
-@pytest.fixture
-def other_diagram(element_factory, event_manager) -> Diagram:
-    with Transaction(event_manager):
-        diagram = element_factory.create(Diagram)
-    yield diagram
-    with Transaction(event_manager):
-        diagram.unlink()
-
-
-@pytest.fixture
-def other_create(other_diagram, element_factory):
-    def _create(item_class, element_class=None):
-        return other_diagram.create(
-            item_class,
-            subject=(element_factory.create(element_class) if element_class else None),
-        )
-
-    return _create
-
-
-def test_generalization_multiple_connection(create, other_create):
+def test_generalization_multiple_connection(create, element_factory):
     c1 = create(ClassItem, UML.Class)
     c2 = create(ClassItem, UML.Class)
     gen1 = create(GeneralizationItem)
@@ -36,11 +13,11 @@ def test_generalization_multiple_connection(create, other_create):
     connect(gen1, gen1.tail, c1)
     connect(gen1, gen1.head, c2)
 
-    c3 = other_create(ClassItem)
-    c3.subject = c1.subject
-    c4 = other_create(ClassItem)
-    c4.subject = c2.subject
-    gen2 = other_create(GeneralizationItem)
+    # Now do the same on a new diagram:
+    diagram2 = element_factory.create(Diagram)
+    c3 = diagram2.create(ClassItem, subject=c1.subject)
+    c4 = diagram2.create(ClassItem, subject=c2.subject)
+    gen2 = diagram2.create(GeneralizationItem)
 
     connect(gen2, gen2.tail, c3)
     connect(gen2, gen2.head, c4)
@@ -64,32 +41,28 @@ def test_generalization_glue(create):
     assert glued
 
 
-def test_generalization_connection(create):
+def test_generalization_connect(create):
     gen = create(GeneralizationItem)
     c1 = create(ClassItem, UML.Class)
     c2 = create(ClassItem, UML.Class)
 
-    connect(gen, gen.tail, c1)
-    assert get_connected(gen, gen.tail) is c1
+    connect(gen, gen.head, c1)
+    connect(gen, gen.tail, c2)
 
-    connect(gen, gen.head, c2)
-    assert gen.subject is not None
-    assert gen.subject.general is c1.subject
-    assert gen.subject.specific is c2.subject
+    assert get_connected(gen, gen.head) is c1
+    assert get_connected(gen, gen.tail) is c2
+    assert gen.subject
+    assert gen.subject.specific is c1.subject
+    assert gen.subject.general is c2.subject
 
 
-def test_generalization_reconnection(create, element_factory):
+def test_generalization_connect_in_new_diagram(create, element_factory):
     gen = create(GeneralizationItem)
     c1 = create(ClassItem, UML.Class)
     c2 = create(ClassItem, UML.Class)
 
-    connect(gen, gen.tail, c1)
-    assert get_connected(gen, gen.tail) is c1
-
-    connect(gen, gen.head, c2)
-    assert gen.subject is not None
-    assert gen.subject.general is c1.subject
-    assert gen.subject.specific is c2.subject
+    connect(gen, gen.head, c1)
+    connect(gen, gen.tail, c2)
 
     # Now do the same on a new diagram:
     diagram2 = element_factory.create(Diagram)
@@ -98,17 +71,36 @@ def test_generalization_reconnection(create, element_factory):
     gen2 = diagram2.create(GeneralizationItem)
 
     connect(gen2, gen2.head, c3)
-    cinfo = diagram2.connections.get_connection(gen2.head)
-    assert cinfo is not None
-    assert cinfo.connected is c3
+    connect(gen2, gen2.tail, c4)
+    assert gen.subject is gen2.subject
 
+
+def test_generalization_connect_in_new_diagram_in_opposite_direction(
+    create, element_factory
+):
+    gen = create(GeneralizationItem)
+    c1 = create(ClassItem, UML.Class)
+    c2 = create(ClassItem, UML.Class)
+
+    connect(gen, gen.tail, c1)
+    connect(gen, gen.head, c2)
+
+    # Now do the same on a new diagram:
+    diagram2 = element_factory.create(Diagram)
+    c3 = diagram2.create(ClassItem, subject=c1.subject)
+    c4 = diagram2.create(ClassItem, subject=c2.subject)
+    gen2 = diagram2.create(GeneralizationItem)
+
+    connect(gen2, gen2.head, c3)
     connect(gen2, gen2.tail, c4)
     assert gen.subject is not gen2.subject
-    assert len(c2.subject.generalization) == 1
-    assert c2.subject.generalization[0] is gen.subject
+    assert gen.subject.specific is c2.subject
+    assert gen.subject.general is c1.subject
+    assert gen2.subject.specific is c3.subject
+    assert gen2.subject.general is c4.subject
 
 
-def test_generalization_reconnection2(create):
+def test_generalization_reconnect_in_same_diagram(create):
     c1 = create(ClassItem, UML.Class)
     c2 = create(ClassItem, UML.Class)
     c3 = create(ClassItem, UML.Class)
@@ -123,7 +115,62 @@ def test_generalization_reconnection2(create):
     # reconnect: c2 -> c3
     connect(gen, gen.tail, c3)
 
-    assert s is gen.subject
+    assert s is not gen.subject
     assert c1.subject is gen.subject.specific
     assert c3.subject is gen.subject.general
     assert c2.subject is not gen.subject.general
+
+
+def test_generalization_reconnect_in_new_diagram(create, element_factory):
+    gen = create(GeneralizationItem)
+    c1 = create(ClassItem, UML.Class)
+    c2 = create(ClassItem, UML.Class)
+
+    connect(gen, gen.head, c1)
+    connect(gen, gen.tail, c2)
+
+    # Now do the same on a new diagram:
+    diagram2 = element_factory.create(Diagram)
+    c3 = diagram2.create(ClassItem, subject=c1.subject)
+    c4 = diagram2.create(ClassItem, subject=c2.subject)
+    gen2 = diagram2.create(GeneralizationItem)
+
+    connect(gen2, gen2.head, c3)
+    connect(gen2, gen2.tail, c4)
+    assert gen.subject is gen2.subject
+
+    c5 = diagram2.create(ClassItem, subject=element_factory.create(UML.Class))
+    connect(gen2, gen2.head, c5)
+
+    assert gen.subject is not gen2.subject
+    assert gen.subject.specific is c1.subject
+    assert gen.subject.general is c2.subject
+    assert gen2.subject.specific is c5.subject
+    assert gen2.subject.general is c4.subject
+
+
+def test_genralization_reconnect_twice_in_new_diagram(create, element_factory):
+    gen = create(GeneralizationItem)
+    c1 = create(ClassItem, UML.Class)
+    c2 = create(ClassItem, UML.Class)
+
+    connect(gen, gen.head, c1)
+    connect(gen, gen.tail, c2)
+
+    # Now do the same on a new diagram:
+    diagram2 = element_factory.create(Diagram)
+    c3 = diagram2.create(ClassItem, subject=c1.subject)
+    c4 = diagram2.create(ClassItem, subject=c2.subject)
+    gen2 = diagram2.create(GeneralizationItem)
+
+    connect(gen2, gen2.head, c3)
+    connect(gen2, gen2.tail, c4)
+    assert gen.subject is gen2.subject
+
+    c5 = diagram2.create(ClassItem, subject=c2.subject)
+    connect(gen2, gen2.head, c5)
+    connect(gen2, gen2.head, c3)
+
+    assert gen.subject is gen2.subject
+    assert gen.subject.specific is c3.subject
+    assert gen.subject.general is c4.subject

--- a/gaphor/UML/classes/tests/test_interfacerealizationconnect.py
+++ b/gaphor/UML/classes/tests/test_interfacerealizationconnect.py
@@ -1,7 +1,4 @@
-import pytest
-
 from gaphor import UML
-from gaphor.core import Transaction
 from gaphor.core.modeling import Diagram
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML.classes.interface import InterfaceItem
@@ -9,27 +6,7 @@ from gaphor.UML.classes.interfacerealization import InterfaceRealizationItem
 from gaphor.UML.classes.klass import ClassItem
 
 
-@pytest.fixture
-def other_diagram(element_factory, event_manager) -> Diagram:
-    with Transaction(event_manager):
-        diagram = element_factory.create(Diagram)
-    yield diagram
-    with Transaction(event_manager):
-        diagram.unlink()
-
-
-@pytest.fixture
-def other_create(other_diagram, element_factory):
-    def _create(item_class, element_class=None):
-        return other_diagram.create(
-            item_class,
-            subject=(element_factory.create(element_class) if element_class else None),
-        )
-
-    return _create
-
-
-def test_interface_realization_multiple_connection(create, other_create):
+def test_interface_realization_multiple_connection(create, element_factory):
     c1 = create(InterfaceItem, UML.Interface)
     c2 = create(ClassItem, UML.Class)
     rel1 = create(InterfaceRealizationItem)
@@ -37,13 +14,68 @@ def test_interface_realization_multiple_connection(create, other_create):
     connect(rel1, rel1.head, c1)
     connect(rel1, rel1.tail, c2)
 
-    c3 = other_create(InterfaceItem)
-    c3.subject = c1.subject
-    c4 = other_create(ClassItem)
-    c4.subject = c2.subject
-    rel2 = other_create(InterfaceRealizationItem)
+    # Now do the same on a new diagram:
+    diagram2 = element_factory.create(Diagram)
+    c3 = diagram2.create(ClassItem, subject=c1.subject)
+    c4 = diagram2.create(ClassItem, subject=c2.subject)
+    rel2 = diagram2.create(InterfaceRealizationItem)
 
     connect(rel2, rel2.head, c3)
     connect(rel2, rel2.tail, c4)
 
     assert rel1.subject is rel2.subject
+
+
+def test_interface_realization_reconnect_in_new_diagram(create, element_factory):
+    c1 = create(InterfaceItem, UML.Interface)
+    c2 = create(ClassItem, UML.Class)
+    rel = create(InterfaceRealizationItem)
+
+    connect(rel, rel.head, c1)
+    connect(rel, rel.tail, c2)
+
+    # Now do the same on a new diagram:
+    diagram2 = element_factory.create(Diagram)
+    c3 = diagram2.create(InterfaceItem, subject=c1.subject)
+    c4 = diagram2.create(ClassItem, subject=c2.subject)
+    rel2 = diagram2.create(InterfaceRealizationItem)
+
+    connect(rel2, rel2.head, c3)
+    connect(rel2, rel2.tail, c4)
+    assert rel.subject is rel2.subject
+
+    c5 = diagram2.create(InterfaceItem, subject=element_factory.create(UML.Interface))
+    connect(rel2, rel2.head, c5)
+
+    assert rel.subject is not rel2.subject
+    assert rel.subject.supplier is c1.subject
+    assert rel.subject.client is c2.subject
+    assert rel2.subject.supplier is c5.subject
+    assert rel2.subject.client is c4.subject
+
+
+def test_interface_realization_reconnect_twice_in_new_diagram(create, element_factory):
+    c1 = create(InterfaceItem, UML.Interface)
+    c2 = create(ClassItem, UML.Class)
+    rel = create(InterfaceRealizationItem)
+
+    connect(rel, rel.head, c1)
+    connect(rel, rel.tail, c2)
+
+    # Now do the same on a new diagram:
+    diagram2 = element_factory.create(Diagram)
+    c3 = diagram2.create(InterfaceItem, subject=c1.subject)
+    c4 = diagram2.create(ClassItem, subject=c2.subject)
+    rel2 = diagram2.create(InterfaceRealizationItem)
+
+    connect(rel2, rel2.head, c3)
+    connect(rel2, rel2.tail, c4)
+    assert rel.subject is rel2.subject
+
+    c5 = diagram2.create(InterfaceItem, subject=element_factory.create(UML.Interface))
+    connect(rel2, rel2.head, c5)
+    connect(rel2, rel2.head, c3)
+
+    assert rel.subject is rel2.subject
+    assert rel.subject.supplier is c1.subject
+    assert rel.subject.client is c2.subject

--- a/gaphor/UML/classes/tests/test_realizationconnect.py
+++ b/gaphor/UML/classes/tests/test_realizationconnect.py
@@ -69,7 +69,7 @@ def test_reconnection(case):
     # reconnect: iface -> c2
     case.connect(impl, impl.tail, c2)
 
-    assert s is impl.subject
+    assert s is not impl.subject
     assert iface.subject is impl.subject.contract
     assert c2.subject is impl.subject.implementatingClassifier
     assert c1.subject is not impl.subject.implementatingClassifier

--- a/gaphor/UML/profiles/packageimportconnect.py
+++ b/gaphor/UML/profiles/packageimportconnect.py
@@ -24,16 +24,6 @@ class PackageImportConnect(RelationshipConnect):
 
         return super().allow(handle, port)
 
-    def reconnect(self, handle, port):
-        line = self.line
-        impl = line.subject
-        assert isinstance(impl, UML.Package)
-        self.reconnect_relationship(
-            handle,
-            UML.PackageImport.importedPackage,
-            UML.PackageImport.importingNamespace,
-        )
-
     def connect_subject(self, handle):
         """Perform import package relationship connection."""
         relation = self.relationship_or_new(

--- a/gaphor/UML/states/tests/test_transition_connect.py
+++ b/gaphor/UML/states/tests/test_transition_connect.py
@@ -48,7 +48,7 @@ class TestTransitionConnector:
         # reconnect: v1 -> v3
         case.connect(t, t.tail, v3)
 
-        assert s is t.subject
+        assert s is not t.subject
         assert len(case.kindof(UML.Transition)) == 1
 
         assert t.subject == v1.subject.outgoing[0]

--- a/gaphor/UML/states/vertexconnect.py
+++ b/gaphor/UML/states/vertexconnect.py
@@ -15,11 +15,6 @@ from gaphor.UML.states.transition import TransitionItem
 class VertexConnect(RelationshipConnect):
     """Abstract relationship between two state vertices."""
 
-    def reconnect(self, handle, port):
-        self.reconnect_relationship(
-            handle, UML.Transition.source, UML.Transition.target
-        )
-
     def connect_subject(self, handle):
         relation = self.relationship_or_new(
             UML.Transition, UML.Transition.source, UML.Transition.target

--- a/gaphor/UML/usecases/tests/test_extend.py
+++ b/gaphor/UML/usecases/tests/test_extend.py
@@ -42,7 +42,7 @@ class TestExtendItem:
         # reconnect: uc1 -> uc2
         case.connect(extend, extend.tail, uc3)
 
-        assert e is extend.subject
+        assert e is not extend.subject
         assert extend.subject.extendedCase is uc1.subject
         assert extend.subject.extension is uc3.subject
 

--- a/gaphor/UML/usecases/tests/test_include.py
+++ b/gaphor/UML/usecases/tests/test_include.py
@@ -42,7 +42,7 @@ class TestIncludeItem:
         # reconnect: uc1 -> uc2
         case.connect(include, include.tail, uc3)
 
-        assert e is include.subject
+        assert e is not include.subject
         assert include.subject.addition is uc1.subject
         assert include.subject.includingCase is uc3.subject
 

--- a/gaphor/UML/usecases/usecaseconnect.py
+++ b/gaphor/UML/usecases/usecaseconnect.py
@@ -19,11 +19,6 @@ class IncludeConnect(RelationshipConnect):
 
         return super().allow(handle, port)
 
-    def reconnect(self, handle, port):
-        self.reconnect_relationship(
-            handle, UML.Include.addition, UML.Include.includingCase
-        )
-
     def connect_subject(self, handle):
         relation = self.relationship_or_new(
             UML.Include, UML.Include.addition, UML.Include.includingCase
@@ -42,11 +37,6 @@ class ExtendConnect(RelationshipConnect):
             return None
 
         return super().allow(handle, port)
-
-    def reconnect(self, handle, port):
-        self.reconnect_relationship(
-            handle, UML.Extend.extendedCase, UML.Extend.extension
-        )
 
     def connect_subject(self, handle):
         relation = self.relationship_or_new(

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -66,7 +66,7 @@ class BaseConnector:
     ) -> None:
         assert (
             element.diagram and element.diagram is line.diagram
-        ), f"Connector without diagram ({element}: {element.diagram}, {line}: {line.diagram})"
+        ), f"Cannot connect with different diagrams ({element}: {element.diagram}, {line}: {line.diagram})"
         self.element = element
         self.line = line
         self.diagram: Diagram = element.diagram
@@ -131,9 +131,9 @@ class UnaryRelationshipConnect(BaseConnector):
     """Base class for relationship connections, such as associations,
     dependencies and implementations.
 
-    Unary relationships are allowed to connect both ends to the same element
+    Unary relationships are allowed to connect both ends to the same element.
 
-    This class introduces a new method: relationship() which is used to
+    This class introduces a new method: `relationship()`, which is used to
     find an existing relationship in the model that does not yet exist
     on the diagram.
     """

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -54,7 +54,6 @@ class BaseConnector:
       disconnects, if required (e.g. 1:1 relationships)
     - ``disconnect()``: Break connection, called when dropping a handle on a
       point where it can not connect.
-    - ``reconnect()`` (*Optional*): Connect to another item (only used if present)
 
     By convention the adapters are registered by (element, line) -- in that order.
     """
@@ -216,31 +215,6 @@ class UnaryRelationshipConnect(BaseConnector):
             setattr(relation, tail.name, line_tail.subject)
         assert isinstance(relation, type)
         return relation
-
-    def reconnect_relationship(
-        self, handle: Handle, head: relation, tail: relation
-    ) -> None:
-        """Reconnect relationship for given handle.
-
-        :Parameters:
-         handle
-            Handle at which reconnection happens.
-         head
-            Relationship head attribute name.
-         tail
-            Relationship tail attribute name.
-        """
-        line = self.line
-        c1 = self.get_connected(line.head)
-        c2 = self.get_connected(line.tail)
-        assert c1
-        assert c2
-        if line.head is handle:
-            setattr(line.subject, head.name, c1.subject)
-        elif line.tail is handle:
-            setattr(line.subject, tail.name, c2.subject)
-        else:
-            raise ValueError("Incorrect handle passed to adapter")
 
     def connect_connected_items(self, connections: None = None) -> None:
         """Cause items connected to ``line`` to reconnect, allowing them to

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -77,8 +77,7 @@ class BaseConnector:
 
     def get_connected(self, handle: Handle) -> Presentation[Element] | None:
         """Get item connected to a handle."""
-        cinfo = self.diagram.connections.get_connection(handle)
-        if cinfo:
+        if cinfo := self.diagram.connections.get_connection(handle):
             return cinfo.connected  # type: ignore[no-any-return] # noqa: F723
         return None
 
@@ -298,8 +297,7 @@ class UnaryRelationshipConnect(BaseConnector):
         if not super().connect(handle, port):
             return False
         opposite = self.line.opposite(handle)
-        oct = self.get_connected(opposite)
-        if oct:
+        if self.get_connected(opposite):
             self.connect_subject(handle)
             line = self.line
             if line.subject:

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -76,8 +76,7 @@ def serialize(value):
 def deserialize(ser, lookup):
     vtype, value = ser
     if vtype == "r":
-        e = lookup(value)
-        if e:
+        if e := lookup(value):
             yield e
     elif vtype == "c":
         for v in value:
@@ -189,8 +188,7 @@ def paste_presentation(copy_data: PresentationCopy, diagram, lookup):
     item = diagram.create(cls)
     yield item
     if parent:
-        p = lookup(parent)
-        if p:
+        if p := lookup(parent):
             item.parent = p
 
     for name, ser in data.items():
@@ -231,8 +229,7 @@ def _paste(copy_data, diagram, lookup, full) -> set[Presentation]:
         if full and looked_up and not isinstance(looked_up, Presentation):
             return looked_up
 
-        looked_up = diagram.lookup(ref)
-        if looked_up:
+        if looked_up := diagram.lookup(ref):
             return looked_up
 
     for old_id in copy_data.elements.keys():

--- a/gaphor/diagram/tools/connector.py
+++ b/gaphor/diagram/tools/connector.py
@@ -126,8 +126,7 @@ class ItemConnected(RevertibeEvent):
         connections = target.diagram.connections
         handle = target.handles()[self.handle_index]
         connector = ConnectorAspect(target, handle, connections)
-        cinfo = connections.get_connection(handle)
-        if cinfo:
+        if cinfo := connections.get_connection(handle):
             cinfo.callback.disable = True
         connector.disconnect()
 

--- a/gaphor/diagram/tools/connector.py
+++ b/gaphor/diagram/tools/connector.py
@@ -49,28 +49,17 @@ class PresentationConnector(ItemConnector):
 
         adapter = Connector(sink.item, item)
         if cinfo:
-            # first disconnect but disable disconnection handle as
-            # reconnection is going to happen
-            try:
-                connect = adapter.reconnect
-            except AttributeError:
-                connect = adapter.connect
-            else:
-                cinfo.callback.disable = True
             self.disconnect()
-        else:
-            # new connection
-            connect = adapter.connect
 
         self.glue(sink)
         if not sink.port:
-            print("No port found", item, sink.item)
+            log.warning("No port found", item, sink.item)
             return
 
         self.connect_handle(sink)
 
         # adapter requires both ends to be connected.
-        connect(handle, sink.port)
+        adapter.connect(handle, sink.port)
         item.handle(ItemConnected(item, handle, sink.item, sink.port))
 
     def connect_handle(self, sink):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Currently, reconnecting a line to another element can make the model and diagrams inconsistent.

Issue Number: #1347 

### What is the new behavior?

Instead of modifying existing relations, create a new relation and copy the properties from the old relation. This way filled in values, like name and guard conditions will stay, although the underlaying model element has been replaced completely.

This change currently works for simple relations, like Dependency and Generalization. The more complex ones (Association, Extension, Connector) do not use this functionality, but should use a similar scheme.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

* When recreating, notifications are issued that unused model elements have been removed.
* A copy of the existing model elements (if any) is made when a `Connector` is created. However in some cases, such as the grayout tool, a `Connector` is created only to call the `allow()` method. This is overhead I accept for now. I want to have a look at simplifying the connector flow (#687).
* #976 should be resolved before this PR can be merged.
* Depends on #1353