### PR TITLE
Fix issue with fully pasting a diagram

### DIFF
--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -340,10 +340,12 @@ class association(umlproperty):
                 save_func(self.name, v)
 
     def load(self, obj, value):
-        if not isinstance(value, self.type):
-            raise TypeError(
-                f"Value for {self.name} should be of type {self.type.__name__} ({type(value).__name__})"
-            )
+        if self.opposite:
+            # Loading should not steal references from other elements
+            opposite = getattr(type(value), self.opposite)
+            if opposite.upper == 1 and opposite.get(value):
+                log.debug(f"Can not steal reference from {value}")
+                return
 
         if self.upper == 1:
             self._set_one(obj, value)

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -402,7 +402,7 @@ class association(umlproperty):
             return
 
         if old:
-            self.delete(obj, old, from_opposite=from_opposite, do_notify=False)
+            self.delete(obj, old, do_notify=False)
 
         if value is not None:
             setattr(obj, self._name, value)
@@ -430,7 +430,8 @@ class association(umlproperty):
         try:
             self._set_opposite(obj, value, from_opposite)
         except Exception:
-            c.items.pop()
+            if value in c.items:
+                c.items.remove(value)
             raise
 
         self.handle(AssociationAdded(obj, self, value))

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -347,10 +347,7 @@ class association(umlproperty):
                 log.debug(f"Can not steal reference from {value}")
                 return
 
-        if self.upper == 1:
-            self._set_one(obj, value)
-        else:
-            self._set_many(obj, value, from_load=True)
+        self.set(obj, value)
 
     def __str__(self):
         if self.lower == self.upper:
@@ -370,7 +367,7 @@ class association(umlproperty):
     def _get_many(self, obj) -> collection[T]:
         v: collection[T] | None = getattr(obj, self._name, None)
         if v is None:
-            # Create the empty collection here since it might
+            # Create the empty collection here since it may
             # be used to add.
             v = collection(self, obj, self.type)
             setattr(obj, self._name, v)

--- a/gaphor/core/modeling/tests/test_properties.py
+++ b/gaphor/core/modeling/tests/test_properties.py
@@ -68,6 +68,26 @@ def test_association_n_x():
     assert b.two is a
 
 
+def test_reassign_association_n_1():
+    class A(Element):
+        many: relation_many[B]
+
+    class B(Element):
+        one: relation_one[A]
+
+    A.many = association("many", B, 0, "*", opposite="one")
+    B.one = association("one", A, 0, 1, opposite="many")
+
+    a = A()
+    aa = A()
+    b = B()
+    a.many = b
+    aa.many = b
+    assert b in aa.many
+    assert not a.many
+    assert b.one is aa
+
+
 def test_association_1_1():
     #
     # 1:1

--- a/gaphor/core/modeling/tests/test_properties.py
+++ b/gaphor/core/modeling/tests/test_properties.py
@@ -48,10 +48,7 @@ def test_association_1_x():
     assert b.two is None
 
 
-def test_association_n_x():
-    #
-    # n:-
-    #
+def test_association_n_1():
     class A(Element):
         one: relation_many[B]
 
@@ -77,7 +74,6 @@ def test_reassign_association_n_1():
 
     A.many = association("many", B, 0, "*", opposite="one")
     B.one = association("one", A, 0, 1, opposite="many")
-
     a = A()
     aa = A()
     b = B()
@@ -88,10 +84,28 @@ def test_reassign_association_n_1():
     assert b.one is aa
 
 
+def test_association_load_does_not_steal_references():
+    class A(Element):
+        many: relation_many[B]
+
+    class B(Element):
+        one: relation_one[A]
+
+    A.many = association("many", B, 0, "*", opposite="one")
+    B.one = association("one", A, 0, 1, opposite="many")
+    a = A()
+    aa = A()
+    b = B()
+    a.many = b
+
+    A.many.load(aa, b)
+
+    assert b in a.many
+    assert not aa.many
+    assert b.one is a
+
+
 def test_association_1_1():
-    #
-    # 1:1
-    #
     class A(Element):
         one: relation_one[B]
 

--- a/gaphor/diagram/tests/test_copypaste_full.py
+++ b/gaphor/diagram/tests/test_copypaste_full.py
@@ -84,3 +84,19 @@ def test_copy_package_with_diagram(element_factory):
     assert diagram in package.ownedDiagram
     assert diagram not in new_package.ownedDiagram
     assert diagram.element is package
+
+
+def test_copy_package_with_owned_package(element_factory):
+    diagram: Diagram = element_factory.create(Diagram)
+    package = element_factory.create(UML.Package)
+    subpackage = element_factory.create(UML.Package)
+    subpackage.package = package
+    package_item = diagram.create(PackageItem, subject=package)
+
+    copy_buffer = copy([package_item])
+    (new_package_item,) = paste_full(copy_buffer, diagram, element_factory.lookup)
+    new_package = new_package_item.subject
+
+    assert subpackage in package.nestedPackage
+    assert subpackage.package is package
+    assert subpackage not in new_package.nestedPackage

--- a/gaphor/diagram/tests/test_copypaste_full.py
+++ b/gaphor/diagram/tests/test_copypaste_full.py
@@ -2,7 +2,7 @@ from gaphor import UML
 from gaphor.core.modeling import Diagram, ElementFactory
 from gaphor.diagram.copypaste import copy, paste_full
 from gaphor.diagram.tests.test_copypaste_link import two_classes_and_a_generalization
-from gaphor.UML.classes import ClassItem, GeneralizationItem
+from gaphor.UML.classes import ClassItem, GeneralizationItem, PackageItem
 
 
 def test_copied_item_references_new_model_element(diagram, element_factory):
@@ -69,3 +69,18 @@ def test_copy_element_factory(diagram, element_factory):
     # new element factory has one more diagram:
     assert len(new_element_factory.lselect(Diagram)) == 2
     assert element_factory.size() == new_element_factory.size() - 1
+
+
+def test_copy_package_with_diagram(element_factory):
+    diagram: Diagram = element_factory.create(Diagram)
+    package = element_factory.create(UML.Package)
+    package.ownedDiagram = diagram
+    package_item = diagram.create(PackageItem, subject=package)
+
+    copy_buffer = copy([package_item])
+    (new_package_item,) = paste_full(copy_buffer, diagram, element_factory.lookup)
+    new_package = new_package_item.subject
+
+    assert diagram in package.ownedDiagram
+    assert diagram not in new_package.ownedDiagram
+    assert diagram.element is package

--- a/gaphor/services/tests/test_undomanager.py
+++ b/gaphor/services/tests/test_undomanager.py
@@ -150,7 +150,7 @@ def test_undo_association_1_x(event_manager, element_factory, undo_manager):
     assert b.two is None
     assert undo_manager.can_redo()
     assert len(undo_manager._redo_stack) == 1
-    assert len(undo_manager._redo_stack[0]._actions) == 2, undo_manager._redo_stack[
+    assert len(undo_manager._redo_stack[0]._actions) == 3, undo_manager._redo_stack[
         0
     ]._actions
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import os
-
 from hypothesis import settings
 
 from gaphor.conftest import test_models


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

A curious construction of packages containing diagrams can not be fully/deep copied.

Issue Number: #1535 

### What is the new behavior?

When pasting (or loading) a relationships is established. However, if the opposite side is already set, and has a multiplicity of `[0..1]`, the existing relation should not be overwritten. 

### Other information
