### PR TITLE
Add Copy/Paste for GTK4

### DIFF
--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -51,7 +51,7 @@ class CopyService(Service, ActionProvider):
         else:
             self.clipboard = Gdk.Display.get_default().get_primary_clipboard()
 
-    if Gtk.get_major_version() == 3:  # noqa C901
+    if Gtk.get_major_version() == 3:
 
         def shutdown(self):
             self.clipboard.disconnect(self._owner_change_id)
@@ -59,19 +59,13 @@ class CopyService(Service, ActionProvider):
         def on_clipboard_owner_change(self, clipboard, event=None):
             view = self.diagrams.get_current_view()
             if view and not view.is_focus():
-                self.clear()
-
-        def clear(self):
-            global copy_buffer
-            copy_buffer = set()
+                global copy_buffer
+                copy_buffer = set()
 
         def copy(self, items):
             global copy_buffer
             if items:
                 copy_buffer = copy(items)
-
-        def can_paste(self):
-            return bool(copy_buffer)
 
         def _paste(self, diagram, paster, callback):
             global copy_buffer
@@ -92,12 +86,6 @@ class CopyService(Service, ActionProvider):
                 copy_buffer = copy(items)
                 v = GObject.Value(CopyBuffer.__gtype__, CopyBuffer(buffer=copy_buffer))
                 self.clipboard.set_content(Gdk.ContentProvider.new_for_value(v))
-
-        def clear(self):
-            pass
-
-        def can_paste(self):
-            return self.clipboard.get_formats().contain_gtype(CopyBuffer.__gtype__)
 
         def _paste(self, diagram, paster, callback):
             def on_paste(_source_object, result):

--- a/gaphor/services/copyservice.py
+++ b/gaphor/services/copyservice.py
@@ -2,7 +2,7 @@
 
 from typing import Set
 
-from gi.repository import Gdk, Gtk
+from gi.repository import Gdk, GLib, GObject, Gtk
 
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import Transaction, action
@@ -10,7 +10,17 @@ from gaphor.core.modeling import Presentation
 from gaphor.diagram.copypaste import copy, paste_full, paste_link
 from gaphor.ui.event import DiagramSelectionChanged
 
-copy_buffer: object = None
+if Gtk.get_major_version() == 3:
+    copy_buffer: object = None
+
+else:
+
+    class CopyBuffer(GObject.Object):
+        def __init__(self, buffer):
+            super().__init__()
+            self.buffer = buffer
+
+        buffer = GObject.Property(type=object)
 
 
 class CopyService(Service, ActionProvider):
@@ -39,51 +49,80 @@ class CopyService(Service, ActionProvider):
                 "owner-change", self.on_clipboard_owner_change
             )
         else:
-            # TODO: GTK4 - implement Gdk.Clipboard
-            ...
+            self.clipboard = Gdk.Display.get_default().get_primary_clipboard()
 
-    def shutdown(self):
-        if Gtk.get_major_version() == 3:
+    if Gtk.get_major_version() == 3:  # noqa C901
+
+        def shutdown(self):
             self.clipboard.disconnect(self._owner_change_id)
 
-    if Gtk.get_major_version() == 3:
-
-        def on_clipboard_owner_change(self, clipboard, event):
+        def on_clipboard_owner_change(self, clipboard, event=None):
             view = self.diagrams.get_current_view()
             if view and not view.is_focus():
                 self.clear()
 
-    def copy(self, items):
-        global copy_buffer
-        if items:
-            copy_buffer = copy(items)
+        def clear(self):
+            global copy_buffer
+            copy_buffer = set()
 
-    def can_paste(self):
-        return bool(copy_buffer)
+        def copy(self, items):
+            global copy_buffer
+            if items:
+                copy_buffer = copy(items)
 
-    def clear(self):
-        global copy_buffer
-        copy_buffer = set()
+        def can_paste(self):
+            return bool(copy_buffer)
 
-    def paste_link(self, diagram):
-        """Paste items in the copy-buffer to the diagram."""
-        with Transaction(self.event_manager):
-            # Create new id's that have to be used to create the items:
-            new_items: Set[Presentation] = paste_link(
-                copy_buffer, diagram, self.element_factory.lookup
+        def _paste(self, diagram, paster, callback):
+            global copy_buffer
+            if not copy_buffer:
+                return
+
+            items = self._paste_internal(diagram, copy_buffer, paster)
+            if callback:
+                callback(items)
+
+    else:
+
+        def shutdown(self):
+            pass
+
+        def copy(self, items):
+            if items:
+                copy_buffer = copy(items)
+                v = GObject.Value(CopyBuffer.__gtype__, CopyBuffer(buffer=copy_buffer))
+                self.clipboard.set_content(Gdk.ContentProvider.new_for_value(v))
+
+        def clear(self):
+            pass
+
+        def can_paste(self):
+            return self.clipboard.get_formats().contain_gtype(CopyBuffer.__gtype__)
+
+        def _paste(self, diagram, paster, callback):
+            def on_paste(_source_object, result):
+                copy_buffer = self.clipboard.read_value_finish(result)
+                items = self._paste_internal(diagram, copy_buffer.buffer, paster)
+                if callback:
+                    callback(items)
+
+            self.clipboard.read_value_async(
+                CopyBuffer.__gtype__,
+                io_priority=GLib.PRIORITY_DEFAULT,
+                cancellable=None,
+                callback=on_paste,
             )
 
-            # move pasted items a bit, so user can see result of his action :)
-            for item in new_items:
-                if item.parent not in new_items:
-                    item.matrix.translate(10, 10)
+    def paste_link(self, diagram, callback=None):
+        self._paste(diagram, paste_link, callback)
 
-        return new_items
+    def paste_full(self, diagram, callback=None):
+        self._paste(diagram, paste_full, callback)
 
-    def paste_full(self, diagram):
+    def _paste_internal(self, diagram, copy_buffer, paster):
         with Transaction(self.event_manager):
             # Create new id's that have to be used to create the items:
-            new_items: Set[Presentation] = paste_full(
+            new_items: Set[Presentation] = paster(
                 copy_buffer, diagram, self.element_factory.lookup
             )
 
@@ -101,28 +140,39 @@ class CopyService(Service, ActionProvider):
     def copy_action(self):
         view = self.diagrams.get_current_view()
         if view.is_focus():
-            self.clipboard.set_text("", -1)
             items = view.selection.selected_items
+            if not items:
+                return
+
+            if Gtk.get_major_version() == 3:
+                self.clipboard.set_text("", -1)
+
             self.copy(items)
 
     @action(name="edit-cut", shortcut="<Primary>x")
     def cut_action(self):
         view = self.diagrams.get_current_view()
         if view.is_focus():
-            self.clipboard.set_text("", -1)
             items = view.selection.selected_items
+            if not items:
+                return
+
+            if Gtk.get_major_version() == 3:
+                self.clipboard.set_text("", -1)
+
             self.copy(items)
+
             with Transaction(self.event_manager):
                 for i in list(items):
                     i.unlink()
 
     @action(name="edit-paste-link", shortcut="<Primary>v")
     def paste_link_action(self):
-        self._paste_action(self.paste_link)
+        self._paste_action(paste_link)
 
     @action(name="edit-paste-full", shortcut="<Primary><Shift>v")
     def paste_full_action(self):
-        self._paste_action(self.paste_full)
+        self._paste_action(paste_full)
 
     def _paste_action(self, paster):
         view = self.diagrams.get_current_view()
@@ -130,13 +180,11 @@ class CopyService(Service, ActionProvider):
         if not (view and view.is_focus()):
             return
 
-        if not copy_buffer:
-            return
+        def select_items(new_items):
+            selection = view.selection
+            selection.unselect_all()
+            selection.select_items(*new_items)
 
-        new_items = paster(diagram)
+            self.event_manager.handle(DiagramSelectionChanged(view, None, new_items))
 
-        selection = view.selection
-        selection.unselect_all()
-        selection.select_items(*new_items)
-
-        self.event_manager.handle(DiagramSelectionChanged(view, None, new_items))
+        self._paste(diagram, paster, select_items)

--- a/gaphor/services/tests/test_copyservice.py
+++ b/gaphor/services/tests/test_copyservice.py
@@ -1,4 +1,5 @@
 import pytest
+from gi.repository import Gtk
 
 from gaphor.core.modeling import Comment, Diagram
 from gaphor.diagram.general import CommentItem
@@ -16,7 +17,31 @@ def diagrams():
 
 
 @pytest.fixture
-def copy_service(event_manager, element_factory, diagrams):
+def copy_service(event_manager, element_factory, diagrams, monkeypatch):
+    if Gtk.get_major_version() != 3:
+        copy_buffer = None
+
+        def set_content(self, content_provider):
+            nonlocal copy_buffer
+            copy_buffer = content_provider.get_value()
+
+        def read_value_async(self, gtype, io_priority, cancellable, callback):
+            callback(None, None)
+
+        def read_value_finish(self, res):
+            return copy_buffer
+
+        monkeypatch.setattr(
+            "gi.repository.Gdk.ContentProvider.new_for_value", lambda v: v
+        )
+        monkeypatch.setattr("gi.repository.Gdk.Clipboard.set_content", set_content)
+        monkeypatch.setattr(
+            "gi.repository.Gdk.Clipboard.read_value_async", read_value_async
+        )
+        monkeypatch.setattr(
+            "gi.repository.Gdk.Clipboard.read_value_finish", read_value_finish
+        )
+
     return CopyService(event_manager, element_factory, diagrams)
 
 

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -263,8 +263,7 @@ class ModelConsistency(RuleBasedStateMachine):
         copy_service = self.session.get_service("copy")
         assume(copy_service.can_paste())
         diagram = data.draw(self.diagrams())
-        new_items = copy_service.paste_full(diagram)
-        self.fully_pasted_items.update(new_items)
+        copy_service.paste_full(diagram, callback=self.fully_pasted_items.update)
 
     @invariant()
     def check_relations(self):

--- a/tests/test_multiple_associations.py
+++ b/tests/test_multiple_associations.py
@@ -20,6 +20,7 @@ from gaphor import UML
 from gaphor.application import Session
 from gaphor.core import Transaction
 from gaphor.core.modeling import Diagram
+from gaphor.diagram.copypaste import copy, paste_link
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML import diagramitems
 from gaphor.UML.recipes import set_navigability
@@ -43,18 +44,13 @@ def element_factory(session):
 
 
 @pytest.fixture
-def copy(session):
-    return session.get_service("copy")
-
-
-@pytest.fixture
 def diagram(event_manager, element_factory):
     with Transaction(event_manager):
         return element_factory.create(Diagram)
 
 
 @pytest.fixture
-def class_and_association_with_copy(diagram, event_manager, element_factory, copy):
+def class_and_association_with_copy(diagram, event_manager, element_factory):
     with Transaction(event_manager):
         c = diagram.create(
             diagramitems.ClassItem, subject=element_factory.create(UML.Class)
@@ -66,9 +62,9 @@ def class_and_association_with_copy(diagram, event_manager, element_factory, cop
 
         set_navigability(a.subject, a.subject.memberEnd[0], True)
 
-        copy.copy({a, c})
+        copy_buffer = copy({a, c})
         new_diagram = element_factory.create(Diagram)
-        pasted_items = copy.paste_link(new_diagram)
+        pasted_items = paste_link(copy_buffer, new_diagram, element_factory.lookup)
 
     aa = pasted_items.pop()
     if not isinstance(aa, diagramitems.AssociationItem):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

No proper copy/paste in our GTK4 version

Issue Number: #274, #618 

### What is the new behavior?

Copy paste works with Gdk.Clipboard.

This will allow us to extend it with copy/paste of images, for example, so you can easily share stuff with other apps. Also we can paste things like text in the application now.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Fix issue when cutting elements in GTK4. Causes error in tree model. #1567