### PR TITLE
Todo example of use for css

### DIFF
--- a/docs/style-sheet-examples.gaphor
+++ b/docs/style-sheet-examples.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.6.5">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.10.0">
 <Package id="9d588440-d7c2-11ea-b8c5-37ef9fca94cd">
 <name>
 <val>style-sheets</val>
@@ -12,6 +12,7 @@
 <ref refid="ba2adb58-d7c3-11ea-b8c5-37ef9fca94cd"/>
 <ref refid="10701d48-d7c4-11ea-b8c5-37ef9fca94cd"/>
 <ref refid="b1cdfe7e-d7c6-11ea-b8c5-37ef9fca94cd"/>
+<ref refid="380f8d3c-fd67-11ec-9897-a87eeaeedf68"/>
 </reflist>
 </ownedDiagram>
 <ownedType>
@@ -46,6 +47,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 38.5, 59.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>131.0</val>
 </width>
@@ -95,7 +99,10 @@ diagram[name=draft] * {
 association:not([memberEnd.navigability*=true]) {
  color: blue;
 }
-</val>
+
+diagram[name=todo] comment[body^="TODO"] {
+  background-color: skyblue;
+}</val>
 </styleSheet>
 </StyleSheet>
 <Class id="a3f548f6-d7c2-11ea-b8c5-37ef9fca94cd">
@@ -184,6 +191,9 @@ association:not([memberEnd.navigability*=true]) {
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 71.0, 85.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>234.5</val>
 </width>
@@ -206,6 +216,9 @@ association:not([memberEnd.navigability*=true]) {
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 35.75, 74.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>163.0</val>
 </width>
@@ -331,6 +344,9 @@ association:not([memberEnd.navigability*=true]) {
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 59.5, 74.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>131.0</val>
 </width>
@@ -348,6 +364,9 @@ association:not([memberEnd.navigability*=true]) {
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 59.5, 231.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>267.5</val>
 </width>
@@ -370,6 +389,9 @@ association:not([memberEnd.navigability*=true]) {
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 49.5, 70.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>163.0</val>
 </width>
@@ -449,6 +471,9 @@ association:not([memberEnd.navigability*=true]) {
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 79.0, 84.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -466,6 +491,9 @@ association:not([memberEnd.navigability*=true]) {
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 335.0, 84.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -545,6 +573,9 @@ association:not([memberEnd.navigability*=true]) {
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 55.5, 109.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>102.5</val>
 </width>
@@ -562,6 +593,9 @@ association:not([memberEnd.navigability*=true]) {
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 343.5, 109.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -791,6 +825,9 @@ association:not([memberEnd.navigability*=true]) {
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 125.0, 72.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -808,6 +845,9 @@ association:not([memberEnd.navigability*=true]) {
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 125.0, 241.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -899,4 +939,81 @@ association:not([memberEnd.navigability*=true]) {
 <ref refid="adf43018-d7c4-11ea-b8c5-37ef9fca94cd"/>
 </type>
 </Property>
+<Diagram id="380f8d3c-fd67-11ec-9897-a87eeaeedf68">
+<diagramType>
+<val></val>
+</diagramType>
+<element>
+<ref refid="9d588440-d7c2-11ea-b8c5-37ef9fca94cd"/>
+</element>
+<name>
+<val>todo</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="410d79c6-fd67-11ec-9897-a87eeaeedf68"/>
+<ref refid="5118c9d8-fd67-11ec-9897-a87eeaeedf68"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<Comment id="410d7480-fd67-11ec-9897-a87eeaeedf68">
+<body>
+<val>TODO: Fix this</val>
+</body>
+<presentation>
+<reflist>
+<ref refid="410d79c6-fd67-11ec-9897-a87eeaeedf68"/>
+</reflist>
+</presentation>
+</Comment>
+<CommentItem id="410d79c6-fd67-11ec-9897-a87eeaeedf68">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 420.0, 335.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>50.0</val>
+</height>
+<diagram>
+<ref refid="380f8d3c-fd67-11ec-9897-a87eeaeedf68"/>
+</diagram>
+<subject>
+<ref refid="410d7480-fd67-11ec-9897-a87eeaeedf68"/>
+</subject>
+</CommentItem>
+<Comment id="5118c2e4-fd67-11ec-9897-a87eeaeedf68">
+<body>
+<val>Other Comment</val>
+</body>
+<presentation>
+<reflist>
+<ref refid="5118c9d8-fd67-11ec-9897-a87eeaeedf68"/>
+</reflist>
+</presentation>
+</Comment>
+<CommentItem id="5118c9d8-fd67-11ec-9897-a87eeaeedf68">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 420.0, 419.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>50.0</val>
+</height>
+<diagram>
+<ref refid="380f8d3c-fd67-11ec-9897-a87eeaeedf68"/>
+</diagram>
+<subject>
+<ref refid="5118c2e4-fd67-11ec-9897-a87eeaeedf68"/>
+</subject>
+</CommentItem>
 </gaphor>

--- a/docs/style_sheets.md
+++ b/docs/style_sheets.md
@@ -317,3 +317,20 @@ association:not([memberEnd.navigability*=true]) {
 :model: style-sheets
 :alt: navigable association
 ```
+
+### Todo note highlight
+
+All comments beginning with the phrase "todo" can be highlighted in
+a different user-specific colour. This can be used to make yourself aware
+that you have to do some additional work to finalize the diagram.
+
+```css
+comment[body^="TODO"] {
+  background-color: skyblue;
+}
+```
+
+```{diagram} todo
+:model: style-sheets
+:alt: highlighted todo note
+```


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->
This PR will add a todo example of use for css in the docs.

The changes result in this new section:
![grafik](https://user-images.githubusercontent.com/22551563/177639757-053320aa-9b9e-40b6-89cc-74ed3d623fa6.png)


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [x] Documentation content changes

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Thanks to @danyeaw kind assist for showing me how to implement the example.