### PR TITLE
Fix GTK4 property page layouts

### DIFF
--- a/gaphor/C4Model/propertypages.ui
+++ b/gaphor/C4Model/propertypages.ui
@@ -1,32 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkLabel" id="00-instructions">
-    <property name="label">To create a fresh model: create a window, create the
-desired element, in the tree view pop upmenu, select
-Remove Parent.
 
-Padding between elements is 6px.
-Top margin is 6 px, 12px for expanders.
-Edit, from the popup menu, will allow you to add cell
-renderers and such.</property>
-    <property name="xalign">0</property>
-  </object>
   <object class="GtkTextBuffer" id="description-text-buffer"/>
+
   <object class="GtkBox" id="description-editor">
-    <property name="margin_top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
-    <property name="baseline_position">top</property>
     <signal name="destroy" handler="container-destroyed" swapped="no"/>
     <child>
-      <object class="GtkLabel" id="label2">
-        <property name="valign">center</property>
+      <object class="GtkLabel">
         <property name="label" translatable="yes">Description</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -34,29 +21,26 @@ renderers and such.</property>
         <child>
           <object class="GtkTextView" id="description">
             <property name="wrap_mode">word</property>
-            <property name="left-margin">6</property>
-            <property name="right-margin">6</property>
-            <property name="top-margin">6</property>
-            <property name="bottom-margin">6</property>
             <property name="buffer">description-text-buffer</property>
+            <property name="height-request">96</property>
           </object>
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkBox" id="technology-editor">
-    <property name="margin_top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
-    <property name="baseline_position">top</property>
     <child>
       <object class="GtkLabel" id="label4">
-        <property name="valign">center</property>
         <property name="label" translatable="yes">Technology</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -64,5 +48,9 @@ renderers and such.</property>
         <signal name="changed" handler="technology-changed" swapped="no"/>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
 </interface>

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk" version="4.0"/>
+  <requires lib="gtk" version="4.0" />
   <object class="GtkLabel" id="00-instructions">
     <property name="label">To create a fresh model: create a window, create the
 desired element, in the tree view pop upmenu, select
@@ -21,14 +21,16 @@ renderers and such.</property>
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Item Flow</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
             <attributes>
-              <attribute name="weight" value="bold"/>
+              <attribute name="weight" value="bold" />
             </attributes>
           </object>
         </child>
         <child>
           <object class="GtkSwitch" id="use-item-flow">
-            <signal name="notify::active" handler="item-flow-active" swapped="no"/>
+            <signal name="notify::active" handler="item-flow-active" swapped="no" />
           </object>
         </child>
       </object>
@@ -44,20 +46,20 @@ renderers and such.</property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkEntry" id="item-flow-name">
-            <signal name="changed" handler="item-flow-name-changed" swapped="no"/>
+            <signal name="changed" handler="item-flow-name-changed" swapped="no" />
           </object>
         </child>
         <child>
           <object class="GtkButton" id="item-flow-invert">
             <property name="tooltip-text" translatable="yes">Invert direction</property>
-            <signal name="clicked" handler="invert-direction-changed" swapped="no"/>
+            <signal name="clicked" handler="invert-direction-changed" swapped="no" />
             <child>
               <object class="GtkImage">
                 <property name="icon-name">object-flip-horizontal-symbolic</property>
               </object>
             </child>
             <style>
-              <class name="flat"/>
+              <class name="flat" />
             </style>
           </object>
         </child>
@@ -72,7 +74,7 @@ renderers and such.</property>
     <child>
       <object class="GtkComboBoxText" id="item-flow-type">
         <property name="has-entry">1</property>
-        <signal name="changed" handler="item-flow-type-changed" swapped="no"/>
+        <signal name="changed" handler="item-flow-type-changed" swapped="no" />
       </object>
     </child>
   </object>
@@ -82,16 +84,18 @@ renderers and such.</property>
     <child>
       <object class="GtkBox">
         <property name="spacing">6</property>
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
             <child>
               <object class="GtkLabel">
                 <property name="label" translatable="yes">Show Parts</property>
+                <property name="halign">start</property>
+                <property name="hexpand">yes</property>
               </object>
             </child>
             <child>
               <object class="GtkSwitch" id="show-parts">
-                <property name="halign">center</property>
                 <signal name="notify::active" handler="show-parts-changed" swapped="no"/>
               </object>
             </child>
@@ -102,12 +106,14 @@ renderers and such.</property>
             <child>
               <object class="GtkLabel">
                 <property name="label" translatable="yes">Show References</property>
+                <property name="halign">start</property>
+                <property name="hexpand">yes</property>
               </object>
             </child>
             <child>
               <object class="GtkSwitch" id="show-references">
                 <property name="halign">center</property>
-                <signal name="notify::active" handler="show-references-changed" swapped="no"/>
+                <signal name="notify::active" handler="show-references-changed" swapped="no" />
               </object>
             </child>
           </object>
@@ -117,12 +123,14 @@ renderers and such.</property>
             <child>
               <object class="GtkLabel">
                 <property name="label" translatable="yes">Show Values</property>
+                <property name="halign">start</property>
+                <property name="hexpand">yes</property>
               </object>
             </child>
             <child>
               <object class="GtkSwitch" id="show-values">
                 <property name="halign">center</property>
-                <signal name="notify::active" handler="show-values-changed" swapped="no"/>
+                <signal name="notify::active" handler="show-values-changed" swapped="no" />
               </object>
             </child>
           </object>
@@ -159,17 +167,17 @@ renderers and such.</property>
           <item id="1" translatable="yes">Shared</item>
           <item id="2" translatable="yes">Composite</item>
         </items>
-        <signal name="changed" handler="aggregation-changed" swapped="no"/>
+        <signal name="changed" handler="aggregation-changed" swapped="no" />
       </object>
     </child>
   </object>
-  <object class="GtkTextBuffer" id="requirement-text-buffer"/>
+  <object class="GtkTextBuffer" id="requirement-text-buffer" />
   <object class="GtkBox" id="requirement-editor">
     <property name="margin_top">6</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
     <property name="baseline_position">top</property>
-    <signal name="destroy" handler="requirement-destroyed" swapped="no"/>
+    <signal name="destroy" handler="requirement-destroyed" swapped="no" />
     <child>
       <object class="GtkLabel" id="label1">
         <property name="valign">center</property>
@@ -182,7 +190,7 @@ renderers and such.</property>
     </child>
     <child>
       <object class="GtkEntry" id="requirement-id">
-        <signal name="changed" handler="requirement-id-changed" swapped="no"/>
+        <signal name="changed" handler="requirement-id-changed" swapped="no" />
       </object>
     </child>
     <child>

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -1,21 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0" />
-  <object class="GtkLabel" id="00-instructions">
-    <property name="label">To create a fresh model: create a window, create the
-desired element, in the tree view pop upmenu, select
-Remove Parent.
 
-Padding between elements is 6px.
-Top margin is 6 px, 12px for expanders.
-Edit, from the popup menu, will allow you to add cell
-renderers and such.</property>
-    <property name="xalign">0</property>
-  </object>
   <object class="GtkBox" id="item-flow-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkBox">
         <child>
@@ -43,10 +31,11 @@ renderers and such.</property>
     </child>
     <child>
       <object class="GtkBox">
-        <property name="spacing">6</property>
         <child>
           <object class="GtkEntry" id="item-flow-name">
             <signal name="changed" handler="item-flow-name-changed" swapped="no" />
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
@@ -77,13 +66,23 @@ renderers and such.</property>
         <signal name="changed" handler="item-flow-type-changed" swapped="no" />
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkExpander" id="compartment-editor">
-    <property name="margin_top">12</property>
     <property name="expanded">1</property>
+    <child type="label">
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Compartments</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
     <child>
       <object class="GtkBox">
-        <property name="spacing">6</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
@@ -112,7 +111,6 @@ renderers and such.</property>
             </child>
             <child>
               <object class="GtkSwitch" id="show-references">
-                <property name="halign">center</property>
                 <signal name="notify::active" handler="show-references-changed" swapped="no" />
               </object>
             </child>
@@ -129,35 +127,30 @@ renderers and such.</property>
             </child>
             <child>
               <object class="GtkSwitch" id="show-values">
-                <property name="halign">center</property>
                 <signal name="notify::active" handler="show-values-changed" swapped="no" />
               </object>
             </child>
           </object>
         </child>
+        <style>
+          <class name="propertypage"/>
+        </style>
       </object>
     </child>
-    <child type="label">
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Compartments</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
-      </object>
-    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkBox" id="property-editor">
-    <property name="margin_top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkLabel" id="label3">
-        <property name="valign">center</property>
         <property name="label" translatable="yes">Aggregation</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -170,22 +163,23 @@ renderers and such.</property>
         <signal name="changed" handler="aggregation-changed" swapped="no" />
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+  
   <object class="GtkTextBuffer" id="requirement-text-buffer" />
+
   <object class="GtkBox" id="requirement-editor">
     <property name="orientation">vertical</property>
-    <!-- <property name="margin_top">6</property>
-    <property name="spacing">6</property> -->
-    <property name="baseline_position">top</property>
     <signal name="destroy" handler="requirement-destroyed" swapped="no" />
     <child>
       <object class="GtkLabel" id="label1">
-        <property name="valign">center</property>
         <property name="label" translatable="yes">Id</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -195,13 +189,11 @@ renderers and such.</property>
     </child>
     <child>
       <object class="GtkLabel" id="label2">
-        <property name="valign">center</property>
-        <property name="margin_top">6</property>
         <property name="label" translatable="yes">Text</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -209,17 +201,15 @@ renderers and such.</property>
         <child>
           <object class="GtkTextView" id="requirement-text">
             <property name="wrap_mode">word</property>
-            <property name="left-margin">6</property>
-            <property name="right-margin">6</property>
-            <property name="top-margin">6</property>
-            <property name="bottom-margin">6</property>
             <property name="buffer">requirement-text-buffer</property>
+            <property name="height-request">96</property>
           </object>
         </child>
       </object>
     </child>
     <style>
-      <class name="property-page"/>
+      <class name="propertypage"/>
     </style>
   </object>
+
 </interface>

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -173,9 +173,9 @@ renderers and such.</property>
   </object>
   <object class="GtkTextBuffer" id="requirement-text-buffer" />
   <object class="GtkBox" id="requirement-editor">
-    <property name="margin_top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
+    <!-- <property name="margin_top">6</property>
+    <property name="spacing">6</property> -->
     <property name="baseline_position">top</property>
     <signal name="destroy" handler="requirement-destroyed" swapped="no" />
     <child>
@@ -218,5 +218,8 @@ renderers and such.</property>
         </child>
       </object>
     </child>
+    <style>
+      <class name="property-page"/>
+    </style>
   </object>
 </interface>

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -1,38 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkLabel" id="00-instructions">
-    <property name="label">To create a fresh model: create a window, create the
-desired element, in the tree view pop upmenu, select
-Remove Parent.
 
-Padding between elements is 6px.
-Top margin is 6 px, 12px for expanders.
-Edit, from the popup menu, will allow you to add cell 
-renderers and such.</property>
-    <property name="xalign">0</property>
-  </object>
   <object class="GtkBox" id="decision-node-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkBox">
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Show type</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
           <object class="GtkSwitch" id="show-type">
-            <property name="halign">center</property>
             <property name="focusable">1</property>
             <signal name="notify::active" handler="show-type-changed" swapped="no"/>
           </object>
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkBox" id="fork-node-editor">
     <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
@@ -42,29 +35,32 @@ renderers and such.</property>
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Horizontal</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
           <object class="GtkSwitch" id="horizontal">
-            <property name="halign">center</property>
             <property name="focusable">1</property>
             <signal name="notify::active" handler="horizontal-changed" swapped="no"/>
           </object>
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkBox" id="join-node-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Join Specification</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -73,7 +69,11 @@ renderers and such.</property>
         <signal name="changed" handler="join-spec-changed" swapped="no"/>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkAdjustment" id="num-partitions-adjustment">
     <property name="lower">1</property>
     <property name="upper">10</property>
@@ -81,17 +81,16 @@ renderers and such.</property>
     <property name="step-increment">1</property>
     <property name="page-increment">5</property>
   </object>
+
   <object class="GtkBox" id="partition-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Swimlanes</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -99,11 +98,12 @@ renderers and such.</property>
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Partitions</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
           <object class="GtkSpinButton" id="num-partitions">
-            <property name="halign">center</property>
             <property name="focusable">1</property>
             <property name="adjustment">num-partitions-adjustment</property>
             <property name="numeric">1</property>
@@ -118,18 +118,20 @@ renderers and such.</property>
         <property name="spacing">12</property>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkBox" id="object-node-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Upper Bound</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -143,11 +145,12 @@ renderers and such.</property>
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Show Ordering</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
           <object class="GtkSwitch" id="show-ordering">
-            <property name="halign">center</property>
             <property name="focusable">1</property>
             <signal name="notify::active" handler="show-ordering-changed" swapped="no"/>
           </object>
@@ -165,7 +168,11 @@ renderers and such.</property>
         <signal name="changed" handler="ordering-changed" swapped="no"/>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkBox" id="partition">
     <property name="margin-start">6</property>
     <property name="spacing">6</property>
@@ -177,7 +184,6 @@ renderers and such.</property>
     <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>
-        <property name="spacing">6</property>
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Name</property>
@@ -202,21 +208,23 @@ renderers and such.</property>
             <signal name="changed" handler="partition-type-changed" swapped="no"/>
           </object>
         </child>
+        <style>
+          <class name="propertypage"/>
+        </style>
       </object>
     </child>
   </object>
+
   <object class="GtkBox" id="transition-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <signal name="destroy" handler="transition-destroy" swapped="no"/>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Guard</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -225,5 +233,9 @@ renderers and such.</property>
         <signal name="changed" handler="guard-changed" swapped="no"/>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
 </interface>

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -1,38 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkLabel" id="00-instructions">
-    <property name="label">To create a fresh model: create a window, create the
-desired element, in the tree view pop upmenu, select
-Remove Parent.
 
-Padding between elements is 6px.
-Top margin is 6 px, 12px for expanders.
-Edit, from the popup menu, will allow you to add cell
-renderers and such.</property>
-    <property name="xalign">0</property>
-  </object>
   <object class="GtkBox" id="association-editor">
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <signal name="destroy" handler="association-editor-destroy" swapped="no"/>
     <child>
       <object class="GtkBox">
-        <property name="spacing">6</property>
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Show Direction</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSwitch" id="show-direction">
-            <property name="focusable">1</property>
-            <property name="valign">center</property>
-            <signal name="notify::active" handler="show-direction-changed" swapped="no"/>
+            <property name="hexpand">yes</property>
+            <property name="halign">start</property>
           </object>
         </child>
         <child>
           <object class="GtkButton">
+            <property name="halign">end</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="tooltip-text" translatable="yes">Invert direction</property>
@@ -47,15 +31,30 @@ renderers and such.</property>
             </style>
           </object>
         </child>
+        <child>
+          <object class="GtkSwitch" id="show-direction">
+            <property name="focusable">1</property>
+            <property name="valign">center</property>
+            <property name="halign">end</property>
+            <signal name="notify::active" handler="show-direction-changed" swapped="no"/>
+          </object>
+        </child>
       </object>
     </child>
     <child>
       <object class="GtkExpander">
         <property name="focusable">1</property>
         <property name="expanded">1</property>
+        <child type="label">
+          <object class="GtkLabel" id="head-title">
+            <property name="label" translatable="yes">Head:</property>
+            <style>
+              <class name="title"/>
+            </style>
+          </object>
+        </child>
         <child>
           <object class="GtkBox">
-            <property name="margin-top">6</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkEntry" id="head-name">
@@ -65,10 +64,7 @@ renderers and such.</property>
             </child>
             <child>
               <object class="GtkLabel" id="head-info-icon">
-                <property name="margin-top">3</property>
                 <property name="halign">end</property>
-                <property name="margin-start">2</property>
-                <property name="margin-end">2</property>
                 <property name="label" translatable="yes">🛈 Help</property>
                 <style>
                   <class name="info"/>
@@ -77,7 +73,6 @@ renderers and such.</property>
             </child>
             <child>
               <object class="GtkComboBoxText" id="head-navigation">
-                <property name="margin-top">6</property>
                 <items>
                   <item id="0" translatable="yes">Unknown navigation</item>
                   <item id="1" translatable="yes">Not navigable</item>
@@ -88,7 +83,6 @@ renderers and such.</property>
             </child>
             <child>
               <object class="GtkComboBoxText" id="head-aggregation">
-                <property name="margin-top">6</property>
                 <items>
                   <item id="0" translatable="yes">No aggregation</item>
                   <item id="1" translatable="yes">Shared</item>
@@ -99,7 +93,6 @@ renderers and such.</property>
             </child>
             <child>
               <object class="GtkFrame" id="head-stereotype-frame">
-                <property name="margin-top">6</property>
                 <property name="child">
                   <object class="GtkTreeView" id="head-stereotype-list">
                     <property name="focusable">1</property>
@@ -144,14 +137,9 @@ renderers and such.</property>
                 </property>
               </object>
             </child>
-          </object>
-        </child>
-        <child type="label">
-          <object class="GtkLabel" id="head-title">
-            <property name="label" translatable="yes">Head:</property>
-            <attributes>
-              <attribute name="weight" value="bold"></attribute>
-            </attributes>
+            <style>
+              <class name="propertypage"/>
+            </style>
           </object>
         </child>
       </object>
@@ -159,11 +147,17 @@ renderers and such.</property>
     <child>
       <object class="GtkExpander">
         <property name="focusable">1</property>
-        <property name="margin-top">6</property>
         <property name="expanded">1</property>
+        <child type="label">
+          <object class="GtkLabel" id="tail-title">
+            <property name="label" translatable="yes">Tail:</property>
+            <style>
+              <class name="title"/>
+            </style>
+          </object>
+        </child>
         <child>
           <object class="GtkBox">
-            <property name="margin-top">6</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkEntry" id="tail-name">
@@ -173,11 +167,7 @@ renderers and such.</property>
             </child>
             <child>
               <object class="GtkLabel" id="tail-info-icon">
-                <property name="visible">1</property>
-                <property name="margin-top">3</property>
                 <property name="halign">end</property>
-                <property name="margin-start">2</property>
-                <property name="margin-end">2</property>
                 <property name="label" translatable="yes">🛈 Help</property>
                 <style>
                   <class name="info"/>
@@ -186,7 +176,6 @@ renderers and such.</property>
             </child>
             <child>
               <object class="GtkComboBoxText" id="tail-navigation">
-                <property name="margin-top">6</property>
                 <items>
                   <item id="0" translatable="yes">Unknown navigation</item>
                   <item id="1" translatable="yes">Not navigable</item>
@@ -197,7 +186,6 @@ renderers and such.</property>
             </child>
             <child>
               <object class="GtkComboBoxText" id="tail-aggregation">
-                <property name="margin-top">6</property>
                 <items>
                   <item id="0" translatable="yes">No aggregation</item>
                   <item id="1" translatable="yes">Shared</item>
@@ -208,7 +196,6 @@ renderers and such.</property>
             </child>
             <child>
               <object class="GtkFrame" id="tail-stereotype-frame">
-                <property name="margin-top">6</property>
                 <property name="child">
                   <object class="GtkTreeView" id="tail-stereotype-list">
                     <property name="focusable">1</property>
@@ -254,28 +241,23 @@ renderers and such.</property>
                 </property>
               </object>
             </child>
-          </object>
-        </child>
-        <child type="label">
-          <object class="GtkLabel" id="tail-title">
-            <property name="label" translatable="yes">Tail:</property>
-            <attributes>
-              <attribute name="weight" value="bold"></attribute>
-            </attributes>
+            <style>
+              <class name="propertypage"/>
+            </style>
           </object>
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkPopover" id="association-info">
     <!-- <property name="relative-to">attributes-info-icon</property> -->
     <property name="position">top</property>
     <property name="child">
       <object class="GtkLabel">
-        <property name="margin-start">6</property>
-        <property name="margin-end">6</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">6</property>
         <property name="label" translatable="yes">Add and edit association ends according to UML syntax.
 
   • &lt;tt&gt;+ name&lt;/tt&gt;
@@ -287,23 +269,34 @@ renderers and such.</property>
 Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
         <property name="use-markup">1</property>
+        <style>
+          <class name="info-popover"/>
+        </style>
       </object>
     </property>
   </object>
+
   <object class="GtkExpander" id="attributes-editor">
     <property name="focusable">1</property>
-    <property name="margin-top">12</property>
     <property name="expanded">1</property>
+    <child type="label">
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Attributes</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
     <child>
       <object class="GtkBox">
-        <property name="margin-top">6</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
-            <property name="spacing">6</property>
             <child>
               <object class="GtkLabel">
                 <property name="label" translatable="yes">Show Attributes</property>
+                <property name="halign">start</property>
+                <property name="hexpand">yes</property>
               </object>
             </child>
             <child>
@@ -316,7 +309,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         </child>
         <child>
           <object class="GtkFrame">
-            <property name="margin-top">6</property>
             <property name="child">
               <object class="GtkTreeView" id="attributes-list">
                 <property name="height-request">112</property>
@@ -368,36 +360,27 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <child>
           <object class="GtkLabel" id="attributes-info-icon">
             <property name="visible">1</property>
-            <property name="margin-top">3</property>
             <property name="halign">end</property>
-            <property name="margin-start">2</property>
-            <property name="margin-end">2</property>
             <property name="label" translatable="yes">🛈 Help</property>
             <style>
               <class name="info"/>
             </style>
           </object>
         </child>
+        <style>
+          <class name="propertypage"/>
+        </style>
       </object>
     </child>
-    <child type="label">
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Attributes</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
-      </object>
-    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkPopover" id="attributes-info">
-    <!-- <property name="relative-to">attributes-info-icon</property> -->
     <property name="position">top</property>
     <property name="child">
       <object class="GtkLabel">
-        <property name="margin-start">6</property>
-        <property name="margin-end">6</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">6</property>
         <property name="label" translatable="yes">Add and edit class attributes according to UML syntax.
 
   • &lt;tt&gt;attr&lt;/tt&gt; (name, defaults to public visibility)
@@ -408,41 +391,46 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
 Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
         <property name="use-markup">1</property>
+        <style>
+          <class name="info-popover"/>
+        </style>
       </object>
     </property>
   </object>
+
   <object class="GtkBox" id="classifier-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkBox">
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Abstract</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
           <object class="GtkSwitch" id="abstract">
-            <property name="halign">center</property>
             <property name="focusable">1</property>
             <signal name="notify::active" handler="abstract-changed" swapped="no"/>
           </object>
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkBox" id="dependency-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Dependency type</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -450,11 +438,12 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Automatic</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
           <object class="GtkSwitch" id="automatic">
-            <property name="halign">center</property>
             <property name="focusable">1</property>
             <signal name="notify::active" handler="automatic-changed" swapped="no"/>
           </object>
@@ -472,9 +461,12 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkBox" id="interface-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
@@ -482,30 +474,33 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
           <object class="GtkLabel">
             <property name="halign">start</property>
             <property name="label" translatable="yes">Folded</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
           <object class="GtkSwitch" id="folded">
             <property name="focusable">1</property>
-            <property name="halign">center</property>
             <signal name="notify::active" handler="folded-changed" swapped="no"/>
           </object>
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkBox" id="named-element-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <property name="baseline-position">top</property>
     <child>
       <object class="GtkLabel" id="label1">
         <property name="label" translatable="yes">Name</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -515,21 +510,32 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <signal name="destroy" handler="name-entry-destroyed" swapped="no"/>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkExpander" id="operations-editor">
     <property name="focusable">1</property>
-    <property name="margin-top">12</property>
     <property name="expanded">1</property>
+    <child type="label">
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Operations</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
     <child>
       <object class="GtkBox">
-        <property name="margin-top">6</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
-            <property name="spacing">6</property>
             <child>
               <object class="GtkLabel">
                 <property name="label" translatable="yes">Show Operations</property>
+                <property name="halign">start</property>
+                <property name="hexpand">yes</property>
               </object>
             </child>
             <child>
@@ -542,7 +548,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         </child>
         <child>
           <object class="GtkFrame">
-            <property name="margin-top">6</property>
             <property name="child">
               <object class="GtkTreeView" id="operations-list">
                 <property name="height-request">112</property>
@@ -607,36 +612,28 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <child>
           <object class="GtkLabel" id="operations-info-icon">
             <property name="visible">1</property>
-            <property name="margin-top">3</property>
             <property name="halign">end</property>
-            <property name="margin-start">2</property>
-            <property name="margin-end">2</property>
             <property name="label" translatable="yes">🛈 Help</property>
             <style>
               <class name="info"/>
             </style>
           </object>
         </child>
+        <style>
+          <class name="propertypage"/>
+        </style>
       </object>
     </child>
-    <child type="label">
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Operations</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
-      </object>
-    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkPopover" id="operations-info">
     <!-- <property name="relative-to">operations-info-icon</property> -->
     <property name="position">top</property>
     <property name="child">
       <object class="GtkLabel">
-        <property name="margin-start">6</property>
-        <property name="margin-end">6</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">6</property>
         <property name="label" translatable="yes">Add and edit class operations according to UML syntax.
 
   • &lt;tt&gt;call()&lt;/tt&gt;
@@ -646,23 +643,34 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
 Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
         <property name="use-markup">1</property>
+        <style>
+          <class name="info-popover"/>
+        </style>
       </object>
     </property>
   </object>
+
   <object class="GtkExpander" id="enumerations-editor">
     <property name="focusable">1</property>
-    <property name="margin-top">12</property>
     <property name="expanded">1</property>
+    <child type="label">
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Enumeration Literals</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
     <child>
       <object class="GtkBox">
-        <property name="margin-top">6</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
-            <property name="spacing">6</property>
             <child>
               <object class="GtkLabel">
                 <property name="label" translatable="yes">Show Enumeration Literals</property>
+                <property name="hexpand">yes</property>
+                <property name="halign">start</property>
               </object>
             </child>
             <child>
@@ -676,7 +684,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         </child>
         <child>
           <object class="GtkFrame">
-            <property name="margin-top">6</property>
             <property name="child">
               <object class="GtkTreeView" id="enumerations-list">
                 <property name="height-request">112</property>
@@ -713,36 +720,27 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <child>
           <object class="GtkLabel" id="enumerations-info-icon">
             <property name="visible">1</property>
-            <property name="margin-top">3</property>
             <property name="halign">end</property>
-            <property name="margin-start">2</property>
-            <property name="margin-end">2</property>
             <property name="label" translatable="yes">🛈 Help</property>
             <style>
               <class name="info"/>
             </style>
           </object>
         </child>
+        <style>
+          <class name="propertypage"/>
+        </style>
       </object>
     </child>
-    <child type="label">
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Enumeration Literals</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
-      </object>
-    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkPopover" id="enumerations-info">
-    <!-- <property name="relative-to">enumerations-info-icon</property> -->
     <property name="position">top</property>
     <property name="child">
       <object class="GtkLabel">
-        <property name="margin-start">6</property>
-        <property name="margin-end">6</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">6</property>
         <property name="label" translatable="yes">Add and edit enumeration literals according to UML syntax.
 
   • &lt;tt&gt;enum&lt;/tt&gt;
@@ -750,27 +748,33 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
 Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
         <property name="use-markup">1</property>
+        <style>
+          <class name="info-popover"/>
+        </style>
       </object>
     </property>
   </object>
+
   <object class="GtkBox" id="component-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkBox">
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Indirectly Instantiated</property>
+            <property name="hexpand">yes</property>
+            <property name="halign">start</property>
           </object>
         </child>
         <child>
           <object class="GtkSwitch" id="indirectly-instantiated">
-            <property name="halign">center</property>
             <signal name="notify::active" handler="indirectly-instantiated-changed" swapped="no"/>
           </object>
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
 </interface>

--- a/gaphor/UML/deployments/propertypages.ui
+++ b/gaphor/UML/deployments/propertypages.ui
@@ -1,29 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkLabel" id="00-instructions">
-    <property name="label">To create a fresh model: create a window, create the
-desired element, in the tree view pop upmenu, select
-Remove Parent.
 
-Padding between elements is 6px.
-Top margin is 6 px, 12px for expanders.
-Edit, from the popup menu, will allow you to add cell
-renderers and such.</property>
-    <property name="xalign">0</property>
-  </object>
   <object class="GtkBox" id="information-flow-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkBox">
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Information Flow</property>
-            <attributes>
-              <attribute name="weight" value="bold"/>
-            </attributes>
+            <property name="hexpand">yes</property>
+            <property name="halign">start</property>
+            <style>
+              <class name="title"/>
+            </style>
           </object>
         </child>
         <child>
@@ -41,7 +31,6 @@ renderers and such.</property>
     </child>
     <child>
       <object class="GtkBox">
-        <property name="spacing">6</property>
         <child>
           <object class="GtkComboBoxText" id="information-flow-combo">
             <property name="has-entry">True</property>
@@ -64,5 +53,9 @@ renderers and such.</property>
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
 </interface>

--- a/gaphor/UML/interactions/propertypages.ui
+++ b/gaphor/UML/interactions/propertypages.ui
@@ -1,28 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkLabel" id="00-instructions">
-    <property name="label">To create a fresh model: create a window, create the
-desired element, in the tree view pop upmenu, select
-Remove Parent.
 
-Padding between elements is 6px.
-Top margin is 6 px, 12px for expanders.
-Edit, from the popup menu, will allow you to add cell
-renderers and such.</property>
-    <property name="xalign">0</property>
-  </object>
   <object class="GtkBox" id="message-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Message Sort</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -36,5 +24,9 @@ renderers and such.</property>
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+  
 </interface>

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -1,28 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkLabel" id="00-instructions">
-    <property name="label">To create a fresh model: create a window, create the
-desired element, in the tree view pop upmenu, select
-Remove Parent.
 
-Padding between elements is 6px.
-Top margin is 6 px, 12px for expanders.
-Edit, from the popup menu, will allow you to add cell
-renderers and such.</property>
-    <property name="xalign">0</property>
-  </object>
   <object class="GtkBox" id="metaclass-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Name</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -32,21 +20,31 @@ renderers and such.</property>
         <signal name="destroy" handler="metaclass-combo-destroy" swapped="no"/>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkExpander" id="stereotypes-editor">
-    <property name="margin-top">12</property>
     <property name="expanded">1</property>
+    <child type="label">
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Stereotypes</property>
+        <style>
+          <class name="title"/>
+        </style>    
+      </object>
+    </child>
     <child>
       <object class="GtkBox">
-        <property name="margin-top">6</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">6</property>
         <child>
           <object class="GtkBox">
-            <property name="spacing">6</property>
             <child>
               <object class="GtkLabel">
                 <property name="label" translatable="yes">Show Stereotypes</property>
+                <property name="halign">start</property>
+                <property name="hexpand">yes</property>
               </object>
             </child>
             <child>
@@ -101,15 +99,14 @@ renderers and such.</property>
             </property>
           </object>
         </child>
+        <style>
+          <class name="propertypage"/>
+        </style>
       </object>
     </child>
-    <child type="label">
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Stereotypes</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
-      </object>
-    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
 </interface>

--- a/gaphor/UML/states/propertypages.ui
+++ b/gaphor/UML/states/propertypages.ui
@@ -1,25 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkLabel" id="00-instructions">
-    <property name="label">To create a fresh model: create a window, create the
-desired element, in the tree view pop upmenu, select
-Remove Parent.
 
-Padding between elements is 6px.
-Top margin is 6 px, 12px for expanders.
-Edit, from the popup menu, will allow you to add cell
-renderers and such.</property>
-    <property name="xalign">0</property>
-  </object>
   <object class="GtkExpander" id="state-editor">
-    <property name="margin-top">12</property>
     <property name="expanded">1</property>
+    <child type="label">
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Activities</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
     <child>
       <object class="GtkBox">
-        <property name="margin-top">6</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">6</property>
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Entry</property>
@@ -53,29 +48,26 @@ renderers and such.</property>
             <signal name="changed" handler="do-activity-changed" swapped="no"/>
           </object>
         </child>
+        <style>
+          <class name="propertypage"/>
+        </style>
       </object>
     </child>
-    <child type="label">
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Activities</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
-      </object>
-    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkBox" id="transition-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <signal name="destroy" handler="transition-destroy"/>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Guard</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -83,5 +75,8 @@ renderers and such.</property>
         <signal name="changed" handler="guard-changed"/>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
 </interface>

--- a/gaphor/diagram/propertypages.ui
+++ b/gaphor/diagram/propertypages.ui
@@ -1,28 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkLabel" id="00-instructions">
-    <property name="label">To create a fresh model: create a window, create the
-desired element, in the tree view pop upmenu, select
-Remove Parent.
 
-Padding between elements is 6px.
-Top margin is 6 px, 12px for expanders.
-Edit, from the popup menu, will allow you to add cell
-renderers and such.</property>
-    <property name="xalign">0</property>
-  </object>
   <object class="GtkBox" id="comment-editor">
-    <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">6</property>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Comment</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="propertypage-title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -30,25 +18,29 @@ renderers and such.</property>
         <property name="child">
           <object class="GtkTextView" id="comment">
             <property name="wrap-mode">word</property>
-            <property name="left-margin">6</property>
-            <property name="right-margin">6</property>
-            <property name="top-margin">6</property>
-            <property name="bottom-margin">6</property>
             <property name="height-request">96</property>
           </object>
         </property>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkExpander" id="line-editor">
-    <property name="margin-top">12</property>
     <property name="expanded">1</property>
+    <child type="label">
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Style</property>
+        <style>
+          <class name="propertypage-title"/>
+        </style>
+      </object>
+    </child>
     <child>
       <object class="GtkBox">
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">12</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">6</property>
         <child>
           <object class="GtkCheckButton" id="line-rectilinear">
             <property name="label" translatable="yes">Rectilinear</property>
@@ -63,41 +55,35 @@ renderers and such.</property>
         </child>
       </object>
     </child>
-    <child type="label">
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Style</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
-      </object>
-    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+
   <object class="GtkExpander" id="note-editor">
-    <property name="margin-top">12</property>
     <property name="expanded">1</property>
     <child type="label">
       <object class="GtkLabel">
         <property name="label" translatable="yes">Note or Remark</property>
         <property name="xalign">0</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
+        <style>
+          <class name="propertypage-title"/>
+        </style>
       </object>
     </child>
     <child>
       <object class="GtkFrame">
-        <property name="margin-top">6</property>
         <property name="child">
           <object class="GtkTextView" id="note">
             <property name="wrap-mode">word</property>
-            <property name="left-margin">6</property>
-            <property name="right-margin">6</property>
-            <property name="top-margin">6</property>
-            <property name="bottom-margin">6</property>
             <property name="height-request">96</property>
           </object>
         </property>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
+  
 </interface>

--- a/gaphor/diagram/propertypages.ui
+++ b/gaphor/diagram/propertypages.ui
@@ -9,7 +9,7 @@
         <property name="label" translatable="yes">Comment</property>
         <property name="xalign">0</property>
         <style>
-          <class name="propertypage-title"/>
+          <class name="title"/>
         </style>
       </object>
     </child>
@@ -34,7 +34,7 @@
       <object class="GtkLabel">
         <property name="label" translatable="yes">Style</property>
         <style>
-          <class name="propertypage-title"/>
+          <class name="title"/>
         </style>
       </object>
     </child>
@@ -67,18 +67,26 @@
         <property name="label" translatable="yes">Note or Remark</property>
         <property name="xalign">0</property>
         <style>
-          <class name="propertypage-title"/>
+          <class name="title"/>
         </style>
       </object>
     </child>
     <child>
-      <object class="GtkFrame">
-        <property name="child">
-          <object class="GtkTextView" id="note">
-            <property name="wrap-mode">word</property>
-            <property name="height-request">96</property>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkFrame">
+            <property name="child">
+              <object class="GtkTextView" id="note">
+                <property name="wrap-mode">word</property>
+                <property name="height-request">96</property>
+              </object>
+            </property>
           </object>
-        </property>
+        </child>
+        <style>
+          <class name="propertypage"/>
+        </style>
       </object>
     </child>
     <style>

--- a/gaphor/ui/styling-gtk4.css
+++ b/gaphor/ui/styling-gtk4.css
@@ -3,3 +3,25 @@
 .greeter flowboxchild:hover {
   -gtk-icon-filter: brightness(1.2);
 }
+
+
+.propertypage {
+  margin-top: 6px;
+  border-spacing: 6px;
+}
+
+expander-widget.propertypage {
+  margin-top: 12px;
+}
+
+expander-widget.propertypage > box > *:last-child {
+  margin-top: 6px;
+}
+
+.propertypage-title {
+  font-weight: bold;
+}
+
+.propertypage frame > textview {
+  padding: 6px;
+}

--- a/gaphor/ui/styling-gtk4.css
+++ b/gaphor/ui/styling-gtk4.css
@@ -4,24 +4,30 @@
   -gtk-icon-filter: brightness(1.2);
 }
 
-
-.propertypage {
+box.propertypage > * {
   margin-top: 6px;
-  border-spacing: 6px;
 }
 
 expander-widget.propertypage {
   margin-top: 12px;
 }
 
-expander-widget.propertypage > box > *:last-child {
-  margin-top: 6px;
+.propertypage box.horizontal:not(.linked) {
+  border-spacing: 6px;
 }
 
-.propertypage-title {
+.propertypage .title {
   font-weight: bold;
+}
+
+.propertypage .info {
+  margin: 3px 2px 0 2px;
 }
 
 .propertypage frame > textview {
   padding: 6px;
+}
+
+.info-popover {
+  margin: 6px;
 }

--- a/gaphor/ui/uipreview.py
+++ b/gaphor/ui/uipreview.py
@@ -1,0 +1,83 @@
+"""Show GTK 4 UI Components.
+
+Usage:
+
+  GAPHOR_USE_GTK=4 \\
+  python -m  gaphor.ui.uipreview <ui file>
+"""
+import os
+import sys
+import xml.etree.ElementTree as etree
+
+from gi.repository import Gio, GLib, Gtk
+
+
+def load_components(ui_filename):
+    with open(ui_filename) as ui_file:
+        ui_xml = load_ui_file(ui_file)
+
+    builder = Gtk.Builder.new_from_string(ui_xml, -1)
+    components = [
+        o
+        for o in builder.get_objects()
+        if isinstance(o, Gtk.Widget) and not o.get_parent()
+    ]
+
+    for component in components:
+        print("show component", component.get_buildable_id())
+        yield component.get_buildable_id(), component
+
+
+def load_ui_file(ui_file) -> str:
+    ui_xml = etree.parse(ui_file)
+    for node in ui_xml.findall(".//*[signal]"):
+        for signal in node.findall("signal"):
+            node.remove(signal)
+    return etree.tostring(ui_xml.getroot(), encoding="unicode", method="xml")
+
+
+def in_window(app, name, component):
+    window = Gtk.Window.new()
+    window.set_child(component)
+    window.set_title(name)
+    window.show()
+    app.add_window(window)
+    return window
+
+
+def app_open(app, files, n_files, hint):
+    file = files[0].get_path()
+    last_modified = 0.0
+    components: dict[str, Gtk.Window] = {}
+
+    def monitor_file(_=None):
+        nonlocal last_modified
+        try:
+            new_mtime = os.stat(file).st_mtime
+            if new_mtime > last_modified:
+                last_modified = new_mtime
+                for name, comp in load_components(file):
+                    if name in components:
+                        components[name].set_child(comp)
+                    else:
+                        components[name] = in_window(app, name, comp)
+        except Exception as e:
+            print(e)
+        return True
+
+    s = GLib.Timeout(1000)
+    s.set_callback(monitor_file)
+    s.attach()
+    monitor_file()
+
+
+if __name__ == "__main__":
+    if Gtk.get_major_version() != 4:
+        print("UI Preview works with GTK 4 only.")
+        sys.exit(1)
+
+    app = Gtk.Application(
+        application_id="org.gaphor.UIPreview", flags=Gio.ApplicationFlags.HANDLES_OPEN
+    )
+    app.connect("open", app_open)
+    app.run(sys.argv)

--- a/gaphor/ui/uipreview.py
+++ b/gaphor/ui/uipreview.py
@@ -11,6 +11,8 @@ import xml.etree.ElementTree as etree
 
 from gi.repository import Gio, GLib, Gtk
 
+from gaphor.ui.styling import Styling
+
 
 def load_components(ui_filename):
     with open(ui_filename) as ui_file:
@@ -40,12 +42,14 @@ def in_window(app, name, component):
     window = Gtk.Window.new()
     window.set_child(component)
     window.set_title(name)
+    window.set_default_size(226, -1)
     window.show()
     app.add_window(window)
     return window
 
 
 def app_open(app, files, n_files, hint):
+    Styling()
     file = files[0].get_path()
     last_modified = 0.0
     components: dict[str, Gtk.Window] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,7 @@ markers = "slow: marks tests as slow (deselect with '-m \"not slow\"')"
 [tool.coverage.run]
 omit = [
     "*tests*",
+    "gaphor/ui/uipreview.py"
 ]
 
 [tool.isort]


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

GTK4 property page layout was off. Switches were not right aligned.

Issue Number: #618 

### What is the new behavior?

Updated the UI to look similar to GTK3. Changed margin properties and such for classes.

I added a little app (`gaphor/ui/uipreview.py`) to check on the preview layouts.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
