### PR TITLE
Fix AppImage Crashes on Save Command

### DIFF
--- a/.github/workflows/appimage-docker.yml
+++ b/.github/workflows/appimage-docker.yml
@@ -36,5 +36,5 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           python -m pip install poethepoet
-          poe appimage-docker-build
+          poe appimage-docker-build-clean
           poe appimage-docker-push

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -66,6 +66,7 @@ jobs:
           path: dist/gaphor-${{ steps.setup_and_test.outputs.version }}-py3-none-any.whl
       - name: Build AppImage
         run: |
+          jhbuild shell
           poetry run poe package
           cd _packaging/appimage
           make dist

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -145,3 +145,6 @@ COPY jhbuildrc /root/.config/jhbuildrc
 RUN jhbuild build \
  && rm -r /root/.config \
  && rm -r /root/.cache
+
+# Environmental variable needed to run GTK for gsettings schema
+ENV XDG_DATA_DIRS="/root/jhbuild/install/share:/usr/share"

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -127,8 +127,7 @@ ENV CHECKOUT=/root/jhbuild/checkout \
     LD_LIBRARY_PATH="/root/jhbuild/install/lib" \
     PKG_CONFIG_PATH="/root/jhbuild/install/lib/pkgconfig" \
     PATH="/root/jhbuild/install/bin:/root/.local/bin:/root/.cargo/bin:$PATH" \
-    JHBUILD_RUN_AS_ROOT="" \
-    GSETTINGS_SCHEMA_DIR="/root/jhbuild/install/share/glib-2.0/schemas"
+    JHBUILD_RUN_AS_ROOT=""
 
 # Install jhbuild
 RUN mkdir -p $CHECKOUT \
@@ -149,3 +148,5 @@ RUN jhbuild build \
  && rm -r /root/.config \
  && rm -r /root/.cache
 
+# Environmental variable needed to run GTK for gsettings schema
+ENV XDG_DATA_DIRS="/root/jhbuild/install/share"

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -114,8 +114,9 @@ RUN wget -q https://www.freedesktop.org/software/fontconfig/release/fontconfig-$
 ENV CHECKOUT=/root/jhbuild/checkout \
     LD_LIBRARY_PATH="/root/jhbuild/install/lib" \
     PKG_CONFIG_PATH="/root/jhbuild/install/lib/pkgconfig" \
-    PATH="/root/jhbuild/install/bin:/root/.local/bin:$PATH" \
-    JHBUILD_RUN_AS_ROOT=""
+    PATH="/root/jhbuild/install/bin:/root/.local/bin:/root/.cargo/bin:$PATH" \
+    JHBUILD_RUN_AS_ROOT="" \
+    GSETTINGS_SCHEMA_DIR="/root/jhbuild/install/share/glib-2.0/schemas"
 
 # Install jhbuild
 RUN mkdir -p $CHECKOUT \

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -143,10 +143,5 @@ COPY jhbuildrc /root/.config/jhbuildrc
 
 # Build GTK, GtkSourceView, and gobject-introspection
 RUN jhbuild build \
- && rm -r /root/jhbuild/checkout \
- && rm -r /root/.local \
  && rm -r /root/.config \
  && rm -r /root/.cache
-
-# Environmental variable needed to run GTK for gsettings schema
-ENV XDG_DATA_DIRS="/root/jhbuild/install/share"

--- a/_packaging/appimage/Dockerfile
+++ b/_packaging/appimage/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-gi-dev \
     python3 \
     python3-dbus \
+    python3-docutils \
     python3-dev \
     python3-flake8 \
     python3-pytest \
@@ -110,6 +111,17 @@ RUN wget -q https://www.freedesktop.org/software/fontconfig/release/fontconfig-$
  && rm -r /fontconfig-* \
 `# Make Deadsnakes Python the default python3` \
  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$PY_VERSION 1
+
+# Newer rust is needed by librsvg
+RUN apt-get update \
+  && apt-get remove -y rustc cargo \
+  && apt-get install -y --no-install-recommends curl \
+  && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+  && apt-get remove -y curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# librsvg needs gi-docgen
+RUN pip install gi-docgen
 
 ENV CHECKOUT=/root/jhbuild/checkout \
     LD_LIBRARY_PATH="/root/jhbuild/install/lib" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ pyinstall = { "script" = "_packaging.make-script:make_pyinstaller" }
 package = ["install-pyinstall", "gaphor-script", "version-file", "pyinstall"]
 win-installer = { "script" = "_packaging.windows.build-win-installer:main" }
 appimage-docker-build = "docker build -t ghcr.io/gaphor/gaphor-appimage _packaging/appimage"
+appimage-docker-build-clean = "docker build --no-cache -t ghcr.io/gaphor/gaphor-appimage _packaging/appimage"
 appimage-docker-push = "docker push ghcr.io/gaphor/gaphor-appimage:latest"
 appimage-docker-run = "docker run --rm -it --volume $PWD:/gaphor ghcr.io/gaphor/gaphor-appimage"
 gettext-pot = "pybabel extract -o po/gaphor.pot -F po/babel.ini gaphor"


### PR DESCRIPTION
This PR sets the environmental variable `XDG_DATA_DIRS` so that Gtk can find the user-specific data files related to GNOME when compiled from source. Also, librsvg was failing to build and this updates the dependencies to fix that issue with the docker image.


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/master/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
AppImage version of Gaphor crashes on save.

Issue Number: #1355 

### What is the new behavior?
No crashes

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
