### PR TITLE
Simulate user behavior with Hypothesis

### DIFF
--- a/.github/workflows/hypothesis-test.yml
+++ b/.github/workflows/hypothesis-test.yml
@@ -1,0 +1,43 @@
+name: Test
+on:
+  schedule:
+    # min hour dom month dow
+    - cron:  '0 6 * * *'
+env:
+  python_version: '3.10'
+
+jobs:
+
+  hypothesis:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python_version: ["3.10"]
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install Linux Dependencies
+        uses: ./.github/actions/linux_dependencies
+      - name: Set up Python
+        uses: actions/setup-python@v2.3.2
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: Use Python Dependency Cache
+        uses: actions/cache@v2.1.7
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-20.04
+      - name: Use Hypothesis Cache
+        uses: actions/cache@v2.1.7
+        with:
+          path: ~/.hypothesis
+          key: ${{ runner.os }}-hypothesis
+      - name: Install Dependencies and Test
+        uses: ./.github/actions/setup_and_test
+        with:
+          xvfb_command: 'xvfb-run'
+      - name: Test with Hypothesis
+        run: ${{ inputs.xvfb_command }} poetry run pytest --hypothesis-profile=ci tests
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ pip-wheel-metadata
 
 # PyTest
 .pytest_cache
+.hypothesis
 
 # MyPy
 .mypy_cache/

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -87,10 +87,7 @@ def removesuffix(self: str, suffix: str) -> str:
 def attrname(obj, lower_name):
     """Look up a real attribute name based on a lower case (normalized)
     name."""
-    for name in dir(obj):
-        if name.lower() == lower_name:
-            return name
-    return lower_name
+    return next((name for name in dir(obj) if name.lower() == lower_name), lower_name)
 
 
 def rgetattr(obj, names):
@@ -126,10 +123,7 @@ def attrstr(obj):
 def qualifiedName(element: Element) -> list[str]:
     """Returns the qualified name of the element as a tuple."""
     name: str = getattr(element, "name", "??")
-    if element.owner:
-        return qualifiedName(element.owner) + [name]
-    else:
-        return [name]
+    return qualifiedName(element.owner) + [name] if element.owner else [name]
 
 
 class StyledDiagram:
@@ -395,8 +389,7 @@ class Diagram(Element):
 
     def _update_items(self, items):
         for item in items:
-            update = getattr(item, "update", None)
-            if update:
+            if update := getattr(item, "update", None):
                 update(UpdateContext(style=self.style(StyledItem(item))))
 
     def _on_constraint_solved(self, cinfo: gaphas.connections.Connection) -> None:

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -5,7 +5,6 @@ Diagrams can be visualized and edited.
 from __future__ import annotations
 
 import logging
-import uuid
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import (
@@ -23,7 +22,7 @@ import gaphas
 from cairo import Context as CairoContext
 
 from gaphor.core.modeling.collection import collection
-from gaphor.core.modeling.element import Element, Id, RepositoryProtocol
+from gaphor.core.modeling.element import Element, Id, RepositoryProtocol, generate_id
 from gaphor.core.modeling.event import AssociationAdded, AssociationDeleted
 from gaphor.core.modeling.presentation import Presentation
 from gaphor.core.modeling.properties import (
@@ -299,7 +298,7 @@ class Diagram(Element):
         subject.
         """
 
-        return self.create_as(type, str(uuid.uuid1()), parent, subject)
+        return self.create_as(type, generate_id(), parent, subject)
 
     def create_as(self, type, id, parent=None, subject=None):
         assert isinstance(self.model, PresentationRepositoryProtocol)

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -36,6 +36,21 @@ class UnlinkEvent:
 Id = str
 
 
+def uuid_generator():
+    while True:
+        yield str(uuid.uuid1())
+
+
+_generator: Iterator[str] = uuid_generator()
+
+
+def generate_id(generator=None):
+    global _generator
+    if generator:
+        _generator = generator
+    return next(_generator)
+
+
 class Element:
     """Base class for all model data classes."""
 
@@ -59,7 +74,7 @@ class Element:
 
         A model can be provided to refer to the model this element belongs to.
         """
-        self._id: Id = id or str(uuid.uuid1())
+        self._id: Id = id or generate_id()
         # The model this element belongs to.
         self._model = model
         self._unlink_lock = 0

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -151,13 +151,11 @@ class Element:
 
     def handle(self, event):
         """Propagate incoming events."""
-        model = self._model
-        if model:
+        if model := self._model:
             model.handle(event)
 
     def watcher(self, default_handler: Handler | None = None) -> EventWatcherProtocol:
-        model = self._model
-        if model:
+        if model := self._model:
             return model.watcher(self, default_handler)
         else:
             return DummyEventWatcher()

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import uuid
 from collections import OrderedDict
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Callable, Iterator, TypeVar, overload
@@ -15,6 +14,7 @@ from gaphor.core.modeling.element import (
     Handler,
     RepositoryProtocol,
     UnlinkEvent,
+    generate_id,
 )
 from gaphor.core.modeling.elementdispatcher import ElementDispatcher, EventWatcher
 from gaphor.core.modeling.event import (
@@ -77,7 +77,7 @@ class ElementFactory(Service):
 
     def create(self, type: type[T]) -> T:
         """Create a new model element of type ``type``."""
-        return self.create_as(type, str(uuid.uuid1()))
+        return self.create_as(type, generate_id())
 
     def create_as(self, type: type[T], id: str, diagram: Diagram = None) -> T:
         """Create a new model element of type 'type' with 'id' as its ID.

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -51,8 +51,7 @@ class CopyService(Service, ActionProvider):
         def on_clipboard_owner_change(self, clipboard, event):
             view = self.diagrams.get_current_view()
             if view and not view.is_focus():
-                global copy_buffer
-                copy_buffer = set()
+                self.clear()
 
     def copy(self, items):
         global copy_buffer
@@ -61,6 +60,10 @@ class CopyService(Service, ActionProvider):
 
     def can_paste(self):
         return bool(copy_buffer)
+
+    def clear(self):
+        global copy_buffer
+        copy_buffer = set()
 
     def paste_link(self, diagram):
         """Paste items in the copy-buffer to the diagram."""

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -59,6 +59,9 @@ class CopyService(Service, ActionProvider):
         if items:
             copy_buffer = copy(items)
 
+    def can_paste(self):
+        return bool(copy_buffer)
+
     def paste_link(self, diagram):
         """Paste items in the copy-buffer to the diagram."""
         with Transaction(self.event_manager):

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -182,6 +182,7 @@ class UndoManager(Service, ActionProvider):
                     erroneous_tx.execute()
                 except Exception:
                     logger.error("Could not rollback transaction", exc_info=True)
+                    raise
         finally:
             # Discard all data collected in the rollback "transaction"
             self._undo_stack = undo_stack

--- a/gaphor/storage/upgrade_canvasitem.py
+++ b/gaphor/storage/upgrade_canvasitem.py
@@ -1,4 +1,4 @@
-import uuid
+from gaphor.core.modeling.element import generate_id
 
 
 def upgrade_canvasitem(item, gaphor_version):
@@ -63,7 +63,7 @@ def upgrade_presentation_item_to_1_1_0(item):
 
 def clone_canvasitem(item, subject_id):
     assert isinstance(item.references["subject"], str)
-    new_item = type(item)(str(uuid.uuid1()), item.type)
+    new_item = type(item)(generate_id(), item.type)
     new_item.values = dict(item.values)
     new_item.references = dict(item.references)
     new_item.references["subject"] = subject_id

--- a/gaphor/transaction.py
+++ b/gaphor/transaction.py
@@ -125,6 +125,7 @@ class Transaction:
                 self.rollback()
             except Exception:
                 log.error("Rollback failed", exc_info=True)
+                raise
         else:
             self.commit()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -221,6 +221,34 @@ optional = false
 python-versions = ">=3.8,<4.0"
 
 [[package]]
+name = "hypothesis"
+version = "6.37.0"
+description = "A library for property-based testing"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+sortedcontainers = ">=2.1.0,<3.0.0"
+
+[package.extras]
+all = ["black (>=19.10b0)", "click (>=7.0)", "django (>=2.2)", "dpcontracts (>=0.4)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=0.25)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "importlib-metadata (>=3.6)", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2021.5)"]
+cli = ["click (>=7.0)", "black (>=19.10b0)", "rich (>=9.0.0)"]
+codemods = ["libcst (>=0.3.16)"]
+dateutil = ["python-dateutil (>=1.4)"]
+django = ["django (>=2.2)"]
+dpcontracts = ["dpcontracts (>=0.4)"]
+ghostwriter = ["black (>=19.10b0)"]
+lark = ["lark-parser (>=0.6.5)"]
+numpy = ["numpy (>=1.9.0)"]
+pandas = ["pandas (>=0.25)"]
+pytest = ["pytest (>=4.6)"]
+pytz = ["pytz (>=2014.1)"]
+redis = ["redis (>=3.0.0)"]
+zoneinfo = ["backports.zoneinfo (>=0.2.1)", "tzdata (>=2021.5)"]
+
+[[package]]
 name = "identify"
 version = "2.4.6"
 description = "File identification library for Python"
@@ -770,6 +798,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "sphinx"
 version = "4.4.0"
 description = "Python documentation generator"
@@ -1003,7 +1039,7 @@ pyinstall = ["poethepoet", "pyinstaller", "pyinstaller-versionfile", "tomli"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "a1617c2f3407c70d31895d2a86bcf3da84d2126a833a00be3bb32be70dce3db1"
+content-hash = "dafb3870d977214412b900ab172111501ed92a622fe8acb6dd47964659de6d58"
 
 [metadata.files]
 alabaster = [
@@ -1148,6 +1184,10 @@ generic = [
     {file = "generic-1.0.1-py3-none-any.whl", hash = "sha256:e6be6d8490a2458c9f8e28e151c4f4a0687f40ac364da35578f7147b0220f264"},
     {file = "generic-1.0.1.tar.gz", hash = "sha256:7b1f7723ea1fa3994feaaa28959c338f14aca5ea898a6637be9077d912c9d349"},
 ]
+hypothesis = [
+    {file = "hypothesis-6.37.0-py3-none-any.whl", hash = "sha256:0f407e8e87644e0c6bd2dad6c2df02892172b923065de9d302ea6ce002e6f345"},
+    {file = "hypothesis-6.37.0.tar.gz", hash = "sha256:f4fd3c11d997aea3675d67f3613bccbbb3ef897a96968ec483d472f5d8aa410d"},
+]
 identify = [
     {file = "identify-2.4.6-py2.py3-none-any.whl", hash = "sha256:cf06b1639e0dca0c184b1504d8b73448c99a68e004a80524c7923b95f7b6837c"},
     {file = "identify-2.4.6.tar.gz", hash = "sha256:233679e3f61a02015d4293dbccf16aa0e4996f868bd114688b8c124f18826706"},
@@ -1189,28 +1229,12 @@ markdown-it-py = [
     {file = "markdown_it_py-2.0.1-py3-none-any.whl", hash = "sha256:31974138ca8cafbcb62213f4974b29571b940e78364584729233f59b8dfdb8bd"},
 ]
 markupsafe = [
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1219,27 +1243,14 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1249,12 +1260,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1467,6 +1472,10 @@ six = [
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
+]
+sortedcontainers = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 sphinx = [
     {file = "Sphinx-4.4.0-py3-none-any.whl", hash = "sha256:5da895959511473857b6d0200f56865ed62c31e8f82dd338063b84ec022701fe"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ babelgladeextractor = "^0.7"
 flake8 = "^4.0"
 isort = "^5.10"
 poethepoet = ">=0.10,<0.13"
+hypothesis = "^6.37.0"
 
 [tool.poetry.extras]
 pyinstall = ["poethepoet", "pyinstaller", "pyinstaller-versionfile", "tomli"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,10 @@ import os
 
 from hypothesis import settings
 
-from gaphor.conftest import Case, case, test_models
+from gaphor.conftest import case, test_models
 
 settings.register_profile(
     "test", derandomize=True, max_examples=5, stateful_step_count=20
 )
-settings.register_profile("ci", max_examples=500)
+settings.register_profile("ci", max_examples=2000)
 settings.load_profile("test")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,11 @@
+import os
+
+from hypothesis import settings
+
 from gaphor.conftest import Case, case, test_models
+
+settings.register_profile(
+    "test", derandomize=True, max_examples=5, stateful_step_count=20
+)
+settings.register_profile("ci", max_examples=500)
+settings.load_profile("test")

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -1,0 +1,184 @@
+"""A Property-based test."""
+
+import pytest
+from hypothesis import assume
+from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
+from hypothesis.strategies import data, sampled_from
+
+from gaphor import UML
+from gaphor.application import Session
+from gaphor.core import Transaction
+from gaphor.core.modeling import Diagram
+from gaphor.diagram.tests.fixtures import allow, connect, disconnect
+from gaphor.UML import diagramitems
+
+N_DIAGRAMS = 5
+
+
+class ModelConsistency(RuleBasedStateMachine):
+    def __init__(self):
+        super().__init__()
+        self.session = Session()
+        for _ in range(N_DIAGRAMS):
+            self.create_diagram()
+
+    @property
+    def model(self):
+        return self.session.get_service("element_factory")
+
+    @property
+    def transaction(self):
+        return Transaction(self.session.get_service("event_manager"))
+
+    def relations(self, diagram):
+        relations = [
+            p
+            for p in diagram.presentation
+            if isinstance(p, diagramitems.DependencyItem)
+        ]
+        assume(relations)
+        return relations
+
+    def targets(self, relation, handle):
+        targets = self.model.lselect(
+            lambda e: isinstance(e, diagramitems.ClassItem)
+            and e.diagram is relation.diagram
+            and allow(relation, handle, e)
+        )
+        assume(targets)
+        return targets
+
+    def create_diagram(self):
+        with self.transaction:
+            return self.model.create(Diagram)
+
+    @rule(data=data())
+    def create_class(self, data):
+        diagram = data.draw(sampled_from(self.model.lselect(Diagram)))
+        with self.transaction:
+            return diagram.create(
+                diagramitems.ClassItem, subject=self.model.create(UML.Class)
+            )
+
+    @rule(data=data())
+    def create_dependency(self, data):
+        diagram = data.draw(sampled_from(self.model.lselect(Diagram)))
+        with self.transaction:
+            relation = diagram.create(diagramitems.DependencyItem)
+        self.connect_relation(data, relation, relation.head)
+        self.connect_relation(data, relation, relation.tail)
+        return relation
+
+    @rule(data=data())
+    def delete_element(self, data):
+        elements = self.model.lselect(lambda e: not isinstance(e, Diagram))
+        assume(elements)
+        element = data.draw(sampled_from(elements))
+        with self.transaction:
+            element.unlink()
+
+    @rule(data=data())
+    def connect_relation(self, data, relation=None, handle=None):
+        diagram = (relation and relation.diagram) or data.draw(
+            sampled_from(self.model.lselect(Diagram))
+        )
+        relation = relation or data.draw(sampled_from(self.relations(diagram)))
+        handle = handle or data.draw(sampled_from([relation.head, relation.tail]))
+        target = data.draw(sampled_from(self.targets(relation, handle)))
+        with self.transaction:
+            connect(relation, handle, target)
+        if get_connected(diagram, relation.head) and get_connected(
+            diagram, relation.tail
+        ):
+            assert relation.subject
+
+    @rule(data=data())
+    def disconnect_relation(self, data):
+        diagram = data.draw(sampled_from(self.model.lselect(Diagram)))
+        relation = data.draw(sampled_from(self.relations(diagram)))
+        handle = data.draw(sampled_from([relation.head, relation.tail]))
+        with self.transaction:
+            disconnect(relation, handle)
+
+    @invariant()
+    def check_relations(self):
+        for relation in self.model.select(diagramitems.DependencyItem):
+            subject = relation.subject
+            diagram = relation.diagram
+            head = get_connected(diagram, relation.head)
+            tail = get_connected(diagram, relation.tail)
+
+            is_not_connected = not subject and not (head and tail)
+            is_connected = subject and head and tail
+            assert is_not_connected or (
+                is_connected
+                and subject.supplier is head.subject
+                and subject.client is tail.subject
+            )
+
+    # TODO: do copy/paste, undo/redo
+
+
+ModelConsistencyTestCase = ModelConsistency.TestCase
+
+
+def get_connected(diagram, handle):
+    """Get item connected to a handle."""
+    cinfo = diagram.connections.get_connection(handle)
+    if cinfo:
+        return cinfo.connected
+    return None
+
+
+@pytest.fixture
+def interactions():
+    return ModelConsistency()
+
+
+class DataStub:
+    def draw(self, data):
+        return data.get_element(0)
+
+
+def test_create_class(interactions: ModelConsistency, data=DataStub()):
+    klass = interactions.create_class(data)
+    assert klass
+    assert klass in interactions.model
+
+
+def test_create_dependency(interactions: ModelConsistency, data=DataStub()):
+    for _ in range(10):
+        interactions.create_class(data)
+
+    relation = interactions.create_dependency(data)
+
+    assert relation
+    assert relation in interactions.model
+    assert relation.subject
+
+
+@pytest.mark.skip
+def test_reconnect_dependency(interactions: ModelConsistency, data=DataStub()):
+    classes = [interactions.create_class(data) for _ in range(10)]
+
+    relation = interactions.create_dependency(data)
+    connect(relation, relation.head, classes[0])
+    connect(relation, relation.tail, classes[1])
+    interactions.connect_relation(data)
+
+    assert relation.subject.supplier
+    assert relation.subject.client
+
+
+@pytest.mark.skip
+def test_disconnect_dependency(interactions: ModelConsistency, data=DataStub()):
+    for _ in range(10):
+        interactions.create_class(data)
+
+    relation = interactions.create_dependency(data)
+    interactions.disconnect_relation(data)
+
+    assert not relation.subject
+    assert bool(get_connected(relation.diagram, relation.head)) != bool(
+        get_connected(relation.diagram, relation.tail)
+    )

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -50,6 +50,9 @@ class ModelConsistency(RuleBasedStateMachine):
         assume(targets)
         return sampled_from(targets)
 
+        copy_service = self.session.get_service("copy")
+        copy_service.clear()
+
     def create_diagram(self):
         with self.transaction:
             return self.model.create(Diagram)
@@ -58,9 +61,7 @@ class ModelConsistency(RuleBasedStateMachine):
     def create_class(self, data):
         diagram = data.draw(sampled_from(self.model.lselect(Diagram)))
         with self.transaction:
-            return diagram.create(
-                diagramitems.ClassItem, subject=self.model.create(UML.Class)
-            )
+            diagram.create(diagramitems.ClassItem, subject=self.model.create(UML.Class))
 
     @rule(data=data())
     def create_dependency(self, data):
@@ -69,7 +70,6 @@ class ModelConsistency(RuleBasedStateMachine):
             relation = diagram.create(diagramitems.DependencyItem)
         self._connect_relation(data, relation, relation.head)
         self._connect_relation(data, relation, relation.tail)
-        return relation
 
     @rule(data=data())
     def delete_element(self, data):
@@ -181,8 +181,6 @@ class ModelConsistency(RuleBasedStateMachine):
         assert (
             new_model.size() == self.model.size()
         ), f"{new_model.lselect()} != {self.model.lselect()}"
-
-    # TODO: do copy/paste
 
 
 ModelConsistencyTestCase = ModelConsistency.TestCase

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -193,8 +193,7 @@ ModelConsistencyTestCase = ModelConsistency.TestCase
 
 def get_connected(diagram, handle):
     """Get item connected to a handle."""
-    cinfo = diagram.connections.get_connection(handle)
-    if cinfo:
+    if cinfo := diagram.connections.get_connection(handle):
         return cinfo.connected
     return None
 

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -73,6 +73,7 @@ class ModelConsistency(RuleBasedStateMachine):
         copy_service.clear()
 
         load_default_model(self.model)
+        self.fully_pasted_items = set()
 
     def create_diagram(self):
         with self.transaction:
@@ -180,7 +181,8 @@ class ModelConsistency(RuleBasedStateMachine):
         copy_service = self.session.get_service("copy")
         assume(copy_service.can_paste())
         diagram = data.draw(self.diagrams())
-        copy_service.paste_full(diagram)
+        new_items = copy_service.paste_full(diagram)
+        self.fully_pasted_items.update(new_items)
 
     @invariant()
     def check_relations(self):
@@ -195,7 +197,7 @@ class ModelConsistency(RuleBasedStateMachine):
                 assert subject
                 assert subject.supplier is head.subject
                 assert subject.client is tail.subject
-            else:
+            elif relation not in self.fully_pasted_items:
                 assert not subject
 
     @invariant()

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -1,10 +1,9 @@
 """A Property-based test."""
 
 import itertools
-import os
 from io import StringIO
 
-from hypothesis import assume, settings
+from hypothesis import assume
 from hypothesis.stateful import RuleBasedStateMachine, initialize, invariant, rule
 from hypothesis.strategies import data, lists, sampled_from
 
@@ -183,6 +182,10 @@ class ModelConsistency(RuleBasedStateMachine):
                 modeling_language=self.session.get_service("modeling_language"),
             )
 
+        if new_model.size() != self.model.size():
+            with open("falsifying_model.gaphor", "w") as out:
+                storage.save(XMLWriter(out), self.model)
+
         assert (
             new_model.size() == self.model.size()
         ), f"{new_model.lselect()} != {self.model.lselect()}"
@@ -200,8 +203,3 @@ def get_connected(diagram, handle):
 
 def ordered(elements):
     return sorted(elements, key=lambda e: e.id)  # type: ignore[no-any-return]
-
-
-settings.register_profile("test", derandomize=True, max_examples=50)
-settings.register_profile("ci", max_examples=500)
-settings.load_profile("ci" if "CI" in os.environ else "test")

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -4,7 +4,13 @@ import itertools
 from io import StringIO
 
 from hypothesis import assume
-from hypothesis.stateful import RuleBasedStateMachine, initialize, invariant, rule
+from hypothesis.stateful import (
+    RuleBasedStateMachine,
+    initialize,
+    invariant,
+    rule,
+    run_state_machine_as_test,
+)
 from hypothesis.strategies import data, lists, sampled_from
 
 from gaphor import UML
@@ -17,7 +23,10 @@ from gaphor.storage import storage
 from gaphor.storage.xmlwriter import XMLWriter
 from gaphor.ui.filemanager import load_default_model
 from gaphor.UML import diagramitems
-from gaphor.UML.classes.dependency import DependencyItem
+
+
+def test_model_consistency():
+    run_state_machine_as_test(ModelConsistency)
 
 
 class ModelConsistency(RuleBasedStateMachine):
@@ -156,7 +165,7 @@ class ModelConsistency(RuleBasedStateMachine):
 
     @invariant()
     def check_relations(self):
-        relation: DependencyItem
+        relation: diagramitems.DependencyItem
         for relation in self.model.select(diagramitems.DependencyItem):  # type: ignore[assignment]
             subject = relation.subject
             diagram = relation.diagram
@@ -189,9 +198,6 @@ class ModelConsistency(RuleBasedStateMachine):
         assert (
             new_model.size() == self.model.size()
         ), f"{new_model.lselect()} != {self.model.lselect()}"
-
-
-ModelConsistencyTestCase = ModelConsistency.TestCase
 
 
 def get_connected(diagram, handle):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

We've seen issues reported by users that we could not properly reproduce.

Issue Number: N/A

### What is the new behavior?

A [Hypothesis Stateful Test](https://hypothesis.readthedocs.io/en/latest/stateful.html) (model-based test) has been added that performs actions a user would do: create/remove items, copy/paste, undo/redo.

So far this test manages to fail in a couple of cases.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
, 

### Other information

* [x] Object id's are generated via 1 functions. The implementation can be swapped (required for Hypothesis to work reliably).
* [ ] work with multiple model elements (now only `Class` and `Dependency` are used
* [ ] Does it miss any actions? Grouping is not supported yet.
* [ ] It's currently using only one diagram. Should probably also add/remove diagrams.

To run an in-depth test, run `pytest --hypothesis-profile=ci tests/test_model_consistency.py`. It should raise an error where connections in the diagram do not match connections in the model.

This change also contains some Sourcery updates, not directly related to the functional change.
The implementation can be extended even more. However, this is a good start, and already uncovered an error. Therefore I think it can be merged.
