### PR TITLE
Move Windows Installation to C:\Program Files

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -379,5 +379,5 @@ jobs:
       - name: Perform self-test
         run: |
           start "" /WAIT "${{ needs.windows.outputs.installer }}" /S
-          start "" /WAIT "C:\Program Files (x86)\Gaphor\gaphor-exe.exe" --self-test
+          start "" /WAIT "C:\Program Files\Gaphor\gaphor-exe.exe" --self-test
         shell: cmd

--- a/_packaging/windows/win_installer.nsi
+++ b/_packaging/windows/win_installer.nsi
@@ -41,12 +41,21 @@ Var UNINST_BIN
 !insertmacro MUI_UNPAGE_CONFIRM
 !insertmacro MUI_UNPAGE_INSTFILES
 
-!insertmacro MUI_LANGUAGE "English"
 !insertmacro MUI_LANGUAGE "Catalan"
+!insertmacro MUI_LANGUAGE "Croatian"
+!insertmacro MUI_LANGUAGE "Czech"
 !insertmacro MUI_LANGUAGE "Dutch"
+!insertmacro MUI_LANGUAGE "English"
 !insertmacro MUI_LANGUAGE "French"
+!insertmacro MUI_LANGUAGE "Galician"
+!insertmacro MUI_LANGUAGE "German"
+!insertmacro MUI_LANGUAGE "Hungarian"
+!insertmacro MUI_LANGUAGE "Italian"
+!insertmacro MUI_LANGUAGE "Japanese"
+!insertmacro MUI_LANGUAGE "Korean"
 !insertmacro MUI_LANGUAGE "PortugueseBR"
 !insertmacro MUI_LANGUAGE "Russian"
+!insertmacro MUI_LANGUAGE "SimpChinese"
 !insertmacro MUI_LANGUAGE "Spanish"
 !insertmacro MUI_LANGUAGE "Swedish"
 

--- a/_packaging/windows/win_installer.nsi
+++ b/_packaging/windows/win_installer.nsi
@@ -1,4 +1,4 @@
-; Copyright 2016 Christoph Reiter, 2019 Dan Yeaw
+; Copyright 2016 Christoph Reiter, 2019-2022 Dan Yeaw
 ;
 ; This program is free software; you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by

--- a/_packaging/windows/win_installer.nsi
+++ b/_packaging/windows/win_installer.nsi
@@ -25,7 +25,7 @@ Name "${NAME} (${VERSION})"
 OutFile "gaphor-LATEST.exe"
 SetCompressor /SOLID /FINAL lzma
 SetCompressorDictSize 32
-InstallDir "$PROGRAMFILES\${NAME}"
+InstallDir "$PROGRAMFILES64\${NAME}"
 RequestExecutionLevel admin
 
 Var INST_BIN
@@ -50,13 +50,8 @@ Var UNINST_BIN
 !insertmacro MUI_LANGUAGE "Spanish"
 !insertmacro MUI_LANGUAGE "Swedish"
 
-
 Section "Install"
     SetShellVarContext all
-
-    ; Use this to make things faster for testing installer changes
-    ;~ SetOutPath "$INSTDIR\bin"
-    ;~ File /r "mingw32\bin\*.exe"
 
     SetOutPath "$INSTDIR"
     File /r "*.*"


### PR DESCRIPTION
This PR moves the installation location on Windows to C:\Program Files from C:\Program Files (x86).

If upgrading versions, it will automatically uninstall previous versions, even if they are in C:\Program Files (x86), or any other location. However, it will by default specify the previous location and the user would need to remove the (x86) if they want it installed somewhere else, which I think is OK. For new installs, it always defaults to C:\Program Files.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Gaphor is installed to C:\Program Files (x86)

Issue Number: #1580

### What is the new behavior?
Gaphor is installed to C:\Program Files

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
