### PR TITLE
Ensure all models are saved with UTF-8 encoding

### DIFF
--- a/gaphor/plugins/xmiexport/exportmodel.py
+++ b/gaphor/plugins/xmiexport/exportmodel.py
@@ -222,30 +222,31 @@ class XMIExport:
         pass
 
     def export(self, filename):
-        out = open(filename, "w")
+        with open(filename, "w", encoding="utf-8") as out:
+            xmi = XMLWriter(out)
 
-        xmi = XMLWriter(out)
+            attributes = {
+                "xmi.version": self.XMI_VERSION,
+                "xmlns:xmi": self.XMI_NAMESPACE,
+                "xmlns:UML": self.UML_NAMESPACE,
+            }
 
-        attributes = {
-            "xmi.version": self.XMI_VERSION,
-            "xmlns:xmi": self.XMI_NAMESPACE,
-            "xmlns:UML": self.UML_NAMESPACE,
-        }
+            xmi.startElement("XMI", attrs=attributes)
 
-        xmi.startElement("XMI", attrs=attributes)
+            for package in self.element_factory.select(self.select_package):
+                self.handle(xmi, package)
 
-        for package in self.element_factory.select(self.select_package):
-            self.handle(xmi, package)
+            for generalization in self.element_factory.select(
+                self.select_generalization
+            ):
+                self.handle(xmi, generalization)
 
-        for generalization in self.element_factory.select(self.select_generalization):
-            self.handle(xmi, generalization)
+            for realization in self.element_factory.select(self.select_realization):
+                self.handle(xmi, realization)
 
-        for realization in self.element_factory.select(self.select_realization):
-            self.handle(xmi, realization)
+            xmi.endElement("XMI")
 
-        xmi.endElement("XMI")
-
-        logger.debug(self.handled_ids)
+            logger.debug(self.handled_ids)
 
     def select_package(self, element):
         return element.__class__.__name__ == "Package"

--- a/gaphor/services/properties.py
+++ b/gaphor/services/properties.py
@@ -145,7 +145,7 @@ class Properties(Service):
         if not self.filename:
             return
 
-        with open(self.filename, "w") as ofile:
+        with open(self.filename, "w", encoding="utf-8") as ofile:
             pprint.pprint(self._properties, ofile)
 
     def get(self, key: str, default=_no_default):

--- a/gaphor/storage/parser.py
+++ b/gaphor/storage/parser.py
@@ -311,7 +311,12 @@ def parse_generator(filename, loader):
     parser.setFeature(handler.feature_namespaces, 1)
     parser.setContentHandler(loader)
 
-    yield from parse_file(filename, parser)
+    try:
+        # returns only a progress percentage
+        yield from parse_file(filename, parser)
+    except UnicodeDecodeError:
+        # Fall back on default encoding
+        yield from parse_file(filename, parser, encoding=None)
 
 
 class ProgressGenerator:
@@ -360,7 +365,7 @@ class ProgressGenerator:
             yield (read_size * 100) / self.file_size
 
 
-def parse_file(filename, parser):
+def parse_file(filename, parser, encoding: str | None = "utf-8"):
     """Parse the supplied file using the supplied parser.
 
     The parser parameter should be a GaphorLoader instance.  The
@@ -374,7 +379,7 @@ def parse_file(filename, parser):
         file_obj: IO | io.IOBase = filename
     else:
         is_fd = False
-        file_obj = open(filename, "r", encoding="utf-8")
+        file_obj = open(filename, "r", encoding=encoding)
 
     try:
         yield from ProgressGenerator(file_obj, parser)

--- a/gaphor/storage/parser.py
+++ b/gaphor/storage/parser.py
@@ -374,7 +374,7 @@ def parse_file(filename, parser):
         file_obj: IO | io.IOBase = filename
     else:
         is_fd = False
-        file_obj = open(filename, "r")
+        file_obj = open(filename, "r", encoding="utf-8")
 
     try:
         yield from ProgressGenerator(file_obj, parser)

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -118,7 +118,7 @@ class FileManager(Service, ActionProvider):
             status_window = StatusWindow(
                 gettext("Loading…"),
                 gettext("Loading model from {filename}").format(filename=filename),
-                parent=self.main_window.window,
+                parent=self.main_window.window if self.main_window else None,
                 queue=queue,
             )
 

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -194,7 +194,7 @@ class FileManager(Service, ActionProvider):
         @g_async(priority=GLib.PRIORITY_DEFAULT_IDLE)
         def async_saver():
             try:
-                with open(filename, "w") as out:
+                with open(filename, "w", encoding="utf-8") as out:
                     for percentage in storage.save_generator(out, self.element_factory):
                         queue.put(percentage)
                         yield

--- a/gaphor/ui/tests/test_filemanager.py
+++ b/gaphor/ui/tests/test_filemanager.py
@@ -32,3 +32,27 @@ def test_model_is_saved_with_utf8_encoding(
 
     with open(model_file, encoding="utf-8") as f:
         f.read()  # raises exception if characters can't be decoded
+
+
+def test_model_is_loaded_with_utf8_encoding(
+    element_factory, file_manager: FileManager, tmp_path
+):
+    class_name = "üëïèàòù"
+    package_name = "안녕하세요 세계"
+
+    class_ = element_factory.create(UML.Class)
+    class_.name = class_name
+    package = element_factory.create(UML.Package)
+    package.name = package_name
+
+    model_file = tmp_path / "model.gaphor"
+    file_manager.save(str(model_file))
+
+    element_factory.flush()
+
+    file_manager.load(str(model_file))
+    new_class = next(element_factory.select(UML.Class))
+    new_package = next(element_factory.select(UML.Package))
+
+    assert new_class.name == class_name
+    assert new_package.name == package_name

--- a/gaphor/ui/tests/test_filemanager.py
+++ b/gaphor/ui/tests/test_filemanager.py
@@ -17,3 +17,18 @@ def test_save(element_factory, file_manager: FileManager, tmp_path):
     file_manager.save(filename=str(out_file))
 
     assert out_file.exists()
+
+
+def test_model_is_saved_with_utf8_encoding(
+    element_factory, file_manager: FileManager, tmp_path
+):
+    class_ = element_factory.create(UML.Class)
+    class_.name = "üëïèàòù"
+    package = element_factory.create(UML.Package)
+    package.name = "안녕하세요 세계"
+
+    model_file = tmp_path / "model.gaphor"
+    file_manager.save(str(model_file))
+
+    with open(model_file, encoding="utf-8") as f:
+        f.read()  # raises exception if characters can't be decoded

--- a/gaphor/ui/tests/test_filemanager.py
+++ b/gaphor/ui/tests/test_filemanager.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from gaphor import UML
@@ -56,3 +58,13 @@ def test_model_is_loaded_with_utf8_encoding(
 
     assert new_class.name == class_name
     assert new_package.name == package_name
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32", reason="Standard encoding on Windows is not UTF-8"
+)
+def test_old_model_is_loaded_without_utf8_encoding(
+    file_manager: FileManager, test_models
+):
+    model_file = test_models / "wrong-encoding.gaphor"
+    file_manager.load(str(model_file))

--- a/test-models/wrong-encoding.gaphor
+++ b/test-models/wrong-encoding.gaphor
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.10.0.dev786+d53a15d0">
+<StyleSheet id="58d6989a-66f8-11ec-b4c8-0456e5e540ed"/>
+<Package id="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed">
+<name>
+<val>New model</val>
+</name>
+<ownedDiagram>
+<reflist>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</reflist>
+</ownedDiagram>
+<ownedType>
+<reflist>
+<ref refid="9cd5fc72-fd53-11ec-bf98-525400c3ab86"/>
+<ref refid="a8894891-fd53-11ec-baca-525400c3ab86"/>
+<ref refid="b6cc6a89-fd53-11ec-83b7-525400c3ab86"/>
+</reflist>
+</ownedType>
+</Package>
+<Diagram id="58d6c536-66f8-11ec-b4c8-0456e5e540ed">
+<element>
+<ref refid="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed"/>
+</element>
+<name>
+<val>main</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="9cd88c33-fd53-11ec-922f-525400c3ab86"/>
+<ref refid="a8897003-fd53-11ec-82f6-525400c3ab86"/>
+<ref refid="b6cc6a8a-fd53-11ec-8e54-525400c3ab86"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<Class id="9cd5fc72-fd53-11ec-bf98-525400c3ab86">
+<name>
+<val>Über-class</val>
+</name>
+<package>
+<ref refid="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="9cd88c33-fd53-11ec-922f-525400c3ab86"/>
+</reflist>
+</presentation>
+</Class>
+<ClassItem id="9cd88c33-fd53-11ec-922f-525400c3ab86">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 69.0, 88.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>58.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<subject>
+<ref refid="9cd5fc72-fd53-11ec-bf98-525400c3ab86"/>
+</subject>
+</ClassItem>
+<Class id="a8894891-fd53-11ec-baca-525400c3ab86">
+<name>
+<val>ça va bien</val>
+</name>
+<package>
+<ref refid="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="a8897003-fd53-11ec-82f6-525400c3ab86"/>
+</reflist>
+</presentation>
+</Class>
+<ClassItem id="a8897003-fd53-11ec-82f6-525400c3ab86">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 69.0, 185.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>58.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<subject>
+<ref refid="a8894891-fd53-11ec-baca-525400c3ab86"/>
+</subject>
+</ClassItem>
+<Class id="b6cc6a89-fd53-11ec-83b7-525400c3ab86">
+<name>
+<val>üëïèàòù</val>
+</name>
+<package>
+<ref refid="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="b6cc6a8a-fd53-11ec-8e54-525400c3ab86"/>
+</reflist>
+</presentation>
+</Class>
+<ClassItem id="b6cc6a8a-fd53-11ec-8e54-525400c3ab86">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 85.0, 338.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>58.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<subject>
+<ref refid="b6cc6a89-fd53-11ec-83b7-525400c3ab86"/>
+</subject>
+</ClassItem>
+</gaphor>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Models with non-ascii characters created on Windows, can't be loaded on Linux.

Issue Number: #1585 

### What is the new behavior?

Files are explicitly saved with UTF-8 encoding.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

I expected UTF-8 to be the default encoding, also for files, since `sys.getdefaultencoding()` returns `utf-8`. 