### PR TITLE
Fix codeql warnings and error

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+env:
+  python_version: '3.10'
 
 permissions:
   contents: read
@@ -18,6 +20,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3.0.2
+    - name: Set up Python
+      uses: actions/setup-python@v4.0.0
+      with:
+        python-version: ${{ env.python_version }}
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,10 @@
 name: "CodeQL"
 
 on:
+  push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 permissions:
   contents: read
@@ -15,15 +18,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3.0.2
-      with:
-        fetch-depth: 2
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
         languages: python
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,9 +24,29 @@ jobs:
       uses: actions/setup-python@v4.0.0
       with:
         python-version: ${{ env.python_version }}
+    - name: Install Linux Dependencies
+      uses: ./.github/actions/linux_dependencies
+    - name: Use Python Dependency Cache
+      uses: actions/cache@v3.0.4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+    - name: Install Poetry
+      run: pip install poetry==1.1.13
+    - name: Configure Poetry
+      run: poetry config virtualenvs.in-project true
+    - name: Install Python Dependencies
+      run: |
+        poetry install
+        # Set the `CODEQL-PYTHON` environment variable to the Python executable
+        # that includes the dependencies
+        echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
         languages: python
+        # Override the default behavior so that the action doesn't attempt
+        # to auto-install Python dependencies
+        setup-python-dependencies: false
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
We are getting two warnings and an error on our CodeQL builds:

1. `git checkout HEAD^2` is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results.
2. Please specify an on.push hook so that Code Scanning can compare pull requests against the state of the base branch.
3. Error: The process '/home/runner/work/_actions/github/codeql-action/v2/python-setup/auto_install_packages.py' failed with exit code 1. Please make sure any necessary dependencies are installed before calling the codeql-action/analyze step, and add a 'setup-python-dependencies: false' argument to this step to disable our automatic dependency installation and avoid this warning.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
