### PR TITLE
Fix instant editors for GTK4

### DIFF
--- a/docs/modeling_language.md
+++ b/docs/modeling_language.md
@@ -112,7 +112,7 @@ When you double click on an item in a diagram, a popup can show up so you can ea
 By default this works for any named element. You can register your own inline editor function if you need to.
 
 ```{eval-rst}
-.. function:: gaphor.diagram.inlineeditors.InlineEditor(item: Item, view, event_manager, pos: Optional[Tuple[int, int]] = None) -> bool
+.. function:: gaphor.diagram.instanteditors.InstantEditor(item: Item, view, event_manager, pos: Optional[Tuple[int, int]] = None) -> bool
 
    Show a small editor popup in the diagram. Makes for
    easy editing without resorting to the Element editor.

--- a/gaphor/UML/actions/actionseditors.py
+++ b/gaphor/UML/actions/actionseditors.py
@@ -1,11 +1,11 @@
-from gaphor.diagram.inlineeditors import InlineEditor, popup_entry, show_popover
+from gaphor.diagram.instanteditors import InstantEditor, popup_entry, show_popover
 from gaphor.transaction import Transaction
 from gaphor.UML.actions.activity import ActivityParameterNodeItem
 from gaphor.UML.actions.activitynodes import ForkNodeItem
 
 
-@InlineEditor.register(ForkNodeItem)
-def fork_node_item_inline_editor(item, view, event_manager, pos=None) -> bool:
+@InstantEditor.register(ForkNodeItem)
+def fork_node_item_editor(item, view, event_manager, pos=None) -> bool:
     """Text edit support for Named items."""
 
     subject = item.subject
@@ -24,8 +24,8 @@ def fork_node_item_inline_editor(item, view, event_manager, pos=None) -> bool:
     return True
 
 
-@InlineEditor.register(ActivityParameterNodeItem)
-def activity_parameter_node_item_inline_editor(
+@InstantEditor.register(ActivityParameterNodeItem)
+def activity_parameter_node_item_editor(
     item: ActivityParameterNodeItem, view, event_manager, pos=None
 ) -> bool:
     subject = item.subject

--- a/gaphor/UML/classes/classeseditors.py
+++ b/gaphor/UML/classes/classeseditors.py
@@ -1,13 +1,13 @@
 from gaphas.geometry import Rectangle, distance_point_point_fast
 
 from gaphor.core.format import format, parse
-from gaphor.diagram.inlineeditors import InlineEditor, popup_entry, show_popover
+from gaphor.diagram.instanteditors import InstantEditor, popup_entry, show_popover
 from gaphor.transaction import Transaction
 from gaphor.UML.classes.association import AssociationItem
 
 
-@InlineEditor.register(AssociationItem)
-def association_item_inline_editor(item, view, event_manager, pos=None) -> bool:
+@InstantEditor.register(AssociationItem)
+def association_item_editor(item, view, event_manager, pos=None) -> bool:
     """Text edit support for Named items."""
 
     subject = item.subject

--- a/gaphor/diagram/general/generaleditors.py
+++ b/gaphor/diagram/general/generaleditors.py
@@ -27,13 +27,16 @@ def CommentItemInlineEditor(item, view, event_manager, pos=None) -> bool:
     buffer.move_mark_by_name("insert", enditer)
 
     text_view = Gtk.TextView.new_with_buffer(buffer)
+    text_view.set_size_request(100, 50)
     box = view.get_item_bounding_box(item)
 
     frame = Gtk.Frame()
-    frame.add(text_view)
-
-    text_view.show()
-    frame.show()
+    if Gtk.get_major_version() == 3:
+        frame.add(text_view)
+        text_view.show()
+        frame.show()
+    else:
+        frame.set_child(text_view)
 
     show_popover(frame, view, box, update_text)
 

--- a/gaphor/diagram/general/generaleditors.py
+++ b/gaphor/diagram/general/generaleditors.py
@@ -1,12 +1,12 @@
 from gi.repository import Gtk
 
 from gaphor.diagram.general.comment import CommentItem
-from gaphor.diagram.inlineeditors import InlineEditor, show_popover
+from gaphor.diagram.instanteditors import InstantEditor, show_popover
 from gaphor.transaction import Transaction
 
 
-@InlineEditor.register(CommentItem)
-def CommentItemInlineEditor(item, view, event_manager, pos=None) -> bool:
+@InstantEditor.register(CommentItem)
+def CommentItemEditor(item, view, event_manager, pos=None) -> bool:
     def update_text():
         text = buffer.get_text(
             buffer.get_start_iter(), buffer.get_end_iter(), include_hidden_chars=True

--- a/gaphor/diagram/inlineeditors.py
+++ b/gaphor/diagram/inlineeditors.py
@@ -66,12 +66,15 @@ def show_popover(widget, view, box, commit):
         popover.set_relative_to(view)
     else:
         popover.set_child(widget)
+        popover.set_parent(view)
+
     gdk_rect = Gdk.Rectangle()
     gdk_rect.x = box.x
     gdk_rect.y = box.y
     gdk_rect.width = box.width
     gdk_rect.height = box.height
     popover.set_pointing_to(gdk_rect)
+    popover.set_position(Gtk.PositionType.TOP)
 
     should_commit = True
 
@@ -102,6 +105,6 @@ def show_popover(widget, view, box, commit):
         controller = Gtk.EventControllerKey.new()
         popover.add_controller(controller)
         controller.connect("key-pressed", on_escape)
-        popover.present()
+        popover.show()
 
     return popover

--- a/gaphor/diagram/instanteditors.py
+++ b/gaphor/diagram/instanteditors.py
@@ -11,7 +11,7 @@ from gaphor.transaction import Transaction
 
 
 @singledispatch
-def InlineEditor(
+def InstantEditor(
     item: Item, view, event_manager, pos: tuple[int, int] | None = None
 ) -> bool:
     """Show a small editor popup in the diagram. Makes for easy editing without
@@ -23,8 +23,8 @@ def InlineEditor(
     return False
 
 
-@InlineEditor.register(Named)
-def named_item_inline_editor(item, view, event_manager, pos=None) -> bool:
+@InstantEditor.register(Named)
+def named_item_editor(item, view, event_manager, pos=None) -> bool:
     """Text edit support for Named items."""
 
     subject = item.subject

--- a/gaphor/diagram/tests/test_instanteditors.py
+++ b/gaphor/diagram/tests/test_instanteditors.py
@@ -3,7 +3,7 @@ from gaphas.painter import BoundingBoxPainter
 from gaphas.view import GtkView
 
 from gaphor import UML
-from gaphor.diagram.inlineeditors import named_item_inline_editor
+from gaphor.diagram.instanteditors import named_item_editor
 from gaphor.diagram.painter import ItemPainter
 from gaphor.diagram.selection import Selection
 
@@ -18,34 +18,28 @@ def view(diagram):
     return view
 
 
-def test_named_item_inline_editor_with_element(
-    diagram, element_factory, view, event_manager
-):
+def test_named_item_editor_with_element(diagram, element_factory, view, event_manager):
     item = diagram.create(
         UML.classes.ClassItem, subject=element_factory.create(UML.Class)
     )
     view.selection.hovered_item = item
-    result = named_item_inline_editor(item, view, event_manager)
+    result = named_item_editor(item, view, event_manager)
 
     assert result is True
 
 
-def test_named_item_inline_editor_with_line(
-    diagram, element_factory, view, event_manager
-):
+def test_named_item_editor_with_line(diagram, element_factory, view, event_manager):
     item = diagram.create(
         UML.classes.DependencyItem, subject=element_factory.create(UML.Dependency)
     )
     view.selection.hovered_item = item
-    result = named_item_inline_editor(item, view, event_manager)
+    result = named_item_editor(item, view, event_manager)
 
     assert result is True
 
 
-def test_named_item_inline_editor_without_item(
-    diagram, element_factory, view, event_manager
-):
+def test_named_item_editor_without_item(diagram, element_factory, view, event_manager):
     item = diagram.create(UML.classes.DependencyItem)
-    result = named_item_inline_editor(item, view, event_manager)
+    result = named_item_editor(item, view, event_manager)
 
     assert result is False

--- a/gaphor/diagram/tools/__init__.py
+++ b/gaphor/diagram/tools/__init__.py
@@ -24,10 +24,10 @@ def apply_default_tool_set(view, modeling_language, event_manager, rubberband_st
     """The default tool set."""
     view.remove_all_controllers()
     view.add_controller(hover_tool(view))
+    view.add_controller(*text_edit_tools(view, event_manager))
     view.add_controller(
         *transactional_tool(item_tool(view), event_manager=event_manager)
     )
-    view.add_controller(*text_edit_tools(view, event_manager))
     view.add_controller(rubberband_tool(view, rubberband_state))
     add_basic_tools(view, modeling_language, event_manager)
 

--- a/gaphor/diagram/tools/placement.py
+++ b/gaphor/diagram/tools/placement.py
@@ -11,7 +11,7 @@ from gaphor.core.eventmanager import EventManager
 from gaphor.diagram.diagramtoolbox import ItemFactory
 from gaphor.diagram.event import DiagramItemPlaced
 from gaphor.diagram.group import group
-from gaphor.diagram.inlineeditors import InlineEditor
+from gaphor.diagram.instanteditors import InstantEditor
 from gaphor.diagram.presentation import ElementPresentation
 from gaphor.diagram.tools.dropzone import grow_parent
 
@@ -115,4 +115,4 @@ def on_drag_end(gesture, offset_x, offset_y, placement_state):
 @g_async(priority=GLib.PRIORITY_LOW)
 def open_editor(item, view, event_manager):
     if isinstance(item, ElementPresentation):
-        InlineEditor(item, view, event_manager)
+        InstantEditor(item, view, event_manager)

--- a/gaphor/diagram/tools/placement.py
+++ b/gaphor/diagram/tools/placement.py
@@ -90,8 +90,7 @@ def connect_opposite_handle(view, new_item, x, y, handle_index):
         if opposite.connectable:
             vpos = (x, y)
             handle_move = HandleMove(new_item, opposite, view)
-            sink = handle_move.glue(vpos)
-            if sink:
+            if handle_move.glue(vpos):
                 handle_move.connect(vpos)
 
 

--- a/gaphor/diagram/tools/textedit.py
+++ b/gaphor/diagram/tools/textedit.py
@@ -1,6 +1,6 @@
 from gi.repository import Gdk, Gtk
 
-from gaphor.diagram.inlineeditors import InlineEditor
+from gaphor.diagram.instanteditors import InstantEditor
 
 
 def text_edit_tools(view, event_manager):
@@ -20,7 +20,7 @@ def on_key_pressed(controller, keyval, keycode, state, event_manager):
     view = controller.get_widget()
     item = view.selection.hovered_item
     if item and keyval == Gdk.KEY_F2:
-        return InlineEditor(item, view, event_manager)
+        return InstantEditor(item, view, event_manager)
 
 
 def on_double_click(gesture, n_press, x, y, event_manager):
@@ -28,4 +28,4 @@ def on_double_click(gesture, n_press, x, y, event_manager):
     item = view.selection.hovered_item
     if item and n_press == 2:
         ix, iy = view.get_matrix_v2i(item).transform_point(x, y)
-        return InlineEditor(item, view, event_manager, (ix, iy))
+        return InstantEditor(item, view, event_manager, (ix, iy))

--- a/gaphor/ui/styling-gtk4.css
+++ b/gaphor/ui/styling-gtk4.css
@@ -24,7 +24,7 @@ expander-widget.propertypage {
   margin: 3px 2px 0 2px;
 }
 
-.propertypage frame > textview {
+frame > textview {
   padding: 6px;
 }
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Instant editors do not work with GTK4.

Issue Number: #1555

### What is the new behavior?

Editors work.

The class `InlineEditor` has been renamed to `InstantEditor`.
