### PR TITLE
Fix diagram dependency cycle

### DIFF
--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -85,6 +85,14 @@ class ElementFactory(Service):
         This method should only be used when loading models, since it
         does not emit an ElementCreated event.
         """
+        if id in self._elements:
+            element = self._elements[id]
+            if not isinstance(element, type):
+                raise TypeError(
+                    "Element {element} already exists but has a different type  {type}"
+                )
+            return element
+
         type_args: dict[str, Diagram | RepositoryProtocol]
         if issubclass(type, Presentation):
             if not diagram:

--- a/gaphor/core/modeling/tests/test_elementfactory.py
+++ b/gaphor/core/modeling/tests/test_elementfactory.py
@@ -125,8 +125,7 @@ def element_factory():
     event_manager = EventManager()
     event_manager.subscribe(handler)
     clear_events()
-    factory = ElementFactory(event_manager)
-    yield factory
+    yield ElementFactory(event_manager)
     clear_events()
 
 

--- a/gaphor/core/modeling/tests/test_elementfactory.py
+++ b/gaphor/core/modeling/tests/test_elementfactory.py
@@ -14,7 +14,7 @@ from gaphor.core.modeling.event import (
     ServiceEvent,
 )
 from gaphor.core.modeling.presentation import Presentation
-from gaphor.UML import Parameter
+from gaphor.UML import Operation, Parameter
 
 
 @pytest.fixture
@@ -34,6 +34,18 @@ def test_element_factory_is_a_container(factory):
 def test_create(factory):
     factory.create(Parameter)
     assert len(list(factory.values())) == 1
+
+
+def test_create_is_idempotent(factory):
+    param = factory.create(Parameter)
+    new_param = factory.create_as(Parameter, param.id)
+    assert param is new_param
+
+
+def test_create_is_idempotent_but_validates_type(factory):
+    param = factory.create(Parameter)
+    with pytest.raises(TypeError):
+        factory.create_as(Operation, param.id)
 
 
 def test_should_not_create_presentation_elements(factory):

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -344,7 +344,13 @@ class UndoManager(Service, ActionProvider):
             event.element.save(save_func)
 
             def undo_delete_event():
-                diagram: Diagram = self.lookup(diagram_id)  # type: ignore[assignment]
+                # If diagram is not there, for some reason, recreate it.
+                # It's probably removed in the same transaction.
+                try:
+                    diagram: Diagram = self.lookup(diagram_id)  # type: ignore[assignment]
+                except ValueError:
+                    diagram = self.element_factory.create_as(Diagram, diagram_id)
+
                 element = diagram.create_as(element_type, element_id)
                 for name, ser in data.items():
                     for value in deserialize(ser, lambda ref: None):

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -307,3 +307,19 @@ def test_reflexive_message_undo(event_manager, element_factory, undo_manager):
         reflexive_message_config(message)
 
     undo_manager.undo_transaction()
+
+
+@pytest.mark.xfail
+def test_delete_item_with_subject_owning_diagram(
+    event_manager, element_factory, undo_manager
+):
+    with Transaction(event_manager):
+        diagram: Diagram = element_factory.create(Diagram)
+        klass = element_factory.create(UML.Class)
+        class_item = diagram.create(ClassItem, subject=klass)
+        diagram.element = klass
+
+    with Transaction(event_manager):
+        class_item.unlink()
+
+    undo_manager.undo_transaction()

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -309,7 +309,6 @@ def test_reflexive_message_undo(event_manager, element_factory, undo_manager):
     undo_manager.undo_transaction()
 
 
-@pytest.mark.xfail
 def test_delete_item_with_subject_owning_diagram(
     event_manager, element_factory, undo_manager
 ):


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

A carefully constructed model can break Gaphro's undo behavior.

Issue Number: #1457 

### What is the new behavior?

* `ElementFactory.create(_as)` is idempotent: when it receives a create request for an id and type it already knows, it returns that element instead of creating a new one.
* When undoing a `Presentation` element, a `Diagram` is created if it does not exist yet. Presentations depend on a diagram in order to be created.

### Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

ElementFactory's create method is idempotent now.

### Other information
