### PR TITLE
Fix pin connections when loading a model

### DIFF
--- a/gaphor/SysML/drop.py
+++ b/gaphor/SysML/drop.py
@@ -1,5 +1,5 @@
 from gaphor.diagram.drop import drop
-from gaphor.diagram.presentation import postload_connect
+from gaphor.diagram.presentation import connect
 from gaphor.diagram.support import get_diagram_item
 from gaphor.SysML.sysml import ProxyPort
 from gaphor.UML.drop import diagram_has_presentation
@@ -21,6 +21,6 @@ def drop_proxy_port(element: ProxyPort, diagram, x, y):
     item.matrix.translate(x, y)
     item.subject = element
 
-    postload_connect(item, item.handles()[0], head_item)
+    connect(item, item.handles()[0], head_item)
 
     return item

--- a/gaphor/UML/actions/activity.py
+++ b/gaphor/UML/actions/activity.py
@@ -3,7 +3,7 @@ from gaphor.diagram.presentation import (
     AttachedPresentation,
     Classified,
     ElementPresentation,
-    postload_connect,
+    connect,
 )
 from gaphor.diagram.shapes import Box, Text, TextAlign, VerticalAlign, draw_border
 from gaphor.diagram.support import represents
@@ -72,7 +72,7 @@ class ActivityItem(Classified, ElementPresentation):
                     ActivityParameterNodeItem, parent=self, subject=node
                 )
                 item.matrix.translate(0, 10)
-                postload_connect(item, item.handles()[0], self)
+                connect(item, item.handles()[0], self)
 
         for node in parameter_items:
             if node not in parameter_nodes:

--- a/gaphor/UML/actions/activityconnect.py
+++ b/gaphor/UML/actions/activityconnect.py
@@ -5,7 +5,7 @@ from gaphas.move import Move
 from gaphas.types import Pos
 
 from gaphor.diagram.connectors import Connector
-from gaphor.diagram.presentation import postload_connect
+from gaphor.diagram.presentation import connect
 from gaphor.diagram.tools.grayout import GrayOutLineHandleMoveMixin
 from gaphor.UML.actions.activity import ActivityItem, ActivityParameterNodeItem
 
@@ -42,7 +42,7 @@ class ActivityParameterNodeItemHandleMove(
 
     def connect(self, pos: Pos) -> None:
         item = self.item
-        postload_connect(item, self.handle, item.parent)
+        connect(item, self.handle, item.parent)
         self.view.model.request_update(item)
 
 

--- a/gaphor/UML/actions/tests/test_pin.py
+++ b/gaphor/UML/actions/tests/test_pin.py
@@ -12,5 +12,5 @@ def test_load_pin(element_factory, diagram, saver, loader):
 
     new_attached = next(element_factory.select(InputPinItem))
 
-    assert tuple(new_attached.handles()[0].pos) == (1, 2)
+    assert tuple(map(float, new_attached.handles()[0].pos)) == (1, 2)
     assert tuple(new_attached.matrix) == (1.0, 0.0, 0.0, 1.0, 10, 20)

--- a/gaphor/UML/drop.py
+++ b/gaphor/UML/drop.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from gaphor import UML
 from gaphor.diagram.drop import drop
-from gaphor.diagram.presentation import postload_connect
+from gaphor.diagram.presentation import connect
 from gaphor.diagram.support import get_diagram_item, get_diagram_item_metadata
 
 
@@ -67,7 +67,7 @@ def _drop(element, head_element, tail_element, diagram, x, y):
     item.matrix.translate(x, y)
     item.subject = element
 
-    postload_connect(item, item.head, head_item)
-    postload_connect(item, item.tail, tail_item)
+    connect(item, item.head, head_item)
+    connect(item, item.tail, tail_item)
 
     return item

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -53,6 +53,12 @@ def from_package_str(item):
     )
 
 
+def connect(item: gaphas.Item, handle: gaphas.Handle, target: gaphas.Item):
+    connector = ConnectorAspect(item, handle, item.diagram.connections)
+    sink = ConnectionSink(target, distance=1e40)
+    connector.connect(sink)
+
+
 def postload_connect(item: gaphas.Item, handle: gaphas.Handle, target: gaphas.Item):
     """Helper function: when loading a model, handles should be connected as
     part of the `postload` step.
@@ -60,9 +66,8 @@ def postload_connect(item: gaphas.Item, handle: gaphas.Handle, target: gaphas.It
     This function finds a suitable spot on the `target` item to connect
     the handle to.
     """
-    connector = ConnectorAspect(item, handle, item.diagram.connections)
-    sink = ConnectionSink(target, distance=1e40)
-    connector.connect(sink)
+    target.postload()
+    connect(item, handle, target)
 
 
 class HandlePositionEvent(RevertibeEvent):

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -372,7 +372,7 @@ class AttachedPresentation(HandlePositionUpdate, Presentation[S]):
         self._width_constraints = []
         self._height_constraints = []
 
-        handle = self._handle = Handle(connectable=True)
+        handle = self._handle = Handle(strength=gaphas.solver.STRONG, connectable=True)
         self.watch_handle(handle)
 
         rh = width / 2
@@ -498,12 +498,10 @@ class AttachedPresentation(HandlePositionUpdate, Presentation[S]):
 
     def save(self, save_func):
         save_func("matrix", tuple(self.matrix))
+        save_func("point", tuple(map(float, self._handle.pos)))
 
         if c := self._connections.get_connection(self._handle):
             save_func("connection", c.connected)
-
-        point = tuple(map(float, self._handle.pos))
-        save_func("point", point)
 
         super().save(save_func)
 
@@ -522,3 +520,4 @@ class AttachedPresentation(HandlePositionUpdate, Presentation[S]):
             del self._load_connection
 
         self.update_shapes()
+        self._connections.solve()

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -1,9 +1,8 @@
-from gaphas.connector import ConnectionSink
-from gaphas.connector import Connector as ConnectorAspect
 from gi.repository import Gtk
 
 from gaphor.diagram.connectors import Connector
 from gaphor.diagram.copypaste import copy, paste_link
+from gaphor.diagram.presentation import connect as _connect
 
 
 def allow(line, handle, item, port=None) -> bool:
@@ -19,14 +18,9 @@ def connect(line, handle, item, port=None):
 
     If port is not provided, then first port is used.
     """
-    diagram = line.diagram
+    _connect(line, handle, item)
 
-    connector = ConnectorAspect(line, handle, diagram.connections)
-    sink = ConnectionSink(item, distance=1e4)
-
-    connector.connect(sink)
-
-    cinfo = diagram.connections.get_connection(handle)
+    cinfo = line.diagram.connections.get_connection(handle)
     assert cinfo.connected is item
     assert cinfo.port
 

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -35,8 +35,7 @@ def disconnect(line, handle):
 
 def get_connected(item, handle):
     assert handle in item.handles()
-    cinfo = item.diagram.connections.get_connection(handle)
-    if cinfo:
+    if cinfo := item.diagram.connections.get_connection(handle):
         return cinfo.connected  # type: ignore[no-any-return] # noqa: F723
     return None
 
@@ -69,8 +68,7 @@ if Gtk.get_major_version() == 3:
             return widget
         if isinstance(widget, Gtk.Container):
             for child in widget.get_children():
-                found = find(child, name)
-                if found:
+                if found := find(child, name):
                     return found
         return None
 
@@ -79,15 +77,11 @@ else:
     def find(widget, name):
         if widget.get_buildable_id() == name:
             return widget
-        sibling = widget.get_next_sibling()
-        if sibling:
-            found = find(sibling, name)
-            if found:
+        if sibling := widget.get_next_sibling():
+            if found := find(sibling, name):
                 return found
-        child = widget.get_first_child()
-        if child:
-            found = find(child, name)
-            if found:
+        if child := widget.get_first_child():
+            if found := find(child, name):
                 return found
 
         return None


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When loading a model with pins, and object flows connected to those pins, the object flow may be connected in wrongly -> not in a state as when you saved it.


### What is the new behavior?

Fix loading of Attached Presentations. The boundaries of an attached presentation are calculated by constraints. By resolving those constraints it ensures the line is connected exactly as when you saved it.

