### PR TITLE
Pin support for activity diagram

### DIFF
--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -15,12 +15,10 @@ from gaphor.UML.recipes import stereotypes_str
 
 def text_position(position):
     return {
-        "text-align": TextAlign.LEFT
-        if position == "left"
-        else (TextAlign.RIGHT if position == "right" else TextAlign.CENTER),
-        "vertical-align": VerticalAlign.TOP
-        if position == "top"
-        else (VerticalAlign.BOTTOM if position == "bottom" else VerticalAlign.MIDDLE),
+        "text-align": TextAlign.LEFT if position == "left" else TextAlign.RIGHT,
+        "vertical-align": VerticalAlign.BOTTOM
+        if position == "bottom"
+        else VerticalAlign.TOP,
     }
 
 

--- a/gaphor/UML/actions/__init__.py
+++ b/gaphor/UML/actions/__init__.py
@@ -7,6 +7,7 @@ from gaphor.UML.actions import (
     copypaste,
     flowconnect,
     partitionpage,
+    pinconnect,
 )
 from gaphor.UML.actions.action import (
     AcceptEventActionItem,

--- a/gaphor/UML/actions/__init__.py
+++ b/gaphor/UML/actions/__init__.py
@@ -25,6 +25,8 @@ from gaphor.UML.actions.activitynodes import (
 from gaphor.UML.actions.flow import ControlFlowItem, ObjectFlowItem
 from gaphor.UML.actions.objectnode import ObjectNodeItem
 from gaphor.UML.actions.partition import PartitionItem
+from gaphor.UML.actions.pin import InputPinItem, OutputPinItem
+
 
 __all__ = [
     "AcceptEventActionItem",
@@ -38,8 +40,10 @@ __all__ = [
     "FlowFinalNodeItem",
     "ForkNodeItem",
     "InitialNodeItem",
+    "InputPinItem",
     "ControlFlowItem",
     "ObjectFlowItem",
     "ObjectNodeItem",
+    "OutputPinItem",
     "PartitionItem",
 ]

--- a/gaphor/UML/actions/actionstoolbox.py
+++ b/gaphor/UML/actions/actionstoolbox.py
@@ -202,5 +202,19 @@ actions = ToolSection(
             ),
             handle_index=SE,
         ),
+        ToolDef(
+            "toolbox-input-pin",
+            gettext("Input pin"),
+            "gaphor-action-symbolic",
+            None,
+            new_item_factory(diagramitems.InputPinItem),
+        ),
+        ToolDef(
+            "toolbox-output-pin",
+            gettext("Output pin"),
+            "gaphor-action-symbolic",
+            None,
+            new_item_factory(diagramitems.OutputPinItem),
+        ),
     ),
 )

--- a/gaphor/UML/actions/actionstoolbox.py
+++ b/gaphor/UML/actions/actionstoolbox.py
@@ -205,14 +205,14 @@ actions = ToolSection(
         ToolDef(
             "toolbox-input-pin",
             gettext("Input pin"),
-            "gaphor-action-symbolic",
+            "gaphor-input-pin-symbolic",
             None,
             new_item_factory(diagramitems.InputPinItem),
         ),
         ToolDef(
             "toolbox-output-pin",
             gettext("Output pin"),
-            "gaphor-action-symbolic",
+            "gaphor-output-pin-symbolic",
             None,
             new_item_factory(diagramitems.OutputPinItem),
         ),

--- a/gaphor/UML/actions/flowconnect.py
+++ b/gaphor/UML/actions/flowconnect.py
@@ -18,6 +18,7 @@ from gaphor.UML.actions.activitynodes import (
 )
 from gaphor.UML.actions.flow import ControlFlowItem, ObjectFlowItem
 from gaphor.UML.actions.objectnode import ObjectNodeItem
+from gaphor.UML.actions.pin import InputPinItem, OutputPinItem
 
 
 class FlowConnect(RelationshipConnect):
@@ -31,9 +32,9 @@ class FlowConnect(RelationshipConnect):
 
         if (
             handle is line.head
-            and isinstance(subject, UML.FinalNode)
+            and isinstance(subject, (UML.FinalNode, UML.InputPin))
             or handle is line.tail
-            and isinstance(subject, UML.InitialNode)
+            and isinstance(subject, (UML.InitialNode, UML.OutputPin))
         ):
             return False
 
@@ -95,6 +96,8 @@ Connector.register(ActivityNodeItem, ObjectFlowItem)(FlowConnect)
 Connector.register(ObjectNodeItem, ObjectFlowItem)(FlowConnect)
 Connector.register(SendSignalActionItem, ObjectFlowItem)(FlowConnect)
 Connector.register(ActivityParameterNodeItem, ObjectFlowItem)(FlowConnect)
+Connector.register(InputPinItem, ObjectFlowItem)(FlowConnect)
+Connector.register(OutputPinItem, ObjectFlowItem)(FlowConnect)
 
 
 class FlowForkDecisionNodeControlFlowConnect(FlowConnect):

--- a/gaphor/UML/actions/pin.py
+++ b/gaphor/UML/actions/pin.py
@@ -1,4 +1,5 @@
 from gaphor import UML
+from gaphor.core import gettext
 from gaphor.diagram.presentation import AttachedPresentation, Named
 from gaphor.diagram.shapes import (
     Box,
@@ -28,10 +29,17 @@ class PinItem(Named, AttachedPresentation[UML.Pin]):
         super().__init__(diagram, id, width=16, height=16)
         self.watch("subject[NamedElement].name")
 
+    def pin_type(self):
+        return ""
+
     def update_shapes(self):
         self.shape = IconBox(
             Box(style={"background-color": (1, 1, 1, 1)}, draw=draw_border),
-            Text(text=lambda: stereotypes_str(self.subject)),
+            Text(
+                text=lambda: stereotypes_str(
+                    self.subject, [] if self.subject else [self.pin_type()]
+                )
+            ),
             Text(text=lambda: self.subject and self.subject.name or ""),
             style=text_position(self.connected_side()),
         )
@@ -39,9 +47,11 @@ class PinItem(Named, AttachedPresentation[UML.Pin]):
 
 @represents(UML.InputPin)
 class InputPinItem(PinItem):
-    pass
+    def pin_type(self):
+        return gettext("input pin")
 
 
 @represents(UML.OutputPin)
 class OutputPinItem(PinItem):
-    pass
+    def pin_type(self):
+        return gettext("output pin")

--- a/gaphor/UML/actions/pin.py
+++ b/gaphor/UML/actions/pin.py
@@ -1,0 +1,47 @@
+from gaphor import UML
+from gaphor.diagram.presentation import AttachedPresentation, Named
+from gaphor.diagram.shapes import (
+    Box,
+    IconBox,
+    Text,
+    TextAlign,
+    VerticalAlign,
+    draw_border,
+)
+from gaphor.diagram.support import represents
+from gaphor.UML.recipes import stereotypes_str
+
+
+def text_position(position):
+    return {
+        "text-align": TextAlign.LEFT
+        if position == "left"
+        else (TextAlign.RIGHT if position == "right" else TextAlign.CENTER),
+        "vertical-align": VerticalAlign.TOP
+        if position == "top"
+        else (VerticalAlign.BOTTOM if position == "bottom" else VerticalAlign.MIDDLE),
+    }
+
+
+class PinItem(Named, AttachedPresentation[UML.Pin]):
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id, width=16, height=16)
+        self.watch("subject[NamedElement].name")
+
+    def update_shapes(self):
+        self.shape = IconBox(
+            Box(style={"background-color": (1, 1, 1, 1)}, draw=draw_border),
+            Text(text=lambda: stereotypes_str(self.subject)),
+            Text(text=lambda: self.subject and self.subject.name or ""),
+            style=text_position(self.connected_side()),
+        )
+
+
+@represents(UML.InputPin)
+class InputPinItem(PinItem):
+    pass
+
+
+@represents(UML.OutputPin)
+class OutputPinItem(PinItem):
+    pass

--- a/gaphor/UML/actions/pin.py
+++ b/gaphor/UML/actions/pin.py
@@ -15,12 +15,10 @@ from gaphor.UML.recipes import stereotypes_str
 
 def text_position(position):
     return {
-        "text-align": TextAlign.LEFT
-        if position == "left"
-        else (TextAlign.RIGHT if position == "right" else TextAlign.CENTER),
-        "vertical-align": VerticalAlign.TOP
-        if position == "top"
-        else (VerticalAlign.BOTTOM if position == "bottom" else VerticalAlign.MIDDLE),
+        "text-align": TextAlign.LEFT if position == "left" else TextAlign.RIGHT,
+        "vertical-align": VerticalAlign.BOTTOM
+        if position == "bottom"
+        else VerticalAlign.TOP,
     }
 
 

--- a/gaphor/UML/actions/pin.py
+++ b/gaphor/UML/actions/pin.py
@@ -31,6 +31,16 @@ class PinItem(Named, AttachedPresentation[UML.Pin]):
         return ""
 
     def update_shapes(self):
+        position = self.connected_side()
+        self.update_width(
+            self.width,
+            factor=0 if position == "left" else 1 if position == "right" else 0.5,
+        )
+        self.update_height(
+            self.width,
+            factor=0 if position == "top" else 1 if position == "bottom" else 0.5,
+        )
+
         self.shape = IconBox(
             Box(style={"background-color": (1, 1, 1, 1)}, draw=draw_border),
             Text(

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -16,6 +16,7 @@ from gaphor.UML.actions.activitynodes import (
 )
 from gaphor.UML.actions.flow import ControlFlowItem, ObjectFlowItem
 from gaphor.UML.actions.objectnode import ObjectNodeItem
+from gaphor.UML.actions.pin import InputPinItem, OutputPinItem
 
 
 def test_initial_node_glue(create):
@@ -106,6 +107,46 @@ def test_connect_to_activity_parameter_node(create, element_factory):
 
     connect(flow, flow.head, anode)
     connect(flow, flow.tail, onode)
+    assert flow.subject
+    assert isinstance(flow.subject, UML.ObjectFlow)
+
+
+def test_do_not_allow_head_to_input_pin(create):
+    flow = create(ObjectFlowItem)
+    pin = create(InputPinItem, UML.InputPin)
+
+    assert not allow(flow, flow.head, pin)
+    assert allow(flow, flow.tail, pin)
+
+
+def test_connect_tail_to_input_pin(create):
+    flow = create(ObjectFlowItem)
+    pin = create(InputPinItem, UML.InputPin)
+    onode = create(ObjectNodeItem, UML.ObjectNode)
+
+    connect(flow, flow.head, onode)
+    connect(flow, flow.tail, pin)
+
+    assert flow.subject
+    assert isinstance(flow.subject, UML.ObjectFlow)
+
+
+def test_do_not_allow_tail_to_output_pin(create):
+    flow = create(ObjectFlowItem)
+    pin = create(OutputPinItem, UML.OutputPin)
+
+    assert allow(flow, flow.head, pin)
+    assert not allow(flow, flow.tail, pin)
+
+
+def test_connect_head_to_output_pin(create):
+    flow = create(ObjectFlowItem)
+    pin = create(OutputPinItem, UML.OutputPin)
+    onode = create(ObjectNodeItem, UML.ObjectNode)
+
+    connect(flow, flow.head, pin)
+    connect(flow, flow.tail, onode)
+
     assert flow.subject
     assert isinstance(flow.subject, UML.ObjectFlow)
 

--- a/gaphor/UML/actions/tests/test_pin.py
+++ b/gaphor/UML/actions/tests/test_pin.py
@@ -1,0 +1,16 @@
+from gaphor.UML.actions.pin import InputPinItem
+
+
+def test_load_pin(element_factory, diagram, saver, loader):
+    attached = diagram.create(InputPinItem)
+
+    attached.handles()[0].pos = (1, 2)
+    attached.matrix.translate(10, 20)
+
+    dump = saver()
+    loader(dump)
+
+    new_attached = next(element_factory.select(InputPinItem))
+
+    assert tuple(new_attached.handles()[0].pos) == (1, 2)
+    assert tuple(new_attached.matrix) == (1.0, 0.0, 0.0, 1.0, 10, 20)

--- a/gaphor/UML/actions/tests/test_pinconnect.py
+++ b/gaphor/UML/actions/tests/test_pinconnect.py
@@ -1,0 +1,76 @@
+import pytest
+
+from gaphor import UML
+from gaphor.diagram.connectors import Connector
+from gaphor.UML.actions.action import ActionItem
+from gaphor.UML.actions.pin import InputPinItem, OutputPinItem
+from gaphor.UML.actions.pinconnect import ActionPinConnector
+
+
+@pytest.fixture
+def action_item(diagram, element_factory):
+    return diagram.create(ActionItem, subject=element_factory.create(UML.Action))
+
+
+@pytest.fixture
+def input_pin_item(diagram):
+    return diagram.create(InputPinItem)
+
+
+@pytest.fixture
+def output_pin_item(diagram):
+    return diagram.create(OutputPinItem)
+
+
+def test_input_pin_can_connect_to_action(action_item, input_pin_item):
+    connector = Connector(action_item, input_pin_item)
+
+    assert isinstance(connector, ActionPinConnector)
+    assert connector.allow(input_pin_item.handles()[0], action_item.ports()[0])
+
+
+def test_output_pin_can_connect_to_action(action_item, output_pin_item):
+    connector = Connector(action_item, output_pin_item)
+
+    assert isinstance(connector, ActionPinConnector)
+    assert connector.allow(output_pin_item.handles()[0], action_item.ports()[0])
+
+
+def test_connect_input_pin_to_action(action_item, input_pin_item):
+    connector = Connector(action_item, input_pin_item)
+
+    connected = connector.connect(input_pin_item.handles()[0], action_item.ports()[0])
+
+    assert connected
+    assert input_pin_item.subject
+    assert input_pin_item.subject in action_item.subject.inputValue
+
+
+def test_disconnect_input_pin_to_action(action_item, input_pin_item):
+    connector = Connector(action_item, input_pin_item)
+    connector.connect(input_pin_item.handles()[0], action_item.ports()[0])
+
+    connector.disconnect(input_pin_item.handles()[0])
+
+    assert input_pin_item.subject is None
+    assert input_pin_item.diagram
+
+
+def test_connect_output_pin_to_action(action_item, output_pin_item):
+    connector = Connector(action_item, output_pin_item)
+
+    connected = connector.connect(output_pin_item.handles()[0], action_item.ports()[0])
+
+    assert connected
+    assert output_pin_item.subject
+    assert output_pin_item.subject in action_item.subject.outputValue
+
+
+def test_disconnect_output_pin_to_action(action_item, output_pin_item):
+    connector = Connector(action_item, output_pin_item)
+    connector.connect(output_pin_item.handles()[0], action_item.ports()[0])
+
+    connector.disconnect(output_pin_item.handles()[0])
+
+    assert output_pin_item.subject is None
+    assert output_pin_item.diagram

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -261,7 +261,7 @@ class UseCase(BehavioredClassifier):
 
 
 class InputPin(Pin):
-    pass
+    opaqueAction: relation_many[OpaqueAction]
 
 
 class Manifestation(Abstraction):
@@ -758,6 +758,12 @@ class InformationFlow(DirectedRelationship, PackageableElement):
     realizingMessage: relation_many[Message]
 
 
+class OpaqueAction(Action):
+    body: _attribute[str] = _attribute("body", str)
+    inputValue: relation_many[InputPin]
+    outputValue: relation_many[OutputPin]
+
+
 # 86: override Lifeline.parse: Callable[[Lifeline, str], None]
 # defined in umloverrides.py
 
@@ -963,6 +969,7 @@ Element.directedRelationship.add(UseCase.extend)  # type: ignore[attr-defined]
 Namespace.ownedMember.add(UseCase.extend)  # type: ignore[attr-defined]
 Element.directedRelationship.add(UseCase.include)  # type: ignore[attr-defined]
 Namespace.ownedMember.add(UseCase.include)  # type: ignore[attr-defined]
+InputPin.opaqueAction = association("opaqueAction", OpaqueAction, opposite="inputValue")
 Manifestation.artifact = association("artifact", Artifact, upper=1, opposite="manifestation")
 Element.owner.add(Manifestation.artifact)  # type: ignore[attr-defined]
 Component.packagedElement = association("packagedElement", PackageableElement, composite=True, opposite="component")
@@ -1122,13 +1129,13 @@ NamedElement.namespace.add(Operation.artifact)  # type: ignore[attr-defined]
 RedefinableElement.redefinitionContext.add(Operation.artifact)  # type: ignore[attr-defined]
 NamedElement.namespace.add(Operation.interface_)  # type: ignore[attr-defined]
 Feature.featuringClassifier.add(Operation.interface_)  # type: ignore[attr-defined]
-Action.input = derivedunion("input", InputPin)
-Action.output = derivedunion("output", OutputPin)
 Action.interaction = association("interaction", Interaction, upper=1, opposite="action")
 Action.context_ = derivedunion("context_", Classifier, upper=1)
+Action.input = derivedunion("input", InputPin)
+Action.output = derivedunion("output", OutputPin)
+Element.owner.add(Action.interaction)  # type: ignore[attr-defined]
 Element.ownedElement.add(Action.input)  # type: ignore[attr-defined]
 Element.ownedElement.add(Action.output)  # type: ignore[attr-defined]
-Element.owner.add(Action.interaction)  # type: ignore[attr-defined]
 Extend.extension = association("extension", UseCase, upper=1, opposite="extend")
 Extend.extensionLocation = association("extensionLocation", ExtensionPoint, lower=1)
 Extend.constraint = association("constraint", Constraint, upper=1, composite=True)
@@ -1297,3 +1304,7 @@ InformationFlow.informationTarget = association("informationTarget", NamedElemen
 Element.owner.add(InformationFlow.realizingConnector)  # type: ignore[attr-defined]
 DirectedRelationship.source.add(InformationFlow.informationSource)  # type: ignore[attr-defined]
 DirectedRelationship.target.add(InformationFlow.informationTarget)  # type: ignore[attr-defined]
+OpaqueAction.outputValue = association("outputValue", OutputPin, composite=True)
+OpaqueAction.inputValue = association("inputValue", InputPin, composite=True, opposite="opaqueAction")
+Action.output.add(OpaqueAction.outputValue)  # type: ignore[attr-defined]
+Action.input.add(OpaqueAction.inputValue)  # type: ignore[attr-defined]

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -405,7 +405,10 @@ class AttachedPresentation(HandlePositionUpdate, Presentation[S]):
 
     @width.setter
     def width(self, width):
-        rv = width / 2
+        self.update_width(width)
+
+    def update_width(self, width, factor=0.5):
+        rv = width * factor
         top_left, _, bottom_right, _ = self._corners
         handle_pos = self._handle.pos
         connections = self._connections
@@ -413,7 +416,7 @@ class AttachedPresentation(HandlePositionUpdate, Presentation[S]):
             connections.remove_constraint(self, c)
 
         self._width_constraints = [
-            constraint(vertical=(top_left, handle_pos), delta=rv),
+            constraint(vertical=(top_left, handle_pos), delta=width - rv),
             constraint(vertical=(handle_pos, bottom_right), delta=rv),
         ]
 
@@ -428,7 +431,10 @@ class AttachedPresentation(HandlePositionUpdate, Presentation[S]):
 
     @height.setter
     def height(self, height):
-        rh = height / 2
+        self.update_height(height)
+
+    def update_height(self, height, factor=0.5):
+        rh = height * factor
         top_left, _, bottom_right, _ = self._corners
         handle_pos = self._handle.pos
         connections = self._connections
@@ -436,7 +442,7 @@ class AttachedPresentation(HandlePositionUpdate, Presentation[S]):
             connections.remove_constraint(self, c)
 
         self._height_constraints = [
-            constraint(horizontal=(top_left, handle_pos), delta=rh),
+            constraint(horizontal=(top_left, handle_pos), delta=height - rh),
             constraint(horizontal=(handle_pos, bottom_right), delta=rh),
         ]
 

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -497,10 +497,15 @@ class AttachedPresentation(HandlePositionUpdate, Presentation[S]):
         if c := self._connections.get_connection(self._handle):
             save_func("connection", c.connected)
 
+        point = tuple(map(float, self._handle.pos))
+        save_func("point", point)
+
         super().save(save_func)
 
     def load(self, name, value):
-        if name == "connection":
+        if name == "point":
+            self._handle.pos = ast.literal_eval(value)
+        elif name == "connection":
             self._load_connection = value
         else:
             super().load(name, value)

--- a/gaphor/ui/icons/Makefile
+++ b/gaphor/ui/icons/Makefile
@@ -39,6 +39,8 @@ ICONS=diagram \
 	initial-node \
 	activity-final-node \
 	activity-parameter-node \
+	input-pin \
+	output-pin \
 	flow-final-node \
 	decision-node \
 	fork-node \

--- a/gaphor/ui/icons/hicolor/scalable/actions/gaphor-input-pin-symbolic.svg
+++ b/gaphor/ui/icons/hicolor/scalable/actions/gaphor-input-pin-symbolic.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="9.9950857"
+   height="15.996572"
+   viewBox="0 0 2.644533 4.2324263"
+   version="1.1"
+   id="svg4268"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4262" />
+  <metadata
+     id="metadata4265">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="input-pin"
+     transform="translate(-2.1171875,-58.208982)">
+    <path
+       style="color:#000000;fill:#000000;stroke-linecap:round;-inkscape-stroke:none"
+       d="m 4.4980488,58.208984 a 0.26458335,0.26458335 0 0 1 0.2636719,0.263672 v 3.705078 a 0.26458335,0.26458335 0 0 1 -0.2636719,0.263672 0.26458335,0.26458335 0 0 1 -0.265625,-0.263672 v -3.705078 a 0.26458335,0.26458335 0 0 1 0.265625,-0.263672 z"
+       id="path8758" />
+    <path
+       style="color:#000000;fill:#000000;stroke-linejoin:round;-inkscape-stroke:none"
+       d="M 4.2324238,59.001953 V 59.53125 H 2.6464863 v 1.587891 h 1.5859375 v 0.529296 H 2.3808613 A 0.26460996,0.26460996 0 0 1 2.1171895,61.382812 v -2.115234 a 0.26460996,0.26460996 0 0 1 0.2636718,-0.265625 z"
+       id="path8793" />
+  </g>
+</svg>

--- a/gaphor/ui/icons/hicolor/scalable/actions/gaphor-output-pin-symbolic.svg
+++ b/gaphor/ui/icons/hicolor/scalable/actions/gaphor-output-pin-symbolic.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="9.9950848"
+   height="15.996572"
+   viewBox="0 0 2.6445328 4.2324263"
+   version="1.1"
+   id="svg4268"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4262" />
+  <metadata
+     id="metadata4265">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="output-pin"
+     transform="translate(-10.054036,-58.209112)">
+    <path
+       style="color:#000000;fill:#000000;stroke-linecap:round;-inkscape-stroke:none"
+       d="m 10.317708,58.209114 a 0.26458335,0.26458335 0 0 0 -0.263672,0.263672 v 3.705078 a 0.26458335,0.26458335 0 0 0 0.263672,0.263672 0.26458335,0.26458335 0 0 0 0.265625,-0.263672 v -3.705078 a 0.26458335,0.26458335 0 0 0 -0.265625,-0.263672 z"
+       id="path8758-3" />
+    <path
+       style="color:#000000;fill:#000000;stroke-linejoin:round;-inkscape-stroke:none"
+       d="m 10.583333,59.002083 v 0.529297 h 1.585938 v 1.587891 h -1.585938 v 0.529296 h 1.851563 a 0.26460996,0.26460996 0 0 0 0.263671,-0.265625 v -2.115234 a 0.26460996,0.26460996 0 0 0 -0.263671,-0.265625 z"
+       id="path8793-0" />
+  </g>
+</svg>

--- a/gaphor/ui/icons/stensil.svg
+++ b/gaphor/ui/icons/stensil.svg
@@ -59,11 +59,11 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.656854"
-     inkscape:cx="95.194255"
-     inkscape:cy="179.25158"
+     inkscape:zoom="11.313708"
+     inkscape:cx="42.205438"
+     inkscape:cy="214.51853"
      inkscape:document-units="px"
-     inkscape:current-layer="activity-parameter-node"
+     inkscape:current-layer="output-pin"
      showgrid="true"
      units="px"
      inkscape:window-width="1920"
@@ -1025,6 +1025,38 @@
        height="4.2333331"
        width="4.2333331"
        id="rect1242"
+       style="display:inline;overflow:visible;visibility:visible;fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.132292;marker:none;enable-background:accumulate" />
+    <rect
+       inkscape:label="512x512"
+       y="58.208332"
+       x="1.3229169"
+       height="4.2333331"
+       width="4.2333331"
+       id="rect1242-4"
+       style="display:inline;overflow:visible;visibility:visible;fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.132292;marker:none;enable-background:accumulate" />
+    <rect
+       inkscape:label="512x512"
+       y="58.208332"
+       x="9.260417"
+       height="4.2333331"
+       width="4.2333331"
+       id="rect1242-5"
+       style="display:inline;overflow:visible;visibility:visible;fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.132292;marker:none;enable-background:accumulate" />
+    <rect
+       inkscape:label="512x512"
+       y="58.208332"
+       x="17.197916"
+       height="4.2333331"
+       width="4.2333331"
+       id="rect1242-2"
+       style="display:inline;overflow:visible;visibility:visible;fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.132292;marker:none;enable-background:accumulate" />
+    <rect
+       inkscape:label="512x512"
+       y="58.208332"
+       x="25.135416"
+       height="4.2333331"
+       width="4.2333331"
+       id="rect1242-54"
        style="display:inline;overflow:visible;visibility:visible;fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.132292;marker:none;enable-background:accumulate" />
     <rect
        inkscape:label="512x512"
@@ -3692,6 +3724,32 @@
        id="path2847-3"
        style="color:#000000;fill:#000000;stroke-linecap:round;-inkscape-stroke:none"
        d="m 19.314453,54.240234 a 0.2645835,0.2645835 0 0 0 -0.263672,0.263672 V 55.5625 a 0.2645835,0.2645835 0 0 0 0.263672,0.263672 0.2645835,0.2645835 0 0 0 0.265625,-0.263672 v -1.058594 a 0.2645835,0.2645835 0 0 0 -0.265625,-0.263672 z m 0,-2.646484 a 0.2645835,0.2645835 0 0 0 -0.263672,0.263672 v 1.058594 a 0.2645835,0.2645835 0 0 0 0.263672,0.265625 0.2645835,0.2645835 0 0 0 0.265625,-0.265625 V 51.857422 A 0.2645835,0.2645835 0 0 0 19.314453,51.59375 Z m -1.587891,1.058594 a 0.26460996,0.26460996 0 0 0 -0.263671,0.263672 v 1.58789 a 0.26460996,0.26460996 0 0 0 0.263671,0.265625 h 3.175782 a 0.26460996,0.26460996 0 0 0 0.263672,-0.265625 v -1.58789 a 0.26460996,0.26460996 0 0 0 -0.263672,-0.263672 z m 0.265625,0.529297 h 2.644532 v 1.058593 h -2.644532 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="input-pin"
+     inkscape:label="input-pin">
+    <path
+       style="color:#000000;fill:#000000;stroke-linecap:round;-inkscape-stroke:none"
+       d="m 4.4980488,58.208984 a -0.26458335,0.26458335 0 0 1 0.2636719,0.263672 v 3.705078 a -0.26458335,0.26458335 0 0 1 -0.2636719,0.263672 -0.26458335,0.26458335 0 0 1 -0.265625,-0.263672 v -3.705078 a -0.26458335,0.26458335 0 0 1 0.265625,-0.263672 z"
+       id="path8758" />
+    <path
+       style="color:#000000;fill:#000000;stroke-linejoin:round;-inkscape-stroke:none"
+       d="M 4.2324238,59.001953 V 59.53125 H 2.6464863 v 1.587891 h 1.5859375 v 0.529296 H 2.3808613 A -0.26460996,0.26460996 0 0 1 2.1171895,61.382812 v -2.115234 a -0.26460996,0.26460996 0 0 1 0.2636718,-0.265625 z"
+       id="path8793" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="output-pin"
+     inkscape:label="output-pin">
+    <path
+       style="color:#000000;fill:#000000;stroke-linecap:round;-inkscape-stroke:none"
+       d="m 10.317708,58.209114 a 0.26458335,0.26458335 0 0 0 -0.263672,0.263672 v 3.705078 a 0.26458335,0.26458335 0 0 0 0.263672,0.263672 0.26458335,0.26458335 0 0 0 0.265625,-0.263672 v -3.705078 a 0.26458335,0.26458335 0 0 0 -0.265625,-0.263672 z"
+       id="path8758-3" />
+    <path
+       style="color:#000000;fill:#000000;stroke-linejoin:round;-inkscape-stroke:none"
+       d="m 10.583333,59.002083 v 0.529297 h 1.585938 v 1.587891 h -1.585938 v 0.529296 h 1.851563 a 0.26460996,0.26460996 0 0 0 0.263671,-0.265625 v -2.115234 a 0.26460996,0.26460996 0 0 0 -0.263671,-0.265625 z"
+       id="path8793-0" />
   </g>
   <g
      inkscape:groupmode="layer"

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -68,40 +68,6 @@
 <ref refid="DCE:F3BF94AC-4B55-11D7-A5E6-6257AF3C5118"/>
 </type>
 </Property>
-<Property id="DCE:B3278BE6-8404-11D8-82A2-7B88E55A3BEC">
-<appliedStereotype>
-<reflist>
-<ref refid="13740e40-ea03-11ea-96dc-bf74f1f80424"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:B3236B06-8404-11D8-82A2-7B88E55A3BEC"/>
-</association>
-<isDerived>
-<val>1</val>
-</isDerived>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<name>
-<val>action</val>
-</name>
-<owningAssociation>
-<ref refid="DCE:B3236B06-8404-11D8-82A2-7B88E55A3BEC"/>
-</owningAssociation>
-<type>
-<ref refid="DCE:0599D668-8324-11D8-8D1E-00C00C03A405"/>
-</type>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-</Property>
 <Generalization id="DCE:D750F4D4-509E-11D7-9F0D-F80F4B06507D">
 <general>
 <ref refid="DCE:22B3AA56-4B32-11D7-B391-02BBFE4396CE"/>
@@ -2361,12 +2327,11 @@
 <ref refid="00ee85c5-63cb-11eb-9492-9757bcbe474b"/>
 <ref refid="00ee85c7-63cb-11eb-9492-9757bcbe474b"/>
 <ref refid="c00771c8-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="0ab9cbf2-bcd7-11ec-bbef-0456e5e540ed"/>
 <ref refid="DCE:4461CCDC-8404-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:475CAA06-8404-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:6EC789E0-8404-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:88A1BF5E-8404-11D8-82A2-7B88E55A3BEC"/>
-<ref refid="DCE:B191E972-8404-11D8-82A2-7B88E55A3BEC"/>
-<ref refid="DCE:B76EF5FC-8404-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="49f2b566-ea03-11ea-96dc-bf74f1f80424"/>
 <ref refid="530f1356-ea03-11ea-96dc-bf74f1f80424"/>
 <ref refid="00ee85c6-63cb-11eb-9492-9757bcbe474b"/>
@@ -2374,6 +2339,8 @@
 <ref refid="ddaa5448-bb63-11ec-a9db-0456e5e540ed"/>
 <ref refid="e8f92f0e-bb63-11ec-a9db-0456e5e540ed"/>
 <ref refid="a7c9194e-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="0f76233e-bcd7-11ec-bbef-0456e5e540ed"/>
+<ref refid="15f5aa2c-bcd7-11ec-bbef-0456e5e540ed"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
@@ -2613,7 +2580,7 @@
 </GeneralizationItem>
 <ClassItem id="DCE:96EB8F86-8404-11D8-82A2-7B88E55A3BEC">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 282.5, 175.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 264.19845298525513, 170.5)</val>
 </matrix>
 <width>
 <val>157.5</val>
@@ -2637,76 +2604,6 @@
 <ref refid="DCE:0599D668-8324-11D8-8D1E-00C00C03A405"/>
 </subject>
 </ClassItem>
-<AssociationItem id="DCE:B191E972-8404-11D8-82A2-7B88E55A3BEC">
-<diagram>
-<ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
-</diagram>
-<head_subject>
-<ref refid="DCE:B325D614-8404-11D8-82A2-7B88E55A3BEC"/>
-</head_subject>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
-<subject>
-<ref refid="DCE:B3236B06-8404-11D8-82A2-7B88E55A3BEC"/>
-</subject>
-<tail_subject>
-<ref refid="DCE:B3278BE6-8404-11D8-82A2-7B88E55A3BEC"/>
-</tail_subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 496.0, 416.0)</val>
-</matrix>
-<points>
-<val>[(56.0, 204.5), (152.0, 204.5), (152.0, -190.5), (-56.0, -190.5)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:2A9E26DE-8404-11D8-82A2-7B88E55A3BEC"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:96EB8F86-8404-11D8-82A2-7B88E55A3BEC"/>
-</tail-connection>
-</AssociationItem>
-<AssociationItem id="DCE:B76EF5FC-8404-11D8-82A2-7B88E55A3BEC">
-<diagram>
-<ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
-</diagram>
-<head_subject>
-<ref refid="DCE:B89D7F92-8404-11D8-82A2-7B88E55A3BEC"/>
-</head_subject>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
-<subject>
-<ref refid="DCE:B89BAA8A-8404-11D8-82A2-7B88E55A3BEC"/>
-</subject>
-<tail_subject>
-<ref refid="DCE:B8A0A756-8404-11D8-82A2-7B88E55A3BEC"/>
-</tail_subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 185.0, 411.0)</val>
-</matrix>
-<points>
-<val>[(-84.0, 197.5), (-151.0, 197.5), (-151.0, -189.0), (97.5, -189.0)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:2DF0AAAC-8404-11D8-82A2-7B88E55A3BEC"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:96EB8F86-8404-11D8-82A2-7B88E55A3BEC"/>
-</tail-connection>
-</AssociationItem>
 <ClassItem id="2dec7b54-ea03-11ea-96dc-bf74f1f80424">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 464.958984375, 933.0)</val>
@@ -2807,7 +2704,7 @@
 </GeneralizationItem>
 <ClassItem id="00ee85c5-63cb-11eb-9492-9757bcbe474b">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 283.4404761904762, 48.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 265.1528281363308, 43.0)</val>
 </matrix>
 <width>
 <val>157.0</val>
@@ -2848,7 +2745,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 675.0, 138.0)</val>
 </matrix>
 <points>
-<val>[(-314.0, 37.5), (-314.0, -28.0)]</val>
+<val>[(-332.30154701474487, 32.5), (-332.2876480541454, -33.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:96EB8F86-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -2859,7 +2756,7 @@
 </GeneralizationItem>
 <ClassItem id="00ee85c7-63cb-11eb-9492-9757bcbe474b">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 699.5, 74.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 552.0, 91.0)</val>
 </matrix>
 <width>
 <val>156.0</val>
@@ -2909,7 +2806,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 669.25, 269.0)</val>
 </matrix>
 <points>
-<val>[(-229.25, -82.0), (-129.25, -82.0), (-129.25, -162.42255758220816), (30.25, -162.42255758220816)]</val>
+<val>[(-247.55154701474487, -87.0), (-189.25, -87.0), (-189.25, -145.42255758220816), (-117.25, -145.42255758220816)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:96EB8F86-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -4578,58 +4475,6 @@
 <visibility>
 <val>public</val>
 </visibility>
-</Property>
-<Association id="DCE:B3236B06-8404-11D8-82A2-7B88E55A3BEC">
-<memberEnd>
-<reflist>
-<ref refid="DCE:B3278BE6-8404-11D8-82A2-7B88E55A3BEC"/>
-<ref refid="DCE:B325D614-8404-11D8-82A2-7B88E55A3BEC"/>
-</reflist>
-</memberEnd>
-<ownedEnd>
-<reflist>
-<ref refid="DCE:B3278BE6-8404-11D8-82A2-7B88E55A3BEC"/>
-</reflist>
-</ownedEnd>
-<package>
-<ref refid="DCE:971866A8-379D-11D9-9FA4-00C00C03A405"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="DCE:B191E972-8404-11D8-82A2-7B88E55A3BEC"/>
-</reflist>
-</presentation>
-</Association>
-<Property id="DCE:B89D7F92-8404-11D8-82A2-7B88E55A3BEC">
-<aggregation>
-<val>composite</val>
-</aggregation>
-<appliedStereotype>
-<reflist>
-<ref refid="1709d486-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:B89BAA8A-8404-11D8-82A2-7B88E55A3BEC"/>
-</association>
-<class_>
-<ref refid="DCE:0599D668-8324-11D8-8D1E-00C00C03A405"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<name>
-<val>input</val>
-</name>
-<type>
-<ref refid="DCE:2DF4E17E-8404-11D8-82A2-7B88E55A3BEC"/>
-</type>
-<upperValue>
-<val>*</val>
-</upperValue>
-<upperValue>
-<val>*</val>
-</upperValue>
 </Property>
 <Generalization id="DCE:4A9BD768-A35C-11D8-9D85-00C00C03A405">
 <general>
@@ -6638,7 +6483,7 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="e9db2742-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="fb7d3a84-bcd6-11ec-bbef-0456e5e540ed"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -12394,40 +12239,6 @@
 </upperValue>
 <upperValue>
 <val>*</val>
-</upperValue>
-</Property>
-<Property id="DCE:B8A0A756-8404-11D8-82A2-7B88E55A3BEC">
-<appliedStereotype>
-<reflist>
-<ref refid="0a6f4a58-ea03-11ea-96dc-bf74f1f80424"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:B89BAA8A-8404-11D8-82A2-7B88E55A3BEC"/>
-</association>
-<isDerived>
-<val>1</val>
-</isDerived>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<name>
-<val>action</val>
-</name>
-<owningAssociation>
-<ref refid="DCE:B89BAA8A-8404-11D8-82A2-7B88E55A3BEC"/>
-</owningAssociation>
-<type>
-<ref refid="DCE:0599D668-8324-11D8-8D1E-00C00C03A405"/>
-</type>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
 </upperValue>
 </Property>
 <Property id="DCE:BAEADF3E-65C6-11D7-89A9-9C62884CFFDE">
@@ -20931,27 +20742,6 @@ specially for Gaphor</val>
 <val>1</val>
 </upperValue>
 </Property>
-<Association id="DCE:B89BAA8A-8404-11D8-82A2-7B88E55A3BEC">
-<memberEnd>
-<reflist>
-<ref refid="DCE:B89D7F92-8404-11D8-82A2-7B88E55A3BEC"/>
-<ref refid="DCE:B8A0A756-8404-11D8-82A2-7B88E55A3BEC"/>
-</reflist>
-</memberEnd>
-<ownedEnd>
-<reflist>
-<ref refid="DCE:B8A0A756-8404-11D8-82A2-7B88E55A3BEC"/>
-</reflist>
-</ownedEnd>
-<package>
-<ref refid="DCE:971866A8-379D-11D9-9FA4-00C00C03A405"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="DCE:B76EF5FC-8404-11D8-82A2-7B88E55A3BEC"/>
-</reflist>
-</presentation>
-</Association>
 <Property id="DCE:E1377E1A-4B34-11D7-B391-02BBFE4396CE">
 <appliedStereotype>
 <reflist>
@@ -21856,6 +21646,11 @@ specially for Gaphor</val>
 <name>
 <val>OutputPin</val>
 </name>
+<ownedAttribute>
+<reflist>
+<ref refid="fe019dcc-bcd6-11ec-bbef-0456e5e540ed"/>
+</reflist>
+</ownedAttribute>
 <package>
 <ref refid="a3b505ae-3801-11e0-87bf-0021e9e5a3cd"/>
 </package>
@@ -22867,9 +22662,10 @@ specially for Gaphor</val>
 <reflist>
 <ref refid="DCE:9B2CD32A-8404-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="5f66f3a9-5561-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="fe01ddc8-bcd6-11ec-bbef-0456e5e540ed"/>
+<ref refid="fb7d80f2-bcd6-11ec-bbef-0456e5e540ed"/>
+<ref refid="ac6e961c-bd9a-11ec-a4df-0456e5e540ed"/>
 <ref refid="DCE:24AA3F0E-8324-11D8-8D1E-00C00C03A405"/>
-<ref refid="DCE:B89D7F92-8404-11D8-82A2-7B88E55A3BEC"/>
-<ref refid="DCE:B325D614-8404-11D8-82A2-7B88E55A3BEC"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -26639,37 +26435,6 @@ specially for Gaphor</val>
 <ref refid="DCE:6C8F2E88-4B3D-11D7-B391-02BBFE4396CE"/>
 </type>
 </Property>
-<Property id="DCE:B325D614-8404-11D8-82A2-7B88E55A3BEC">
-<aggregation>
-<val>composite</val>
-</aggregation>
-<appliedStereotype>
-<reflist>
-<ref refid="17630d8a-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:B3236B06-8404-11D8-82A2-7B88E55A3BEC"/>
-</association>
-<class_>
-<ref refid="DCE:0599D668-8324-11D8-8D1E-00C00C03A405"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<name>
-<val>output</val>
-</name>
-<type>
-<ref refid="DCE:2AA1B3CA-8404-11D8-82A2-7B88E55A3BEC"/>
-</type>
-<upperValue>
-<val>*</val>
-</upperValue>
-<upperValue>
-<val>*</val>
-</upperValue>
-</Property>
 <Generalization id="DCE:04A9AC5C-A41D-11D8-B0B1-00061BC22919">
 <general>
 <ref refid="DCE:F3BF94AC-4B55-11D7-A5E6-6257AF3C5118"/>
@@ -27181,7 +26946,6 @@ directly in a model.</val>
 <ref refid="DCE:BEBC1974-8402-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:3CF6BFB2-8403-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:41E88FF4-8405-11D8-82A2-7B88E55A3BEC"/>
-<ref refid="DCE:B3236B06-8404-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:B2B2706C-8324-11D8-8D1E-00C00C03A405"/>
 <ref refid="DCE:3AEC26CA-8405-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:7F971C42-8406-11D8-82A2-7B88E55A3BEC"/>
@@ -27203,7 +26967,6 @@ directly in a model.</val>
 <ref refid="DCE:3DD222A6-8405-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:99210436-8321-11D8-BEC8-00C00C03A405"/>
 <ref refid="DCE:4AB79F34-8403-11D8-82A2-7B88E55A3BEC"/>
-<ref refid="DCE:B89BAA8A-8404-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:0BCB2D7E-8403-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:FB6167F2-8405-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:E0CC5228-8406-11D8-82A2-7B88E55A3BEC"/>
@@ -38223,6 +37986,10 @@ swimlanes</val>
 <ref refid="e64aa2be-bb64-11ec-a9db-0456e5e540ed"/>
 <ref refid="f67638b0-bb64-11ec-a9db-0456e5e540ed"/>
 <ref refid="0886a7d8-bb65-11ec-a9db-0456e5e540ed"/>
+<ref refid="c9c15f20-bd99-11ec-8a35-0456e5e540ed"/>
+<ref refid="d0ed71e4-bd99-11ec-8a35-0456e5e540ed"/>
+<ref refid="dcd19c7e-bd99-11ec-8a35-0456e5e540ed"/>
+<ref refid="e1ebcfd6-bd99-11ec-8a35-0456e5e540ed"/>
 </reflist>
 </slot>
 <typeValue>
@@ -38940,11 +38707,6 @@ swimlanes</val>
 <ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
 </reflist>
 </classifier>
-<extended>
-<reflist>
-<ref refid="DCE:B89D7F92-8404-11D8-82A2-7B88E55A3BEC"/>
-</reflist>
-</extended>
 <slot>
 <reflist>
 <ref refid="170ae650-fa90-11de-bd51-00224128e79d"/>
@@ -42499,11 +42261,6 @@ swimlanes</val>
 <ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
 </reflist>
 </classifier>
-<extended>
-<reflist>
-<ref refid="DCE:B325D614-8404-11D8-82A2-7B88E55A3BEC"/>
-</reflist>
-</extended>
 <slot>
 <reflist>
 <ref refid="1763574a-fa90-11de-bd51-00224128e79d"/>
@@ -44764,8 +44521,8 @@ to accommodate simpleAttribute</val>
 <ref refid="72139548-909d-11ea-9685-03ae027faeeb"/>
 <ref refid="85907820-909d-11ea-9685-03ae027faeeb"/>
 <ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
-<ref refid="e9dae53e-bb63-11ec-a9db-0456e5e540ed"/>
-<ref refid="a877e640-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="fb7d0c30-bcd6-11ec-bbef-0456e5e540ed"/>
+<ref refid="fe017400-bcd6-11ec-bbef-0456e5e540ed"/>
 </reflist>
 </ownedType>
 <presentation>
@@ -52728,11 +52485,6 @@ association:not([memberEnd.navigability*=true]) {
 <ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
 </reflist>
 </classifier>
-<extended>
-<reflist>
-<ref refid="DCE:B8A0A756-8404-11D8-82A2-7B88E55A3BEC"/>
-</reflist>
-</extended>
 <slot>
 <reflist>
 <ref refid="0c5383a2-ea03-11ea-96dc-bf74f1f80424"/>
@@ -52756,11 +52508,6 @@ association:not([memberEnd.navigability*=true]) {
 <ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
 </reflist>
 </classifier>
-<extended>
-<reflist>
-<ref refid="DCE:B3278BE6-8404-11D8-82A2-7B88E55A3BEC"/>
-</reflist>
-</extended>
 <slot>
 <reflist>
 <ref refid="150a110a-ea03-11ea-96dc-bf74f1f80424"/>
@@ -55618,8 +55365,6 @@ have an opposite end.
 <ownedAttribute>
 <reflist>
 <ref refid="cf4d4b3a-bb63-11ec-a9db-0456e5e540ed"/>
-<ref refid="a8783654-bb64-11ec-a9db-0456e5e540ed"/>
-<ref refid="e9db4aa6-bb63-11ec-a9db-0456e5e540ed"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -55633,7 +55378,7 @@ have an opposite end.
 </Class>
 <ClassItem id="c00771c8-bb63-11ec-a9db-0456e5e540ed">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 301.5, 354.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 283.19845298525513, 349.0)</val>
 </matrix>
 <width>
 <val>119.0</val>
@@ -55676,7 +55421,7 @@ have an opposite end.
 <val>(1.0, 0.0, 0.0, 1.0, 363.0, 271.0)</val>
 </matrix>
 <points>
-<val>[(-0.3551486584481438, 83.0), (0.14485134155188462, 3.5)]</val>
+<val>[(-18.656695673192985, 78.0), (-18.156695673192985, -1.5)]</val>
 </points>
 <head-connection>
 <ref refid="c00771c8-bb63-11ec-a9db-0456e5e540ed"/>
@@ -55703,7 +55448,7 @@ have an opposite end.
 <ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
 <head_subject>
-<ref refid="e9db2742-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="fb7d3a84-bcd6-11ec-bbef-0456e5e540ed"/>
 </head_subject>
 <horizontal>
 <val>1</val>
@@ -55712,92 +55457,30 @@ have an opposite end.
 <val>1</val>
 </orthogonal>
 <subject>
-<ref refid="e9dae53e-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="fb7d0c30-bcd6-11ec-bbef-0456e5e540ed"/>
 </subject>
 <tail_subject>
-<ref refid="e9db4aa6-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="fb7d80f2-bcd6-11ec-bbef-0456e5e540ed"/>
 </tail_subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 329.0, 412.0)</val>
 </matrix>
 <points>
-<val>[(-27.5, -21.0), (-165.25, -21.0), (-165.25, 166.0)]</val>
+<val>[(-64.80154701474487, -158.0), (-165.25, -158.0), (-165.25, 166.0)]</val>
 </points>
 <head-connection>
-<ref refid="c00771c8-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="DCE:96EB8F86-8404-11D8-82A2-7B88E55A3BEC"/>
 </head-connection>
 <tail-connection>
 <ref refid="DCE:2DF0AAAC-8404-11D8-82A2-7B88E55A3BEC"/>
 </tail-connection>
 </AssociationItem>
-<Association id="e9dae53e-bb63-11ec-a9db-0456e5e540ed">
-<memberEnd>
-<reflist>
-<ref refid="e9db2742-bb63-11ec-a9db-0456e5e540ed"/>
-<ref refid="e9db4aa6-bb63-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</memberEnd>
-<package>
-<ref refid="a3b505ae-3801-11e0-87bf-0021e9e5a3cd"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="e8f92f0e-bb63-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</presentation>
-</Association>
-<Property id="e9db2742-bb63-11ec-a9db-0456e5e540ed">
-<appliedStereotype>
-<reflist>
-<ref refid="fcc475fc-bb63-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="e9dae53e-bb63-11ec-a9db-0456e5e540ed"/>
-</association>
-<class_>
-<ref refid="DCE:2DF4E17E-8404-11D8-82A2-7B88E55A3BEC"/>
-</class_>
-<name>
-<val>opaqueAction</val>
-</name>
-<type>
-<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
-</type>
-</Property>
-<Property id="e9db4aa6-bb63-11ec-a9db-0456e5e540ed">
-<aggregation>
-<val>composite</val>
-</aggregation>
-<appliedStereotype>
-<reflist>
-<ref refid="06129d7c-bb65-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="e9dae53e-bb63-11ec-a9db-0456e5e540ed"/>
-</association>
-<class_>
-<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
-</class_>
-<name>
-<val>inputValue</val>
-</name>
-<type>
-<ref refid="DCE:2DF4E17E-8404-11D8-82A2-7B88E55A3BEC"/>
-</type>
-</Property>
 <InstanceSpecification id="fcc475fc-bb63-11ec-a9db-0456e5e540ed">
 <classifier>
 <reflist>
 <ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
 </reflist>
 </classifier>
-<extended>
-<reflist>
-<ref refid="e9db2742-bb63-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</extended>
 <slot>
 <reflist>
 <ref refid="018d75f2-bb64-11ec-a9db-0456e5e540ed"/>
@@ -55820,7 +55503,7 @@ have an opposite end.
 <ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
 <head_subject>
-<ref refid="a87815ca-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="fe019dcc-bcd6-11ec-bbef-0456e5e540ed"/>
 </head_subject>
 <horizontal>
 <val>1</val>
@@ -55829,97 +55512,30 @@ have an opposite end.
 <val>1</val>
 </orthogonal>
 <subject>
-<ref refid="a877e640-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="fe017400-bcd6-11ec-bbef-0456e5e540ed"/>
 </subject>
 <tail_subject>
-<ref refid="a8783654-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="fe01ddc8-bcd6-11ec-bbef-0456e5e540ed"/>
 </tail_subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 397.0, 393.0)</val>
 </matrix>
 <points>
-<val>[(23.5, -2.0), (92.5, -2.0), (92.5, 192.0)]</val>
+<val>[(24.69845298525513, -139.0), (92.5, -139.0), (92.5, 192.0)]</val>
 </points>
 <head-connection>
-<ref refid="c00771c8-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="DCE:96EB8F86-8404-11D8-82A2-7B88E55A3BEC"/>
 </head-connection>
 <tail-connection>
 <ref refid="DCE:2A9E26DE-8404-11D8-82A2-7B88E55A3BEC"/>
 </tail-connection>
 </AssociationItem>
-<Association id="a877e640-bb64-11ec-a9db-0456e5e540ed">
-<memberEnd>
-<reflist>
-<ref refid="a87815ca-bb64-11ec-a9db-0456e5e540ed"/>
-<ref refid="a8783654-bb64-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</memberEnd>
-<ownedEnd>
-<reflist>
-<ref refid="a87815ca-bb64-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</ownedEnd>
-<package>
-<ref refid="a3b505ae-3801-11e0-87bf-0021e9e5a3cd"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="a7c9194e-bb64-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</presentation>
-</Association>
-<Property id="a87815ca-bb64-11ec-a9db-0456e5e540ed">
-<appliedStereotype>
-<reflist>
-<ref refid="e300c0fc-bb64-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="a877e640-bb64-11ec-a9db-0456e5e540ed"/>
-</association>
-<name>
-<val>opaqueAction</val>
-</name>
-<owningAssociation>
-<ref refid="a877e640-bb64-11ec-a9db-0456e5e540ed"/>
-</owningAssociation>
-<type>
-<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
-</type>
-</Property>
-<Property id="a8783654-bb64-11ec-a9db-0456e5e540ed">
-<aggregation>
-<val>composite</val>
-</aggregation>
-<appliedStereotype>
-<reflist>
-<ref refid="f4029664-bb64-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="a877e640-bb64-11ec-a9db-0456e5e540ed"/>
-</association>
-<class_>
-<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
-</class_>
-<name>
-<val>outputValue</val>
-</name>
-<type>
-<ref refid="DCE:2AA1B3CA-8404-11D8-82A2-7B88E55A3BEC"/>
-</type>
-</Property>
 <InstanceSpecification id="e300c0fc-bb64-11ec-a9db-0456e5e540ed">
 <classifier>
 <reflist>
 <ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
 </reflist>
 </classifier>
-<extended>
-<reflist>
-<ref refid="a87815ca-bb64-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</extended>
 <slot>
 <reflist>
 <ref refid="e64aa2be-bb64-11ec-a9db-0456e5e540ed"/>
@@ -55943,11 +55559,6 @@ have an opposite end.
 <ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
 </reflist>
 </classifier>
-<extended>
-<reflist>
-<ref refid="a8783654-bb64-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</extended>
 <slot>
 <reflist>
 <ref refid="f67638b0-bb64-11ec-a9db-0456e5e540ed"/>
@@ -55971,11 +55582,6 @@ have an opposite end.
 <ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
 </reflist>
 </classifier>
-<extended>
-<reflist>
-<ref refid="e9db4aa6-bb63-11ec-a9db-0456e5e540ed"/>
-</reflist>
-</extended>
 <slot>
 <reflist>
 <ref refid="0886a7d8-bb65-11ec-a9db-0456e5e540ed"/>
@@ -55993,4 +55599,360 @@ have an opposite end.
 <val>input</val>
 </value>
 </Slot>
+<Association id="fb7d0c30-bcd6-11ec-bbef-0456e5e540ed">
+<comment>
+<reflist>
+<ref refid="0ab9c422-bcd7-11ec-bbef-0456e5e540ed"/>
+</reflist>
+</comment>
+<memberEnd>
+<reflist>
+<ref refid="fb7d3a84-bcd6-11ec-bbef-0456e5e540ed"/>
+<ref refid="fb7d80f2-bcd6-11ec-bbef-0456e5e540ed"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="a3b505ae-3801-11e0-87bf-0021e9e5a3cd"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="e8f92f0e-bb63-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="fb7d3a84-bcd6-11ec-bbef-0456e5e540ed">
+<appliedStereotype>
+<reflist>
+<ref refid="c4841624-bd99-11ec-8a35-0456e5e540ed"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="fb7d0c30-bcd6-11ec-bbef-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="DCE:2DF4E17E-8404-11D8-82A2-7B88E55A3BEC"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>opaqueAction</val>
+</name>
+<type>
+<ref refid="DCE:0599D668-8324-11D8-8D1E-00C00C03A405"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<Property id="fb7d80f2-bcd6-11ec-bbef-0456e5e540ed">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<appliedStereotype>
+<reflist>
+<ref refid="cd212038-bd99-11ec-8a35-0456e5e540ed"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="fb7d0c30-bcd6-11ec-bbef-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="DCE:0599D668-8324-11D8-8D1E-00C00C03A405"/>
+</class_>
+<name>
+<val>inputValue</val>
+</name>
+<type>
+<ref refid="DCE:2DF4E17E-8404-11D8-82A2-7B88E55A3BEC"/>
+</type>
+<upperValue>
+<val>*</val>
+</upperValue>
+<upperValue>
+<val>*</val>
+</upperValue>
+</Property>
+<Association id="fe017400-bcd6-11ec-bbef-0456e5e540ed">
+<comment>
+<reflist>
+<ref refid="0ab9c422-bcd7-11ec-bbef-0456e5e540ed"/>
+</reflist>
+</comment>
+<memberEnd>
+<reflist>
+<ref refid="fe019dcc-bcd6-11ec-bbef-0456e5e540ed"/>
+<ref refid="fe01ddc8-bcd6-11ec-bbef-0456e5e540ed"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="a3b505ae-3801-11e0-87bf-0021e9e5a3cd"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="a7c9194e-bb64-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="fe019dcc-bcd6-11ec-bbef-0456e5e540ed">
+<appliedStereotype>
+<reflist>
+<ref refid="d649e438-bd99-11ec-8a35-0456e5e540ed"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="fe017400-bcd6-11ec-bbef-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="DCE:2AA1B3CA-8404-11D8-82A2-7B88E55A3BEC"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>opaqueAction</val>
+</name>
+<type>
+<ref refid="DCE:0599D668-8324-11D8-8D1E-00C00C03A405"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<Property id="fe01ddc8-bcd6-11ec-bbef-0456e5e540ed">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<appliedStereotype>
+<reflist>
+<ref refid="df5dd30e-bd99-11ec-8a35-0456e5e540ed"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="fe017400-bcd6-11ec-bbef-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="DCE:0599D668-8324-11D8-8D1E-00C00C03A405"/>
+</class_>
+<name>
+<val>outputValue</val>
+</name>
+<type>
+<ref refid="DCE:2AA1B3CA-8404-11D8-82A2-7B88E55A3BEC"/>
+</type>
+<upperValue>
+<val>*</val>
+</upperValue>
+<upperValue>
+<val>*</val>
+</upperValue>
+</Property>
+<Comment id="0ab9c422-bcd7-11ec-bbef-0456e5e540ed">
+<annotatedElement>
+<reflist>
+<ref refid="fb7d0c30-bcd6-11ec-bbef-0456e5e540ed"/>
+<ref refid="fe017400-bcd6-11ec-bbef-0456e5e540ed"/>
+</reflist>
+</annotatedElement>
+<body>
+<val>Associations have been moved from OpaqueAction to Action.</val>
+</body>
+<presentation>
+<reflist>
+<ref refid="0ab9cbf2-bcd7-11ec-bbef-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Comment>
+<CommentItem id="0ab9cbf2-bcd7-11ec-bbef-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 271.0, 439.0)</val>
+</matrix>
+<width>
+<val>125.0</val>
+</width>
+<height>
+<val>112.0</val>
+</height>
+<diagram>
+<ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
+</diagram>
+<subject>
+<ref refid="0ab9c422-bcd7-11ec-bbef-0456e5e540ed"/>
+</subject>
+</CommentItem>
+<CommentLineItem id="0f76233e-bcd7-11ec-bbef-0456e5e540ed">
+<diagram>
+<ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 248.0, 507.0)</val>
+</matrix>
+<points>
+<val>[(23.0, -19.70041543026707), (-84.25, -27.520376175548563)]</val>
+</points>
+<head-connection>
+<ref refid="0ab9cbf2-bcd7-11ec-bbef-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="e8f92f0e-bb63-11ec-a9db-0456e5e540ed"/>
+</tail-connection>
+</CommentLineItem>
+<CommentLineItem id="15f5aa2c-bcd7-11ec-bbef-0456e5e540ed">
+<diagram>
+<ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 308.0, 515.0)</val>
+</matrix>
+<points>
+<val>[(88.0, -27.70041543026707), (181.5, -35.595092024539895)]</val>
+</points>
+<head-connection>
+<ref refid="0ab9cbf2-bcd7-11ec-bbef-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="a7c9194e-bb64-11ec-a9db-0456e5e540ed"/>
+</tail-connection>
+</CommentLineItem>
+<InstanceSpecification id="c4841624-bd99-11ec-8a35-0456e5e540ed">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="fb7d3a84-bcd6-11ec-bbef-0456e5e540ed"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="c9c15f20-bd99-11ec-8a35-0456e5e540ed"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="c9c15f20-bd99-11ec-8a35-0456e5e540ed">
+<definingFeature>
+<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
+</definingFeature>
+<owningInstance>
+<ref refid="c4841624-bd99-11ec-8a35-0456e5e540ed"/>
+</owningInstance>
+<value>
+<val>owner</val>
+</value>
+</Slot>
+<InstanceSpecification id="cd212038-bd99-11ec-8a35-0456e5e540ed">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="fb7d80f2-bcd6-11ec-bbef-0456e5e540ed"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="d0ed71e4-bd99-11ec-8a35-0456e5e540ed"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="d0ed71e4-bd99-11ec-8a35-0456e5e540ed">
+<definingFeature>
+<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
+</definingFeature>
+<owningInstance>
+<ref refid="cd212038-bd99-11ec-8a35-0456e5e540ed"/>
+</owningInstance>
+<value>
+<val>ownedElement</val>
+</value>
+</Slot>
+<InstanceSpecification id="d649e438-bd99-11ec-8a35-0456e5e540ed">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="fe019dcc-bcd6-11ec-bbef-0456e5e540ed"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="dcd19c7e-bd99-11ec-8a35-0456e5e540ed"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="dcd19c7e-bd99-11ec-8a35-0456e5e540ed">
+<definingFeature>
+<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
+</definingFeature>
+<owningInstance>
+<ref refid="d649e438-bd99-11ec-8a35-0456e5e540ed"/>
+</owningInstance>
+<value>
+<val>owner</val>
+</value>
+</Slot>
+<InstanceSpecification id="df5dd30e-bd99-11ec-8a35-0456e5e540ed">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="fe01ddc8-bcd6-11ec-bbef-0456e5e540ed"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="e1ebcfd6-bd99-11ec-8a35-0456e5e540ed"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="e1ebcfd6-bd99-11ec-8a35-0456e5e540ed">
+<definingFeature>
+<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
+</definingFeature>
+<owningInstance>
+<ref refid="df5dd30e-bd99-11ec-8a35-0456e5e540ed"/>
+</owningInstance>
+<value>
+<val>ownedElement</val>
+</value>
+</Slot>
+<Property id="ac6e961c-bd9a-11ec-a4df-0456e5e540ed">
+<class_>
+<ref refid="DCE:0599D668-8324-11D8-8D1E-00C00C03A405"/>
+</class_>
+<name>
+<val>body</val>
+</name>
+<typeValue>
+<val>String</val>
+</typeValue>
+</Property>
 </gaphor>

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -2360,6 +2360,7 @@
 <ref refid="403edd6a-ea03-11ea-96dc-bf74f1f80424"/>
 <ref refid="00ee85c5-63cb-11eb-9492-9757bcbe474b"/>
 <ref refid="00ee85c7-63cb-11eb-9492-9757bcbe474b"/>
+<ref refid="c00771c8-bb63-11ec-a9db-0456e5e540ed"/>
 <ref refid="DCE:4461CCDC-8404-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:475CAA06-8404-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:6EC789E0-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -2370,12 +2371,15 @@
 <ref refid="530f1356-ea03-11ea-96dc-bf74f1f80424"/>
 <ref refid="00ee85c6-63cb-11eb-9492-9757bcbe474b"/>
 <ref refid="00ee85c9-63cb-11eb-9492-9757bcbe474b"/>
+<ref refid="ddaa5448-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="e8f92f0e-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="a7c9194e-bb64-11ec-a9db-0456e5e540ed"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
 <ClassItem id="DCE:23064746-8404-11D8-82A2-7B88E55A3BEC">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 359.5, 592.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 322.5, 794.0)</val>
 </matrix>
 <width>
 <val>209.0</val>
@@ -2398,7 +2402,7 @@
 </ClassItem>
 <ClassItem id="DCE:2A9E26DE-8404-11D8-82A2-7B88E55A3BEC">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 371.0, 380.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 427.0, 585.0)</val>
 </matrix>
 <width>
 <val>125.0</val>
@@ -2421,7 +2425,7 @@
 </ClassItem>
 <ClassItem id="DCE:2DF0AAAC-8404-11D8-82A2-7B88E55A3BEC">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 185.0, 380.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 101.0, 578.0)</val>
 </matrix>
 <width>
 <val>125.5</val>
@@ -2456,10 +2460,10 @@
 <ref refid="DCE:451778CA-8404-11D8-82A2-7B88E55A3BEC"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 492.62, 592.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 491.70203125, 794.0)</val>
 </matrix>
 <points>
-<val>[(0.0, -149.5), (0.0, -134.5), (-57.7594230769231, -134.5), (-57.7594230769231, 0.0)]</val>
+<val>[(-2.2020312500000045, -147.0), (-2.2020312500000045, -101.0), (-52.743046875000005, -101.0), (-52.743046875000005, 0.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:2A9E26DE-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -2482,10 +2486,10 @@
 <ref refid="DCE:48521FD4-8404-11D8-82A2-7B88E55A3BEC"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 451.02, 592.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 583.5708742559523, 794.0)</val>
 </matrix>
 <points>
-<val>[(-140.51999999999998, -149.5), (-140.51999999999998, -101.0), (-91.51999999999998, -101.0), (-91.51999999999998, 0.0)]</val>
+<val>[(-409.5708742559523, -154.0), (-409.5708742559523, -101.0), (-144.61188988095228, -101.0), (-144.61188988095228, 0.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:2DF0AAAC-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -2496,7 +2500,7 @@
 </GeneralizationItem>
 <ClassItem id="DCE:5014B45C-8404-11D8-82A2-7B88E55A3BEC">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 165.0, 558.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 84.0, 763.0)</val>
 </matrix>
 <width>
 <val>125.0</val>
@@ -2522,7 +2526,7 @@
 </ClassItem>
 <ClassItem id="DCE:64791782-8404-11D8-82A2-7B88E55A3BEC">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 136.5, 687.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 54.5, 889.0)</val>
 </matrix>
 <width>
 <val>174.0</val>
@@ -2569,10 +2573,10 @@
 <ref refid="DCE:70B7EEC2-8404-11D8-82A2-7B88E55A3BEC"/>
 </tail_subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 223.5, 620.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 222.5, 822.0)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (0.6444444444455257, 67.0)]</val>
+<val>[(-80.0, 3.0), (-80.35555555555447, 67.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:5014B45C-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -2595,10 +2599,10 @@
 <ref refid="DCE:8A67FB14-8404-11D8-82A2-7B88E55A3BEC"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 218.0, 442.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 217.0, 644.5)</val>
 </matrix>
 <points>
-<val>[(0.0, 115.5), (-1.5, 0.0)]</val>
+<val>[(-80.0, 118.5), (-80.0, -4.5)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:5014B45C-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -2659,7 +2663,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 496.0, 416.0)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (71.5, 0.0), (71.5, -190.5), (-56.0, -190.5)]</val>
+<val>[(56.0, 204.5), (152.0, 204.5), (152.0, -190.5), (-56.0, -190.5)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:2A9E26DE-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -2694,7 +2698,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 185.0, 411.0)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (-68.0, 0.0), (-68.0, -189.0), (97.5, -189.0)]</val>
+<val>[(-84.0, 197.5), (-151.0, 197.5), (-151.0, -189.0), (97.5, -189.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:2DF0AAAC-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -2705,7 +2709,7 @@
 </AssociationItem>
 <ClassItem id="2dec7b54-ea03-11ea-96dc-bf74f1f80424">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 506.958984375, 722.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 464.958984375, 933.0)</val>
 </matrix>
 <width>
 <val>165.0</val>
@@ -2728,7 +2732,7 @@
 </ClassItem>
 <ClassItem id="403edd6a-ea03-11ea-96dc-bf74f1f80424">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 365.958984375, 722.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 328.0, 933.0)</val>
 </matrix>
 <width>
 <val>110.0</val>
@@ -2763,10 +2767,10 @@
 <ref refid="DCE:7A536F14-8324-11D8-8D1E-00C00C03A405"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 413.958984375, 722.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 413.748046875, 924.5)</val>
 </matrix>
 <points>
-<val>[(1.6140865981365096, -64.5), (1.6140865981365096, -40.0), (47.0, -40.0), (47.0, 0.0)]</val>
+<val>[(25.2109375, -64.5), (25.2109375, -40.0), (-30.748046875, -40.0), (-30.748046875, 8.5)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:23064746-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -2789,10 +2793,10 @@
 <ref refid="530f1357-ea03-11ea-96dc-bf74f1f80424"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 546.958984375, 722.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 545.958984375, 924.5)</val>
 </matrix>
 <points>
-<val>[(0.9012451171875, -64.5), (0.9012451171875, -40.0), (-40.0, -40.0), (-40.0, 0.0)]</val>
+<val>[(-106.958984375, -64.5), (-106.958984375, -40.0), (1.5, -40.0), (1.5, 8.5)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:23064746-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -2803,7 +2807,7 @@
 </GeneralizationItem>
 <ClassItem id="00ee85c5-63cb-11eb-9492-9757bcbe474b">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 281.0, 48.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 283.4404761904762, 48.0)</val>
 </matrix>
 <width>
 <val>157.0</val>
@@ -2844,7 +2848,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 675.0, 138.0)</val>
 </matrix>
 <points>
-<val>[(-314.0, 37.5), (-315.0595238095238, -28.0)]</val>
+<val>[(-314.0, 37.5), (-314.0, -28.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:96EB8F86-8404-11D8-82A2-7B88E55A3BEC"/>
@@ -6632,6 +6636,11 @@
 <name>
 <val>InputPin</val>
 </name>
+<ownedAttribute>
+<reflist>
+<ref refid="e9db2742-bb63-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</ownedAttribute>
 <package>
 <ref refid="a3b505ae-3801-11e0-87bf-0021e9e5a3cd"/>
 </package>
@@ -22856,11 +22865,11 @@ specially for Gaphor</val>
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="DCE:B89D7F92-8404-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:9B2CD32A-8404-11D8-82A2-7B88E55A3BEC"/>
-<ref refid="DCE:B325D614-8404-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="5f66f3a9-5561-11ea-8c7d-fd01dce16f0a"/>
 <ref refid="DCE:24AA3F0E-8324-11D8-8D1E-00C00C03A405"/>
+<ref refid="DCE:B89D7F92-8404-11D8-82A2-7B88E55A3BEC"/>
+<ref refid="DCE:B325D614-8404-11D8-82A2-7B88E55A3BEC"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -22883,6 +22892,7 @@ specially for Gaphor</val>
 <ref refid="7f3159b0-38fd-11e0-98cd-0021e9e5a3cd"/>
 <ref refid="632a652a-909d-11ea-9685-03ae027faeeb"/>
 <ref refid="cde1ab60-ea04-11ea-96dc-bf74f1f80424"/>
+<ref refid="de901442-bb63-11ec-a9db-0456e5e540ed"/>
 </reflist>
 </specialization>
 </Class>
@@ -38209,6 +38219,10 @@ swimlanes</val>
 <ref refid="68f90158-9a43-11ec-8e48-0456e5e540ed"/>
 <ref refid="dfe49b2e-b339-11ec-940a-0456e5e540ed"/>
 <ref refid="31351666-b33a-11ec-940a-0456e5e540ed"/>
+<ref refid="018d75f2-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="e64aa2be-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="f67638b0-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="0886a7d8-bb65-11ec-a9db-0456e5e540ed"/>
 </reflist>
 </slot>
 <typeValue>
@@ -44749,6 +44763,9 @@ to accommodate simpleAttribute</val>
 <ref refid="5765c342-909d-11ea-9685-03ae027faeeb"/>
 <ref refid="72139548-909d-11ea-9685-03ae027faeeb"/>
 <ref refid="85907820-909d-11ea-9685-03ae027faeeb"/>
+<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="e9dae53e-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="a877e640-bb64-11ec-a9db-0456e5e540ed"/>
 </reflist>
 </ownedType>
 <presentation>
@@ -55587,6 +55604,393 @@ have an opposite end.
 </owningInstance>
 <value>
 <val>owner</val>
+</value>
+</Slot>
+<Class id="c00739e2-bb63-11ec-a9db-0456e5e540ed">
+<generalization>
+<reflist>
+<ref refid="de901442-bb63-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</generalization>
+<name>
+<val>OpaqueAction</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="cf4d4b3a-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="a8783654-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="e9db4aa6-bb63-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="a3b505ae-3801-11e0-87bf-0021e9e5a3cd"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="c00771c8-bb63-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Class>
+<ClassItem id="c00771c8-bb63-11ec-a9db-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 301.5, 354.0)</val>
+</matrix>
+<width>
+<val>119.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
+</subject>
+</ClassItem>
+<Property id="cf4d4b3a-bb63-11ec-a9db-0456e5e540ed">
+<class_>
+<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
+</class_>
+<name>
+<val>body</val>
+</name>
+<typeValue>
+<val>String</val>
+</typeValue>
+</Property>
+<GeneralizationItem id="ddaa5448-bb63-11ec-a9db-0456e5e540ed">
+<diagram>
+<ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="de901442-bb63-11ec-a9db-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 363.0, 271.0)</val>
+</matrix>
+<points>
+<val>[(-0.3551486584481438, 83.0), (0.14485134155188462, 3.5)]</val>
+</points>
+<head-connection>
+<ref refid="c00771c8-bb63-11ec-a9db-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="DCE:96EB8F86-8404-11D8-82A2-7B88E55A3BEC"/>
+</tail-connection>
+</GeneralizationItem>
+<Generalization id="de901442-bb63-11ec-a9db-0456e5e540ed">
+<general>
+<ref refid="DCE:0599D668-8324-11D8-8D1E-00C00C03A405"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="ddaa5448-bb63-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
+</specific>
+</Generalization>
+<AssociationItem id="e8f92f0e-bb63-11ec-a9db-0456e5e540ed">
+<diagram>
+<ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
+</diagram>
+<head_subject>
+<ref refid="e9db2742-bb63-11ec-a9db-0456e5e540ed"/>
+</head_subject>
+<horizontal>
+<val>1</val>
+</horizontal>
+<orthogonal>
+<val>1</val>
+</orthogonal>
+<subject>
+<ref refid="e9dae53e-bb63-11ec-a9db-0456e5e540ed"/>
+</subject>
+<tail_subject>
+<ref refid="e9db4aa6-bb63-11ec-a9db-0456e5e540ed"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 329.0, 412.0)</val>
+</matrix>
+<points>
+<val>[(-27.5, -21.0), (-165.25, -21.0), (-165.25, 166.0)]</val>
+</points>
+<head-connection>
+<ref refid="c00771c8-bb63-11ec-a9db-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="DCE:2DF0AAAC-8404-11D8-82A2-7B88E55A3BEC"/>
+</tail-connection>
+</AssociationItem>
+<Association id="e9dae53e-bb63-11ec-a9db-0456e5e540ed">
+<memberEnd>
+<reflist>
+<ref refid="e9db2742-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="e9db4aa6-bb63-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="a3b505ae-3801-11e0-87bf-0021e9e5a3cd"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="e8f92f0e-bb63-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="e9db2742-bb63-11ec-a9db-0456e5e540ed">
+<appliedStereotype>
+<reflist>
+<ref refid="fcc475fc-bb63-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="e9dae53e-bb63-11ec-a9db-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="DCE:2DF4E17E-8404-11D8-82A2-7B88E55A3BEC"/>
+</class_>
+<name>
+<val>opaqueAction</val>
+</name>
+<type>
+<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
+</type>
+</Property>
+<Property id="e9db4aa6-bb63-11ec-a9db-0456e5e540ed">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<appliedStereotype>
+<reflist>
+<ref refid="06129d7c-bb65-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="e9dae53e-bb63-11ec-a9db-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
+</class_>
+<name>
+<val>inputValue</val>
+</name>
+<type>
+<ref refid="DCE:2DF4E17E-8404-11D8-82A2-7B88E55A3BEC"/>
+</type>
+</Property>
+<InstanceSpecification id="fcc475fc-bb63-11ec-a9db-0456e5e540ed">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="e9db2742-bb63-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="018d75f2-bb64-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="018d75f2-bb64-11ec-a9db-0456e5e540ed">
+<definingFeature>
+<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
+</definingFeature>
+<owningInstance>
+<ref refid="fcc475fc-bb63-11ec-a9db-0456e5e540ed"/>
+</owningInstance>
+<value>
+<val>action</val>
+</value>
+</Slot>
+<AssociationItem id="a7c9194e-bb64-11ec-a9db-0456e5e540ed">
+<diagram>
+<ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
+</diagram>
+<head_subject>
+<ref refid="a87815ca-bb64-11ec-a9db-0456e5e540ed"/>
+</head_subject>
+<horizontal>
+<val>1</val>
+</horizontal>
+<orthogonal>
+<val>1</val>
+</orthogonal>
+<subject>
+<ref refid="a877e640-bb64-11ec-a9db-0456e5e540ed"/>
+</subject>
+<tail_subject>
+<ref refid="a8783654-bb64-11ec-a9db-0456e5e540ed"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 397.0, 393.0)</val>
+</matrix>
+<points>
+<val>[(23.5, -2.0), (92.5, -2.0), (92.5, 192.0)]</val>
+</points>
+<head-connection>
+<ref refid="c00771c8-bb63-11ec-a9db-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="DCE:2A9E26DE-8404-11D8-82A2-7B88E55A3BEC"/>
+</tail-connection>
+</AssociationItem>
+<Association id="a877e640-bb64-11ec-a9db-0456e5e540ed">
+<memberEnd>
+<reflist>
+<ref refid="a87815ca-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="a8783654-bb64-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</memberEnd>
+<ownedEnd>
+<reflist>
+<ref refid="a87815ca-bb64-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</ownedEnd>
+<package>
+<ref refid="a3b505ae-3801-11e0-87bf-0021e9e5a3cd"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="a7c9194e-bb64-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="a87815ca-bb64-11ec-a9db-0456e5e540ed">
+<appliedStereotype>
+<reflist>
+<ref refid="e300c0fc-bb64-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="a877e640-bb64-11ec-a9db-0456e5e540ed"/>
+</association>
+<name>
+<val>opaqueAction</val>
+</name>
+<owningAssociation>
+<ref refid="a877e640-bb64-11ec-a9db-0456e5e540ed"/>
+</owningAssociation>
+<type>
+<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
+</type>
+</Property>
+<Property id="a8783654-bb64-11ec-a9db-0456e5e540ed">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<appliedStereotype>
+<reflist>
+<ref refid="f4029664-bb64-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="a877e640-bb64-11ec-a9db-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="c00739e2-bb63-11ec-a9db-0456e5e540ed"/>
+</class_>
+<name>
+<val>outputValue</val>
+</name>
+<type>
+<ref refid="DCE:2AA1B3CA-8404-11D8-82A2-7B88E55A3BEC"/>
+</type>
+</Property>
+<InstanceSpecification id="e300c0fc-bb64-11ec-a9db-0456e5e540ed">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="a87815ca-bb64-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="e64aa2be-bb64-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="e64aa2be-bb64-11ec-a9db-0456e5e540ed">
+<definingFeature>
+<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
+</definingFeature>
+<owningInstance>
+<ref refid="e300c0fc-bb64-11ec-a9db-0456e5e540ed"/>
+</owningInstance>
+<value>
+<val>action</val>
+</value>
+</Slot>
+<InstanceSpecification id="f4029664-bb64-11ec-a9db-0456e5e540ed">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="a8783654-bb64-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="f67638b0-bb64-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="f67638b0-bb64-11ec-a9db-0456e5e540ed">
+<definingFeature>
+<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
+</definingFeature>
+<owningInstance>
+<ref refid="f4029664-bb64-11ec-a9db-0456e5e540ed"/>
+</owningInstance>
+<value>
+<val>output</val>
+</value>
+</Slot>
+<InstanceSpecification id="06129d7c-bb65-11ec-a9db-0456e5e540ed">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="e9db4aa6-bb63-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="0886a7d8-bb65-11ec-a9db-0456e5e540ed"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="0886a7d8-bb65-11ec-a9db-0456e5e540ed">
+<definingFeature>
+<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
+</definingFeature>
+<owningInstance>
+<ref refid="06129d7c-bb65-11ec-a9db-0456e5e540ed"/>
+</owningInstance>
+<value>
+<val>input</val>
 </value>
 </Slot>
 </gaphor>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Pins are not supported.

Issue Number: N/A

### What is the new behavior?

Support for input and output pins.

- [x] Pins connect to actions
- [x] Object flow connects to pins
- [x] copy/paste
- [x] Pins shall be children of an action, when connected
- [x] What to do with pin names?
- [x] Icons for input and output pin
- [x] ~Pins show arrow when no object flows are connected~ Use stereotype to clarify pin type. There's now enough space for an arrow.
- [x] For input pins, only allow incoming object flow
- [x] For output pins, only allow outgoing object flow
- [x] Pins should be located on the side of the action, not on top of it.


### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

- [x] Improve name label placement for _ProxyPort_ and _Pin_.

![image](https://user-images.githubusercontent.com/96249/164081903-5d84dac7-0ea0-447b-bcce-6eb52f6dcc65.png)
