### PR TITLE
Fix/paste full

### DIFF
--- a/gaphor/UML/classes/copypaste.py
+++ b/gaphor/UML/classes/copypaste.py
@@ -1,7 +1,8 @@
 import itertools
 
-from gaphor.diagram.copypaste import copy, copy_named_element
+from gaphor.diagram.copypaste import copy
 from gaphor.UML import Association, Class, DataType, Enumeration, Interface, Operation
+from gaphor.UML.copypaste import copy_named_element
 
 
 @copy.register(Class)

--- a/gaphor/UML/copypaste.py
+++ b/gaphor/UML/copypaste.py
@@ -11,7 +11,7 @@ from gaphor.diagram.copypaste import (
     paste_element,
 )
 from gaphor.UML.recipes import owner_package
-from gaphor.UML.uml import NamedElement
+from gaphor.UML.uml import NamedElement, Relationship
 
 
 class NamedElementCopy(NamedTuple):
@@ -34,7 +34,12 @@ def _copy_named_element(element: NamedElement) -> Iterator[tuple[Id, NamedElemen
 
 
 def paste_named_element(copy_data: NamedElementCopy, diagram, lookup):
-    paster = paste_element(copy_data.element_copy, diagram, lookup)
+    paster = paste_element(
+        copy_data.element_copy,
+        diagram,
+        lookup,
+        filter=lambda n, v: not isinstance(v, Relationship),
+    )
     element = next(paster)
     yield element
     next(paster, None)

--- a/gaphor/UML/copypaste.py
+++ b/gaphor/UML/copypaste.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Iterator, NamedTuple
+
+from gaphor.core.modeling.element import Id
+from gaphor.diagram.copypaste import (
+    ElementCopy,
+    copy,
+    copy_element,
+    paste,
+    paste_element,
+)
+from gaphor.UML.recipes import owner_package
+from gaphor.UML.uml import NamedElement
+
+
+class NamedElementCopy(NamedTuple):
+    element_copy: ElementCopy
+    with_namespace: bool
+
+
+def copy_named_element(
+    element: NamedElement, blacklist: list[str] | None = None
+) -> NamedElementCopy:
+    return NamedElementCopy(
+        element_copy=copy_element(element, blacklist),
+        with_namespace=bool(element.namespace),
+    )
+
+
+@copy.register
+def _copy_named_element(element: NamedElement) -> Iterator[tuple[Id, NamedElementCopy]]:
+    yield element.id, copy_named_element(element)
+
+
+def paste_named_element(copy_data: NamedElementCopy, diagram, lookup):
+    paster = paste_element(copy_data.element_copy, diagram, lookup)
+    element = next(paster)
+    yield element
+    next(paster, None)
+    if copy_data.with_namespace and not element.namespace:
+        element.package = owner_package(diagram.owner)
+
+
+paste.register(NamedElementCopy, paste_named_element)

--- a/gaphor/UML/deployments/copypaste.py
+++ b/gaphor/UML/deployments/copypaste.py
@@ -1,5 +1,6 @@
-from gaphor.diagram.copypaste import copy, copy_element, copy_named_element
+from gaphor.diagram.copypaste import copy, copy_element
 from gaphor.UML import Connector, ConnectorEnd
+from gaphor.UML.copypaste import copy_named_element
 
 
 @copy.register

--- a/gaphor/UML/interactions/copypaste.py
+++ b/gaphor/UML/interactions/copypaste.py
@@ -1,5 +1,6 @@
-from gaphor.diagram.copypaste import copy, copy_named_element
+from gaphor.diagram.copypaste import copy
 from gaphor.UML import ExecutionSpecification, Message
+from gaphor.UML.copypaste import copy_named_element
 
 
 @copy.register

--- a/gaphor/UML/modelinglanguage.py
+++ b/gaphor/UML/modelinglanguage.py
@@ -6,7 +6,7 @@ from typing import Iterable
 from gaphor.abc import ModelingLanguage
 from gaphor.core import gettext
 from gaphor.diagram.diagramtoolbox import DiagramType, ToolboxDefinition
-from gaphor.UML import diagramitems, uml
+from gaphor.UML import copypaste, diagramitems, uml  # noqa F401
 from gaphor.UML.toolbox import uml_diagram_types, uml_toolbox_actions
 
 

--- a/gaphor/UML/states/copypaste.py
+++ b/gaphor/UML/states/copypaste.py
@@ -1,5 +1,6 @@
-from gaphor.diagram.copypaste import copy, copy_named_element
+from gaphor.diagram.copypaste import copy
 from gaphor.UML import State, Transition
+from gaphor.UML.copypaste import copy_named_element
 
 
 @copy.register

--- a/gaphor/UML/tests/test_copypaste.py
+++ b/gaphor/UML/tests/test_copypaste.py
@@ -1,0 +1,15 @@
+from gaphor.diagram.copypaste import copy, paste_full
+from gaphor.diagram.tests.test_copypaste_link import two_classes_and_a_generalization
+
+
+def test_copy_connected_item(diagram, element_factory):
+    spc_cls_item, gen_cls_item, gen_item = two_classes_and_a_generalization(
+        diagram, element_factory
+    )
+
+    buffer = copy({spc_cls_item})
+    (new_cls_item,) = paste_full(buffer, diagram, element_factory.lookup)
+
+    assert new_cls_item.subject
+    assert gen_item.subject.general is gen_cls_item.subject
+    assert gen_item.subject.specific is spc_cls_item.subject

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -22,8 +22,6 @@ from typing import Callable, Iterator, NamedTuple
 from gaphor.core.modeling import Diagram, Presentation
 from gaphor.core.modeling.collection import collection
 from gaphor.core.modeling.element import Element, Id
-from gaphor.UML import NamedElement
-from gaphor.UML.recipes import owner_package
 
 Opaque = object
 
@@ -120,37 +118,6 @@ def paste_element(copy_data: ElementCopy, diagram, lookup):
 
 
 paste.register(ElementCopy, paste_element)
-
-
-class NamedElementCopy(NamedTuple):
-    element_copy: ElementCopy
-    with_namespace: bool
-
-
-def copy_named_element(
-    element: NamedElement, blacklist: list[str] | None = None
-) -> NamedElementCopy:
-    return NamedElementCopy(
-        element_copy=copy_element(element, blacklist),
-        with_namespace=bool(element.namespace),
-    )
-
-
-@copy.register
-def _copy_named_element(element: NamedElement) -> Iterator[tuple[Id, NamedElementCopy]]:
-    yield element.id, copy_named_element(element)
-
-
-def paste_named_element(copy_data: NamedElementCopy, diagram, lookup):
-    paster = paste_element(copy_data.element_copy, diagram, lookup)
-    element = next(paster)
-    yield element
-    next(paster, None)
-    if copy_data.with_namespace and not element.namespace:
-        element.package = owner_package(diagram.owner)
-
-
-paste.register(NamedElementCopy, paste_named_element)
 
 
 @copy.register

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -107,13 +107,19 @@ def _copy_element(element: Element) -> Iterator[tuple[Id, ElementCopy]]:
     yield element.id, copy_element(element)
 
 
-def paste_element(copy_data: ElementCopy, diagram, lookup):
+def paste_element(
+    copy_data: ElementCopy,
+    diagram,
+    lookup,
+    filter: Callable[[str, str | int | Element], bool] | None = None,
+):
     cls, _id, data = copy_data
     element = diagram.model.create(cls)
     yield element
     for name, ser in data.items():
         for value in deserialize(ser, lookup):
-            element.load(name, value)
+            if not filter or filter(name, value):
+                element.load(name, value)
     element.postload()
 
 

--- a/gaphor/diagram/tests/test_copypaste_full.py
+++ b/gaphor/diagram/tests/test_copypaste_full.py
@@ -39,7 +39,7 @@ def test_copy_multiple_items(diagram, element_factory):
 
 
 def test_copy_items_with_connections(diagram, element_factory):
-    gen_cls_item, spc_cls_item, gen_item = two_classes_and_a_generalization(
+    spc_cls_item, gen_cls_item, gen_item = two_classes_and_a_generalization(
         diagram, element_factory
     )
 

--- a/gaphor/diagram/tests/test_copypaste_link.py
+++ b/gaphor/diagram/tests/test_copypaste_link.py
@@ -67,8 +67,8 @@ def two_classes_and_a_generalization(diagram, element_factory):
     gen_cls_item = diagram.create(ClassItem, subject=gen_cls)
     spc_cls_item = diagram.create(ClassItem, subject=spc_cls)
     gen_item = diagram.create(GeneralizationItem)
-    connect(gen_item, gen_item.handles()[0], gen_cls_item)
-    connect(gen_item, gen_item.handles()[1], spc_cls_item)
+    connect(gen_item, gen_item.head, gen_cls_item)
+    connect(gen_item, gen_item.tail, spc_cls_item)
 
     return gen_cls_item, spc_cls_item, gen_item
 
@@ -115,7 +115,7 @@ def test_copy_item_when_subject_has_been_removed(diagram, element_factory):
     cls.unlink()  # normally handled by the sanitizer service
 
     assert set(diagram.ownedPresentation) == set(diagram.get_all_items())
-    assert len(list(diagram.get_all_items())) == 0
+    assert not list(diagram.get_all_items())
     assert cls not in element_factory.select()
     assert not element_factory.lookup(orig_cls_id)
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

It's possible to make the model inconsistent with the diagrams by copying and (fully) pasting a connected element.

### What is the new behavior?

All connections referencing a `UML.Relationship` should be initiated from the relationship.

This implies that all relationships used in gaphor have bi-directional references. At least the relationship should reference both ends.

I haven't checked if the assertions holds true 100%.

### Other information

This issue is found by the Hypothesis test introduced in #1365.
