### PR TITLE
Allow to drag and drop all elements from tree view to diagram

### DIFF
--- a/docs/modeling_language.md
+++ b/docs/modeling_language.md
@@ -25,6 +25,7 @@ language implementation can offer?
 * A toolbox definition
 * [Connectors](#connectors), allow diagram items to connect
 * [Grouping](#grouping), allow elements to be nested in one another
+* [Dropping](#dropping), allow elements to be dragged from the tree view onto a diagram
 * [Editor pages](#editor-property-pages), shown in the collapsible pane on the right side
 * [Inline (diagram) editor popups](#inline-diagram-editor-popups)
 * [Automatic cleanup rules](#automated-model-cleanup) to keep the model consistent
@@ -73,6 +74,23 @@ Grouping is done by dragging one item on top of another, in a diagram or in the 
    without actually performing a group operation.
    This is not 100% accurate.
 ```
+
+## Dropping
+
+Dropping is performed by dragging an element from the tree view and drop it on a diagram.
+This is an easy way to extend a diagram with already existing model elements.
+
+```{eval-rst}
+.. function:: gaphor.diagram.drop.drop(element: Element, diagram: Diagram, x: float, y: float) -> Presentation | None
+
+   The drop function creates a new presentation for an element on the diagram.
+   For relationships, a drop only works if both connected elements are present in the
+   same diagram.
+
+   The big difference with dragging an element from the toolbox, is that dragging from the toolbox
+   will actually place a new ``Presentation`` element on the diagram. ``drop`` works the other way
+   around: it starts with a model element and creates an accompanying ``Presentation``.
+```   
 
 ## Editor property pages
 

--- a/gaphor/SysML/drop.py
+++ b/gaphor/SysML/drop.py
@@ -1,0 +1,26 @@
+from gaphor.diagram.drop import drop
+from gaphor.diagram.presentation import postload_connect
+from gaphor.diagram.support import get_diagram_item
+from gaphor.SysML.sysml import ProxyPort
+from gaphor.UML.drop import diagram_has_presentation
+
+
+@drop.register
+def drop_proxy_port(element: ProxyPort, diagram, x, y):
+    item_class = get_diagram_item(type(element))
+    if not item_class:
+        return None
+
+    head_item = diagram_has_presentation(diagram, element.encapsulatedClassifier)
+    if not head_item:
+        return None
+
+    item = diagram.create(item_class)
+    assert item
+
+    item.matrix.translate(x, y)
+    item.subject = element
+
+    postload_connect(item, item.handles()[0], head_item)
+
+    return item

--- a/gaphor/SysML/modelinglanguage.py
+++ b/gaphor/SysML/modelinglanguage.py
@@ -26,7 +26,4 @@ class SysMLModelingLanguage(ModelingLanguage):
         yield from sysml_diagram_types
 
     def lookup_element(self, name):
-        element_type = getattr(sysml, name, None)
-        if not element_type:
-            element_type = getattr(diagramitems, name, None)
-        return element_type
+        return getattr(sysml, name, None) or getattr(diagramitems, name, None)

--- a/gaphor/SysML/modelinglanguage.py
+++ b/gaphor/SysML/modelinglanguage.py
@@ -3,6 +3,7 @@ assets."""
 
 from typing import Iterable
 
+import gaphor.SysML.drop  # noqa
 import gaphor.SysML.propertypages  # noqa
 from gaphor.abc import ModelingLanguage
 from gaphor.core import gettext

--- a/gaphor/SysML/tests/test_drop.py
+++ b/gaphor/SysML/tests/test_drop.py
@@ -17,3 +17,19 @@ def test_drop_connector(diagram, element_factory):
     assert item
     assert diagram.connections.get_connection(item.head).connected is proxy_port_item
     assert diagram.connections.get_connection(item.tail).connected is property_item
+
+
+def test_drop_proxy_port(diagram, element_factory):
+    block = element_factory.create(sysml.Block)
+    proxy_port = element_factory.create(sysml.ProxyPort)
+    proxy_port.encapsulatedClassifier = block
+
+    drop(block, diagram, 0, 0)
+
+    item = drop(proxy_port, diagram, 0, 0)
+
+    assert item
+    assert (
+        diagram.connections.get_connection(item.handles()[0]).connected
+        is block.presentation[0]
+    )

--- a/gaphor/SysML/tests/test_drop.py
+++ b/gaphor/SysML/tests/test_drop.py
@@ -1,0 +1,19 @@
+from gaphor import UML
+from gaphor.diagram.drop import drop
+from gaphor.SysML import sysml
+from gaphor.SysML.blocks import PropertyItem, ProxyPortItem
+from gaphor.UML.recipes import create_connector
+
+
+def test_drop_connector(diagram, element_factory):
+    proxy_port = element_factory.create(sysml.ProxyPort)
+    proxy_port_item = diagram.create(ProxyPortItem, subject=proxy_port)
+    property = element_factory.create(UML.Property)
+    property_item = diagram.create(PropertyItem, subject=property)
+    connector = create_connector(proxy_port, property)
+
+    item = drop(connector, diagram, 0, 0)
+
+    assert item
+    assert diagram.connections.get_connection(item.head).connected is proxy_port_item
+    assert diagram.connections.get_connection(item.tail).connected is property_item

--- a/gaphor/UML/__init__.py
+++ b/gaphor/UML/__init__.py
@@ -2,5 +2,6 @@
 import gaphor.UML.umloverrides
 from gaphor.UML.uml import *
 import gaphor.UML.deletable
+import gaphor.UML.drop
 import gaphor.UML.iconname
 import gaphor.UML.group

--- a/gaphor/UML/drop.py
+++ b/gaphor/UML/drop.py
@@ -1,24 +1,9 @@
 from __future__ import annotations
 
-from functools import singledispatch
-
 from gaphor import UML
-from gaphor.core.modeling import Diagram, Element
+from gaphor.diagram.drop import drop
 from gaphor.diagram.presentation import postload_connect
 from gaphor.diagram.support import get_diagram_item, get_diagram_item_metadata
-
-
-@singledispatch
-def drop(element: Element, diagram: Diagram, x: float, y: float):
-    if item_class := get_diagram_item(type(element)):
-        item = diagram.create(item_class)
-        assert item
-
-        item.matrix.translate(x, y)
-        item.subject = element
-
-        return item
-    return None
 
 
 @drop.register

--- a/gaphor/UML/drop.py
+++ b/gaphor/UML/drop.py
@@ -16,8 +16,48 @@ def drop_relationship(element: UML.Relationship, diagram, x, y):
     if not metadata:
         return None
 
-    head_item = diagram_has_presentation(diagram, metadata["head"].get(element))
-    tail_item = diagram_has_presentation(diagram, metadata["tail"].get(element))
+    return _drop(
+        element,
+        metadata["head"].get(element),
+        metadata["tail"].get(element),
+        diagram,
+        x,
+        y,
+    )
+
+
+def diagram_has_presentation(diagram, element):
+    return next((p for p in element.presentation if p.diagram is diagram), None)
+
+
+@drop.register
+def drop_association(element: UML.Association, diagram, x, y):
+    return _drop(
+        element, element.memberEnd[0].type, element.memberEnd[1].type, diagram, x, y
+    )
+
+
+@drop.register
+def drop_connector(element: UML.Connector, diagram, x, y):
+    return _drop(element, element.end[0].role, element.end[1].role, diagram, x, y)
+
+
+@drop.register
+def drop_message(element: UML.Message, diagram, x, y):
+    assert isinstance(element.sendEvent, UML.MessageOccurrenceSpecification)
+    assert isinstance(element.receiveEvent, UML.MessageOccurrenceSpecification)
+    return _drop(
+        element, element.sendEvent.covered, element.receiveEvent.covered, diagram, x, y
+    )
+
+
+def _drop(element, head_element, tail_element, diagram, x, y):
+    item_class = get_diagram_item(type(element))
+    if not item_class:
+        return None
+
+    head_item = diagram_has_presentation(diagram, head_element)
+    tail_item = diagram_has_presentation(diagram, tail_element)
     if not head_item or not tail_item:
         return None
 
@@ -31,12 +71,3 @@ def drop_relationship(element: UML.Relationship, diagram, x, y):
     postload_connect(item, item.tail, tail_item)
 
     return item
-
-
-def diagram_has_presentation(diagram, element):
-    return next((p for p in element.presentation if p.diagram is diagram), None)
-
-
-@drop.register
-def drop_association(element: UML.Association, diagram, x, y):
-    return None

--- a/gaphor/UML/recipes.py
+++ b/gaphor/UML/recipes.py
@@ -33,6 +33,7 @@ from gaphor.UML.uml import (
     Realization,
     Slot,
     Stereotype,
+    Type,
     Usage,
 )
 
@@ -225,7 +226,7 @@ def create_generalization(general, specific):
     return gen
 
 
-def create_association(type_a, type_b):
+def create_association(type_a: Type, type_b: Type):
     """Create an association between two items."""
     assert type_a.model is type_b.model, "Head and Tail end are from different models"
     model = type_a.model

--- a/gaphor/UML/recipes.py
+++ b/gaphor/UML/recipes.py
@@ -55,8 +55,7 @@ def stereotypes_str(element: Element, stereotypes: Sequence[str] = ()):
         )
     else:
         applied = ()
-    s = ", ".join(itertools.chain(stereotypes, applied))
-    if s:
+    if s := ", ".join(itertools.chain(stereotypes, applied)):
         return f"«{s}»"
     else:
         return ""

--- a/gaphor/UML/tests/test_drop.py
+++ b/gaphor/UML/tests/test_drop.py
@@ -1,5 +1,8 @@
 from gaphor import UML
 from gaphor.diagram.drop import drop
+from gaphor.UML.interactions import MessageItem
+from gaphor.UML.interactions.interactionsconnect import connect_lifelines
+from gaphor.UML.recipes import create_association, create_extension
 
 
 def test_drop_class(diagram, element_factory):
@@ -20,12 +23,8 @@ def test_drop_dependency(diagram, element_factory):
 
     drop(client, diagram, 0, 0)
     drop(supplier, diagram, 0, 0)
-    drop(dependency, diagram, 0, 0)
-    print(element_factory.lselect())
-    dep_item = dependency.presentation[0]
+    dep_item = drop(dependency, diagram, 0, 0)
 
-    assert client.presentation
-    assert supplier.presentation
     assert dep_item
     assert (
         diagram.connections.get_connection(dep_item.head).connected
@@ -35,3 +34,54 @@ def test_drop_dependency(diagram, element_factory):
         diagram.connections.get_connection(dep_item.tail).connected
         is client.presentation[0]
     )
+
+
+def test_drop_association(diagram, element_factory):
+    a = element_factory.create(UML.Class)
+    b = element_factory.create(UML.Class)
+    association = create_association(a, b)
+
+    drop(a, diagram, 0, 0)
+    drop(b, diagram, 0, 0)
+    item = drop(association, diagram, 0, 0)
+
+    assert item
+    assert diagram.connections.get_connection(item.head).connected is a.presentation[0]
+    assert diagram.connections.get_connection(item.tail).connected is b.presentation[0]
+
+
+def test_drop_extension(diagram, element_factory):
+    metaclass = element_factory.create(UML.Class)
+    stereotype = element_factory.create(UML.Stereotype)
+    extension = create_extension(metaclass, stereotype)
+
+    drop(metaclass, diagram, 0, 0)
+    drop(stereotype, diagram, 0, 0)
+    item = drop(extension, diagram, 0, 0)
+
+    assert item
+    assert (
+        diagram.connections.get_connection(item.head).connected
+        is metaclass.presentation[0]
+    )
+    assert (
+        diagram.connections.get_connection(item.tail).connected
+        is stereotype.presentation[0]
+    )
+
+
+def test_drop_message(diagram, element_factory):
+    a = element_factory.create(UML.Lifeline)
+    b = element_factory.create(UML.Lifeline)
+
+    a_item = drop(a, diagram, 0, 0)
+    b_item = drop(b, diagram, 0, 0)
+    msg_item = diagram.create(MessageItem)
+    connect_lifelines(msg_item, a_item, b_item)
+    message = msg_item.subject
+
+    item = drop(message, diagram, 0, 0)
+
+    assert item
+    assert diagram.connections.get_connection(item.head).connected is a.presentation[0]
+    assert diagram.connections.get_connection(item.tail).connected is b.presentation[0]

--- a/gaphor/UML/tests/test_drop.py
+++ b/gaphor/UML/tests/test_drop.py
@@ -1,0 +1,37 @@
+from gaphor import UML
+from gaphor.diagram.drop import drop
+
+
+def test_drop_class(diagram, element_factory):
+    klass = element_factory.create(UML.Class)
+
+    drop(klass, diagram, 0, 0)
+
+    assert klass.presentation
+    assert klass.presentation[0] in diagram.ownedPresentation
+
+
+def test_drop_dependency(diagram, element_factory):
+    client = element_factory.create(UML.Class)
+    supplier = element_factory.create(UML.Class)
+    dependency = element_factory.create(UML.Dependency)
+    dependency.client = client
+    dependency.supplier = supplier
+
+    drop(client, diagram, 0, 0)
+    drop(supplier, diagram, 0, 0)
+    drop(dependency, diagram, 0, 0)
+    print(element_factory.lselect())
+    dep_item = dependency.presentation[0]
+
+    assert client.presentation
+    assert supplier.presentation
+    assert dep_item
+    assert (
+        diagram.connections.get_connection(dep_item.head).connected
+        is supplier.presentation[0]
+    )
+    assert (
+        diagram.connections.get_connection(dep_item.tail).connected
+        is client.presentation[0]
+    )

--- a/gaphor/core/__init__.py
+++ b/gaphor/core/__init__.py
@@ -1,7 +1,4 @@
-"""The Core module provides an entry point for Gaphor's core constructs.
-
-An average module should only need to import this module.
-"""
+"""The Core module provides an entry point for Gaphor's core constructs."""
 
 from gaphor.action import action
 from gaphor.core.eventmanager import event_handler

--- a/gaphor/core/modeling/collection.py
+++ b/gaphor/core/modeling/collection.py
@@ -91,13 +91,13 @@ class collection(Generic[T]):
 
     def append(self, value: T) -> None:
         if isinstance(value, self.type):
-            self.property._set(self.object, value)
+            self.property.set(self.object, value)
         else:
             raise TypeError(f"Object is not of type {self.type.__name__}")
 
     def remove(self, value: T) -> None:
         if value in self.items:
-            self.property._del(self.object, value)
+            self.property.delete(self.object, value)
 
     def index(self, key: T) -> int:
         """Given an object, return the position of that object in the

--- a/gaphor/core/modeling/collection.py
+++ b/gaphor/core/modeling/collection.py
@@ -119,16 +119,10 @@ class collection(Generic[T]):
         return self.items.count(o)
 
     def includesAll(self, c):
-        for o in c:
-            if o not in self.items:
-                return 0
-        return 1
+        return next((0 for o in c if o not in self.items), 1)
 
     def excludesAll(self, c):
-        for o in c:
-            if o in self.items:
-                return 0
-        return 1
+        return next((0 for o in c if o in self.items), 1)
 
     def select(self, f):
         return [v for v in self.items if f(v)]

--- a/gaphor/core/modeling/elementdispatcher.py
+++ b/gaphor/core/modeling/elementdispatcher.py
@@ -186,10 +186,10 @@ class ElementDispatcher(Service):
         # Apply remaining path
         if remainder:
             if property.upper == "*" or property.upper > 1:
-                for e in property._get(element):
+                for e in property.get(element):
                     self._add_handlers(e, remainder, handler)
             else:
-                e = property._get(element)
+                e = property.get(element)
                 if e and remainder:
                     self._add_handlers(e, remainder, handler)
 
@@ -202,11 +202,11 @@ class ElementDispatcher(Service):
 
         if property.upper == "*" or property.upper > 1:
             for remainder in handlers.get(handler, ()):
-                for e in property._get(element):
+                for e in property.get(element):
                     self._remove_handlers(e, remainder[0], handler)
         else:
             for remainder in handlers.get(handler, ()):
-                if e := property._get(element):
+                if e := property.get(element):
                     self._remove_handlers(e, remainder[0], handler)
         try:
             del handlers[handler]

--- a/gaphor/core/modeling/tests/test_collection.py
+++ b/gaphor/core/modeling/tests/test_collection.py
@@ -17,7 +17,7 @@ class MockProperty:
     def __init__(self):
         self.values = []
 
-    def _set(self, object, value):
+    def set(self, object, value):
         self.values.append((object, value))
 
 

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -181,8 +181,8 @@ class RelationshipConnect(BaseConnector):
         # First check if the right subject is already connected:
         if (
             line.subject
-            and getattr(line.subject, head.name) is head_subject
-            and getattr(line.subject, tail.name) is tail_subject
+            and head.get(line.subject) is head_subject
+            and tail.get(line.subject) is tail_subject
         ):
             return line.subject  # type: ignore[return-value]
 
@@ -197,7 +197,7 @@ class RelationshipConnect(BaseConnector):
             if not isinstance(gen, required_type):
                 continue
 
-            gen_head = getattr(gen, head.name)
+            gen_head = head.get(gen)
             try:
                 if head_subject not in gen_head:
                     continue
@@ -248,8 +248,8 @@ class RelationshipConnect(BaseConnector):
 
         assert line_head
         assert line_tail
-        setattr(relation, head.name, line_head.subject)
-        setattr(relation, tail.name, line_tail.subject)
+        head.set(relation, line_head.subject)
+        tail.set(relation, line_tail.subject)
 
         assert isinstance(relation, type)
         return relation

--- a/gaphor/diagram/drop.py
+++ b/gaphor/diagram/drop.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import singledispatch
 
-from gaphor.core.modeling import Diagram, Element
+from gaphor.core.modeling import Diagram, Element, Presentation
 from gaphor.diagram.support import get_diagram_item
 
 
@@ -16,4 +16,9 @@ def drop(element: Element, diagram: Diagram, x: float, y: float):
         item.subject = element
 
         return item
+    return None
+
+
+@drop.register
+def drop_presentation(element: Presentation, diagram: Diagram, x: float, y: float):
     return None

--- a/gaphor/diagram/drop.py
+++ b/gaphor/diagram/drop.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from functools import singledispatch
+
+from gaphor.core.modeling import Diagram, Element
+from gaphor.diagram.support import get_diagram_item
+
+
+@singledispatch
+def drop(element: Element, diagram: Diagram, x: float, y: float):
+    if item_class := get_diagram_item(type(element)):
+        item = diagram.create(item_class)
+        assert item
+
+        item.matrix.translate(x, y)
+        item.subject = element
+
+        return item
+    return None

--- a/gaphor/diagram/tools/dnd.py
+++ b/gaphor/diagram/tools/dnd.py
@@ -17,5 +17,4 @@ def on_drop(target, tool_name, x, y, modeling_language, event_manager):
     tool_def = get_tool_def(modeling_language, tool_name)
     with Transaction(event_manager):
         create_item(view, tool_def.item_factory, x, y)
-
     return True

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -372,7 +372,7 @@ class UndoManager(Service, ActionProvider):
 
         def c_undo_attribute_change_event():
             element = self.lookup(element_id)
-            attribute._set(element, value)
+            attribute.set(element, value)
 
         c_undo_attribute_change_event.__doc__ = (
             f"Revert {event.element}.{attribute.name} to {value}."
@@ -392,7 +392,7 @@ class UndoManager(Service, ActionProvider):
         def c_undo_association_set_event():
             element = self.lookup(element_id)
             value = value_id and self.lookup(value_id)
-            association._set(element, value, from_opposite=True)
+            association.set(element, value, from_opposite=True)
 
         c_undo_association_set_event.__doc__ = (
             f"Revert {event.element}.{association.name} to {event.old_value}."
@@ -412,7 +412,7 @@ class UndoManager(Service, ActionProvider):
         def c_undo_association_add_event():
             element = self.lookup(element_id)
             value = self.lookup(value_id)
-            association._del(element, value, from_opposite=True)
+            association.delete(element, value, from_opposite=True)
 
         c_undo_association_add_event.__doc__ = (
             f"{event.element}.{association.name} delete {event.new_value}."
@@ -432,7 +432,7 @@ class UndoManager(Service, ActionProvider):
         def c_undo_association_delete_event():
             element = self.lookup(element_id)
             value = self.lookup(value_id)
-            association._set(element, value, from_opposite=True)
+            association.set(element, value, from_opposite=True)
 
         c_undo_association_delete_event.__doc__ = (
             f"{event.element}.{association.name} add {event.old_value}."

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -15,6 +15,7 @@ from gaphor.core.modeling import StyleSheet
 from gaphor.core.modeling.diagram import Diagram, StyledDiagram
 from gaphor.core.modeling.event import AttributeUpdated, ElementDeleted
 from gaphor.diagram.diagramtoolbox import get_tool_def, tooliter
+from gaphor.diagram.drop import drop
 from gaphor.diagram.painter import DiagramTypePainter, ItemPainter
 from gaphor.diagram.selection import Selection
 from gaphor.diagram.tools import (
@@ -26,7 +27,6 @@ from gaphor.diagram.tools.magnet import MagnetPainter
 from gaphor.diagram.tools.placement import create_item, open_editor
 from gaphor.event import Notification
 from gaphor.transaction import Transaction
-from gaphor.ui.drop import drop
 from gaphor.ui.event import DiagramSelectionChanged, ToolSelected
 
 log = logging.getLogger(__name__)

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -355,8 +355,7 @@ class DiagramPage:
 
 
 def drop(element, diagram, x, y):
-    item_class = get_diagram_item(type(element))
-    if item_class:
+    if item_class := get_diagram_item(type(element)):
         item = diagram.create(item_class)
         assert item
 

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -10,7 +10,6 @@ from gaphas.tool.rubberband import RubberbandPainter, RubberbandState
 from gaphas.view import GtkView
 from gi.repository import Gdk, GdkPixbuf, Gtk
 
-from gaphor import UML
 from gaphor.core import event_handler, gettext
 from gaphor.core.modeling import StyleSheet
 from gaphor.core.modeling.diagram import Diagram, StyledDiagram
@@ -337,35 +336,32 @@ class DiagramPage:
                 element = self.element_factory.lookup(element_id)
                 assert element
 
-                if not isinstance(
-                    element, (UML.Classifier, UML.Package, UML.Property)
-                ) or isinstance(element, UML.Association):
-                    self.event_manager.handle(
-                        Notification(
-                            gettext(
-                                "Drag to diagram is (temporarily) limited to Classifiers, Packages, and Properties, not {type}."
-                            ).format(type=type(element).__name__)
+                x, y = view.matrix.inverse().transform_point(x, y)
+                with Transaction(self.event_manager):
+                    if item := drop(element, self.diagram, x, y):
+                        view.selection.unselect_all()
+                        view.selection.focused_item = item
+
+                        context.finish(True, False, time)
+                    else:
+                        self.event_manager.handle(
+                            Notification(
+                                gettext("Element can’t be represented on a diagram.")
+                            )
                         )
-                    )
-                    context.finish(True, False, time)
-                    return
-
-                if item_class := get_diagram_item(type(element)):
-                    with Transaction(self.event_manager):
-                        item = self.diagram.create(item_class)
-                        assert item
-
-                        x, y = view.get_matrix_v2i(item).transform_point(x, y)
-                        item.matrix.translate(x, y)
-                        item.subject = element
-
-                    view.selection.unselect_all()
-                    view.selection.focused_item = item
-
-                else:
-                    log.warning(
-                        f"No graphical representation for element {type(element).__name__}"
-                    )
-                context.finish(True, False, time)
+                        context.finish(False, False, time)
             else:
                 context.finish(False, False, time)
+
+
+def drop(element, diagram, x, y):
+    item_class = get_diagram_item(type(element))
+    if item_class:
+        item = diagram.create(item_class)
+        assert item
+
+        item.matrix.translate(x, y)
+        item.subject = element
+
+        return item
+    return None

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -17,7 +17,6 @@ from gaphor.core.modeling.event import AttributeUpdated, ElementDeleted
 from gaphor.diagram.diagramtoolbox import get_tool_def, tooliter
 from gaphor.diagram.painter import DiagramTypePainter, ItemPainter
 from gaphor.diagram.selection import Selection
-from gaphor.diagram.support import get_diagram_item
 from gaphor.diagram.tools import (
     apply_default_tool_set,
     apply_magnet_tool_set,
@@ -27,6 +26,7 @@ from gaphor.diagram.tools.magnet import MagnetPainter
 from gaphor.diagram.tools.placement import create_item, open_editor
 from gaphor.event import Notification
 from gaphor.transaction import Transaction
+from gaphor.ui.drop import drop
 from gaphor.ui.event import DiagramSelectionChanged, ToolSelected
 
 log = logging.getLogger(__name__)
@@ -352,15 +352,3 @@ class DiagramPage:
                         context.finish(False, False, time)
             else:
                 context.finish(False, False, time)
-
-
-def drop(element, diagram, x, y):
-    if item_class := get_diagram_item(type(element)):
-        item = diagram.create(item_class)
-        assert item
-
-        item.matrix.translate(x, y)
-        item.subject = element
-
-        return item
-    return None

--- a/gaphor/ui/drop.py
+++ b/gaphor/ui/drop.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from functools import singledispatch
+
+from gaphor import UML
+from gaphor.core.modeling import Element
+from gaphor.diagram.support import get_diagram_item
+
+
+@singledispatch
+def drop(element: Element, diagram, x, y):
+    return None
+
+
+@drop.register
+def drop_namespace(element: UML.Namespace, diagram, x, y):
+    if item_class := get_diagram_item(type(element)):
+        item = diagram.create(item_class)
+        assert item
+
+        item.matrix.translate(x, y)
+        item.subject = element
+
+        return item
+    return None
+
+
+@drop.register
+def drop_association(element: UML.Association, diagram, x, y):
+    return None

--- a/gaphor/ui/drop.py
+++ b/gaphor/ui/drop.py
@@ -3,17 +3,13 @@ from __future__ import annotations
 from functools import singledispatch
 
 from gaphor import UML
-from gaphor.core.modeling import Element
-from gaphor.diagram.support import get_diagram_item
+from gaphor.core.modeling import Diagram, Element
+from gaphor.diagram.presentation import postload_connect
+from gaphor.diagram.support import get_diagram_item, get_diagram_item_metadata
 
 
 @singledispatch
-def drop(element: Element, diagram, x, y):
-    return None
-
-
-@drop.register
-def drop_namespace(element: UML.Namespace, diagram, x, y):
+def drop(element: Element, diagram: Diagram, x: float, y: float):
     if item_class := get_diagram_item(type(element)):
         item = diagram.create(item_class)
         assert item
@@ -23,6 +19,37 @@ def drop_namespace(element: UML.Namespace, diagram, x, y):
 
         return item
     return None
+
+
+@drop.register
+def drop_relationship(element: UML.Relationship, diagram, x, y):
+    item_class = get_diagram_item(type(element))
+    if not item_class:
+        return None
+
+    metadata = get_diagram_item_metadata(item_class)
+    if not metadata:
+        return None
+
+    head_item = diagram_has_presentation(diagram, metadata["head"].get(element))
+    tail_item = diagram_has_presentation(diagram, metadata["tail"].get(element))
+    if not head_item or not tail_item:
+        return None
+
+    item = diagram.create(item_class)
+    assert item
+
+    item.matrix.translate(x, y)
+    item.subject = element
+
+    postload_connect(item, item.head, head_item)
+    postload_connect(item, item.tail, tail_item)
+
+    return item
+
+
+def diagram_has_presentation(diagram, element):
+    return next((p for p in element.presentation if p.diagram is diagram), None)
 
 
 @drop.register

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -42,6 +42,7 @@ from gaphor.core import Transaction
 from gaphor.core.modeling import Diagram, ElementFactory, StyleSheet
 from gaphor.core.modeling.element import generate_id, uuid_generator
 from gaphor.diagram.deletable import deletable
+from gaphor.diagram.drop import drop
 from gaphor.diagram.group import can_group
 from gaphor.diagram.presentation import LinePresentation
 from gaphor.diagram.tests.fixtures import allow, connect, disconnect
@@ -186,6 +187,16 @@ class ModelConsistency(RuleBasedStateMachine):
             if not changed:
                 tx.rollback()
         assume(changed)
+
+    @rule(data=data())
+    def drop(self, data):
+        diagram = data.draw(self.diagrams())
+        element = data.draw(self.select())
+        with self.transaction as tx:
+            item = drop(element, diagram, 0, 0)
+            if not item:
+                tx.rollback()
+        assume(item)
 
     @rule()
     def undo(self):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Only classes, packages can be dragged from tree view to diagram.

Issue Number: #648 

### What is the new behavior?

Model elements can be dragged from tree view to diagram.

- [x] Relationships will connect to their ends
- [x] Relationships can only be dropped if both ends are present on the diagram, otherwise a notification will be shown

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Covered "simple" elements and relationships, complex relationships (Association, Extension, Connector, Message) and Proxy port.

I think that's all.