### PR TITLE
Fix unlinking elements from the model 

### DIFF
--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -26,7 +26,11 @@ log = logging.getLogger(__name__)
 
 
 class UnlinkEvent:
-    """Used to tell event handlers this element should be unlinked."""
+    """Used to tell event handlers this element should be unlinked.
+
+    This event is used internally and should not be handled outside
+    `gaphor.core.modeling`.
+    """
 
     def __init__(self, element: Element, diagram: Diagram | None = None):
         self.element = element
@@ -90,6 +94,7 @@ class Element:
         """
         self._id: Id = id or generate_id()
         # The model this element belongs to.
+        # NOTE: Will be unset by ElementFactory once it's `unlink()`ed.
         self._model = model
         self._unlink_lock = 0
 
@@ -161,8 +166,7 @@ class Element:
             prop.unlink(self)
 
         log.debug("unlinking %s", self)
-        self.handle(unlink_event or UnlinkEvent(self))
-        self._model = None
+        self.handle(unlink_event)
 
     def handle(self, event):
         """Propagate incoming events."""

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Callable, Iterator, TypeVar, overload
+from typing import Callable, Iterator, Protocol, TypeVar, overload
 
 from gaphor.abc import Service
+from gaphor.core.eventmanager import EventManager, event_handler
 from gaphor.core.modeling.diagram import Diagram
 from gaphor.core.modeling.element import (
     Element,
@@ -25,17 +26,28 @@ from gaphor.core.modeling.event import (
 )
 from gaphor.core.modeling.presentation import Presentation
 
-if TYPE_CHECKING:
-    from gaphor.core.eventmanager import EventManager  # noqa
-
-
 T = TypeVar("T", bound=Element)
 P = TypeVar("P", bound=Presentation)
 
 
-class BlockingEventManager:
+class EventHandler(Protocol):
     def handle(self, *events):
-        pass
+        ...
+
+
+class UnlinkOnlyEventManager:
+    """Block all events.
+
+    The one exception is `UnlinkEvent`, which is handled internally.
+    """
+
+    def __init__(self, on_unlink):
+        self.on_unlink = on_unlink
+
+    def handle(self, *events):
+        for event in events:
+            if isinstance(event, UnlinkEvent):
+                self.on_unlink(event)
 
 
 class RecordingEventManager:
@@ -68,12 +80,16 @@ class ElementFactory(Service):
         event_manager: EventManager | None = None,
         element_dispatcher: ElementDispatcher | None = None,
     ):
-        self.event_manager = event_manager
+        self.event_manager: EventHandler | None = event_manager
         self.element_dispatcher = element_dispatcher
         self._elements: dict[str, Element] = OrderedDict()
+        if event_manager:
+            event_manager.subscribe(self._on_unlink_event)
 
     def shutdown(self) -> None:
         self.flush()
+        if isinstance(self.event_manager, EventManager):
+            self.event_manager.unsubscribe(self._on_unlink_event)
 
     def create(self, type: type[T]) -> T:
         """Create a new model element of type ``type``."""
@@ -204,14 +220,16 @@ class ElementFactory(Service):
         self.handle(ModelReady(self))
 
     @contextmanager
-    def block_events(self, new_event_manager=BlockingEventManager()):
+    def block_events(self, new_event_manager: EventHandler | None = None):
         """Block events from being emitted.
 
         Instead, events are directed to `new_event_manager`, which
         defaults to a blocking event manager.
         """
         current_event_manager = self.event_manager
-        self.event_manager = new_event_manager
+        self.event_manager = new_event_manager or UnlinkOnlyEventManager(
+            self._on_unlink_event
+        )
         try:
             yield self
         finally:
@@ -219,13 +237,21 @@ class ElementFactory(Service):
 
     def handle(self, event: object) -> None:
         """Handle events coming from elements."""
-        if isinstance(event, UnlinkEvent):
-            element = event.element
-            assert isinstance(element.id, str)
-            try:
-                del self._elements[element.id]
-            except KeyError:
-                return
-            event = ElementDeleted(self, event.element, event.diagram)
         if self.event_manager:
             self.event_manager.handle(event)
+        elif isinstance(event, UnlinkEvent):
+            self._on_unlink_event(event)
+
+    @event_handler(UnlinkEvent)
+    def _on_unlink_event(self, event):
+        element = event.element
+        element._model = None
+        assert isinstance(element.id, str)
+        try:
+            del self._elements[element.id]
+        except KeyError:
+            return
+        if self.event_manager:
+            self.event_manager.handle(
+                ElementDeleted(self, event.element, event.diagram)
+            )

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -35,21 +35,6 @@ class EventHandler(Protocol):
         ...
 
 
-class UnlinkOnlyEventManager:
-    """Block all events.
-
-    The one exception is `UnlinkEvent`, which is handled internally.
-    """
-
-    def __init__(self, on_unlink):
-        self.on_unlink = on_unlink
-
-    def handle(self, *events):
-        for event in events:
-            if isinstance(event, UnlinkEvent):
-                self.on_unlink(event)
-
-
 class RecordingEventManager:
     def __init__(self, event_manager):
         self.event_manager = event_manager
@@ -227,9 +212,7 @@ class ElementFactory(Service):
         defaults to a blocking event manager.
         """
         current_event_manager = self.event_manager
-        self.event_manager = new_event_manager or UnlinkOnlyEventManager(
-            self._on_unlink_event
-        )
+        self.event_manager = new_event_manager
         try:
             yield self
         finally:

--- a/gaphor/core/modeling/tests/test_elementfactory.py
+++ b/gaphor/core/modeling/tests/test_elementfactory.py
@@ -4,8 +4,6 @@ from collections.abc import Container, Iterable
 import pytest
 
 from gaphor.core import event_handler
-from gaphor.core.eventmanager import EventManager
-from gaphor.core.modeling import ElementFactory
 from gaphor.core.modeling.event import (
     ElementCreated,
     ElementDeleted,
@@ -114,12 +112,11 @@ def clear_events():
     last_event = None
 
 
-@pytest.fixture
-def element_factory():
-    event_manager = EventManager()
+@pytest.fixture(autouse=True)
+def subscribe_handlers(event_manager):
     event_manager.subscribe(handler)
     clear_events()
-    yield ElementFactory(event_manager)
+    yield None
     clear_events()
 
 
@@ -165,7 +162,6 @@ class CheckModel:
         self.element = element
 
 
-@pytest.mark.xfail()
 def test_indirect_delete_of_element(event_manager, element_factory):
     @event_handler(CheckModel)
     def on_check_model(event):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

I ran into a nice edge case. In gaphor 2.10 we changed the behavior of the EventManager. If an event B is triggered while event A is being handled, B is held back and handled once all handlers for A have been executed.
This fixed some issues in our Undo manager.

However, it seems like it can also introduce some unexpected behavior.

We have a Sanitizer service. This service is responsible for deleting a model element if there are no presentations of that element left. The effect (removed from model and Element.model set to None) takes effect immediately. However the event is added to the queue where a bunch of events still need to be handled. Some of the event handlers expect Element.model to be set.
One way to solve it is to ensure the effect (Element.model set to None) only takes place once that event is to be handled.
Another is to assume that Element.model can be unset (raises exception) and handle this exception accordingly.

Issue Number: N/A

### What is the new behavior?

The actual unlinking happens when the event `UnlinkEvent` is handled. A `ElementDeleted` event is resubmitted after this event has been processed.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
