### PR TITLE
Update connection behavior for Association

### DIFF
--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -481,8 +481,7 @@ class AssociationEnd:
             return
 
         cr = context.cairo
-        text_color = context.style.get("text-color")
-        if text_color:
+        if text_color := context.style.get("text-color"):
             cr.set_source_rgba(*text_color)
 
         cr.move_to(self._name_bounds.x, self._name_bounds.y)

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -19,7 +19,7 @@ from gaphas.connector import Handle
 from gaphas.geometry import Rectangle, distance_rectangle_point
 
 from gaphor import UML
-from gaphor.core.modeling.properties import association, attribute
+from gaphor.core.modeling.properties import association, attribute, enumeration
 from gaphor.core.styling import Style, merge_styles
 from gaphor.diagram.presentation import LinePresentation, Named
 from gaphor.diagram.shapes import (
@@ -95,9 +95,14 @@ class AssociationItem(LinePresentation[UML.Association], Named):
             "subject[Association].navigableOwnedEnd"
         ).watch(
             "show_direction"
+        ).watch(
+            "preferred_aggregation", self.on_association_end_value
         )
 
     show_direction: attribute[int] = attribute("show_direction", int, default=False)
+    preferred_aggregation = enumeration(
+        "preferred_aggregation", ("none", "shared", "composite"), "none"
+    )
 
     def load(self, name, value):
         # end_head and end_tail were used in an older Gaphor version
@@ -165,7 +170,12 @@ class AssociationItem(LinePresentation[UML.Association], Named):
             else:
                 self.draw_tail = draw_default_tail
         else:
-            self.draw_head = draw_default_head
+            if self.preferred_aggregation == "composite":
+                self.draw_head = draw_head_composite
+            elif self.preferred_aggregation == "shared":
+                self.draw_head = draw_head_shared
+            else:
+                self.draw_head = draw_default_head
             self.draw_tail = draw_default_tail
 
         self.request_update()

--- a/gaphor/UML/classes/classconnect.py
+++ b/gaphor/UML/classes/classconnect.py
@@ -84,10 +84,7 @@ class AssociationConnect(UnaryRelationshipConnect):
 
     def allow(self, handle, port):
         # Element should be a Classifier
-        if not isinstance(self.element.subject, UML.Classifier):
-            return False
-
-        return True
+        return isinstance(self.element.subject, UML.Classifier)
 
     def relationship(  # type:ignore[override]
         self, head_subject, tail_subject
@@ -111,8 +108,7 @@ class AssociationConnect(UnaryRelationshipConnect):
         diagram = self.diagram
 
         a: UML.Association
-        for a in line.model.select(UML.Association):
-            if (
+        return next((a for a in line.model.select(UML.Association) if (
                 (
                     head_subject is a.memberEnd[0].type
                     and tail_subject is a.memberEnd[1].type
@@ -121,10 +117,7 @@ class AssociationConnect(UnaryRelationshipConnect):
                     head_subject is a.memberEnd[1].type
                     and tail_subject is a.memberEnd[0].type
                 )
-            ) and diagram not in a.presentation[:].diagram:
-                return a
-
-        return None
+            ) and diagram not in a.presentation[:].diagram), None)
 
     def new_relation(self, head_subject, tail_subject) -> UML.Association:  # type: ignore[override]
         return UML.recipes.create_association(head_subject, tail_subject)  # type: ignore[no-any-return]

--- a/gaphor/UML/classes/classconnect.py
+++ b/gaphor/UML/classes/classconnect.py
@@ -77,15 +77,15 @@ class AssociationConnect(UnaryRelationshipConnect):
 
     def allow(self, handle, port):
         element = self.element
+        line = self.line
 
         # Element should be a Classifier
         if not isinstance(element.subject, UML.Classifier):
             return None
 
-        if not self.line.subject:
+        if not line.subject:
             return True
 
-        line = self.line
         subject = line.subject
         is_head = handle is line.head
 
@@ -105,25 +105,29 @@ class AssociationConnect(UnaryRelationshipConnect):
 
         assert element.diagram
 
-        c1 = self.get_connected(line.head)
-        c2 = self.get_connected(line.tail)
-        if c1 and c2:
+        head_end = self.get_connected(line.head)
+        tail_end = self.get_connected(line.tail)
 
-            if not line.subject:
-                relation = UML.recipes.create_association(c1.subject, c2.subject)
-                relation.package = owner_package(element.diagram.owner)
-                line.head_subject = relation.memberEnd[0]
-                line.tail_subject = relation.memberEnd[1]
-                UML.recipes.set_navigability(relation, line.head_subject, None)
-                if line.preferred_aggregation in ("shared", "composite"):
-                    UML.recipes.set_navigability(relation, line.tail_subject, True)
-                line.tail_subject.aggregation = line.preferred_aggregation
+        assert head_end
+        assert tail_end
 
-                # Set subject last so that event handlers can trigger
-                line.subject = relation
+        if not line.subject:
+            relation = UML.recipes.create_association(
+                head_end.subject, tail_end.subject
+            )
+            relation.package = owner_package(element.diagram.owner)
+            line.head_subject = relation.memberEnd[0]
+            line.tail_subject = relation.memberEnd[1]
+            UML.recipes.set_navigability(relation, line.head_subject, None)
+            if line.preferred_aggregation in ("shared", "composite"):
+                UML.recipes.set_navigability(relation, line.tail_subject, True)
+            line.tail_subject.aggregation = line.preferred_aggregation
 
-            line.head_subject.type = c1.subject
-            line.tail_subject.type = c2.subject
+            # Set subject last so that event handlers can trigger
+            line.subject = relation
+
+            line.head_subject.type = head_end.subject
+            line.tail_subject.type = tail_end.subject
 
     def disconnect_subject(self, handle: Handle) -> None:
         """Disconnect the type of each member end.

--- a/gaphor/UML/classes/classconnect.py
+++ b/gaphor/UML/classes/classconnect.py
@@ -92,32 +92,29 @@ class AssociationConnect(UnaryRelationshipConnect):
         line = self.line
         subject = line.subject
 
-        # First check if the right subject is already connected:
-        if line.subject and (
-            (
+        def member_ends_match(subject):
+            return (
                 head_subject is subject.memberEnd[0].type
                 and tail_subject is subject.memberEnd[1].type
-            )
-            or (
+            ) or (
                 head_subject is subject.memberEnd[1].type
                 and tail_subject is subject.memberEnd[0].type
             )
-        ):
+
+        # First check if the right subject is already connected:
+        if line.subject and member_ends_match(line.subject):
             return subject
 
         diagram = self.diagram
 
-        a: UML.Association
-        return next((a for a in line.model.select(UML.Association) if (
-                (
-                    head_subject is a.memberEnd[0].type
-                    and tail_subject is a.memberEnd[1].type
-                )
-                or (
-                    head_subject is a.memberEnd[1].type
-                    and tail_subject is a.memberEnd[0].type
-                )
-            ) and diagram not in a.presentation[:].diagram), None)
+        return next(
+            (
+                a
+                for a in line.model.select(UML.Association)
+                if member_ends_match(a) and diagram not in a.presentation[:].diagram
+            ),
+            None,
+        )
 
     def new_relation(self, head_subject, tail_subject) -> UML.Association:  # type: ignore[override]
         return UML.recipes.create_association(head_subject, tail_subject)  # type: ignore[no-any-return]

--- a/gaphor/UML/classes/classconnect.py
+++ b/gaphor/UML/classes/classconnect.py
@@ -114,6 +114,10 @@ class AssociationConnect(UnaryRelationshipConnect):
                 relation.package = owner_package(element.diagram.owner)
                 line.head_subject = relation.memberEnd[0]
                 line.tail_subject = relation.memberEnd[1]
+                UML.recipes.set_navigability(relation, line.head_subject, None)
+                if line.preferred_aggregation in ("shared", "composite"):
+                    UML.recipes.set_navigability(relation, line.tail_subject, True)
+                line.tail_subject.aggregation = line.preferred_aggregation
 
                 # Set subject last so that event handlers can trigger
                 line.subject = relation

--- a/gaphor/UML/classes/classestoolbox.py
+++ b/gaphor/UML/classes/classestoolbox.py
@@ -1,7 +1,5 @@
 """The definition for the classes section of the toolbox."""
 
-from enum import Enum
-
 from gaphas.item import SE
 
 from gaphor import UML
@@ -9,40 +7,18 @@ from gaphor.core import gettext
 from gaphor.diagram.diagramtoolbox import (
     ToolDef,
     ToolSection,
-    default_namespace,
     namespace_config,
     new_item_factory,
 )
 from gaphor.UML import diagramitems
 
 
-class AssociationType(Enum):
-    COMPOSITE = "composite"
-    SHARED = "shared"
-
-
-def create_association(
-    assoc_item: diagramitems.AssociationItem, association_type: AssociationType
-) -> None:
-    default_namespace(assoc_item)
-    assoc = assoc_item.subject
-    assoc.memberEnd.append(assoc_item.model.create(UML.Property))
-    assoc.memberEnd.append(assoc_item.model.create(UML.Property))
-
-    assoc_item.head_subject = assoc.memberEnd[0]
-    assoc_item.tail_subject = assoc.memberEnd[1]
-
-    UML.recipes.set_navigability(assoc, assoc_item.head_subject, None)
-    UML.recipes.set_navigability(assoc, assoc_item.tail_subject, True)
-    assoc_item.tail_subject.aggregation = association_type.value
-
-
 def composite_association_config(assoc_item: diagramitems.AssociationItem) -> None:
-    create_association(assoc_item, AssociationType.COMPOSITE)
+    assoc_item.preferred_aggregation = "composite"
 
 
 def shared_association_config(assoc_item: diagramitems.AssociationItem) -> None:
-    create_association(assoc_item, AssociationType.SHARED)
+    assoc_item.preferred_aggregation = "shared"
 
 
 classes = ToolSection(
@@ -108,7 +84,6 @@ classes = ToolSection(
             "<Shift>Z",
             new_item_factory(
                 diagramitems.AssociationItem,
-                UML.Association,
                 config_func=composite_association_config,
             ),
         ),
@@ -119,7 +94,6 @@ classes = ToolSection(
             "<Shift>Q",
             new_item_factory(
                 diagramitems.AssociationItem,
-                UML.Association,
                 config_func=shared_association_config,
             ),
         ),

--- a/gaphor/UML/profiles/tests/test_extensionconnect.py
+++ b/gaphor/UML/profiles/tests/test_extensionconnect.py
@@ -1,31 +1,40 @@
 """Extension item connection adapter tests."""
 
 from gaphor import UML
+from gaphor.core.modeling.diagram import Diagram
 from gaphor.diagram.tests.fixtures import allow, connect
 from gaphor.UML.classes.klass import ClassItem
 from gaphor.UML.profiles.extension import ExtensionItem
 
 
-def test_glue(element_factory, diagram):
-    """Test extension item glue."""
-
+def test_glue_head_to_stereotype(element_factory, diagram):
     ext = diagram.create(ExtensionItem)
     st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
-    cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+
+    glued = allow(ext, ext.head, st)
+
+    assert glued
+
+
+def test_glue_tail_to_stereotype(element_factory, diagram):
+    ext = diagram.create(ExtensionItem)
+    st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
 
     glued = allow(ext, ext.tail, st)
 
     assert glued
-    connect(ext, ext.tail, st)
+
+
+def test_glue_head_to_class(element_factory, diagram):
+    ext = diagram.create(ExtensionItem)
+    cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
     glued = allow(ext, ext.head, cls)
 
     assert glued
 
 
-def test_class_glue(element_factory, diagram):
-    """Test extension item gluing to a class."""
-
+def test_glue_tail_to_class(element_factory, diagram):
     ext = diagram.create(ExtensionItem)
     cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
@@ -34,36 +43,18 @@ def test_class_glue(element_factory, diagram):
     assert not glued
 
 
-def test_stereotype_glue(element_factory, diagram):
-    """Test extension item gluing to a stereotype.
-
-    Connecting a Stereotype should work because it is derived from the
-    UML Class.
-    """
-
-    ext = diagram.create(ExtensionItem)
-    st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
-    assert isinstance(st.subject, UML.Stereotype)
-
-    glued = allow(ext, ext.head, st)
-
-    assert glued
-
-
 def test_connection(element_factory, diagram):
-    """Test extension item connection."""
-
     ext = diagram.create(ExtensionItem)
     st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
     cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
 
     connect(ext, ext.tail, st)
-
     connect(ext, ext.head, cls)
+
+    assert ext.subject
 
 
 def test_connection_namespace(element_factory, diagram):
-    """Test extension item connection."""
     pkg = element_factory.create(UML.Package)
     diagram.element = pkg
     ext = diagram.create(ExtensionItem)
@@ -74,3 +65,22 @@ def test_connection_namespace(element_factory, diagram):
     connect(ext, ext.head, cls)
 
     assert ext.subject.package is pkg
+
+
+def test_reuse_extension_in_new_diagram(element_factory, diagram):
+    ext = diagram.create(ExtensionItem)
+    st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
+    cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+
+    connect(ext, ext.tail, st)
+    connect(ext, ext.head, cls)
+
+    diagram2 = element_factory.create(Diagram)
+    ext2 = diagram2.create(ExtensionItem)
+    st2 = diagram2.create(ClassItem, subject=st.subject)
+    cls2 = diagram2.create(ClassItem, subject=cls.subject)
+
+    connect(ext2, ext2.tail, st2)
+    connect(ext2, ext2.head, cls2)
+
+    assert ext.subject is ext2.subject

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -71,10 +71,6 @@ class BaseConnector:
         self.line = line
         self.diagram: Diagram = element.diagram
 
-    def get_connection(self, handle: Handle) -> Connection | None:
-        """Get connection information."""
-        return self.diagram.connections.get_connection(handle)
-
     def get_connected(self, handle: Handle) -> Presentation[Element] | None:
         """Get item connected to a handle."""
         if cinfo := self.diagram.connections.get_connection(handle):

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -157,6 +157,9 @@ class UnaryRelationshipConnect(BaseConnector):
         head - tuple (association name on line, association name on element)
         tail - tuple (association name on line, association name on element)
         """
+        assert isinstance(head, (association, redefine)), f"head is {head}"
+        assert isinstance(tail, (association, redefine)), f"tail is {tail}"
+
         line = self.line
 
         line_head = self.get_connected(line.head)
@@ -173,9 +176,6 @@ class UnaryRelationshipConnect(BaseConnector):
             and getattr(line.subject, tail.name) is tail_subject
         ):
             return line.subject
-
-        assert isinstance(head, (association, redefine)), f"head is {head}"
-        assert isinstance(tail, (association, redefine)), f"tail is {tail}"
 
         # Try to find a relationship, that is already created, but not
         # yet displayed in the diagram on the tail side, since tail should

--- a/tests/test_composite_association.py
+++ b/tests/test_composite_association.py
@@ -17,7 +17,7 @@ from gaphor.UML.classes.classestoolbox import composite_association_config
 def test_connect_composite_association(create, diagram):
     c1 = create(ClassItem, UML.Class)
     c2 = create(ClassItem, UML.Class)
-    a = create(AssociationItem, UML.Association)
+    a = create(AssociationItem)
     composite_association_config(a)
 
     property_page = AssociationPropertyPage(a)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

* Association is the only relation type that holds a model element when disconnected.
* It's not able to find existing associations from the model when a relation is drawn in a diagram.

Issue Number: #1009?

### What is the new behavior?

This PR unifies the behavior of Association with other relation types. Associations can be looked up, it can use the  copy functionality introduced in #1351.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Requires #1351 to be merged.