### PR TITLE
Add createMessage to element support with auto convert

### DIFF
--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -136,13 +136,23 @@ def convert_create_message(line, convert_back=False):
     def communication_element(elem):
         return isinstance(elem, LifelineItem) and not elem.lifetime.visible
 
-    if tail and communication_element(tail) and head and not communication_element(head):
-        if convert_back and line.subject and line.subject.messageSort == "createMessage":
+    if (
+        tail
+        and communication_element(tail)
+        and head
+        and not communication_element(head)
+    ):
+        if (
+            convert_back
+            and line.subject
+            and line.subject.messageSort == "createMessage"
+        ):
             line.subject.messageSort = "synchCall"
         else:
             line.subject.messageSort = "createMessage"
         return True
     return False
+
 
 @Connector.register(LifelineItem, MessageItem)
 class MessageLifelineConnect(BaseConnector):
@@ -170,11 +180,17 @@ class MessageLifelineConnect(BaseConnector):
         connected = self.get_connected(opposite)
 
         if not connected:
-            return handle is line.tail or not (lifetime.visible ^ (port is lifetime.port))
+            return handle is line.tail or not (
+                lifetime.visible ^ (port is lifetime.port)
+            )
         if isinstance(connected, LifelineItem):
             if handle is line.head:
-                return connected.lifetime.visible and port is lifetime.port \
-                       or (not lifetime.visible and not connected.lifetime.visible) or port is lifetime.port
+                return (
+                    connected.lifetime.visible
+                    and port is lifetime.port
+                    or (not lifetime.visible and not connected.lifetime.visible)
+                    or port is lifetime.port
+                )
             if handle is line.tail:
                 return connected.lifetime.visible or not lifetime.visible
         return True
@@ -335,7 +351,7 @@ class ExecutionSpecificationExecutionSpecificationConnect(BaseConnector):
 @ConnectionSink.register(LifelineItem)
 class LifelineConnectionSink(ItemConnectionSink):
     def glue(
-            self, pos: SupportsFloatPos, secondary_pos: Optional[SupportsFloatPos] = None
+        self, pos: SupportsFloatPos, secondary_pos: Optional[SupportsFloatPos] = None
     ) -> Optional[Pos]:
         """Glue a line to the lifeline item, have a preference for the lifetime
         line."""

--- a/gaphor/UML/interactions/message.py
+++ b/gaphor/UML/interactions/message.py
@@ -224,6 +224,11 @@ class MessageItem(Named, LinePresentation[UML.Message]):
         diagram."""
         c1 = self._connections.get_connection(self.head)
         c2 = self._connections.get_connection(self.tail)
+
+        """createMessages can't be a communicationMessage
+        """
+        if self.subject and self.subject.messageSort == "createMessage":
+            return False
         return (
             c1
             and isinstance(c1.connected, LifelineItem)


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
 Issue Number:  #1599

### What is the new behavior?
A message is converted automatically to a `createMessage` as soon as it's clear that it can only be a `createMessage`. Also, I relaxed the allowed connections of messages in general quite a bit.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
