### PR TITLE
Fix color scheme warning with libadwaita

### DIFF
--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -63,9 +63,16 @@ def main(argv=sys.argv) -> int:
 
     # Set dark mode for non-FreeDesktop platforms only:
     if sys.platform in ("darwin", "win32"):
-        Gtk.Settings.get_default().set_property(
-            "gtk-application-prefer-dark-theme", darkdetect.isDark()
-        )
+        if Gtk.get_major_version() == 3:
+            Gtk.Settings.get_default().set_property(
+                "gtk-application-prefer-dark-theme", darkdetect.isDark()
+            )
+        else:
+            if darkdetect.isDark():
+                color_scheme = Adw.ColorScheme.PREFER_DARK
+            else:
+                color_scheme = Adw.ColorScheme.PREFER_LIGHT
+            Adw.StyleManager.get_default().set_color_scheme(color_scheme)
 
     if has_option("-p", "--profiler"):
 


### PR DESCRIPTION
Using `GtkSettings:gtk-application-prefer-dark-theme` with libadwaita is unsupported. This PR updates to use `AdwStyleManager:color-scheme` instead when running in GTK4.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Color scheme warning seen in some macOS builds

Issue Number: N/A

### What is the new behavior?
No warning

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
