### PR TITLE
Transition can self-reference State 

### DIFF
--- a/gaphor/UML/states/finalstate.py
+++ b/gaphor/UML/states/finalstate.py
@@ -3,15 +3,14 @@
 from gaphas.util import path_ellipse
 
 from gaphor import UML
-from gaphor.diagram.presentation import ElementPresentation
+from gaphor.diagram.presentation import ElementPresentation, Named
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.recipes import stereotypes_str
-from gaphor.UML.states.state import VertexItem
 
 
 @represents(UML.FinalState)
-class FinalStateItem(VertexItem, ElementPresentation):
+class FinalStateItem(ElementPresentation, Named):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=30, height=30)
         for h in self.handles():

--- a/gaphor/UML/states/pseudostates.py
+++ b/gaphor/UML/states/pseudostates.py
@@ -7,15 +7,14 @@ from gaphas.item import SE
 from gaphas.util import path_ellipse
 
 from gaphor import UML
-from gaphor.diagram.presentation import ElementPresentation
+from gaphor.diagram.presentation import ElementPresentation, Named
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.recipes import stereotypes_str
-from gaphor.UML.states.state import VertexItem
 
 
 @represents(UML.Pseudostate)
-class PseudostateItem(VertexItem, ElementPresentation):
+class PseudostateItem(ElementPresentation, Named):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=20, height=20)
         for h in self.handles():

--- a/gaphor/UML/states/state.py
+++ b/gaphor/UML/states/state.py
@@ -9,16 +9,8 @@ from gaphor.diagram.support import represents
 from gaphor.UML.recipes import stereotypes_str
 
 
-class VertexItem(Named):
-    """Abstract class for all vertices.
-
-    All state, pseudostate items derive from VertexItem, which
-    simplifies transition connection adapters.
-    """
-
-
 @represents(UML.State)
-class StateItem(VertexItem, ElementPresentation[UML.State]):
+class StateItem(ElementPresentation[UML.State], Named):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=50, height=30)
 

--- a/gaphor/UML/states/tests/test_transition_connect.py
+++ b/gaphor/UML/states/tests/test_transition_connect.py
@@ -9,12 +9,10 @@ from gaphor.UML.states.transition import TransitionItem
 
 
 def test_vertex_connect(create, kindof):
-    """Test transition to state vertex connection."""
     v1 = create(StateItem, UML.State)
     v2 = create(StateItem, UML.State)
 
     t = create(TransitionItem)
-    assert t.subject is None
 
     # connect vertices with transition
     connect(t, t.head, v1)
@@ -31,7 +29,6 @@ def test_vertex_connect(create, kindof):
 
 
 def test_vertex_reconnect(create, kindof):
-    """Test transition to state vertex reconnection."""
     v1 = create(StateItem, UML.State)
     v2 = create(StateItem, UML.State)
     v3 = create(StateItem, UML.State)
@@ -62,7 +59,6 @@ def test_vertex_reconnect(create, kindof):
 
 
 def test_vertex_disconnect(create, kindof):
-    """Test transition and state vertices disconnection."""
     t = create(TransitionItem)
     v1 = create(StateItem, UML.State)
     v2 = create(StateItem, UML.State)
@@ -84,13 +80,21 @@ def test_vertex_disconnect(create, kindof):
     assert t.subject is None
 
 
+def test_state_connect_to_same_item(create, kindof):
+    """Test transition to state vertex connection."""
+    v1 = create(StateItem, UML.State)
+    t = create(TransitionItem)
+
+    connect(t, t.head, v1)
+
+    assert allow(t, t.tail, v1)
+
+
 def test_initial_pseudostate_connect(create, kindof):
-    """Test transition and initial pseudostate connection."""
     v1 = create(PseudostateItem, UML.Pseudostate)
     v2 = create(StateItem, UML.State)
 
     t = create(TransitionItem)
-    assert t.subject is None
 
     # connect head of transition to an initial pseudostate
     connect(t, t.head, v1)

--- a/gaphor/core/modeling/tests/test_literal_eval.py
+++ b/gaphor/core/modeling/tests/test_literal_eval.py
@@ -1,8 +1,14 @@
+import sys
+
 import pytest
 
 from gaphor.core.modeling.presentation import literal_eval
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="literal_eval only strips leading spaces in Python 3.10+",
+)
 @pytest.mark.parametrize(
     "text,expected",
     [


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Transitions can't start and end on the same State.

Issue Number: #1577 

### What is the new behavior?

Transitions can be self-referencing.

