### PR TITLE
Fix "rename" from popover

### DIFF
--- a/gaphor/ui/treecomponent.py
+++ b/gaphor/ui/treecomponent.py
@@ -319,6 +319,7 @@ def list_item_factory_setup(_factory, list_item, event_manager, modeling_languag
     drag_source = Gtk.DragSource.new()
     drag_source.set_actions(Gdk.DragAction.MOVE | Gdk.DragAction.COPY)
     drag_source.connect("prepare", list_item_drag_prepare, list_item)
+    drag_source.connect("drag-begin", list_item_drag_begin, list_item)
     row.add_controller(drag_source)
 
     drop_target = Gtk.DropTarget.new(ElementDragData.__gtype__, Gdk.DragAction.COPY)
@@ -370,6 +371,16 @@ def list_item_drag_prepare(
     if isinstance(tree_item, RelationshipItem):
         return None
 
+    v = GObject.Value(
+        ElementDragData.__gtype__, ElementDragData(element=tree_item.element)
+    )
+    return Gdk.ContentProvider.new_for_value(v)
+
+
+def list_item_drag_begin(
+    source: Gtk.DragSource, drag: Gdk.Drag, list_item: Gtk.ListItem
+) -> None:
+    tree_item = list_item.get_item().get_item()
     display = Gdk.Display.get_default()
     theme_icon = Gtk.IconTheme.get_for_display(display).lookup_icon(
         tree_item.icon,
@@ -380,11 +391,6 @@ def list_item_drag_prepare(
         Gtk.IconLookupFlags.FORCE_SYMBOLIC,
     )
     source.set_icon(theme_icon, 0, 0)
-
-    v = GObject.Value(
-        ElementDragData.__gtype__, ElementDragData(element=tree_item.element)
-    )
-    return Gdk.ContentProvider.new_for_value(v)
 
 
 def list_item_drop_accept(

--- a/gaphor/ui/treecomponent.py
+++ b/gaphor/ui/treecomponent.py
@@ -244,11 +244,10 @@ class TreeComponent(UIComponent, ActionProvider):
     def on_diagram_selection_changed(self, event):
         if not event.focused_item:
             return
-        element = event.focused_item.subject
-        if not element:
+        if element := event.focused_item.subject:
+            self.select_element(element)
+        else:
             return
-
-        self.select_element(element)
 
 
 def new_list_item_ui():

--- a/gaphor/ui/treecomponent.py
+++ b/gaphor/ui/treecomponent.py
@@ -157,7 +157,7 @@ class TreeComponent(UIComponent, ActionProvider):
     def tree_view_rename_selected(self):
         if row_item := self.selection.get_selected_item():
             tree_item: TreeItem = row_item.get_item()
-            tree_item.start_editing()
+            GLib.timeout_add(200, tree_item.start_editing)
 
     @action(name="win.create-diagram")
     def tree_view_create_diagram(self, diagram_type: str):

--- a/gaphor/ui/treecomponent.py
+++ b/gaphor/ui/treecomponent.py
@@ -303,6 +303,14 @@ def list_item_factory_setup(_factory, list_item, event_manager, modeling_languag
     row = builder.get_object("row")
 
     def on_show_popup(ctrl, n_press, x, y):
+        list_item.get_child().activate_action(
+            "list.select-item",
+            GLib.Variant.new_tuple(
+                GLib.Variant.new_uint32(list_item.get_position()),
+                GLib.Variant.new_boolean(False),
+                GLib.Variant.new_boolean(False),
+            ),
+        )
         element = list_item.get_item().get_item().element
         menu = Gtk.PopoverMenu.new_from_model(popup_model(element, modeling_language))
         menu.set_parent(row)

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -40,6 +40,7 @@ class TreeItem(GObject.Object):
     def sync(self) -> None:
         if element := self.element:
             self.text = format(element) or gettext("<None>")
+            self.notify("edit-text")
             self.icon = get_icon_name(element)
             self.icon_visible = bool(
                 self.icon


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When you select the "Rename" entry from the popover menu in the tree view, the text is not editable on Wayland.

On X11 it works fine, though :/.

### What is the new behavior?

"Rename" is available fro a shortcut (`F2`). I could not find a way to make the popover work in combination with the edit feature.
Therefore I propose to remove the "Rename" option from the popover.


### Other information
