### PR TITLE
Support stereotypes inherited from other stereotypes

### DIFF
--- a/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
@@ -7,51 +7,45 @@ from gaphor.UML.profiles.stereotypepropertypages import (
 )
 
 
-def test_stereotype_property_page_without_stereotype(diagram, element_factory):
+def create_property_page(diagram, element_factory) -> StereotypePage:
     item = diagram.create(
         UML.classes.ClassItem, subject=element_factory.create(UML.Class)
     )
-    property_page = StereotypePage(item)
+    return StereotypePage(item)
 
+
+def get_model(property_page: StereotypePage):
     widget = property_page.construct()
+    show_stereotypes = find(widget, "stereotype-list")
+    return show_stereotypes.get_model()
 
-    assert widget is None
 
-
-def test_stereotype_property_page_with_stereotype(diagram, element_factory):
+def metaclass_and_stereotype(element_factory):
     metaclass = element_factory.create(UML.Class)
     metaclass.name = "Class"
     stereotype = element_factory.create(UML.Stereotype)
     stereotype.name = "Stereotype"
     UML.recipes.create_extension(metaclass, stereotype)
+    return metaclass, stereotype
 
-    item = diagram.create(
-        UML.classes.ClassItem, subject=element_factory.create(UML.Class)
-    )
-    property_page = StereotypePage(item)
+
+def test_stereotype_property_page_with_stereotype(diagram, element_factory):
+    metaclass, stereotype = metaclass_and_stereotype(element_factory)
+    property_page = create_property_page(diagram, element_factory)
 
     widget = property_page.construct()
     show_stereotypes = find(widget, "show-stereotypes")
     show_stereotypes.set_active(True)
 
-    assert item.show_stereotypes
+    assert property_page.item.show_stereotypes
 
 
 def test_stereotype_property_page_apply_stereotype(diagram, element_factory):
-    metaclass = element_factory.create(UML.Class)
-    metaclass.name = "Class"
-    stereotype = element_factory.create(UML.Stereotype)
-    stereotype.name = "Stereotype"
-    UML.recipes.create_extension(metaclass, stereotype)
+    _metaclass, stereotype = metaclass_and_stereotype(element_factory)
 
-    item = diagram.create(
-        UML.classes.ClassItem, subject=element_factory.create(UML.Class)
-    )
-    property_page = StereotypePage(item)
-
-    widget = property_page.construct()
-    show_stereotypes = find(widget, "stereotype-list")
-    model = show_stereotypes.get_model()
+    property_page = create_property_page(diagram, element_factory)
+    item = property_page.item
+    model = get_model(property_page)
     toggle_stereotype(None, (0,), item.subject, model)
 
     assert stereotype in item.subject.appliedStereotype[0].classifier
@@ -65,14 +59,9 @@ def test_stereotype_property_page_slot_value(diagram, element_factory):
     stereotype.ownedAttribute = element_factory.create(UML.Property)
     UML.recipes.create_extension(metaclass, stereotype)
 
-    item = diagram.create(
-        UML.classes.ClassItem, subject=element_factory.create(UML.Class)
-    )
-    property_page = StereotypePage(item)
-
-    widget = property_page.construct()
-    show_stereotypes = find(widget, "stereotype-list")
-    model = show_stereotypes.get_model()
+    property_page = create_property_page(diagram, element_factory)
+    item = property_page.item
+    model = get_model(property_page)
     toggle_stereotype(None, (0,), item.subject, model)
     set_value(None, (0, 0), "test", model)
     slot = item.subject.appliedStereotype[0].slot[0]

--- a/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
@@ -68,3 +68,20 @@ def test_stereotype_property_page_slot_value(diagram, element_factory):
 
     assert stereotype.ownedAttribute[0] is slot.definingFeature
     assert "test" == slot.value
+
+
+def test_inherited_stereotype(diagram, element_factory):
+    metaclass, stereotype = metaclass_and_stereotype(element_factory)
+    substereotype = element_factory.create(UML.Stereotype)
+    substereotype.name = "SubStereotype"
+    generalization: UML.Generalization = element_factory.create(UML.Generalization)
+    generalization.general = stereotype
+    generalization.specific = substereotype
+
+    property_page = create_property_page(diagram, element_factory)
+    model = get_model(property_page)
+
+    assert model[(0,)]
+    assert model[(0,)][0] == "Stereotype"
+    assert model[(1,)]
+    assert model[(1,)][0] == "SubStereotype"

--- a/gaphor/UML/recipes.py
+++ b/gaphor/UML/recipes.py
@@ -128,7 +128,13 @@ def get_stereotypes(element):
     # find stereotypes that extend element class
     classes = model.select(lambda e: e.isKindOf(Class) and e.name in names)
 
-    stereotypes = {ext.ownedEnd.type for cls in classes for ext in cls.extension}
+    stereotypes = list({ext.ownedEnd.type for cls in classes for ext in cls.extension})
+
+    for s in stereotypes:
+        for sub in s.specialization[:].specific:
+            if isinstance(sub, Stereotype) and sub not in stereotypes:
+                stereotypes.append(sub)
+
     # Lambda key sort issue in mypy: https://github.com/python/mypy/issues/9656
     return sorted(stereotypes, key=lambda st: st.name)  # type: ignore
 

--- a/gaphor/UML/tests/test_recipes.py
+++ b/gaphor/UML/tests/test_recipes.py
@@ -110,6 +110,26 @@ def test_getting_stereotypes_unique(element_factory):
     assert ("st1", "st2") == result
 
 
+def test_inherited_stereotype(element_factory):
+    metaclass = element_factory.create(UML.Class)
+    metaclass.name = "Class"
+    stereotype = element_factory.create(UML.Stereotype)
+    stereotype.name = "Stereotype"
+    UML.recipes.create_extension(metaclass, stereotype)
+    substereotype = element_factory.create(UML.Stereotype)
+    substereotype.name = "SubStereotype"
+    generalization: UML.Generalization = element_factory.create(UML.Generalization)
+    generalization.general = stereotype
+    generalization.specific = substereotype
+
+    c = element_factory.create(UML.Class)
+
+    stereotypes = UML.recipes.get_stereotypes(c)
+
+    assert stereotype in stereotypes
+    assert substereotype in stereotypes
+
+
 # Association tests
 
 

--- a/gaphor/UML/tests/test_recipes.py
+++ b/gaphor/UML/tests/test_recipes.py
@@ -118,9 +118,7 @@ def test_inherited_stereotype(element_factory):
     UML.recipes.create_extension(metaclass, stereotype)
     substereotype = element_factory.create(UML.Stereotype)
     substereotype.name = "SubStereotype"
-    generalization: UML.Generalization = element_factory.create(UML.Generalization)
-    generalization.general = stereotype
-    generalization.specific = substereotype
+    UML.recipes.create_generalization(stereotype, substereotype)
 
     c = element_factory.create(UML.Class)
 

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -134,6 +134,56 @@ def test_extension_deletion(element_factory, diagram):
     assert not klass.appliedStereotype
 
 
+def test_extension_with_generalization_delete_extension(element_factory):
+    create = element_factory.create
+    metaklass = create(UML.Class)
+    metaklass.name = "Class"
+    klass = create(UML.Class)
+    stereotype = create(UML.Stereotype)
+    ext = UML.recipes.create_extension(metaklass, stereotype)
+    substereotype = create(UML.Stereotype)
+    UML.recipes.create_generalization(stereotype, substereotype)
+    UML.recipes.apply_stereotype(klass, substereotype)
+
+    ext.unlink()
+
+    assert not klass.appliedStereotype
+
+
+def test_extension_with_generalization_retain_specific_sterotype(element_factory):
+    create = element_factory.create
+    metaklass = create(UML.Class)
+    metaklass.name = "Class"
+    klass = create(UML.Class)
+    stereotype = create(UML.Stereotype)
+    UML.recipes.create_extension(metaklass, stereotype)
+    ext = UML.recipes.create_extension(metaklass, stereotype)
+    substereotype = create(UML.Stereotype)
+    UML.recipes.create_generalization(stereotype, substereotype)
+    UML.recipes.create_generalization(substereotype, stereotype)
+    UML.recipes.apply_stereotype(klass, substereotype)
+
+    ext.unlink()
+
+    assert substereotype in klass.appliedStereotype[:].classifier
+
+
+def test_extension_with_generalization_delete_generalization(element_factory):
+    create = element_factory.create
+    metaklass = create(UML.Class)
+    metaklass.name = "Class"
+    klass = create(UML.Class)
+    stereotype = create(UML.Stereotype)
+    UML.recipes.create_extension(metaklass, stereotype)
+    substereotype = create(UML.Stereotype)
+    gen = UML.recipes.create_generalization(stereotype, substereotype)
+    UML.recipes.apply_stereotype(klass, substereotype)
+
+    gen.unlink()
+
+    assert not klass.appliedStereotype
+
+
 def test_extension_deletion_with_2_metaclasses(element_factory):
     create = element_factory.create
     metaklass = create(UML.Class)

--- a/gaphor/UML/tests/test_uml2.py
+++ b/gaphor/UML/tests/test_uml2.py
@@ -65,10 +65,10 @@ def test_class(factory):
     assert (
         property1 in element.attribute
     ), f"Classifier.attribute does not contain ownedAttribute - {element.attribute}"
-    assert property1 in element.ownedMember, (
-        "Namespace.ownedMember does not contain ownedAttribute - %s"
-        % element.ownedMember
-    )
+    assert (
+        property1 in element.ownedMember
+    ), f"Namespace.ownedMember does not contain ownedAttribute - {element.ownedMember}"
+
 
     assert (
         operation1 in element.feature
@@ -100,10 +100,10 @@ def test_constraint(factory):
     element.constrainedElement = constrainedElement
     element.specification = "Constraint specification"
 
-    assert constrainedElement in element.constrainedElement, (
-        "Constraint.constrainedElement does not contain the correct element - %s"
-        % element.constrainedElement
-    )
+    assert (
+        constrainedElement in element.constrainedElement
+    ), f"Constraint.constrainedElement does not contain the correct element - {element.constrainedElement}"
+
     assert (
         element.specification == "Constraint specification"
     ), f"Constraint.specification is incorrect - {element.specification}"

--- a/gaphor/UML/tests/test_uml2.py
+++ b/gaphor/UML/tests/test_uml2.py
@@ -69,7 +69,6 @@ def test_class(factory):
         property1 in element.ownedMember
     ), f"Namespace.ownedMember does not contain ownedAttribute - {element.ownedMember}"
 
-
     assert (
         operation1 in element.feature
     ), f"Classifier.feature does not contain ownedOperation - {element.feature}"

--- a/gaphor/UML/tests/test_uml2.py
+++ b/gaphor/UML/tests/test_uml2.py
@@ -294,14 +294,13 @@ def test_metaclass_extension(factory):
     s = factory.create(UML.Stereotype)
     s.name = "Stereotype"
 
-    assert [] == c.extension
-    assert [] == s.extension
+    assert not c.extension
+    assert not s.extension
 
     e = UML.recipes.create_extension(c, s)
 
-    print(e.memberEnd)
-    assert [e] == c.extension
-    assert [] == s.extension
+    assert e in c.extension
+    assert not s.extension
     assert e.ownedEnd.type is s
 
 

--- a/gaphor/ui/treecomponent.py
+++ b/gaphor/ui/treecomponent.py
@@ -246,11 +246,10 @@ class TreeComponent(UIComponent, ActionProvider):
     def on_diagram_selection_changed(self, event):
         if not event.focused_item:
             return
-        element = event.focused_item.subject
-        if not element:
+        if element := event.focused_item.subject:
+            self.select_element(element)
+        else:
             return
-
-        self.select_element(element)
 
 
 def new_list_item_ui():


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Stereotypes inherited from other stereotypes can not be assigned. They are not shown in the property page.

Issue Number: #672

### What is the new behavior?

- [x] Stereotypes inherited fom other stereotypes show in property page
- [x] Removing generalization between stereotypes removes stereotype application from affected elements
- [x] Removing extension between metaclass and stereotype also removes application for specializations
- [x] (property page) Stereotype can also assign attributes from parent stereotype
- [x] Removal of attribute from parent stereotypes also removes it for child stereotype

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
