### PR TITLE
Fix stereotype application

### DIFF
--- a/gaphor/UML/profiles/extensionconnect.py
+++ b/gaphor/UML/profiles/extensionconnect.py
@@ -73,19 +73,7 @@ class ExtensionConnect(DirectionalRelationshipConnect):
             relation.package = owner_package(element.diagram.owner)
             line.subject = relation
 
-    def disconnect_subject(self, handle):
-        """Disconnect model element.
-
-        Disconnect property (memberEnd) too, in case of end of life for
-        Extension.
-        """
-        opposite = self.line.opposite(handle)
-        hct = self.get_connected(handle)
-        oct = self.get_connected(opposite)
-        if hct and oct:
-            old = self.line.subject
-            del self.line.subject
-            if old and len(old.presentation) == 0:
-                for e in old.memberEnd:
-                    e.unlink()
-                old.unlink()
+    def disconnect_subject(self, handle) -> None:
+        extension = self.line.subject
+        UML.recipes.unapply_stereotype_by_extension(extension)
+        return super().disconnect_subject(handle)

--- a/gaphor/UML/profiles/extensionconnect.py
+++ b/gaphor/UML/profiles/extensionconnect.py
@@ -75,5 +75,6 @@ class ExtensionConnect(DirectionalRelationshipConnect):
 
     def disconnect_subject(self, handle) -> None:
         extension = self.line.subject
-        UML.recipes.unapply_stereotype_by_extension(extension)
+        if extension:
+            UML.recipes.unapply_stereotype_by_extension(extension)
         return super().disconnect_subject(handle)

--- a/gaphor/UML/profiles/extensionconnect.py
+++ b/gaphor/UML/profiles/extensionconnect.py
@@ -74,7 +74,6 @@ class ExtensionConnect(DirectionalRelationshipConnect):
             line.subject = relation
 
     def disconnect_subject(self, handle) -> None:
-        extension = self.line.subject
-        if extension:
+        if extension := self.line.subject:
             UML.recipes.unapply_stereotype_by_extension(extension)
         return super().disconnect_subject(handle)

--- a/gaphor/UML/profiles/tests/test_classifier_stereotypes.py
+++ b/gaphor/UML/profiles/tests/test_classifier_stereotypes.py
@@ -79,25 +79,6 @@ def test_removing_last_slot(case, create):
     assert not compartments(c)
 
 
-def test_deleting_extension(case, create):
-    """Test if stereotype is removed when extension is deleted."""
-    c = create(ComponentItem, UML.Component)
-
-    c.show_stereotypes = True
-
-    instance_spec = UML.recipes.apply_stereotype(c.subject, case.st1)
-    slot = UML.recipes.add_slot(instance_spec, case.st1.ownedAttribute[0])
-    slot.value = "foo"
-
-    # test precondition
-    assert len(compartments(c)) == 1
-    assert len(c.subject.appliedStereotype) == 1
-
-    case.ext1.unlink()
-    assert len(c.subject.appliedStereotype) == 0
-    assert len(compartments(c)) == 0
-
-
 def test_deleting_stereotype(case, create):
     """Test if stereotype is removed when stereotype is deleted."""
     c = create(ComponentItem, UML.Component)

--- a/gaphor/UML/profiles/tests/test_extensionconnect.py
+++ b/gaphor/UML/profiles/tests/test_extensionconnect.py
@@ -3,7 +3,7 @@
 from gaphor import UML
 from gaphor.core.modeling.diagram import Diagram
 from gaphor.diagram.tests.fixtures import allow, connect, disconnect
-from gaphor.UML.classes.klass import ClassItem
+from gaphor.UML.classes import ClassItem, InterfaceItem
 from gaphor.UML.profiles.extension import ExtensionItem
 
 
@@ -104,3 +104,60 @@ def test_disconnect(element_factory, diagram):
     assert member_end[0] not in element_factory
     assert member_end[1] not in element_factory
     assert subject not in element_factory
+
+
+def test_extension_deletion(element_factory, diagram):
+    ext = diagram.create(ExtensionItem)
+    stereotype = diagram.create(
+        ClassItem, subject=element_factory.create(UML.Stereotype)
+    )
+    metaclass = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    metaclass.subject.name = "Class"
+    klass = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+
+    connect(ext, ext.tail, stereotype)
+    connect(ext, ext.head, metaclass)
+
+    st_attr = element_factory.create(UML.Property)
+    stereotype.subject.ownedAttribute = st_attr
+
+    instspec = UML.recipes.apply_stereotype(klass.subject, stereotype.subject)
+    UML.recipes.add_slot(instspec, st_attr)
+
+    assert stereotype.subject in klass.subject.appliedStereotype[:].classifier
+
+    # disconnect indirectly, by deleting the item
+    ext.unlink()
+
+    assert not klass.subject.appliedStereotype
+
+
+def test_extension_deletion_with_2_metaclasses(element_factory, diagram):
+    ext = diagram.create(ExtensionItem)
+    stereotype = diagram.create(
+        ClassItem, subject=element_factory.create(UML.Stereotype)
+    )
+    metaclass = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    metaclass.subject.name = "Class"
+    metaiface = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    metaiface.subject.name = "Interface"
+
+    connect(ext, ext.tail, stereotype)
+    connect(ext, ext.head, metaclass)
+
+    UML.recipes.create_extension(metaiface.subject, stereotype.subject)
+
+    # Apply stereotype to class and create slot
+    klass = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+    iface = diagram.create(InterfaceItem, subject=element_factory.create(UML.Interface))
+    UML.recipes.apply_stereotype(klass.subject, stereotype.subject)
+    instspec2 = UML.recipes.apply_stereotype(iface.subject, stereotype.subject)
+
+    assert stereotype.subject in klass.subject.appliedStereotype[:].classifier
+    assert klass.subject in element_factory
+
+    ext.unlink()
+
+    assert not klass.subject.appliedStereotype
+    assert klass.subject in element_factory
+    assert [instspec2] == list(iface.subject.appliedStereotype)

--- a/gaphor/UML/profiles/tests/test_extensionconnect.py
+++ b/gaphor/UML/profiles/tests/test_extensionconnect.py
@@ -2,7 +2,7 @@
 
 from gaphor import UML
 from gaphor.core.modeling.diagram import Diagram
-from gaphor.diagram.tests.fixtures import allow, connect
+from gaphor.diagram.tests.fixtures import allow, connect, disconnect
 from gaphor.UML.classes.klass import ClassItem
 from gaphor.UML.profiles.extension import ExtensionItem
 
@@ -52,6 +52,9 @@ def test_connection(element_factory, diagram):
     connect(ext, ext.head, cls)
 
     assert ext.subject
+    assert ext.subject.memberEnd[0].type is cls.subject
+    assert ext.subject.memberEnd[1].type is st.subject
+    assert ext.subject.memberEnd[1] is ext.subject.ownedEnd
 
 
 def test_connection_namespace(element_factory, diagram):
@@ -84,3 +87,20 @@ def test_reuse_extension_in_new_diagram(element_factory, diagram):
     connect(ext2, ext2.head, cls2)
 
     assert ext.subject is ext2.subject
+
+
+def test_disconnect(element_factory, diagram):
+    ext = diagram.create(ExtensionItem)
+    st = diagram.create(ClassItem, subject=element_factory.create(UML.Stereotype))
+    cls = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
+
+    connect(ext, ext.tail, st)
+    connect(ext, ext.head, cls)
+    subject = ext.subject
+    member_end = list(subject.memberEnd)
+
+    disconnect(ext, ext.head)
+
+    assert member_end[0] not in element_factory
+    assert member_end[1] not in element_factory
+    assert subject not in element_factory

--- a/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
@@ -7,51 +7,45 @@ from gaphor.UML.profiles.stereotypepropertypages import (
 )
 
 
-def test_stereotype_property_page_without_stereotype(diagram, element_factory):
+def create_property_page(diagram, element_factory) -> StereotypePage:
     item = diagram.create(
         UML.classes.ClassItem, subject=element_factory.create(UML.Class)
     )
-    property_page = StereotypePage(item)
+    return StereotypePage(item)
 
+
+def get_model(property_page: StereotypePage):
     widget = property_page.construct()
+    show_stereotypes = find(widget, "stereotype-list")
+    return show_stereotypes.get_model()
 
-    assert widget is None
 
-
-def test_stereotype_property_page_with_stereotype(diagram, element_factory):
+def metaclass_and_stereotype(element_factory):
     metaclass = element_factory.create(UML.Class)
     metaclass.name = "Class"
     stereotype = element_factory.create(UML.Stereotype)
     stereotype.name = "Stereotype"
     UML.recipes.create_extension(metaclass, stereotype)
+    return metaclass, stereotype
 
-    item = diagram.create(
-        UML.classes.ClassItem, subject=element_factory.create(UML.Class)
-    )
-    property_page = StereotypePage(item)
+
+def test_stereotype_property_page_with_stereotype(diagram, element_factory):
+    metaclass, stereotype = metaclass_and_stereotype(element_factory)
+    property_page = create_property_page(diagram, element_factory)
 
     widget = property_page.construct()
     show_stereotypes = find(widget, "show-stereotypes")
     show_stereotypes.set_active(True)
 
-    assert item.show_stereotypes
+    assert property_page.item.show_stereotypes
 
 
 def test_stereotype_property_page_apply_stereotype(diagram, element_factory):
-    metaclass = element_factory.create(UML.Class)
-    metaclass.name = "Class"
-    stereotype = element_factory.create(UML.Stereotype)
-    stereotype.name = "Stereotype"
-    UML.recipes.create_extension(metaclass, stereotype)
+    _metaclass, stereotype = metaclass_and_stereotype(element_factory)
 
-    item = diagram.create(
-        UML.classes.ClassItem, subject=element_factory.create(UML.Class)
-    )
-    property_page = StereotypePage(item)
-
-    widget = property_page.construct()
-    show_stereotypes = find(widget, "stereotype-list")
-    model = show_stereotypes.get_model()
+    property_page = create_property_page(diagram, element_factory)
+    item = property_page.item
+    model = get_model(property_page)
     toggle_stereotype(None, (0,), item.subject, model)
 
     assert stereotype in item.subject.appliedStereotype[0].classifier
@@ -65,14 +59,9 @@ def test_stereotype_property_page_slot_value(diagram, element_factory):
     stereotype.ownedAttribute = element_factory.create(UML.Property)
     UML.recipes.create_extension(metaclass, stereotype)
 
-    item = diagram.create(
-        UML.classes.ClassItem, subject=element_factory.create(UML.Class)
-    )
-    property_page = StereotypePage(item)
-
-    widget = property_page.construct()
-    show_stereotypes = find(widget, "stereotype-list")
-    model = show_stereotypes.get_model()
+    property_page = create_property_page(diagram, element_factory)
+    item = property_page.item
+    model = get_model(property_page)
     toggle_stereotype(None, (0,), item.subject, model)
     set_value(None, (0, 0), "test", model)
     slot = item.subject.appliedStereotype[0].slot[0]

--- a/gaphor/UML/recipes.py
+++ b/gaphor/UML/recipes.py
@@ -185,8 +185,7 @@ def unapply_stereotype_by_extension(extension: Extension):
     if isinstance(property, ExtensionEnd):
         property, extension_end = extension_end, property
     metaclass = property.type
-    stereotype = extension_end.type
-    if stereotype:
+    if stereotype := extension_end.type:
         meta_type = (
             getattr(gaphor.UML.uml, metaclass.name, None)
             if metaclass and metaclass.name

--- a/gaphor/UML/recipes.py
+++ b/gaphor/UML/recipes.py
@@ -9,6 +9,7 @@ Functions collected in this module allow to
 import itertools
 from typing import Iterable, Optional, Sequence
 
+import gaphor.UML.uml
 from gaphor.UML.uml import (
     Association,
     Class,
@@ -170,6 +171,33 @@ def create_extension(metaclass: Class, stereotype: Stereotype) -> Extension:
     metaclass.ownedAttribute = ext_end
 
     return ext
+
+
+def unapply_stereotype_by_extension(extension: Extension):
+    """Remove stereotype application for all types associated with the
+    stereotype base type."""
+
+    try:
+        property, extension_end = extension.memberEnd
+    except ValueError:
+        return False
+
+    if isinstance(property, ExtensionEnd):
+        property, extension_end = extension_end, property
+    metaclass = property.type
+    stereotype = extension_end.type
+    if stereotype:
+        meta_type = (
+            getattr(gaphor.UML.uml, metaclass.name, None)
+            if metaclass and metaclass.name
+            else None
+        )
+        instances = find_instances(stereotype)
+
+        for i in list(instances):
+            for e in i.extended:
+                if not meta_type or isinstance(e, meta_type):
+                    i.unlink()
 
 
 def is_metaclass(element):

--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -1,6 +1,7 @@
 """The Sanitize module is dedicated to adapters (stuff) that keeps the model
 clean and in sync with diagrams."""
 
+import logging
 
 from gaphor import UML
 from gaphor.abc import Service
@@ -11,6 +12,8 @@ from gaphor.diagram.deletable import deletable
 from gaphor.diagram.general import CommentLineItem
 from gaphor.event import Notification
 from gaphor.i18n import gettext
+
+log = logging.getLogger(__name__)
 
 
 def undo_guard(func):
@@ -130,15 +133,15 @@ class SanitizerService(Service):
     @event_handler(AssociationSet)
     @undo_guard
     def _disconnect_extension_end(self, event):
-        if event.property is UML.ExtensionEnd.type and event.old_value:
-            ext = event.element
-            p = ext.opposite
-            if not p:
-                return
-            st = event.old_value
-            if st:
-                meta = p.type and getattr(UML, p.type.name, None)
-                self.perform_unlink_for_instances(st, meta)
+        if (
+            isinstance(event.element, UML.ExtensionEnd)
+            and event.property is UML.Property.type
+            and event.old_value
+            and event.new_value
+        ):
+            log.warning(
+                "Reassigning UML.ExtensionEnd.type can cause inconsistency in the model"
+            )
 
     @event_handler(AssociationDeleted)
     @undo_guard

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -20,23 +20,12 @@ def sanitizer(event_manager):
     sanitizer.shutdown()
 
 
-@pytest.fixture
-def create_item(element_factory, diagram):
-    def create(item_cls, subject_cls=None, subject=None):
-        """Create an item with specified subject."""
-        if subject_cls is not None:
-            subject = element_factory.create(subject_cls)
-        return diagram.create(item_cls, subject=subject)
-
-    return create
-
-
-def test_connect_element_with_comments(create_item, diagram):
-    comment = create_item(CommentItem, Comment)
-    line = create_item(CommentLineItem)
-    gi = create_item(GeneralizationItem)
-    clazz1 = create_item(ClassItem, UML.Class)
-    clazz2 = create_item(ClassItem, UML.Class)
+def test_connect_element_with_comments(create, diagram):
+    comment = create(CommentItem, Comment)
+    line = create(CommentLineItem)
+    gi = create(GeneralizationItem)
+    clazz1 = create(ClassItem, UML.Class)
+    clazz2 = create(ClassItem, UML.Class)
 
     connect(line, line.head, comment)
     connect(line, line.tail, gi)
@@ -50,9 +39,9 @@ def test_connect_element_with_comments(create_item, diagram):
     assert gi.subject in comment.subject.annotatedElement
 
 
-def test_presentation_delete(create_item, element_factory):
+def test_presentation_delete(create, element_factory):
     """Remove element if the last instance of an item is deleted."""
-    klassitem = create_item(ClassItem, UML.Class)
+    klassitem = create(ClassItem, UML.Class)
     klass = klassitem.subject
 
     assert klassitem.subject.presentation[0] is klassitem
@@ -127,9 +116,10 @@ def test_extension_deletion(element_factory):
 
     assert stereotype in klass.appliedStereotype[:].classifier
 
+    # instead, disconnect
     ext.unlink()
 
-    assert [] == list(klass.appliedStereotype)
+    assert not klass.appliedStereotype
 
 
 def test_extension_deletion_with_2_metaclasses(element_factory):

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -5,7 +5,6 @@ from gaphor.core.modeling import Comment, Diagram
 from gaphor.diagram.general import CommentItem, CommentLineItem
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML.classes import ClassItem, GeneralizationItem
-from gaphor.UML.profiles import ExtensionItem
 from gaphor.UML.sanitizerservice import SanitizerService
 
 
@@ -99,58 +98,6 @@ def test_extension_disconnect(element_factory):
     del ext.ownedEnd.type
 
     assert klass.appliedStereotype
-
-
-@pytest.mark.xfail()
-def test_extension_deletion(element_factory, diagram):
-    create = element_factory.create
-    metaklass = create(UML.Class)
-    metaklass.name = "Class"
-    klass = create(UML.Class)
-    stereotype = create(UML.Stereotype)
-    st_attr = create(UML.Property)
-    stereotype.ownedAttribute = st_attr
-    ext = UML.recipes.create_extension(metaklass, stereotype)
-    ext_item = diagram.create(ExtensionItem, subject=ext)
-    # Apply stereotype to class and create slot
-    instspec = UML.recipes.apply_stereotype(klass, stereotype)
-    UML.recipes.add_slot(instspec, st_attr)
-
-    assert stereotype in klass.appliedStereotype[:].classifier
-
-    # disconnect indirectly, by deleting the item
-    ext_item.unlink()
-
-    assert not klass.appliedStereotype
-
-
-def test_extension_deletion_with_2_metaclasses(element_factory):
-    create = element_factory.create
-    metaklass = create(UML.Class)
-    metaklass.name = "Class"
-    metaiface = create(UML.Class)
-    metaiface.name = "Interface"
-    klass = create(UML.Class)
-    iface = create(UML.Interface)
-    stereotype = create(UML.Stereotype)
-    st_attr = create(UML.Property)
-    stereotype.ownedAttribute = st_attr
-    ext1 = UML.recipes.create_extension(metaklass, stereotype)
-    UML.recipes.create_extension(metaiface, stereotype)
-
-    # Apply stereotype to class and create slot
-    instspec1 = UML.recipes.apply_stereotype(klass, stereotype)
-    instspec2 = UML.recipes.apply_stereotype(iface, stereotype)
-    UML.recipes.add_slot(instspec1, st_attr)
-
-    assert stereotype in klass.appliedStereotype[:].classifier
-    assert klass in element_factory
-
-    ext1.unlink()
-
-    assert not klass.appliedStereotype
-    assert klass in element_factory
-    assert [instspec2] == list(iface.appliedStereotype)
 
 
 def test_stereotype_deletion(element_factory):

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -5,6 +5,7 @@ from gaphor.core.modeling import Comment, Diagram
 from gaphor.diagram.general import CommentItem, CommentLineItem
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML.classes import ClassItem, GeneralizationItem
+from gaphor.UML.profiles import ExtensionItem
 from gaphor.UML.sanitizerservice import SanitizerService
 
 
@@ -74,8 +75,8 @@ def test_stereotype_attribute_delete(element_factory):
 
     st_attr.unlink()
 
-    assert [] == list(stereotype.ownedMember)
-    assert [] == list(instspec.slot)
+    assert not stereotype.ownedMember
+    assert not instspec.slot
 
 
 def test_extension_disconnect(element_factory):
@@ -97,10 +98,11 @@ def test_extension_disconnect(element_factory):
     # Causes set event
     del ext.ownedEnd.type
 
-    assert [] == list(klass.appliedStereotype)
+    assert klass.appliedStereotype
 
 
-def test_extension_deletion(element_factory):
+@pytest.mark.xfail()
+def test_extension_deletion(element_factory, diagram):
     create = element_factory.create
     metaklass = create(UML.Class)
     metaklass.name = "Class"
@@ -109,15 +111,15 @@ def test_extension_deletion(element_factory):
     st_attr = create(UML.Property)
     stereotype.ownedAttribute = st_attr
     ext = UML.recipes.create_extension(metaklass, stereotype)
-
+    ext_item = diagram.create(ExtensionItem, subject=ext)
     # Apply stereotype to class and create slot
     instspec = UML.recipes.apply_stereotype(klass, stereotype)
     UML.recipes.add_slot(instspec, st_attr)
 
     assert stereotype in klass.appliedStereotype[:].classifier
 
-    # instead, disconnect
-    ext.unlink()
+    # disconnect indirectly, by deleting the item
+    ext_item.unlink()
 
     assert not klass.appliedStereotype
 
@@ -146,7 +148,7 @@ def test_extension_deletion_with_2_metaclasses(element_factory):
 
     ext1.unlink()
 
-    assert [] == list(klass.appliedStereotype)
+    assert not klass.appliedStereotype
     assert klass in element_factory
     assert [instspec2] == list(iface.appliedStereotype)
 
@@ -169,7 +171,7 @@ def test_stereotype_deletion(element_factory):
 
     stereotype.unlink()
 
-    assert [] == list(klass.appliedStereotype)
+    assert not klass.appliedStereotype
 
 
 def test_diagram_move(element_factory, mocker):

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -760,7 +760,7 @@ class derivedunion(derived[T]):
             if s is exclude or not object_has_property(obj, s):
                 continue
 
-            tmp = s.__get__(obj)
+            tmp: Iterable[T] | T | None = s.get(obj)
             if isinstance(tmp, Iterable):
                 u.update(tmp)
             elif tmp:


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

stereotypes were not removed from elements when the extension relation was broken in the profle.

Issue Number: #1635 

### What is the new behavior?

Stereotype unapplication is handled explicitly in the connector. This behavior could no longer be handled by the Sanatizer service, due to the number of properties involved -- and events that get handled much later than the actual action.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
