### PR TITLE
Include all diagram items in test model

### DIFF
--- a/gaphor/RAAML/stpa/stpatoolbox.py
+++ b/gaphor/RAAML/stpa/stpatoolbox.py
@@ -148,7 +148,6 @@ stpa = ToolSection(
             "r",
             new_item_factory(
                 diagramitems.RelevantToItem,
-                raaml.RelevantTo,
             ),
         ),
         ToolDef(

--- a/gaphor/SysML/blocks/blockstoolbox.py
+++ b/gaphor/SysML/blocks/blockstoolbox.py
@@ -50,7 +50,6 @@ blocks = ToolSection(
             "<Shift>Z",
             new_item_factory(
                 uml_items.AssociationItem,
-                UML.Association,
                 config_func=composite_association_config,
             ),
         ),
@@ -61,7 +60,6 @@ blocks = ToolSection(
             "<Shift>Q",
             new_item_factory(
                 uml_items.AssociationItem,
-                UML.Association,
                 config_func=shared_association_config,
             ),
         ),

--- a/gaphor/UML/profiles/metaclasspropertypage.py
+++ b/gaphor/UML/profiles/metaclasspropertypage.py
@@ -57,11 +57,14 @@ class MetaclassPropertyPage(PropertyPageBase):
             combo, self.CLASSES, self.subject and self.subject.name or ""
         )
 
+        changed_id = combo.connect("changed", self._on_name_changed)
         entry = combo.get_child()
 
         def handler(event):
             if event.element is self.subject and entry.get_text() != event.new_value:
+                combo.handler_block(changed_id)
                 entry.set_text(event.new_value or "")
+                combo.handler_unblock(changed_id)
 
         self.watcher.watch("name", handler)
 

--- a/gaphor/UML/profiles/propertypages.glade
+++ b/gaphor/UML/profiles/propertypages.glade
@@ -33,7 +33,6 @@ renderers and such.</property>
       <object class="GtkComboBoxText" id="metaclass-combo">
         <property name="visible">1</property>
         <property name="has-entry">1</property>
-        <signal name="changed" handler="metaclass-combo-changed" swapped="no"/>
         <signal name="destroy" handler="metaclass-combo-destroy" swapped="no"/>
       </object>
       <packing>

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -28,7 +28,6 @@ renderers and such.</property>
     <child>
       <object class="GtkComboBoxText" id="metaclass-combo">
         <property name="has-entry">1</property>
-        <signal name="changed" handler="metaclass-combo-changed" swapped="no"/>
         <signal name="destroy" handler="metaclass-combo-destroy" swapped="no"/>
       </object>
     </child>

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -304,30 +304,30 @@ class UndoManager(Service, ActionProvider):
     def undo_reversible_event(self, event: RevertibeEvent):
         element_id = event.element.id
 
-        def b_undo_reversible_event():
+        def undo_reversible_event():
             element = self.lookup(element_id)
             event.revert(element)
 
-        b_undo_reversible_event.__doc__ = (
+        undo_reversible_event.__doc__ = (
             f"Reverse event {event.__class__.__name__} for element {event.element}."
         )
 
         self.add_undo_action(
-            b_undo_reversible_event, requires_transaction=event.requires_transaction
+            undo_reversible_event, requires_transaction=event.requires_transaction
         )
 
     @event_handler(ElementCreated)
     def undo_create_element_event(self, event: ElementCreated):
         element_id = event.element.id
 
-        def d_undo_create_event():
+        def undo_create_event():
             element = self.lookup(element_id)
             element.unlink()
 
-        d_undo_create_event.__doc__ = f"Undo create element {event.element}."
+        undo_create_event.__doc__ = f"Undo create element {event.element}."
         del event
 
-        self.add_undo_action(d_undo_create_event)
+        self.add_undo_action(undo_create_event)
 
     @event_handler(ElementDeleted)
     def undo_delete_element_event(self, event: ElementDeleted):
@@ -343,20 +343,17 @@ class UndoManager(Service, ActionProvider):
 
             event.element.save(save_func)
 
-            def b_undo_delete_event():
+            def undo_delete_event():
                 diagram: Diagram = self.lookup(diagram_id)  # type: ignore[assignment]
                 element = diagram.create_as(element_type, element_id)
                 for name, ser in data.items():
                     for value in deserialize(ser, lambda ref: None):
                         element.load(name, value)
 
-            undo_delete_event = b_undo_delete_event
         else:
 
-            def a_undo_delete_event():
+            def undo_delete_event():
                 self.element_factory.create_as(element_type, element_id)
-
-            undo_delete_event = a_undo_delete_event
 
         undo_delete_event.__doc__ = f"Recreate element {element_type} ({element_id})."
         del event
@@ -369,16 +366,16 @@ class UndoManager(Service, ActionProvider):
         element_id = event.element.id
         value = event.old_value
 
-        def c_undo_attribute_change_event():
+        def undo_attribute_change_event():
             element = self.lookup(element_id)
             attribute.set(element, value)
 
-        c_undo_attribute_change_event.__doc__ = (
+        undo_attribute_change_event.__doc__ = (
             f"Revert {event.element}.{attribute.name} to {value}."
         )
         del event
 
-        self.add_undo_action(c_undo_attribute_change_event)
+        self.add_undo_action(undo_attribute_change_event)
 
     @event_handler(AssociationSet)
     def undo_association_set_event(self, event: AssociationSet):
@@ -388,17 +385,17 @@ class UndoManager(Service, ActionProvider):
         element_id = event.element.id
         value_id = event.old_value and event.old_value.id
 
-        def c_undo_association_set_event():
+        def undo_association_set_event():
             element = self.lookup(element_id)
             value = value_id and self.lookup(value_id)
             association.set(element, value, from_opposite=True)
 
-        c_undo_association_set_event.__doc__ = (
+        undo_association_set_event.__doc__ = (
             f"Revert {event.element}.{association.name} to {event.old_value}."
         )
         del event
 
-        self.add_undo_action(c_undo_association_set_event)
+        self.add_undo_action(undo_association_set_event)
 
     @event_handler(AssociationAdded)
     def undo_association_add_event(self, event: AssociationAdded):
@@ -408,17 +405,17 @@ class UndoManager(Service, ActionProvider):
         element_id = event.element.id
         value_id = event.new_value.id
 
-        def c_undo_association_add_event():
+        def undo_association_add_event():
             element = self.lookup(element_id)
             value = self.lookup(value_id)
             association.delete(element, value, from_opposite=True)
 
-        c_undo_association_add_event.__doc__ = (
+        undo_association_add_event.__doc__ = (
             f"{event.element}.{association.name} delete {event.new_value}."
         )
         del event
 
-        self.add_undo_action(c_undo_association_add_event)
+        self.add_undo_action(undo_association_add_event)
 
     @event_handler(AssociationDeleted)
     def undo_association_delete_event(self, event: AssociationDeleted):
@@ -428,14 +425,14 @@ class UndoManager(Service, ActionProvider):
         element_id = event.element.id
         value_id = event.old_value.id
 
-        def c_undo_association_delete_event():
+        def undo_association_delete_event():
             element = self.lookup(element_id)
             value = self.lookup(value_id)
             association.set(element, value, from_opposite=True)
 
-        c_undo_association_delete_event.__doc__ = (
+        undo_association_delete_event.__doc__ = (
             f"{event.element}.{association.name} add {event.old_value}."
         )
         del event
 
-        self.add_undo_action(c_undo_association_delete_event)
+        self.add_undo_action(undo_association_delete_event)

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -65,7 +65,6 @@ class ActionStack:
     @transactional
     def execute(self):
         self._actions.reverse()
-        self._actions.sort(key=lambda fn: fn.__name__)
 
         for act in self._actions:
             logger.debug(act.__doc__)

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -25,7 +25,9 @@ from __future__ import annotations
 import itertools
 from functools import singledispatch
 from io import StringIO
+from typing import Iterable
 
+from gaphas.connector import Handle
 from hypothesis.control import assume, cleanup
 from hypothesis.errors import UnsatisfiedAssumption
 from hypothesis.stateful import (
@@ -41,12 +43,13 @@ from gaphor import UML
 from gaphor.application import Session
 from gaphor.C4Model.toolbox import c4
 from gaphor.core import Transaction
-from gaphor.core.modeling import Diagram, ElementFactory, StyleSheet
-from gaphor.core.modeling.element import generate_id, uuid_generator
+from gaphor.core.modeling import Diagram, ElementFactory, Presentation, StyleSheet
+from gaphor.core.modeling.element import Element, generate_id, uuid_generator
 from gaphor.diagram.deletable import deletable
 from gaphor.diagram.drop import drop
 from gaphor.diagram.group import can_group
 from gaphor.diagram.presentation import LinePresentation
+from gaphor.diagram.support import get_diagram_item_metadata
 from gaphor.diagram.tests.fixtures import allow, connect, disconnect
 from gaphor.RAAML.toolbox import fta, stpa
 from gaphor.storage import storage
@@ -299,44 +302,26 @@ class ModelConsistency(RuleBasedStateMachine):
             raise
 
 
-def get_connected(diagram, handle):
+def get_connected(diagram: Diagram, handle: Handle) -> Presentation | None:
     """Get item connected to a handle."""
     if cinfo := diagram.connections.get_connection(handle):
-        return cinfo.connected
+        return cinfo.connected  # type: ignore[no-any-return]
     return None
 
 
-def ordered(elements):
-    return sorted(elements, key=lambda e: e.id)  # type: ignore[no-any-return]
+def ordered(elements: Iterable[Element]) -> list[Element]:
+    return sorted(elements, key=lambda e: e.id)
 
 
 @singledispatch
-def check_relation(relation: object, head, tail):
-    assert False, f"No comparison function for {relation}"
-
-
-@check_relation.register
-def _(relation: diagramitems.DependencyItem, head, tail):
+def check_relation(relation: Presentation, head: Presentation, tail: Presentation):
     subject = relation.subject
     assert subject
-    assert subject.supplier is head.subject
-    assert subject.client is tail.subject
 
-
-@check_relation.register
-def _(relation: diagramitems.GeneralizationItem, head, tail):
-    subject = relation.subject
-    assert subject
-    assert subject.specific is head.subject
-    assert subject.general is tail.subject
-
-
-@check_relation.register
-def _(relation: diagramitems.InterfaceRealizationItem, head, tail):
-    subject = relation.subject
-    assert subject
-    assert subject.contract is head.subject
-    assert subject.implementatingClassifier is tail.subject
+    metadata = get_diagram_item_metadata(type(relation))
+    assert metadata, f"No comparison function for {relation}"
+    assert metadata["head"]._get(subject) is head.subject
+    assert metadata["tail"]._get(subject) is tail.subject
 
 
 @check_relation.register
@@ -363,22 +348,6 @@ def _(relation: diagramitems.ExtensionItem, head, tail):
 
 
 @check_relation.register
-def _(relation: diagramitems.ControlFlowItem, head, tail):
-    subject = relation.subject
-    assert subject
-    assert subject.source is head.subject
-    assert subject.target is tail.subject
-
-
-@check_relation.register
-def _(relation: diagramitems.ObjectFlowItem, head, tail):
-    subject = relation.subject
-    assert subject
-    assert subject.source is head.subject
-    assert subject.target is tail.subject
-
-
-@check_relation.register
 def _(relation: diagramitems.MessageItem, head, tail):
     subject = relation.subject
     assert subject
@@ -386,11 +355,3 @@ def _(relation: diagramitems.MessageItem, head, tail):
     assert isinstance(subject.receiveEvent, UML.MessageOccurrenceSpecification)
     assert subject.sendEvent.covered is head.subject
     assert subject.receiveEvent.covered is tail.subject
-
-
-@check_relation.register
-def _(relation: diagramitems.TransitionItem, head, tail):
-    subject = relation.subject
-    assert subject
-    assert subject.source is head.subject
-    assert subject.target is tail.subject

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -37,7 +37,9 @@ from hypothesis.stateful import (
 )
 from hypothesis.strategies import data, integers, lists, sampled_from
 
+from gaphor import UML
 from gaphor.application import Session
+from gaphor.C4Model.toolbox import c4
 from gaphor.core import Transaction
 from gaphor.core.modeling import Diagram, ElementFactory, StyleSheet
 from gaphor.core.modeling.element import generate_id, uuid_generator
@@ -46,12 +48,22 @@ from gaphor.diagram.drop import drop
 from gaphor.diagram.group import can_group
 from gaphor.diagram.presentation import LinePresentation
 from gaphor.diagram.tests.fixtures import allow, connect, disconnect
+from gaphor.RAAML.toolbox import fta, stpa
 from gaphor.storage import storage
 from gaphor.storage.xmlwriter import XMLWriter
+from gaphor.SysML.toolbox import blocks, internal_blocks, requirements
 from gaphor.ui.filemanager import load_default_model
 from gaphor.ui.namespacemodel import change_owner
 from gaphor.UML import diagramitems
-from gaphor.UML.toolbox import actions, classes, deployments, profiles, use_cases
+from gaphor.UML.toolbox import (
+    actions,
+    classes,
+    deployments,
+    interactions,
+    profiles,
+    states,
+    use_cases,
+)
 
 
 def test_model_consistency():
@@ -62,11 +74,23 @@ def tooldef():
     return sampled_from(
         list(
             itertools.chain(
+                # UML
                 classes.tools,
                 deployments.tools,
                 use_cases.tools,
                 profiles.tools,
                 actions.tools,
+                interactions.tools,
+                states.tools,
+                # C4
+                c4.tools,
+                # SysML
+                blocks.tools,
+                internal_blocks.tools,
+                requirements.tools,
+                # RAAML
+                stpa.tools,
+                fta.tools,
             )
         )
     )
@@ -348,6 +372,24 @@ def _(relation: diagramitems.ControlFlowItem, head, tail):
 
 @check_relation.register
 def _(relation: diagramitems.ObjectFlowItem, head, tail):
+    subject = relation.subject
+    assert subject
+    assert subject.source is head.subject
+    assert subject.target is tail.subject
+
+
+@check_relation.register
+def _(relation: diagramitems.MessageItem, head, tail):
+    subject = relation.subject
+    assert subject
+    assert isinstance(subject.sendEvent, UML.MessageOccurrenceSpecification)
+    assert isinstance(subject.receiveEvent, UML.MessageOccurrenceSpecification)
+    assert subject.sendEvent.covered is head.subject
+    assert subject.receiveEvent.covered is tail.subject
+
+
+@check_relation.register
+def _(relation: diagramitems.TransitionItem, head, tail):
     subject = relation.subject
     assert subject
     assert subject.source is head.subject

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -8,6 +8,8 @@ from gaphor.core import Transaction
 from gaphor.core.modeling import Diagram
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML.classes import AssociationItem, ClassItem, GeneralizationItem
+from gaphor.UML.interactions import MessageItem
+from gaphor.UML.interactions.interactionstoolbox import reflexive_message_config
 
 
 @pytest.fixture
@@ -295,3 +297,14 @@ def test_can_undo_diagram_with_content(event_manager, element_factory, undo_mana
 
     assert new_diagram
     assert new_diagram.ownedPresentation
+
+
+def test_reflexive_message_undo(event_manager, element_factory, undo_manager):
+    with Transaction(event_manager):
+        diagram: Diagram = element_factory.create(Diagram)
+
+    with Transaction(event_manager):
+        message = diagram.create(MessageItem)
+        reflexive_message_config(message)
+
+    undo_manager.undo_transaction()

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -52,8 +52,7 @@ def test_class_association_undo_redo(event_manager, element_factory, undo_manage
 
     def get_connected(handle):
         """Get item connected to line via handle."""
-        cinfo = diagram.connections.get_connection(handle)
-        if cinfo:
+        if cinfo := diagram.connections.get_connection(handle):
             return cinfo.connected
         return None
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the new behavior?

The Model Based Test (`tests/test_model_consistency.py`) has been extended to include all model elements currenly in use, from all modeling languages.

This uncovered a few (small) issues:

* Shared and Composite Association should not have a subject by default
* STPA relation RelevantTo should not have a subject by default
* Reflexive Message could not be undone. This had to do with how events were emitted.

#### Event emission changes

Previously, events were emited directly. This ment that when one event was "in flight", a new (nested) event could be handled. This can cause for some issues in event ordering, as was the case with Undo Manager.

In the new implementation, events are queued, instead of handled. This means that one event is handled by *all* event handlers before  the next event is handled. This way the order of events can be preserved.


### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No



### Other information
