### PR TITLE
Fix scroll speed for touch screens

### DIFF
--- a/gaphor/diagram/tools/__init__.py
+++ b/gaphor/diagram/tools/__init__.py
@@ -3,10 +3,10 @@ from gaphas.tool import (
     hover_tool,
     item_tool,
     rubberband_tool,
-    scroll_tools,
     view_focus_tool,
     zoom_tool,
 )
+from gaphas.tool.scroll import pan_tool
 from gi.repository import Gtk
 
 import gaphor.diagram.tools.connector
@@ -62,7 +62,7 @@ def apply_placement_tool_set(
 
 
 def add_basic_tools(view, modeling_language, event_manager):
-    view.add_controller(*scroll_tools(view))
+    view.add_controller(pan_tool(view))
     view.add_controller(zoom_tool(view))
     view.add_controller(view_focus_tool(view))
     view.add_controller(shortcut_tool(view, modeling_language, event_manager))

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -142,6 +142,7 @@ class DiagramPage:
 
         view = GtkView(selection=Selection())
         if Gtk.get_major_version() == 3:
+            view.add_events(Gdk.EventMask.SMOOTH_SCROLL_MASK)
             view.drag_dest_set(
                 Gtk.DestDefaults.ALL,
                 DiagramPage.VIEW_DND_TARGETS,


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When scrolling with a touch screen, the scrolling happens too fast.

Issue Number: #1425

### What is the new behavior?

Scrolling works as expected with touchscreens.

Gaphor no longer uses the `scroll_tool` from Gaphas. Instead it relies on the scroll behavior of the `ScrolledWindow`, underneath the diagram. This way scroll behavior is similar to, for example, the toolbox.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

This is a `packaging` branch, so I can test the results on a Windows machine with touchscreen.