### PR TITLE
Add element to diagram by double click

### DIFF
--- a/gaphor/ui/event.py
+++ b/gaphor/ui/event.py
@@ -1,6 +1,11 @@
 """UI related events."""
 
 
+class ElementOpened:
+    def __init__(self, element):
+        self.element = element
+
+
 class DiagramOpened:
     def __init__(self, diagram):
         self.diagram = diagram

--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -21,7 +21,7 @@ from gaphor.diagram.deletable import deletable
 from gaphor.transaction import Transaction
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.actiongroup import create_action_group
-from gaphor.ui.event import DiagramOpened, DiagramSelectionChanged
+from gaphor.ui.event import DiagramOpened, DiagramSelectionChanged, ElementOpened
 from gaphor.ui.mainwindow import create_diagram_types_model
 from gaphor.ui.namespacemodel import (
     RELATIONSHIPS,
@@ -43,7 +43,11 @@ def popup_model(element, modeling_language):
     model = Gio.Menu.new()
 
     part = Gio.Menu.new()
-    part.append(gettext("_Open"), "tree-view.open")
+
+    part.append(
+        gettext("_Open") if isinstance(element, Diagram) else gettext("Add to diagram"),
+        "tree-view.open",
+    )
     part.append(gettext("_Rename"), "tree-view.rename")
     model.append_section(None, part)
 
@@ -219,7 +223,6 @@ class Namespace(UIComponent, ActionProvider):
         if Gtk.get_major_version() == 3:
             action_group = view.get_action_group("tree-view")
 
-            action_group.lookup_action("open").set_enabled(isinstance(element, Diagram))
             action_group.lookup_action("create-package").set_enabled(
                 isinstance(element, UML.Package)
             )
@@ -278,7 +281,7 @@ class Namespace(UIComponent, ActionProvider):
         if isinstance(element, Diagram):
             self.event_manager.handle(DiagramOpened(element))
         else:
-            log.debug(f"No action defined for element {type(element).__name__}")
+            self.event_manager.handle(ElementOpened(element))
 
     @action(name="tree-view.show-in-diagram")
     def tree_view_show_in_diagram(self, diagram_id: str) -> None:


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Currently diagram items can only be added from the tree view by means of drag-and-drop. It would be good to be able to perform this without DnD.

Issue Number: #1520 

### What is the new behavior?

Elements can be added by double click and by an entry in the popup menu.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
