### PR TITLE
State machines and regions

### DIFF
--- a/examples/state-machine.gaphor
+++ b/examples/state-machine.gaphor
@@ -1,0 +1,1237 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.11.0">
+<StyleSheet id="58d6989a-66f8-11ec-b4c8-0456e5e540ed"/>
+<Package id="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed">
+<name>
+<val>New model</val>
+</name>
+<ownedDiagram>
+<reflist>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</reflist>
+</ownedDiagram>
+<ownedType>
+<reflist>
+<ref refid="ad648cec-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</ownedType>
+</Package>
+<Diagram id="58d6c536-66f8-11ec-b4c8-0456e5e540ed">
+<element>
+<ref refid="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed"/>
+</element>
+<name>
+<val>main</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="ad65350c-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="b1bf678a-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="b3ac88e8-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="1e6df72a-1fd0-11ed-8429-0456e5e540ed"/>
+<ref refid="d7b7efb6-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="b7748c5a-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="dd4ee204-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="ecda33d6-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="b5c206e4-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="b9d5b1cc-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="c42fcd60-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="fe52c92a-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="0743b490-1fd0-11ed-8429-0456e5e540ed"/>
+<ref refid="bd0c1250-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="bfe9b48c-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="c9730490-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="d430313c-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="e1a8bd0c-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="e4026b70-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="e860b3e8-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="f9aff3a2-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="fbbe02b0-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="01a415de-1fd0-11ed-8429-0456e5e540ed"/>
+<ref refid="04a3e886-1fd0-11ed-8429-0456e5e540ed"/>
+<ref refid="0969e582-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<StateMachine id="ad648cec-1fcf-11ed-8429-0456e5e540ed">
+<name>
+<val>New StateMachine</val>
+</name>
+<package>
+<ref refid="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="ad65350c-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<region>
+<reflist>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="afb49eba-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</region>
+</StateMachine>
+<StateMachineItem id="ad65350c-1fcf-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 132.26173400878906, 154.84376525878906)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>349.00779724121094</val>
+</width>
+<height>
+<val>355.7460479736328</val>
+</height>
+<children>
+<reflist>
+<ref refid="b1bf678a-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="b3ac88e8-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="d7b7efb6-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="b7748c5a-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="dd4ee204-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="ecda33d6-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="b5c206e4-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</children>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<subject>
+<ref refid="ad648cec-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+</StateMachineItem>
+<Region id="aeedd64a-1fcf-11ed-8429-0456e5e540ed">
+<stateMachine>
+<ref refid="ad648cec-1fcf-11ed-8429-0456e5e540ed"/>
+</stateMachine>
+<subvertex>
+<reflist>
+<ref refid="b1bef3fe-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="b3ac207e-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="b9d54ac0-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="c42f6cda-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="d7b78bb6-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="fe5271aa-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="07433f6a-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</subvertex>
+</Region>
+<Region id="afb49eba-1fcf-11ed-8429-0456e5e540ed">
+<stateMachine>
+<ref refid="ad648cec-1fcf-11ed-8429-0456e5e540ed"/>
+</stateMachine>
+<subvertex>
+<reflist>
+<ref refid="b7742800-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="dd4eb7e8-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="ecd9cd9c-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="b5c19484-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</subvertex>
+</Region>
+<State id="b1bef3fe-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<incoming>
+<reflist>
+<ref refid="bdff0dac-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</incoming>
+<name>
+<val>A</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="d547c396-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="b1bf678a-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+</State>
+<StateItem id="b1bf678a-1fcf-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 59.62890625, 106.80206807454425)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>76.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<parent>
+<ref refid="ad65350c-1fcf-11ed-8429-0456e5e540ed"/>
+</parent>
+<subject>
+<ref refid="b1bef3fe-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+</StateItem>
+<State id="b3ac207e-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<incoming>
+<reflist>
+<ref refid="d547c396-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</incoming>
+<name>
+<val>B</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="02cdff2e-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="b3ac88e8-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<region>
+<reflist>
+<ref refid="1e6e8fa0-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</region>
+</State>
+<StateItem id="b3ac88e8-1fcf-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 177.91795349121094, 59.46092224121094)</val>
+</matrix>
+<top-left>
+<val>(10.32421875, 0.0)</val>
+</top-left>
+<width>
+<val>124.4296875</val>
+</width>
+<height>
+<val>128.0</val>
+</height>
+<children>
+<reflist>
+<ref refid="1e6df72a-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</children>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<parent>
+<ref refid="ad65350c-1fcf-11ed-8429-0456e5e540ed"/>
+</parent>
+<subject>
+<ref refid="b3ac207e-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+</StateItem>
+<State id="b5c19484-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="afb49eba-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<incoming>
+<reflist>
+<ref refid="c13961ac-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</incoming>
+<name>
+<val>C</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="e9560118-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="b5c206e4-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+</State>
+<StateItem id="b5c206e4-1fcf-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 45.73828125, 260.98435974121094)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>76.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<parent>
+<ref refid="ad65350c-1fcf-11ed-8429-0456e5e540ed"/>
+</parent>
+<subject>
+<ref refid="b5c19484-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+</StateItem>
+<State id="b7742800-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="afb49eba-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<incoming>
+<reflist>
+<ref refid="e4a634bc-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</incoming>
+<name>
+<val>E</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="fc558a40-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="b7748c5a-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+</State>
+<StateItem id="b7748c5a-1fcf-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 220.84373474121094, 294.01170349121094)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>76.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<parent>
+<ref refid="ad65350c-1fcf-11ed-8429-0456e5e540ed"/>
+</parent>
+<subject>
+<ref refid="b7742800-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+</StateItem>
+<Pseudostate id="b9d54ac0-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<incoming>
+<reflist>
+<ref refid="cb0e97ec-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</incoming>
+<kind>
+<val>fork</val>
+</kind>
+<outgoing>
+<reflist>
+<ref refid="bdff0dac-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="c13961ac-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="b9d5b1cc-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Pseudostate>
+<PseudostateItem id="b9d5b1cc-1fcf-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 68.41407012939453, 332.71678924560547)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>6.0</val>
+</width>
+<height>
+<val>40.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<subject>
+<ref refid="b9d54ac0-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+</PseudostateItem>
+<TransitionItem id="bd0c1250-1fcf-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="bdff0dac-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 75.46094512939453, 342.3046875)</val>
+</matrix>
+<points>
+<val>[(-1.046875, 0.0), (116.42969512939453, -65.65885416666669)]</val>
+</points>
+<head-connection>
+<ref refid="b9d5b1cc-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="b1bf678a-1fcf-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="bdff0dac-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="bdfffbe0-1fcf-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="bd0c1250-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="b9d54ac0-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="b1bef3fe-1fcf-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="bdfffbe0-1fcf-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="bdff0dac-1fcf-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<TransitionItem id="bfe9b48c-1fcf-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="c13961ac-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 76.92969512939453, 365.55859375)</val>
+</matrix>
+<points>
+<val>[(-2.515625, 0.0), (101.07032012939453, 65.26953125)]</val>
+</points>
+<head-connection>
+<ref refid="b9d5b1cc-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="b5c206e4-1fcf-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="c13961ac-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="c13b2c62-1fcf-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="bfe9b48c-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="b9d54ac0-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="b5c19484-1fcf-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="c13b2c62-1fcf-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="c13961ac-1fcf-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<Pseudostate id="c42f6cda-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<outgoing>
+<reflist>
+<ref refid="cb0e97ec-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="c42fcd60-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Pseudostate>
+<PseudostateItem id="c42fcd60-1fcf-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 18.007814407348633, 342.71678924560547)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>20.0</val>
+</width>
+<height>
+<val>20.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<subject>
+<ref refid="c42f6cda-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+</PseudostateItem>
+<TransitionItem id="c9730490-1fcf-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="cb0e97ec-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 36.277347564697266, 351.7421875)</val>
+</matrix>
+<points>
+<val>[(1.7304668426513672, 0.9746017456054688), (32.136722564697266, 0.0)]</val>
+</points>
+<head-connection>
+<ref refid="c42fcd60-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="b9d5b1cc-1fcf-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="cb0e97ec-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="cb105cda-1fcf-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="c9730490-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="c42f6cda-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="b9d54ac0-1fcf-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="cb105cda-1fcf-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="cb0e97ec-1fcf-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<TransitionItem id="d430313c-1fcf-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="d547c396-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 273.0390625, 292.41015625)</val>
+</matrix>
+<points>
+<val>[(-5.1484222412109375, -14.506510416666686), (47.46484375, -14.10546875)]</val>
+</points>
+<head-connection>
+<ref refid="b1bf678a-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="b3ac88e8-1fcf-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="d547c396-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="d548beb8-1fcf-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="d430313c-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="b1bef3fe-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="b3ac207e-1fcf-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="d548beb8-1fcf-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="d547c396-1fcf-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<Pseudostate id="d7b78bb6-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<incoming>
+<reflist>
+<ref refid="e9560118-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</incoming>
+<kind>
+<val>choice</val>
+</kind>
+<outgoing>
+<reflist>
+<ref refid="e24c5250-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="e4a634bc-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="d7b7efb6-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Pseudostate>
+<PseudostateItem id="d7b7efb6-1fcf-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 167.03123474121094, 260.98435974121094)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>30.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<parent>
+<ref refid="ad65350c-1fcf-11ed-8429-0456e5e540ed"/>
+</parent>
+<subject>
+<ref refid="d7b78bb6-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+</PseudostateItem>
+<State id="dd4eb7e8-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="afb49eba-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<incoming>
+<reflist>
+<ref refid="e24c5250-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</incoming>
+<name>
+<val>D</val>
+</name>
+<outgoing>
+<reflist>
+<ref refid="fa5d475a-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="dd4ee204-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+</State>
+<StateItem id="dd4ee204-1fcf-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 217.14060974121094, 232.40232849121094)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>76.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<parent>
+<ref refid="ad65350c-1fcf-11ed-8429-0456e5e540ed"/>
+</parent>
+<subject>
+<ref refid="dd4eb7e8-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+</StateItem>
+<TransitionItem id="e1a8bd0c-1fcf-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="e24c5250-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 320.50390625, 422.1875)</val>
+</matrix>
+<points>
+<val>[(0.0, -6.359375), (28.8984375, -19.94140625)]</val>
+</points>
+<head-connection>
+<ref refid="d7b7efb6-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="dd4ee204-1fcf-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="e24c5250-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="e24d2608-1fcf-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="e1a8bd0c-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="d7b78bb6-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="dd4eb7e8-1fcf-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="e24d2608-1fcf-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="e24c5250-1fcf-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<TransitionItem id="e4026b70-1fcf-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="e4a634bc-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 324.6328125, 441.0116882324219)</val>
+</matrix>
+<points>
+<val>[(-4.12890625, 4.816436767578125), (28.47265625, 22.843780517578125)]</val>
+</points>
+<head-connection>
+<ref refid="d7b7efb6-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="b7748c5a-1fcf-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="e4a634bc-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="e4a7ee24-1fcf-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="e4026b70-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="d7b78bb6-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="b7742800-1fcf-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="e4a7ee24-1fcf-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="e4a634bc-1fcf-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<TransitionItem id="e860b3e8-1fcf-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="e9560118-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 274.22265625, 431.2148132324219)</val>
+</matrix>
+<points>
+<val>[(-20.222640991210938, -0.386688232421875), (25.0703125, -0.386688232421875)]</val>
+</points>
+<head-connection>
+<ref refid="b5c206e4-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="d7b7efb6-1fcf-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="e9560118-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="e95758e2-1fcf-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="e860b3e8-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="b5c19484-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="d7b78bb6-1fcf-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="e95758e2-1fcf-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="e9560118-1fcf-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<Pseudostate id="ecd9cd9c-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="afb49eba-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<incoming>
+<reflist>
+<ref refid="fa5d475a-1fcf-11ed-8429-0456e5e540ed"/>
+<ref refid="fc558a40-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</incoming>
+<kind>
+<val>fork</val>
+</kind>
+<outgoing>
+<reflist>
+<ref refid="058aa6d6-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="ecda33d6-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Pseudostate>
+<PseudostateItem id="ecda33d6-1fcf-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 323.00779724121094, 255.98435974121094)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>6.0</val>
+</width>
+<height>
+<val>40.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<parent>
+<ref refid="ad65350c-1fcf-11ed-8429-0456e5e540ed"/>
+</parent>
+<subject>
+<ref refid="ecd9cd9c-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+</PseudostateItem>
+<TransitionItem id="f9aff3a2-1fcf-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="fa5d475a-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 433.390625, 404.328125)</val>
+</matrix>
+<points>
+<val>[(-7.98828125, -1.609375), (21.87890625, 14.52734375)]</val>
+</points>
+<head-connection>
+<ref refid="dd4ee204-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="ecda33d6-1fcf-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="fa5d475a-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="afb49eba-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="fa5ed7a0-1fcf-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="f9aff3a2-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="dd4eb7e8-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="ecd9cd9c-1fcf-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="fa5ed7a0-1fcf-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="fa5d475a-1fcf-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<TransitionItem id="fbbe02b0-1fcf-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="fc558a40-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 434.09375, 464.3476257324219)</val>
+</matrix>
+<points>
+<val>[(-4.98828125, 0.0), (21.17578125, -24.4609375)]</val>
+</points>
+<head-connection>
+<ref refid="b7748c5a-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="ecda33d6-1fcf-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="fc558a40-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="afb49eba-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="fc5743c6-1fcf-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="fbbe02b0-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="b7742800-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="ecd9cd9c-1fcf-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="fc5743c6-1fcf-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="fc558a40-1fcf-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<Pseudostate id="fe5271aa-1fcf-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<incoming>
+<reflist>
+<ref refid="02cdff2e-1fd0-11ed-8429-0456e5e540ed"/>
+<ref refid="058aa6d6-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</incoming>
+<kind>
+<val>join</val>
+</kind>
+<outgoing>
+<reflist>
+<ref refid="0a4be4b4-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</outgoing>
+<presentation>
+<reflist>
+<ref refid="fe52c92a-1fcf-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Pseudostate>
+<PseudostateItem id="fe52c92a-1fcf-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 535.3047485351562, 331.7421875)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>6.0</val>
+</width>
+<height>
+<val>40.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<subject>
+<ref refid="fe5271aa-1fcf-11ed-8429-0456e5e540ed"/>
+</subject>
+</PseudostateItem>
+<TransitionItem id="01a415de-1fd0-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="02cdff2e-1fd0-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 402.94921875, 290.078125)</val>
+</matrix>
+<points>
+<val>[(41.984375, 0.3098958333333144), (132.35552978515625, 62.63866424560547)]</val>
+</points>
+<head-connection>
+<ref refid="b3ac88e8-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="fe52c92a-1fcf-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="02cdff2e-1fd0-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="02cf438e-1fd0-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="01a415de-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="b3ac207e-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="fe5271aa-1fcf-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="02cf438e-1fd0-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="02cdff2e-1fd0-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<TransitionItem id="04a3e886-1fd0-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="058aa6d6-1fd0-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 463.203125, 434.2538757324219)</val>
+</matrix>
+<points>
+<val>[(-1.93359375, 0.0), (72.10162353515625, -76.19918823242188)]</val>
+</points>
+<head-connection>
+<ref refid="ecda33d6-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="fe52c92a-1fcf-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="058aa6d6-1fd0-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="afb49eba-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="058bf57c-1fd0-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="04a3e886-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="ecd9cd9c-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="fe5271aa-1fcf-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="058bf57c-1fd0-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="058aa6d6-1fd0-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<FinalState id="07433f6a-1fd0-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<incoming>
+<reflist>
+<ref refid="0a4be4b4-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</incoming>
+<presentation>
+<reflist>
+<ref refid="0743b490-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+</FinalState>
+<FinalStateItem id="0743b490-1fd0-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 594.9297485351562, 341.7421875)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>30.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<subject>
+<ref refid="07433f6a-1fd0-11ed-8429-0456e5e540ed"/>
+</subject>
+</FinalStateItem>
+<TransitionItem id="0969e582-1fd0-11ed-8429-0456e5e540ed">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<subject>
+<ref refid="0a4be4b4-1fd0-11ed-8429-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 547.4141235351562, 356.7578125)</val>
+</matrix>
+<points>
+<val>[(-6.109375, 0.0), (47.515625, 0.09375)]</val>
+</points>
+<head-connection>
+<ref refid="fe52c92a-1fcf-11ed-8429-0456e5e540ed"/>
+</head-connection>
+<tail-connection>
+<ref refid="0743b490-1fd0-11ed-8429-0456e5e540ed"/>
+</tail-connection>
+</TransitionItem>
+<Transition id="0a4be4b4-1fd0-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="aeedd64a-1fcf-11ed-8429-0456e5e540ed"/>
+</container>
+<guard>
+<ref refid="0a4d85f8-1fd0-11ed-8429-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="0969e582-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="fe5271aa-1fcf-11ed-8429-0456e5e540ed"/>
+</source>
+<target>
+<ref refid="07433f6a-1fd0-11ed-8429-0456e5e540ed"/>
+</target>
+</Transition>
+<Constraint id="0a4d85f8-1fd0-11ed-8429-0456e5e540ed">
+<transition>
+<ref refid="0a4be4b4-1fd0-11ed-8429-0456e5e540ed"/>
+</transition>
+</Constraint>
+<State id="1e6d9082-1fd0-11ed-8429-0456e5e540ed">
+<container>
+<ref refid="1e6e8fa0-1fd0-11ed-8429-0456e5e540ed"/>
+</container>
+<name>
+<val>b'</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="1e6df72a-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</presentation>
+</State>
+<StateItem id="1e6df72a-1fd0-11ed-8429-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 39.22265625, 49.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>76.0</val>
+</width>
+<height>
+<val>30.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<parent>
+<ref refid="b3ac88e8-1fcf-11ed-8429-0456e5e540ed"/>
+</parent>
+<subject>
+<ref refid="1e6d9082-1fd0-11ed-8429-0456e5e540ed"/>
+</subject>
+</StateItem>
+<Region id="1e6e8fa0-1fd0-11ed-8429-0456e5e540ed">
+<state>
+<ref refid="b3ac207e-1fcf-11ed-8429-0456e5e540ed"/>
+</state>
+<subvertex>
+<reflist>
+<ref refid="1e6d9082-1fd0-11ed-8429-0456e5e540ed"/>
+</reflist>
+</subvertex>
+</Region>
+</gaphor>

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -17,11 +17,8 @@ from gaphor.diagram.support import represents
 from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.SysML.sysml import Block, ValueType
-from gaphor.UML.classes.klass import (
-    attribute_watches,
-    stereotype_compartments,
-    stereotype_watches,
-)
+from gaphor.UML.classes.klass import attribute_watches
+from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
 from gaphor.UML.recipes import stereotypes_str
 from gaphor.UML.umlfmt import format_property
 

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -21,9 +21,8 @@ from gaphor.UML.classes.klass import (
     attributes_compartment,
     operation_watches,
     operations_compartment,
-    stereotype_compartments,
-    stereotype_watches,
 )
+from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
 from gaphor.UML.recipes import stereotypes_str
 
 

--- a/gaphor/UML/classes/datatype.py
+++ b/gaphor/UML/classes/datatype.py
@@ -17,9 +17,8 @@ from gaphor.UML.classes.klass import (
     attributes_compartment,
     operation_watches,
     operations_compartment,
-    stereotype_compartments,
-    stereotype_watches,
 )
+from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
 
 log = logging.getLogger(__name__)
 

--- a/gaphor/UML/classes/enumeration.py
+++ b/gaphor/UML/classes/enumeration.py
@@ -16,9 +16,8 @@ from gaphor.UML.classes.klass import (
     attributes_compartment,
     operation_watches,
     operations_compartment,
-    stereotype_compartments,
-    stereotype_watches,
 )
+from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
 
 log = logging.getLogger(__name__)
 

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -18,7 +18,7 @@ from gaphor.diagram.presentation import (
 )
 from gaphor.diagram.shapes import Box, Text, draw_border, draw_top_separator
 from gaphor.diagram.support import represents
-from gaphor.UML.classes.stereotype import stereotype_compartments
+from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
 
 log = logging.getLogger(__name__)
 
@@ -148,16 +148,6 @@ def operation_watches(presentation, cast):
         f"subject[{cast}].ownedOperation.ownedParameter.typeValue"
     ).watch(
         f"subject[{cast}].ownedOperation.ownedParameter.defaultValue"
-    )
-
-
-def stereotype_watches(presentation):
-    presentation.watch("subject.appliedStereotype", presentation.update_shapes).watch(
-        "subject.appliedStereotype.classifier.name"
-    ).watch("subject.appliedStereotype.slot", presentation.update_shapes).watch(
-        "subject.appliedStereotype.slot.definingFeature.name"
-    ).watch(
-        "subject.appliedStereotype.slot.value", presentation.update_shapes
     )
 
 

--- a/gaphor/UML/classes/stereotype.py
+++ b/gaphor/UML/classes/stereotype.py
@@ -5,6 +5,16 @@ from gaphor.core.styling import TextAlign, VerticalAlign
 from gaphor.diagram.shapes import Box, Text, draw_top_separator
 
 
+def stereotype_watches(presentation):
+    presentation.watch("subject.appliedStereotype", presentation.update_shapes).watch(
+        "subject.appliedStereotype.classifier.name"
+    ).watch("subject.appliedStereotype.slot", presentation.update_shapes).watch(
+        "subject.appliedStereotype.slot.definingFeature.name"
+    ).watch(
+        "subject.appliedStereotype.slot.value", presentation.update_shapes
+    )
+
+
 def stereotype_compartments(subject):
     return filter(
         None,

--- a/gaphor/UML/states/__init__.py
+++ b/gaphor/UML/states/__init__.py
@@ -1,4 +1,4 @@
-from gaphor.UML.states import copypaste, propertypages, vertexconnect
+from gaphor.UML.states import copypaste, group, propertypages, vertexconnect
 from gaphor.UML.states.finalstate import FinalStateItem
 from gaphor.UML.states.pseudostates import PseudostateItem
 from gaphor.UML.states.state import StateItem

--- a/gaphor/UML/states/__init__.py
+++ b/gaphor/UML/states/__init__.py
@@ -2,11 +2,13 @@ from gaphor.UML.states import copypaste, propertypages, vertexconnect
 from gaphor.UML.states.finalstate import FinalStateItem
 from gaphor.UML.states.pseudostates import PseudostateItem
 from gaphor.UML.states.state import StateItem
+from gaphor.UML.states.statemachine import StateMachineItem
 from gaphor.UML.states.transition import TransitionItem
 
 __all__ = [
     "FinalStateItem",
     "PseudostateItem",
     "StateItem",
+    "StateMachineItem",
     "TransitionItem",
 ]

--- a/gaphor/UML/states/__init__.py
+++ b/gaphor/UML/states/__init__.py
@@ -1,4 +1,4 @@
-from gaphor.UML.states import copypaste, group, propertypages, vertexconnect
+from gaphor.UML.states import copypaste, group, propertypages, vertexconnect, dropzone
 from gaphor.UML.states.finalstate import FinalStateItem
 from gaphor.UML.states.pseudostates import PseudostateItem
 from gaphor.UML.states.state import StateItem

--- a/gaphor/UML/states/dropzone.py
+++ b/gaphor/UML/states/dropzone.py
@@ -26,24 +26,24 @@ class RegionDropZoneMoveMixin(DropZoneMoveMixin):
         old_parent = item.parent
 
         try:
+            if not item.subject:
+                return
+
+            item_pos = view.get_matrix_v2i(new_parent).transform_point(*pos)
+            target_subject = new_parent.subject_at_point(item_pos)
+
+            if target_subject is item.subject.container:
+                return
 
             if old_parent and ungroup(old_parent.subject, item.subject):
                 item.change_parent(None)
                 old_parent.request_update()
 
-            if new_parent and item.subject:
-                item_pos = view.get_matrix_v2i(new_parent).transform_point(*pos)
-                for region, bounds in new_parent.regions:
-                    if item_pos in bounds:
-                        break
-                if region:
-                    target_subject = region
-                else:
-                    target_subject = new_parent.subject
-
-                if group(target_subject, item.subject):
-                    grow_parent(new_parent, item)
-                    item.change_parent(new_parent)
+            item_pos = view.get_matrix_v2i(new_parent).transform_point(*pos)
+            target_subject = new_parent.subject_at_point(item_pos)
+            if group(target_subject, item.subject):
+                grow_parent(new_parent, item)
+                item.change_parent(new_parent)
         finally:
             view.selection.dropzone_item = None
 

--- a/gaphor/UML/states/dropzone.py
+++ b/gaphor/UML/states/dropzone.py
@@ -28,12 +28,14 @@ class RegionDropZoneMoveMixin(DropZoneMoveMixin):
         old_parent = item.parent
 
         if not item.subject:
+            GuidedItemMoveMixin.stop_move(self, pos)
             return
 
         item_pos = view.get_matrix_v2i(new_parent).transform_point(*pos)
         target_subject = new_parent.subject_at_point(item_pos)
 
         if target_subject is item.subject.container:
+            GuidedItemMoveMixin.stop_move(self, pos)
             return
 
         if old_parent and ungroup(old_parent.subject, item.subject):
@@ -45,6 +47,8 @@ class RegionDropZoneMoveMixin(DropZoneMoveMixin):
         if group(target_subject, item.subject):
             grow_parent(new_parent, item)
             item.change_parent(new_parent)
+
+        GuidedItemMoveMixin.stop_move(self, pos)
 
 
 @MoveAspect.register(StateItem)

--- a/gaphor/UML/states/dropzone.py
+++ b/gaphor/UML/states/dropzone.py
@@ -7,6 +7,7 @@ from gaphor.diagram.tools.dropzone import DropZoneMoveMixin, grow_parent
 from gaphor.UML.states.pseudostates import PseudostateItem
 from gaphor.UML.states.state import StateItem
 from gaphor.UML.states.statemachine import StateMachineItem
+from gaphor.UML.states.transition import TransitionItem
 
 
 class RegionDropZoneMoveMixin(DropZoneMoveMixin):
@@ -48,5 +49,6 @@ class RegionDropZoneMoveMixin(DropZoneMoveMixin):
 
 @MoveAspect.register(StateItem)
 @MoveAspect.register(PseudostateItem)
+@MoveAspect.register(TransitionItem)
 class DropZoneMove(RegionDropZoneMoveMixin, GuidedItemMoveMixin, ItemMove):
     pass

--- a/gaphor/UML/states/dropzone.py
+++ b/gaphor/UML/states/dropzone.py
@@ -17,7 +17,7 @@ class RegionDropZoneMoveMixin(DropZoneMoveMixin):
         view = self.view
         new_parent = view.selection.dropzone_item
         if (
-            not isinstance(new_parent, StateMachineItem)
+            not isinstance(new_parent, (StateItem, StateMachineItem))
             or not new_parent.subject
             or not new_parent.subject.region
         ):

--- a/gaphor/UML/states/dropzone.py
+++ b/gaphor/UML/states/dropzone.py
@@ -1,0 +1,53 @@
+from gaphas.guide import GuidedItemMoveMixin
+from gaphas.move import ItemMove
+from gaphas.move import Move as MoveAspect
+
+from gaphor.diagram.group import group, ungroup
+from gaphor.diagram.tools.dropzone import DropZoneMoveMixin, grow_parent
+from gaphor.UML.states.state import StateItem
+from gaphor.UML.states.statemachine import StateMachineItem
+
+
+class RegionDropZoneMoveMixin(DropZoneMoveMixin):
+    """This drop zone aspect has some specifics to drop a state in the right
+    region on a state (machine)."""
+
+    def stop_move(self, pos):
+        view = self.view
+        new_parent = view.selection.dropzone_item
+        if (
+            not isinstance(new_parent, StateMachineItem)
+            or not new_parent.subject
+            or not new_parent.subject.region
+        ):
+            return super().stop_move(pos)
+
+        item = self.item
+        old_parent = item.parent
+
+        try:
+
+            if old_parent and ungroup(old_parent.subject, item.subject):
+                item.change_parent(None)
+                old_parent.request_update()
+
+            if new_parent and item.subject:
+                item_pos = view.get_matrix_v2i(new_parent).transform_point(*pos)
+                for region, bounds in new_parent.regions:
+                    if item_pos in bounds:
+                        break
+                if region:
+                    target_subject = region
+                else:
+                    target_subject = new_parent.subject
+
+                if group(target_subject, item.subject):
+                    grow_parent(new_parent, item)
+                    item.change_parent(new_parent)
+        finally:
+            view.selection.dropzone_item = None
+
+
+@MoveAspect.register(StateItem)
+class DropZoneMove(RegionDropZoneMoveMixin, GuidedItemMoveMixin, ItemMove):
+    pass

--- a/gaphor/UML/states/dropzone.py
+++ b/gaphor/UML/states/dropzone.py
@@ -26,27 +26,24 @@ class RegionDropZoneMoveMixin(DropZoneMoveMixin):
         item = self.item
         old_parent = item.parent
 
-        try:
-            if not item.subject:
-                return
+        if not item.subject:
+            return
 
-            item_pos = view.get_matrix_v2i(new_parent).transform_point(*pos)
-            target_subject = new_parent.subject_at_point(item_pos)
+        item_pos = view.get_matrix_v2i(new_parent).transform_point(*pos)
+        target_subject = new_parent.subject_at_point(item_pos)
 
-            if target_subject is item.subject.container:
-                return
+        if target_subject is item.subject.container:
+            return
 
-            if old_parent and ungroup(old_parent.subject, item.subject):
-                item.change_parent(None)
-                old_parent.request_update()
+        if old_parent and ungroup(old_parent.subject, item.subject):
+            item.change_parent(None)
+            old_parent.request_update()
 
-            item_pos = view.get_matrix_v2i(new_parent).transform_point(*pos)
-            target_subject = new_parent.subject_at_point(item_pos)
-            if group(target_subject, item.subject):
-                grow_parent(new_parent, item)
-                item.change_parent(new_parent)
-        finally:
-            view.selection.dropzone_item = None
+        item_pos = view.get_matrix_v2i(new_parent).transform_point(*pos)
+        target_subject = new_parent.subject_at_point(item_pos)
+        if group(target_subject, item.subject):
+            grow_parent(new_parent, item)
+            item.change_parent(new_parent)
 
 
 @MoveAspect.register(StateItem)

--- a/gaphor/UML/states/dropzone.py
+++ b/gaphor/UML/states/dropzone.py
@@ -4,6 +4,7 @@ from gaphas.move import Move as MoveAspect
 
 from gaphor.diagram.group import group, ungroup
 from gaphor.diagram.tools.dropzone import DropZoneMoveMixin, grow_parent
+from gaphor.UML.states.pseudostates import PseudostateItem
 from gaphor.UML.states.state import StateItem
 from gaphor.UML.states.statemachine import StateMachineItem
 
@@ -49,5 +50,6 @@ class RegionDropZoneMoveMixin(DropZoneMoveMixin):
 
 
 @MoveAspect.register(StateItem)
+@MoveAspect.register(PseudostateItem)
 class DropZoneMove(RegionDropZoneMoveMixin, GuidedItemMoveMixin, ItemMove):
     pass

--- a/gaphor/UML/states/group.py
+++ b/gaphor/UML/states/group.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from gaphor.core import gettext
 from gaphor.diagram.group import group, ungroup
-from gaphor.UML.uml import Region, State, StateMachine, Vertex
+from gaphor.UML.uml import Region, State, StateMachine, Transition, Vertex
 
 
 @group.register(State, Vertex)
@@ -30,14 +30,16 @@ def state_machine_vertex_ungroup(state_machine: State | StateMachine, vertex: Ve
 
 
 @group.register(Region, Vertex)
-def region_vertex_group(region, vertex):
-    vertex.container = region
+@group.register(Region, Transition)
+def region_vertex_group(region, vertex_or_transition):
+    vertex_or_transition.container = region
     return True
 
 
 @ungroup.register(Region, Vertex)
-def region_vertex_ungroup(region, vertex):
-    if vertex.container is region:
-        del vertex.container
+@ungroup.register(Region, Transition)
+def region_vertex_ungroup(region, vertex_or_transition):
+    if vertex_or_transition.container is region:
+        del vertex_or_transition.container
         return True
     return False

--- a/gaphor/UML/states/group.py
+++ b/gaphor/UML/states/group.py
@@ -1,0 +1,39 @@
+from gaphor.core import gettext
+from gaphor.diagram.group import group, ungroup
+from gaphor.UML.uml import Region, StateMachine, Vertex
+
+
+@group.register(StateMachine, Vertex)
+def state_machine_vertex_group(state_machine, vertex):
+    """Add State to a State Machine, add a Region if necessary."""
+    if state_machine.region:
+        region = state_machine.region[0]
+    else:
+        region = state_machine.model.create(Region)
+        region.name = gettext("Default Region")
+        region.stateMachine = state_machine
+
+    vertex.container = region
+    return True
+
+
+@ungroup.register(StateMachine, Vertex)
+def state_machine_vertex_ungroup(state_machine, vertex):
+    if vertex.container and vertex.container in state_machine.region:
+        del vertex.container
+        return True
+    return False
+
+
+@group.register(Region, Vertex)
+def region_vertex_group(region, vertex):
+    vertex.container = region
+    return True
+
+
+@ungroup.register(Region, Vertex)
+def region_vertex_ungroup(region, vertex):
+    if vertex.container is region:
+        del vertex.container
+        return True
+    return False

--- a/gaphor/UML/states/group.py
+++ b/gaphor/UML/states/group.py
@@ -1,24 +1,28 @@
+from __future__ import annotations
+
 from gaphor.core import gettext
 from gaphor.diagram.group import group, ungroup
-from gaphor.UML.uml import Region, StateMachine, Vertex
+from gaphor.UML.uml import Region, State, StateMachine, Vertex
 
 
+@group.register(State, Vertex)
 @group.register(StateMachine, Vertex)
-def state_machine_vertex_group(state_machine, vertex):
+def state_machine_vertex_group(state_machine: State | StateMachine, vertex: Vertex):
     """Add State to a State Machine, add a Region if necessary."""
     if state_machine.region:
         region = state_machine.region[0]
     else:
         region = state_machine.model.create(Region)
         region.name = gettext("Default Region")
-        region.stateMachine = state_machine
+        state_machine.region = region
 
     vertex.container = region
     return True
 
 
+@ungroup.register(State, Vertex)
 @ungroup.register(StateMachine, Vertex)
-def state_machine_vertex_ungroup(state_machine, vertex):
+def state_machine_vertex_ungroup(state_machine: State | StateMachine, vertex: Vertex):
     if vertex.container and vertex.container in state_machine.region:
         del vertex.container
         return True

--- a/gaphor/UML/states/group.py
+++ b/gaphor/UML/states/group.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from gaphor.core import gettext
 from gaphor.diagram.group import group, ungroup
 from gaphor.UML.uml import Region, State, StateMachine, Transition, Vertex
 
@@ -13,7 +12,6 @@ def state_machine_vertex_group(state_machine: State | StateMachine, vertex: Vert
         region = state_machine.region[0]
     else:
         region = state_machine.model.create(Region)
-        region.name = gettext("Default Region")
         state_machine.region = region
 
     vertex.container = region

--- a/gaphor/UML/states/propertypages.glade
+++ b/gaphor/UML/states/propertypages.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkLabel" id="00-instructions">
@@ -13,6 +13,80 @@ Top margin is 6 px, 12px for expanders.
 Edit, from the popup menu, will allow you to add cell
 renderers and such.</property>
     <property name="xalign">0</property>
+  </object>
+  <object class="GtkAdjustment" id="num-regions-adjustment">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkExpander" id="region-editor">
+    <property name="visible">1</property>
+    <property name="can-focus">1</property>
+    <property name="margin-top">12</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="margin-top">6</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Show Regions</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="show-regions">
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <signal name="notify::active" handler="show-regions-changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="pack-type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Regions</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSpinButton" id="num-regions">
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="adjustment">num-regions-adjustment</property>
+                <signal name="value-changed" handler="regions-changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="pack-type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child type="label">
+      <object class="GtkLabel">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">Regions</property>
+        <attributes>
+          <attribute name="weight" value="bold"/>
+        </attributes>
+      </object>
+    </child>
   </object>
   <object class="GtkExpander" id="state-editor">
     <property name="visible">1</property>

--- a/gaphor/UML/states/propertypages.py
+++ b/gaphor/UML/states/propertypages.py
@@ -15,8 +15,7 @@ from gaphor.diagram.propertypages import (
     new_resource_builder,
 )
 from gaphor.UML.states.state import StateItem
-
-from .statemachine import StateMachineItem
+from gaphor.UML.states.statemachine import StateMachineItem
 
 new_builder = new_resource_builder("gaphor.UML.states")
 

--- a/gaphor/UML/states/propertypages.ui
+++ b/gaphor/UML/states/propertypages.ui
@@ -71,11 +71,69 @@
       </object>
     </child>
     <child>
-      <object class="GtkEntry" id="guard">
-      </object>
+      <object class="GtkEntry" id="guard"/>
     </child>
     <style>
       <class name="propertypage"/>
     </style>
+  </object>
+
+  <object class="GtkAdjustment" id="num-regions-adjustment">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+
+  <object class="GtkExpander" id="region-editor">
+    <property name="margin-top">12</property>
+    <child type="label">
+      <object class="GtkLabel" id="titlelabel">
+        <property name="label" translatable="1">Regions</property>
+        <attributes>
+          <attribute name="weight" value="bold"></attribute>
+        </attributes>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox" id="childbox">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <child>
+              <object class="GtkLabel">
+                <property name="label" translatable="1">Show Regions</property>
+                <property name="halign">start</property>
+                <property name="hexpand">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="show-regions">
+                <signal name="notify::active" handler="show-regions-changed" swapped="no"/>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <child>
+              <object class="GtkLabel">
+                <property name="label" translatable="1">Regions</property>
+                <property name="halign">start</property>
+                <property name="hexpand">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSpinButton" id="num-regions">
+                <property name="adjustment">num-regions-adjustment</property>
+                <signal name="value-changed" handler="regions-changed" swapped="no"/>
+              </object>
+            </child>
+          </object>
+        </child>
+        <style>
+          <class name="propertypage"/>
+        </style>
+      </object>
+    </child>
   </object>
 </interface>

--- a/gaphor/UML/states/region.py
+++ b/gaphor/UML/states/region.py
@@ -1,0 +1,26 @@
+from gaphor.core.styling import TextAlign, VerticalAlign
+from gaphor.diagram.shapes import BoundedBox, Text, draw_top_separator
+
+
+def region_compartment(subject):
+    if not subject:
+        return
+
+    for index, region in enumerate(subject.region):
+        yield _create_region_compartment(region, index)
+
+
+def _create_region_compartment(region, index):
+    return BoundedBox(
+        Text(
+            text=lambda: region.name or "",
+            style={"text-align": TextAlign.LEFT},
+        ),
+        style={
+            "padding": (4, 4, 4, 4),
+            "min-height": 100,
+            "vertical-align": VerticalAlign.TOP,
+            "dash-style": (7, 3) if index > 0 else (),
+        },
+        draw=draw_top_separator,
+    )

--- a/gaphor/UML/states/state.py
+++ b/gaphor/UML/states/state.py
@@ -28,6 +28,7 @@ class StateItem(ElementPresentation[UML.State], Named):
         self.watch("subject[State].doActivity.name", self.update_shapes)
         self.watch("subject[State].region.name")
         self.watch("subject[State].region", self.update_shapes)
+        self.watch("show_regions", self.update_shapes)
 
     show_regions: attribute[int] = attribute("show_regions", int, default=True)
 

--- a/gaphor/UML/states/state.py
+++ b/gaphor/UML/states/state.py
@@ -1,26 +1,40 @@
 """State diagram item."""
 
+from __future__ import annotations
+
+from gaphas.types import Pos
 
 from gaphor import UML
+from gaphor.core.modeling.element import Element
+from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import TextAlign, VerticalAlign
+from gaphor.core.styling.properties import JustifyContent
 from gaphor.diagram.presentation import ElementPresentation, Named
 from gaphor.diagram.shapes import Box, Text, draw_top_separator, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.recipes import stereotypes_str
+from gaphor.UML.states.region import region_compartment
 
 
 @represents(UML.State)
 class StateItem(ElementPresentation[UML.State], Named):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=50, height=30)
-
+        self._region_boxes = []
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[State].entry.name", self.update_shapes)
         self.watch("subject[State].exit.name", self.update_shapes)
         self.watch("subject[State].doActivity.name", self.update_shapes)
+        self.watch("subject[State].region.name")
+        self.watch("subject[State].region", self.update_shapes)
+
+    show_regions: attribute[int] = attribute("show_regions", int, default=True)
 
     def update_shapes(self, event=None):
+        self._region_boxes = (
+            list(region_compartment(self.subject)) if self.show_regions else []
+        )
         compartment = Box(
             Text(
                 text=lambda: self.subject.entry.name
@@ -55,10 +69,24 @@ class StateItem(ElementPresentation[UML.State], Named):
                 style={"padding": (4, 4, 4, 4)},
             ),
             compartment,
+            Box(
+                *(self._region_boxes),
+                style={"justify-content": JustifyContent.STRETCH},
+            ),
             style={
                 "vertical-align": VerticalAlign.TOP,
             },
             draw=draw_state,
+        )
+
+    def subject_at_point(self, pos: Pos) -> Element | None:
+        return next(
+            (
+                region
+                for region, bounds in zip(self.subject.region, self._region_boxes)
+                if pos in bounds
+            ),
+            self.subject,
         )
 
 

--- a/gaphor/UML/states/statemachine.py
+++ b/gaphor/UML/states/statemachine.py
@@ -3,7 +3,7 @@ from gaphor.core import gettext
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import FontWeight, VerticalAlign
 from gaphor.diagram.presentation import Classified, ElementPresentation
-from gaphor.diagram.shapes import Box, Text, draw_border
+from gaphor.diagram.shapes import Box, Text, draw_border, draw_top_separator
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
 
@@ -19,6 +19,7 @@ class StateMachineItem(Classified, ElementPresentation):
         stereotype_watches(self)
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
+    show_regions: attribute[int] = attribute("show_regions", int, default=True)
 
     def update_shapes(self, event=None):
         self.shape = Box(
@@ -35,10 +36,22 @@ class StateMachineItem(Classified, ElementPresentation):
                 style={"padding": (4, 4, 4, 4)},
             ),
             *(self.show_stereotypes and stereotype_compartments(self.subject) or []),
+            *(self.show_regions and region_compartment(self.subject) or []),
             style={
                 "vertical-align": VerticalAlign.TOP
-                if self.diagram and self.children
+                if (self.diagram and self.children) or self.show_regions
                 else VerticalAlign.MIDDLE,
             },
             draw=draw_border
+        )
+
+
+def region_compartment(subject):
+    if not subject:
+        return
+
+    for index, region in enumerate(subject.region):
+        yield Box(
+            style={"min-height": 100, "dash-style": (7, 3)},
+            draw=draw_top_separator if index > 0 else None,
         )

--- a/gaphor/UML/states/statemachine.py
+++ b/gaphor/UML/states/statemachine.py
@@ -1,9 +1,10 @@
-from typing import Iterable
+from __future__ import annotations
 
-from gaphas.geometry import Rectangle
+from gaphas.types import Pos
 
 from gaphor import UML
 from gaphor.core import gettext
+from gaphor.core.modeling.element import Element
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import FontWeight, TextAlign, VerticalAlign
 from gaphor.core.styling.properties import JustifyContent
@@ -14,7 +15,7 @@ from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_wa
 
 
 @represents(UML.StateMachine)
-class StateMachineItem(Classified, ElementPresentation):
+class StateMachineItem(Classified, ElementPresentation[UML.StateMachine]):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
         self._region_boxes = []
@@ -27,11 +28,6 @@ class StateMachineItem(Classified, ElementPresentation):
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
     show_regions: attribute[int] = attribute("show_regions", int, default=True)
-
-    @property
-    def regions(self) -> Iterable[tuple[UML.Region, Rectangle]]:
-        if self.subject:
-            yield from zip(self.subject.region, self._region_boxes)
 
     def update_shapes(self, event=None):
         self._region_boxes = (
@@ -62,6 +58,13 @@ class StateMachineItem(Classified, ElementPresentation):
             },
             draw=draw_border,
         )
+
+    def subject_at_point(self, pos: Pos) -> Element | None:
+        region: UML.Region
+        for region, bounds in zip(self.subject.region, self._region_boxes):
+            if pos in bounds:
+                return region
+        return self.subject
 
 
 def region_compartment(subject):

--- a/gaphor/UML/states/statemachine.py
+++ b/gaphor/UML/states/statemachine.py
@@ -61,10 +61,14 @@ class StateMachineItem(Classified, ElementPresentation[UML.StateMachine]):
 
     def subject_at_point(self, pos: Pos) -> Element | None:
         region: UML.Region
-        for region, bounds in zip(self.subject.region, self._region_boxes):
-            if pos in bounds:
-                return region
-        return self.subject
+        return next(
+            (
+                region
+                for region, bounds in zip(self.subject.region, self._region_boxes)
+                if pos in bounds
+            ),
+            self.subject,
+        )
 
 
 def region_compartment(subject):

--- a/gaphor/UML/states/statemachine.py
+++ b/gaphor/UML/states/statemachine.py
@@ -6,6 +6,7 @@ from gaphor import UML
 from gaphor.core import gettext
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import FontWeight, TextAlign, VerticalAlign
+from gaphor.core.styling.properties import JustifyContent
 from gaphor.diagram.presentation import Classified, ElementPresentation
 from gaphor.diagram.shapes import BoundedBox, Box, Text, draw_border, draw_top_separator
 from gaphor.diagram.support import represents
@@ -50,13 +51,16 @@ class StateMachineItem(Classified, ElementPresentation):
                 style={"padding": (4, 4, 4, 4)},
             ),
             *(self.show_stereotypes and stereotype_compartments(self.subject) or []),
-            *(self._region_boxes),
+            Box(
+                *(self._region_boxes),
+                style={"justify-content": JustifyContent.STRETCH},
+            ),
             style={
                 "vertical-align": VerticalAlign.TOP
                 if (self.diagram and self.children) or self.show_regions
                 else VerticalAlign.MIDDLE,
             },
-            draw=draw_border
+            draw=draw_border,
         )
 
 

--- a/gaphor/UML/states/statemachine.py
+++ b/gaphor/UML/states/statemachine.py
@@ -1,7 +1,7 @@
 from gaphor import UML
 from gaphor.core import gettext
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import FontWeight, VerticalAlign
+from gaphor.core.styling import FontWeight, TextAlign, VerticalAlign
 from gaphor.diagram.presentation import Classified, ElementPresentation
 from gaphor.diagram.shapes import Box, Text, draw_border, draw_top_separator
 from gaphor.diagram.support import represents
@@ -14,7 +14,10 @@ class StateMachineItem(Classified, ElementPresentation):
         super().__init__(diagram, id)
 
         self.watch("show_stereotypes", self.update_shapes)
+        self.watch("show_regions", self.update_shapes)
         self.watch("subject[NamedElement].name")
+        self.watch("subject[StateMachine].region.name")
+        self.watch("subject[StateMachine].region", self.update_shapes)
         self.watch("children", self.update_shapes)
         stereotype_watches(self)
 
@@ -51,7 +54,20 @@ def region_compartment(subject):
         return
 
     for index, region in enumerate(subject.region):
-        yield Box(
-            style={"min-height": 100, "dash-style": (7, 3)},
-            draw=draw_top_separator if index > 0 else None,
-        )
+        yield _create_region_compartment(region, index)
+
+
+def _create_region_compartment(region, index):
+    return Box(
+        Text(
+            text=lambda: region.name or "",
+            style={"text-align": TextAlign.LEFT},
+        ),
+        style={
+            "padding": (4, 4, 4, 4),
+            "min-height": 100,
+            "vertical-align": VerticalAlign.TOP,
+            "dash-style": (7, 3) if index > 0 else (),
+        },
+        draw=draw_top_separator,
+    )

--- a/gaphor/UML/states/statemachine.py
+++ b/gaphor/UML/states/statemachine.py
@@ -1,0 +1,43 @@
+from gaphor import UML
+from gaphor.core import gettext
+from gaphor.core.modeling.properties import attribute
+from gaphor.core.styling import FontWeight, VerticalAlign
+from gaphor.diagram.presentation import Classified, ElementPresentation
+from gaphor.diagram.shapes import Box, Text, draw_border
+from gaphor.diagram.support import represents
+from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
+
+
+@represents(UML.StateMachine)
+class StateMachineItem(Classified, ElementPresentation):
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
+
+        self.watch("show_stereotypes", self.update_shapes)
+        self.watch("subject[NamedElement].name")
+        stereotype_watches(self)
+
+    show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
+
+    def update_shapes(self, event=None):
+        self.shape = Box(
+            Box(
+                Text(
+                    text=lambda: UML.recipes.stereotypes_str(
+                        self.subject, [gettext("statemachine")]
+                    ),
+                ),
+                Text(
+                    text=lambda: self.subject.name or "",
+                    style={"font-weight": FontWeight.BOLD},
+                ),
+                style={"padding": (4, 4, 4, 4)},
+            ),
+            *(self.show_stereotypes and stereotype_compartments(self.subject) or []),
+            style={
+                "vertical-align": VerticalAlign.TOP
+                if self.diagram and self.children
+                else VerticalAlign.MIDDLE,
+            },
+            draw=draw_border
+        )

--- a/gaphor/UML/states/statemachine.py
+++ b/gaphor/UML/states/statemachine.py
@@ -15,6 +15,7 @@ class StateMachineItem(Classified, ElementPresentation):
 
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject[NamedElement].name")
+        self.watch("children", self.update_shapes)
         stereotype_watches(self)
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)

--- a/gaphor/UML/states/statemachine.py
+++ b/gaphor/UML/states/statemachine.py
@@ -6,12 +6,13 @@ from gaphor import UML
 from gaphor.core import gettext
 from gaphor.core.modeling.element import Element
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import FontWeight, TextAlign, VerticalAlign
+from gaphor.core.styling import FontWeight, VerticalAlign
 from gaphor.core.styling.properties import JustifyContent
 from gaphor.diagram.presentation import Classified, ElementPresentation
-from gaphor.diagram.shapes import BoundedBox, Box, Text, draw_border, draw_top_separator
+from gaphor.diagram.shapes import Box, Text, draw_border
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
+from gaphor.UML.states.region import region_compartment
 
 
 @represents(UML.StateMachine)
@@ -60,7 +61,6 @@ class StateMachineItem(Classified, ElementPresentation[UML.StateMachine]):
         )
 
     def subject_at_point(self, pos: Pos) -> Element | None:
-        region: UML.Region
         return next(
             (
                 region
@@ -69,27 +69,3 @@ class StateMachineItem(Classified, ElementPresentation[UML.StateMachine]):
             ),
             self.subject,
         )
-
-
-def region_compartment(subject):
-    if not subject:
-        return
-
-    for index, region in enumerate(subject.region):
-        yield _create_region_compartment(region, index)
-
-
-def _create_region_compartment(region, index):
-    return BoundedBox(
-        Text(
-            text=lambda: region.name or "",
-            style={"text-align": TextAlign.LEFT},
-        ),
-        style={
-            "padding": (4, 4, 4, 4),
-            "min-height": 100,
-            "vertical-align": VerticalAlign.TOP,
-            "dash-style": (7, 3) if index > 0 else (),
-        },
-        draw=draw_top_separator,
-    )

--- a/gaphor/UML/states/statestoolbox.py
+++ b/gaphor/UML/states/statestoolbox.py
@@ -6,7 +6,12 @@ from gaphas.item import SE
 
 from gaphor import UML
 from gaphor.core import gettext
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
+from gaphor.diagram.diagramtoolbox import (
+    ToolDef,
+    ToolSection,
+    namespace_config,
+    new_item_factory,
+)
 from gaphor.UML import diagramitems
 from gaphor.UML.recipes import owner_package
 
@@ -58,6 +63,18 @@ def state_machine_config(new_item, name=None):
 states = ToolSection(
     gettext("States"),
     (
+        ToolDef(
+            "toolbox-state-machine",
+            gettext("State Machine"),
+            "gaphor-state-machine-symbolic",
+            None,
+            new_item_factory(
+                diagramitems.StateMachineItem,
+                UML.StateMachine,
+                config_func=namespace_config,
+            ),
+            handle_index=SE,
+        ),
         ToolDef(
             "toolbox-state",
             gettext("State"),

--- a/gaphor/UML/states/statestoolbox.py
+++ b/gaphor/UML/states/statestoolbox.py
@@ -54,7 +54,6 @@ def state_machine_config(new_item, name=None):
         region = state_machine.region[0]
     else:
         region = subject.model.create(UML.Region)
-        region.name = gettext("Default Region")
         region.stateMachine = state_machine
 
     subject.container = region

--- a/gaphor/UML/states/tests/test_group.py
+++ b/gaphor/UML/states/tests/test_group.py
@@ -27,6 +27,7 @@ def test_state_in_region(element_factory):
     group(region, s)
 
     assert s.container is region
+    assert s in region.subvertex
 
 
 def test_state_in_state(element_factory):

--- a/gaphor/UML/states/tests/test_group.py
+++ b/gaphor/UML/states/tests/test_group.py
@@ -1,0 +1,61 @@
+from gaphor import UML
+from gaphor.diagram.group import group, ungroup
+
+
+def test_state_in_state_machine(element_factory):
+    s = element_factory.create(UML.State)
+    sm = element_factory.create(UML.StateMachine)
+
+    group(sm, s)
+
+    assert s.container in sm.region
+
+
+def test_pseudostate_in_state_machine(element_factory):
+    s = element_factory.create(UML.Pseudostate)
+    sm = element_factory.create(UML.StateMachine)
+
+    group(sm, s)
+
+    assert s.container in sm.region
+
+
+def test_state_in_region(element_factory):
+    s = element_factory.create(UML.State)
+    region = element_factory.create(UML.Region)
+
+    group(region, s)
+
+    assert s.container is region
+
+
+def test_ungroup_state_in_state_machine(element_factory):
+    s = element_factory.create(UML.State)
+    sm = element_factory.create(UML.StateMachine)
+
+    group(sm, s)
+    ungroup(sm, s)
+
+    assert not s.container
+    assert sm.region
+
+
+def test_ungroup_pseudostate_in_state_machine(element_factory):
+    s = element_factory.create(UML.Pseudostate)
+    sm = element_factory.create(UML.StateMachine)
+
+    group(sm, s)
+    ungroup(sm, s)
+
+    assert not s.container
+    assert sm.region
+
+
+def test_ungroup_state_in_region(element_factory):
+    s = element_factory.create(UML.State)
+    region = element_factory.create(UML.Region)
+
+    group(region, s)
+    ungroup(region, s)
+
+    assert not s.container

--- a/gaphor/UML/states/tests/test_group.py
+++ b/gaphor/UML/states/tests/test_group.py
@@ -29,6 +29,15 @@ def test_state_in_region(element_factory):
     assert s.container is region
 
 
+def test_state_in_state(element_factory):
+    s = element_factory.create(UML.State)
+    parent = element_factory.create(UML.State)
+
+    group(parent, s)
+
+    assert s.container in parent.region
+
+
 def test_ungroup_state_in_state_machine(element_factory):
     s = element_factory.create(UML.State)
     sm = element_factory.create(UML.StateMachine)
@@ -59,3 +68,14 @@ def test_ungroup_state_in_region(element_factory):
     ungroup(region, s)
 
     assert not s.container
+
+
+def test_ungroup_state_in_state(element_factory):
+    s = element_factory.create(UML.State)
+    parent = element_factory.create(UML.State)
+
+    group(parent, s)
+    ungroup(parent, s)
+
+    assert not s.container
+    assert parent.region

--- a/gaphor/UML/states/tests/test_propertypages.py
+++ b/gaphor/UML/states/tests/test_propertypages.py
@@ -1,6 +1,11 @@
 from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
-from gaphor.UML.states.propertypages import StatePropertyPage, TransitionPropertyPage
+from gaphor.UML.states.propertypages import (
+    RegionPropertyPage,
+    StatePropertyPage,
+    TransitionPropertyPage,
+)
+from gaphor.UML.states.state import StateItem
 
 
 def test_state_property_page_entry(element_factory):
@@ -45,3 +50,14 @@ def test_transition_property_page(element_factory):
     guard.set_text("test")
 
     assert subject.guard.specification == "test"
+
+
+def test_region_property_page(create):
+    item = create(StateItem, UML.State)
+    property_page = RegionPropertyPage(item)
+
+    widget = property_page.construct()
+    num_regions = find(widget, "num-regions")
+    num_regions.set_value(4)
+
+    assert len(item.subject.region) == 4

--- a/gaphor/UML/states/tests/test_states.py
+++ b/gaphor/UML/states/tests/test_states.py
@@ -1,11 +1,15 @@
 from gaphor import UML
 from gaphor.core.modeling import Diagram
 from gaphor.UML.states.state import StateItem
+from gaphor.UML.states.statemachine import StateMachineItem
 
 
 def test_state(create):
-    """Test creation of states."""
     assert create(StateItem, UML.State)
+
+
+def test_statemachine(create):
+    assert create(StateMachineItem, UML.StateMachine)
 
 
 def test_activities_persistence(create, element_factory, saver, loader):

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -624,6 +624,7 @@ class State(Namespace, Vertex):
     doActivity: relation_one[Behavior]
     entry: relation_one[Behavior]
     exit: relation_one[Behavior]
+    region: relation_many[Region]
     statevariant: relation_one[Constraint]
     submachine: relation_one[StateMachine]
 
@@ -1224,7 +1225,7 @@ StateMachine.region = association("region", Region, lower=1, composite=True, opp
 Namespace.ownedMember.add(StateMachine.region)  # type: ignore[attr-defined]
 Region.stateMachine = association("stateMachine", StateMachine, upper=1, opposite="region")
 Region.subvertex = association("subvertex", Vertex, composite=True, opposite="container")
-Region.state = association("state", State, upper=1)
+Region.state = association("state", State, upper=1, opposite="region")
 NamedElement.namespace.add(Region.stateMachine)  # type: ignore[attr-defined]
 Namespace.ownedMember.add(Region.subvertex)  # type: ignore[attr-defined]
 NamedElement.namespace.add(Region.state)  # type: ignore[attr-defined]
@@ -1240,23 +1241,25 @@ Vertex.container = association("container", Region, upper=1, opposite="subvertex
 Vertex.outgoing = association("outgoing", Transition, opposite="source")
 Vertex.incoming = association("incoming", Transition, opposite="target")
 NamedElement.namespace.add(Vertex.container)  # type: ignore[attr-defined]
-Pseudostate.stateMachine = association("stateMachine", StateMachine, upper=1)
 Pseudostate.state = association("state", State, upper=1)
-NamedElement.namespace.add(Pseudostate.stateMachine)  # type: ignore[attr-defined]
+Pseudostate.stateMachine = association("stateMachine", StateMachine, upper=1)
 Element.owner.add(Pseudostate.state)  # type: ignore[attr-defined]
+NamedElement.namespace.add(Pseudostate.stateMachine)  # type: ignore[attr-defined]
+ConnectionPointReference.state = association("state", State, upper=1)
 ConnectionPointReference.exit = association("exit", Pseudostate)
 ConnectionPointReference.entry = association("entry", Pseudostate)
-ConnectionPointReference.state = association("state", State, upper=1)
 NamedElement.namespace.add(ConnectionPointReference.state)  # type: ignore[attr-defined]
 State.entry = association("entry", Behavior, upper=1, composite=True)
 State.exit = association("exit", Behavior, upper=1, composite=True)
 State.doActivity = association("doActivity", Behavior, upper=1, composite=True)
 State.statevariant = association("statevariant", Constraint, upper=1, composite=True, opposite="owningState")
 State.submachine = association("submachine", StateMachine, upper=1)
+State.region = association("region", Region, composite=True, opposite="state")
 Element.ownedElement.add(State.entry)  # type: ignore[attr-defined]
 Element.ownedElement.add(State.exit)  # type: ignore[attr-defined]
 Element.ownedElement.add(State.doActivity)  # type: ignore[attr-defined]
 Element.ownedElement.add(State.statevariant)  # type: ignore[attr-defined]
+Namespace.ownedMember.add(State.region)  # type: ignore[attr-defined]
 Port.encapsulatedClassifier = association("encapsulatedClassifier", EncapsulatedClassifier, upper=1, opposite="ownedPort")
 NamedElement.namespace.add(Port.encapsulatedClassifier)  # type: ignore[attr-defined]
 Deployment.location = association("location", DeploymentTarget, upper=1, opposite="deployment")

--- a/gaphor/core/styling/declarations.py
+++ b/gaphor/core/styling/declarations.py
@@ -73,7 +73,7 @@ def parse_value(tokens):
         elif token.type in ("dimension", "number"):
             value.append(token.int_value if token.is_integer else token.value)
         elif token.type == "hash":
-            value.append("#" + token.value)
+            value.append(f"#{token.value}")
         elif token.type == "function":
             value.append(token)
         else:
@@ -86,11 +86,7 @@ number = (int, float)
 
 
 def _clip_color(c):
-    if c < 0:
-        return 0
-    if c > 1:
-        return 1
-    return c
+    return 0 if c < 0 else min(c, 1)
 
 
 @declarations.register("background-color", "color", "text-color")
@@ -110,18 +106,14 @@ def parse_color(prop, value):
     "border-radius",
 )
 def parse_positive_number(prop, value) -> Optional[Number]:
-    if isinstance(value, number) and value >= 0:
-        return value
-    return None
+    return value if isinstance(value, number) and value >= 0 else None
 
 
 @declarations.register(
     "opacity",
 )
 def parse_factor(prop, value) -> Optional[Number]:
-    if isinstance(value, number) and 0 <= value <= 1:
-        return value
-    return None
+    return value if isinstance(value, number) and 0 <= value <= 1 else None
 
 
 @declarations.register("font-family")
@@ -137,9 +129,7 @@ def parse_string(prop, value) -> Optional[str]:
 def parse_font_size(prop, value) -> Union[None, int, float, str]:
     if isinstance(value, number) and value > 0:
         return value
-    if isinstance(value, str) and value in FONT_SIZE_VALUES:
-        return value
-    return None
+    return value if isinstance(value, str) and value in FONT_SIZE_VALUES else None
 
 
 @declarations.register("padding")

--- a/gaphor/core/styling/declarations.py
+++ b/gaphor/core/styling/declarations.py
@@ -6,6 +6,7 @@ from tinycss2.parser import parse_declaration_list
 from gaphor.core.styling.properties import (
     FontStyle,
     FontWeight,
+    JustifyContent,
     Number,
     Padding,
     TextAlign,
@@ -173,6 +174,7 @@ def parse_sequence_numbers(
 enum_styles: Dict[str, Dict[str, object]] = {
     "font-style": {e.value: e for e in FontStyle},
     "font-weight": {e.value: e for e in FontWeight},
+    "justify-content": {e.value: e for e in JustifyContent},
     "text-decoration": {e.value: e for e in TextDecoration},
     "text-align": {e.value: e for e in TextAlign},
     "vertical-align": {e.value: e for e in VerticalAlign},

--- a/gaphor/core/styling/properties.py
+++ b/gaphor/core/styling/properties.py
@@ -19,6 +19,11 @@ class VerticalAlign(Enum):
     BOTTOM = "bottom"
 
 
+class JustifyContent(Enum):
+    START = "start"
+    STRETCH = "stretch"
+
+
 class FontStyle(Enum):
     NORMAL = "normal"
     ITALIC = "italic"
@@ -48,6 +53,7 @@ Style = TypedDict(
         "font-size": Union[int, float, str],
         "font-style": FontStyle,
         "font-weight": FontWeight,
+        "justify-content": JustifyContent,
         "line-style": Number,
         "line-width": Number,
         "min-width": Number,

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -154,6 +154,29 @@ class Box:
             y += h
 
 
+class BoundedBox(Box):
+    """A Box.
+
+    It keeps track of the latest bounding box used for drawing.
+    """
+
+    def __init__(
+        self,
+        *children,
+        style: Style = {},
+        draw: Callable[[Box, DrawContext, Rectangle], None] | None = None,
+    ):
+        super().__init__(*children, style=style, draw=draw)
+        self.bounding_box = Rectangle()
+
+    def draw(self, context: DrawContext, bounding_box: Rectangle):
+        self.bounding_box = bounding_box
+        return super().draw(context, bounding_box)
+
+    def __contains__(self, pos_or_rect):
+        return pos_or_rect in self.bounding_box
+
+
 class IconBox:
     """A special type of box: the icon element is given the full width/height
     and all other shapes are drawn below the main icon shape.

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -136,7 +136,7 @@ class Box:
         sizes = self.sizes
 
         justify_content = style.get("justify-content", JustifyContent.START)
-        if justify_content is JustifyContent.STRETCH:
+        if justify_content is JustifyContent.STRETCH and sizes:
             height = bounding_box.height
             avg_height = height / len(sizes)
             oversized = [h for _w, h in sizes if h > avg_height]

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -77,6 +77,9 @@ else:
     def find(widget, name):
         if widget.get_buildable_id() == name:
             return widget
+        if isinstance(widget, Gtk.Expander):
+            # Iterating children will only iterate the label section
+            return find(widget.get_child(), name)
         if sibling := widget.get_next_sibling():
             if found := find(sibling, name):
                 return found

--- a/gaphor/diagram/tests/test_shapes.py
+++ b/gaphor/diagram/tests/test_shapes.py
@@ -65,6 +65,25 @@ def test_draw_box_with_custom_draw_function(context):
     assert called
 
 
+def test_draw_last_box_with_all_remaining_space(context):
+    bounding_boxes = []
+
+    def draw(_box, _context, bounding_box):
+        bounding_boxes.append(bounding_box)
+
+    box = Box(
+        Box(style={"min-height": 80}, draw=draw),
+        Box(draw=draw),
+        style={"vertical-align": VerticalAlign.TOP},
+    )
+
+    box.size(context=context)
+    box.draw(context=context, bounding_box=Rectangle(0, 0, 100, 120))
+
+    assert bounding_boxes[0].height == 80
+    assert bounding_boxes[1].height == 40
+
+
 def test_draw_box_with_stretched_content(context):
     bounding_boxes = []
 

--- a/gaphor/diagram/tests/test_shapes.py
+++ b/gaphor/diagram/tests/test_shapes.py
@@ -3,6 +3,7 @@ import pytest
 from gaphas.geometry import Rectangle
 
 from gaphor.core.modeling.diagram import FALLBACK_STYLE
+from gaphor.core.styling.properties import JustifyContent
 from gaphor.diagram.shapes import (
     Box,
     DrawContext,
@@ -62,6 +63,46 @@ def test_draw_box_with_custom_draw_function(context):
     box.draw(context=context, bounding_box=Rectangle())
 
     assert called
+
+
+def test_draw_box_with_stretched_content(context):
+    bounding_boxes = []
+
+    def draw(_box, _context, bounding_box):
+        bounding_boxes.append(bounding_box)
+
+    box = Box(
+        Box(draw=draw),
+        Box(draw=draw),
+        style={"justify-content": JustifyContent.STRETCH},
+    )
+
+    box.size(context=context)
+    box.draw(context=context, bounding_box=Rectangle(0, 0, 100, 120))
+
+    assert bounding_boxes[0].height == 60
+    assert bounding_boxes[1].height == 60
+
+
+def test_draw_box_with_stretched_oversized_content(context):
+    bounding_boxes = []
+
+    def draw(_box, _context, bounding_box):
+        bounding_boxes.append(bounding_box)
+
+    box = Box(
+        Box(draw=draw),
+        Box(style={"min-height": 80}, draw=draw),
+        style={"justify-content": JustifyContent.STRETCH},
+    )
+
+    box.size(context=context)
+    box.draw(context=context, bounding_box=Rectangle(0, 0, 100, 120))
+
+    assert bounding_boxes[0].y == 0
+    assert bounding_boxes[0].height == 40
+    assert bounding_boxes[1].y == 40
+    assert bounding_boxes[1].height == 80
 
 
 def test_draw_icon_box(context):

--- a/gaphor/diagram/tools/__init__.py
+++ b/gaphor/diagram/tools/__init__.py
@@ -1,11 +1,5 @@
 """Tools for handling items on a diagram."""
-from gaphas.tool import (
-    hover_tool,
-    item_tool,
-    rubberband_tool,
-    view_focus_tool,
-    zoom_tool,
-)
+from gaphas.tool import hover_tool, rubberband_tool, view_focus_tool, zoom_tool
 from gi.repository import Gtk
 
 import gaphor.diagram.tools.connector
@@ -13,6 +7,7 @@ import gaphor.diagram.tools.grayout
 import gaphor.diagram.tools.segment
 from gaphor.diagram.tools.dnd import drop_target_tool
 from gaphor.diagram.tools.dropzone import drop_zone_tool
+from gaphor.diagram.tools.itemtool import item_tool
 from gaphor.diagram.tools.magnet import magnet_tool
 from gaphor.diagram.tools.placement import placement_tool
 from gaphor.diagram.tools.shortcut import shortcut_tool

--- a/gaphor/diagram/tools/dropzone.py
+++ b/gaphor/diagram/tools/dropzone.py
@@ -104,26 +104,22 @@ class DropZoneMoveMixin:
         view = self.view
         old_parent = item.parent
         new_parent = view.selection.dropzone_item
-        try:
 
-            if new_parent is old_parent:
-                if old_parent is not None:
-                    old_parent.request_update()
-                return
-
-            if old_parent and ungroup(old_parent.subject, item.subject):
-                item.change_parent(None)
+        if new_parent is old_parent:
+            if old_parent is not None:
                 old_parent.request_update()
+            return
 
-            if new_parent and item.subject and group(new_parent.subject, item.subject):
-                grow_parent(new_parent, item)
-                item.change_parent(new_parent)
-            elif item.subject:
-                diagram_parent = owner_package(item.diagram)
-                group(diagram_parent, item.subject)
+        if old_parent and ungroup(old_parent.subject, item.subject):
+            item.change_parent(None)
+            old_parent.request_update()
 
-        finally:
-            view.selection.dropzone_item = None
+        if new_parent and item.subject and group(new_parent.subject, item.subject):
+            grow_parent(new_parent, item)
+            item.change_parent(new_parent)
+        elif item.subject:
+            diagram_parent = owner_package(item.diagram)
+            group(diagram_parent, item.subject)
 
 
 @MoveAspect.register(ElementPresentation)

--- a/gaphor/diagram/tools/itemtool.py
+++ b/gaphor/diagram/tools/itemtool.py
@@ -1,0 +1,14 @@
+from gaphas.tool import item_tool as _item_tool
+from gaphas.view import GtkView
+from gi.repository import Gtk
+
+
+def item_tool(view: GtkView) -> Gtk.GestureDrag:
+    gesture = _item_tool(view)
+    gesture.connect_after("drag-end", on_drag_end)
+    return gesture
+
+
+def on_drag_end(gesture, _offset_x, _offset_y):
+    view = gesture.get_widget()
+    view.selection.dropzone_item = None

--- a/gaphor/templates/sysml.gaphor
+++ b/gaphor/templates/sysml.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.7.1">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.11.0">
 <StyleSheet id="58d6989a-66f8-11ec-b4c8-0456e5e540ed"/>
 <Package id="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed">
 <name>
@@ -78,6 +78,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 161.0, 272.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>38.0</val>
 </width>
@@ -108,6 +111,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 426.0, 245.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>126.0</val>
 </width>
@@ -303,6 +309,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 208.0, 47.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -333,6 +342,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 78.0, 231.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -364,6 +376,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 208.0, 231.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -394,6 +409,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 347.0, 231.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -734,11 +752,14 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 162.0, 109.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>193.0</val>
 </width>
 <height>
-<val>134.0</val>
+<val>152.0</val>
 </height>
 <diagram>
 <ref refid="01a97fa8-70f6-11ec-aabc-f47b099bf663"/>
@@ -751,6 +772,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 345.0, 112.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>315.0</val>
 </width>
@@ -879,6 +903,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 160.0, 58.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -909,6 +936,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 49.0, 219.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -939,6 +969,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 169.0, 219.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1294,7 +1327,7 @@
 </container>
 <outgoing>
 <reflist>
-<ref refid="422fa2d6-716a-11ec-999a-f47b099bf663"/>
+<ref refid="3e391fc0-1f86-11ed-bf44-0456e5e540ed"/>
 </reflist>
 </outgoing>
 <presentation>
@@ -1305,8 +1338,11 @@
 </Pseudostate>
 <PseudostateItem id="390d548c-716a-11ec-999a-f47b099bf663">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 86.0, 109.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 86.0, 139.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>20.0</val>
 </width>
@@ -1351,8 +1387,8 @@
 </container>
 <incoming>
 <reflist>
-<ref refid="422fa2d6-716a-11ec-999a-f47b099bf663"/>
-<ref refid="924799a4-716a-11ec-999a-f47b099bf663"/>
+<ref refid="3e391fc0-1f86-11ed-bf44-0456e5e540ed"/>
+<ref refid="4ddc31b0-1f86-11ed-bf44-0456e5e540ed"/>
 </reflist>
 </incoming>
 <name>
@@ -1360,7 +1396,7 @@
 </name>
 <outgoing>
 <reflist>
-<ref refid="502f82a2-716a-11ec-999a-f47b099bf663"/>
+<ref refid="46b8c6b4-1f86-11ed-bf44-0456e5e540ed"/>
 </reflist>
 </outgoing>
 <presentation>
@@ -1373,6 +1409,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 183.0, 119.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>113.0</val>
 </width>
@@ -1394,13 +1433,13 @@
 <val>0</val>
 </horizontal>
 <subject>
-<ref refid="422fa2d6-716a-11ec-999a-f47b099bf663"/>
+<ref refid="3e391fc0-1f86-11ed-bf44-0456e5e540ed"/>
 </subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 96.0, 132.0)</val>
 </matrix>
 <points>
-<val>[(10.0, -13.0), (87.0, -13.0)]</val>
+<val>[(10.0, 17.0), (87.0, 17.0)]</val>
 </points>
 <head-connection>
 <ref refid="390d548c-716a-11ec-999a-f47b099bf663"/>
@@ -1409,37 +1448,13 @@
 <ref refid="3abd1b1e-716a-11ec-999a-f47b099bf663"/>
 </tail-connection>
 </TransitionItem>
-<Transition id="422fa2d6-716a-11ec-999a-f47b099bf663">
-<container>
-<ref refid="390e5a58-716a-11ec-999a-f47b099bf663"/>
-</container>
-<guard>
-<ref refid="42316274-716a-11ec-999a-f47b099bf663"/>
-</guard>
-<presentation>
-<reflist>
-<ref refid="40ebe11e-716a-11ec-999a-f47b099bf663"/>
-</reflist>
-</presentation>
-<source>
-<ref refid="390d1102-716a-11ec-999a-f47b099bf663"/>
-</source>
-<target>
-<ref refid="3abce6ee-716a-11ec-999a-f47b099bf663"/>
-</target>
-</Transition>
-<Constraint id="42316274-716a-11ec-999a-f47b099bf663">
-<transition>
-<ref refid="422fa2d6-716a-11ec-999a-f47b099bf663"/>
-</transition>
-</Constraint>
 <State id="4998f9fa-716a-11ec-999a-f47b099bf663">
 <container>
 <ref refid="390e5a58-716a-11ec-999a-f47b099bf663"/>
 </container>
 <incoming>
 <reflist>
-<ref refid="502f82a2-716a-11ec-999a-f47b099bf663"/>
+<ref refid="46b8c6b4-1f86-11ed-bf44-0456e5e540ed"/>
 </reflist>
 </incoming>
 <name>
@@ -1447,7 +1462,7 @@
 </name>
 <outgoing>
 <reflist>
-<ref refid="924799a4-716a-11ec-999a-f47b099bf663"/>
+<ref refid="4ddc31b0-1f86-11ed-bf44-0456e5e540ed"/>
 </reflist>
 </outgoing>
 <presentation>
@@ -1458,8 +1473,11 @@
 </State>
 <StateItem id="49992736-716a-11ec-999a-f47b099bf663">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 183.0, 219.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 183.0, 247.50001525878906)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>113.0</val>
 </width>
@@ -1481,13 +1499,13 @@
 <val>0</val>
 </horizontal>
 <subject>
-<ref refid="502f82a2-716a-11ec-999a-f47b099bf663"/>
+<ref refid="46b8c6b4-1f86-11ed-bf44-0456e5e540ed"/>
 </subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 193.0, 146.0)</val>
 </matrix>
 <points>
-<val>[(5.694444444444457, 3.0), (5.694444444444457, 73.0)]</val>
+<val>[(5.694444444444457, 33.0), (5.694444444444457, 101.50001525878906)]</val>
 </points>
 <head-connection>
 <ref refid="3abd1b1e-716a-11ec-999a-f47b099bf663"/>
@@ -1496,36 +1514,6 @@
 <ref refid="49992736-716a-11ec-999a-f47b099bf663"/>
 </tail-connection>
 </TransitionItem>
-<Transition id="502f82a2-716a-11ec-999a-f47b099bf663">
-<container>
-<ref refid="390e5a58-716a-11ec-999a-f47b099bf663"/>
-</container>
-<guard>
-<ref refid="5030b898-716a-11ec-999a-f47b099bf663"/>
-</guard>
-<name>
-<val></val>
-</name>
-<presentation>
-<reflist>
-<ref refid="4fe38da2-716a-11ec-999a-f47b099bf663"/>
-</reflist>
-</presentation>
-<source>
-<ref refid="3abce6ee-716a-11ec-999a-f47b099bf663"/>
-</source>
-<target>
-<ref refid="4998f9fa-716a-11ec-999a-f47b099bf663"/>
-</target>
-</Transition>
-<Constraint id="5030b898-716a-11ec-999a-f47b099bf663">
-<specification>
-<val>Turn On</val>
-</specification>
-<transition>
-<ref refid="502f82a2-716a-11ec-999a-f47b099bf663"/>
-</transition>
-</Constraint>
 <TransitionItem id="91665f70-716a-11ec-999a-f47b099bf663">
 <diagram>
 <ref refid="17fffb68-70f8-11ec-aabc-f47b099bf663"/>
@@ -1534,13 +1522,13 @@
 <val>0</val>
 </horizontal>
 <subject>
-<ref refid="924799a4-716a-11ec-999a-f47b099bf663"/>
+<ref refid="4ddc31b0-1f86-11ed-bf44-0456e5e540ed"/>
 </subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 243.0, 223.0)</val>
 </matrix>
 <points>
-<val>[(34.166666666666686, -4.0), (34.166666666666686, -74.0)]</val>
+<val>[(34.166666666666686, 24.500015258789062), (34.166666666666686, -44.0)]</val>
 </points>
 <head-connection>
 <ref refid="49992736-716a-11ec-999a-f47b099bf663"/>
@@ -1549,37 +1537,13 @@
 <ref refid="3abd1b1e-716a-11ec-999a-f47b099bf663"/>
 </tail-connection>
 </TransitionItem>
-<Transition id="924799a4-716a-11ec-999a-f47b099bf663">
-<container>
-<ref refid="390e5a58-716a-11ec-999a-f47b099bf663"/>
-</container>
-<guard>
-<ref refid="92493502-716a-11ec-999a-f47b099bf663"/>
-</guard>
-<presentation>
-<reflist>
-<ref refid="91665f70-716a-11ec-999a-f47b099bf663"/>
-</reflist>
-</presentation>
-<source>
-<ref refid="4998f9fa-716a-11ec-999a-f47b099bf663"/>
-</source>
-<target>
-<ref refid="3abce6ee-716a-11ec-999a-f47b099bf663"/>
-</target>
-</Transition>
-<Constraint id="92493502-716a-11ec-999a-f47b099bf663">
-<specification>
-<val>Turn Off</val>
-</specification>
-<transition>
-<ref refid="924799a4-716a-11ec-999a-f47b099bf663"/>
-</transition>
-</Constraint>
 <PropertyItem id="c937d76c-716a-11ec-999a-f47b099bf663">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 89.0, 133.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>173.0</val>
 </width>
@@ -1597,6 +1561,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 348.0, 133.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>192.0</val>
 </width>
@@ -1627,6 +1594,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 300.0, 220.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1792,6 +1762,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 133.0, 106.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>95.0</val>
 </width>
@@ -1827,6 +1800,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 124.0, 199.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>113.0</val>
 </width>
@@ -1840,7 +1816,7 @@
 <ref refid="30945a44-716f-11ec-999a-f47b099bf663"/>
 </subject>
 </ActionItem>
-<FlowItem id="3a53f580-716f-11ec-999a-f47b099bf663">
+<ControlFlowItem id="3a53f580-716f-11ec-999a-f47b099bf663">
 <diagram>
 <ref refid="1328f1ae-716f-11ec-999a-f47b099bf663"/>
 </diagram>
@@ -1862,7 +1838,7 @@
 <tail-connection>
 <ref refid="30947dc6-716f-11ec-999a-f47b099bf663"/>
 </tail-connection>
-</FlowItem>
+</ControlFlowItem>
 <ControlFlow id="3b887fd4-716f-11ec-999a-f47b099bf663">
 <activity>
 <ref refid="200ad022-716f-11ec-999a-f47b099bf663"/>
@@ -1902,6 +1878,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 157.0, 123.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1919,6 +1898,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 671.0, 133.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>155.0</val>
 </width>
@@ -2000,7 +1982,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 506.0, 185.0)</val>
 </matrix>
 <points>
-<val>[(34.0, 0.6428571428571459), (119.0, 0.5)]</val>
+<val>[(34.0, 0.6428571428571459), (165.0, 0.5)]</val>
 </points>
 <head-connection>
 <ref refid="ca7fa9ec-716a-11ec-999a-f47b099bf663"/>
@@ -2129,6 +2111,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 109.0, 137.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>542.0</val>
 </width>
@@ -2217,6 +2202,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 25.0, 104.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>212.0</val>
 </width>
@@ -2260,6 +2248,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 379.0, 104.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>134.0</val>
 </width>
@@ -2276,7 +2267,7 @@
 <ref refid="dde1fb1e-7171-11ec-999a-f47b099bf663"/>
 </subject>
 </ActionItem>
-<FlowItem id="4d3bebdc-7172-11ec-999a-f47b099bf663">
+<ControlFlowItem id="4d3bebdc-7172-11ec-999a-f47b099bf663">
 <diagram>
 <ref refid="9fdf0b3c-7170-11ec-999a-f47b099bf663"/>
 </diagram>
@@ -2290,7 +2281,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 343.0, 279.0)</val>
 </matrix>
 <points>
-<val>[(3.0, 0.0), (141.0, 0.0)]</val>
+<val>[(3.0, 0.0), (145.0, 0.0)]</val>
 </points>
 <head-connection>
 <ref refid="d2272ff2-7170-11ec-999a-f47b099bf663"/>
@@ -2298,7 +2289,7 @@
 <tail-connection>
 <ref refid="dde21dec-7171-11ec-999a-f47b099bf663"/>
 </tail-connection>
-</FlowItem>
+</ControlFlowItem>
 <ControlFlow id="4f1023ba-7172-11ec-999a-f47b099bf663">
 <activity>
 <ref refid="a8576570-7170-11ec-999a-f47b099bf663"/>
@@ -2341,6 +2332,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 167.0, 102.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>158.0</val>
 </width>
@@ -2384,6 +2378,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 274.0, 129.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -2414,6 +2411,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 118.0, 287.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -2444,6 +2444,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 276.0, 287.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -2474,6 +2477,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 449.0, 287.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -2756,6 +2762,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 28.0, 100.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>232.0</val>
 </width>
@@ -2773,6 +2782,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 356.0, 100.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -2790,6 +2802,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 578.0, 100.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>133.0</val>
 </width>
@@ -2928,6 +2943,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 131.0, 103.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>573.0</val>
 </width>
@@ -3032,6 +3050,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 14.0, 125.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>157.0</val>
 </width>
@@ -3080,6 +3101,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 216.0, 117.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>141.0</val>
 </width>
@@ -3123,6 +3147,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 424.0, 117.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>113.0</val>
 </width>
@@ -3139,7 +3166,7 @@
 <ref refid="01be6880-7175-11ec-999a-f47b099bf663"/>
 </subject>
 </ActionItem>
-<FlowItem id="168e3d26-7175-11ec-999a-f47b099bf663">
+<ControlFlowItem id="168e3d26-7175-11ec-999a-f47b099bf663">
 <diagram>
 <ref refid="c67aea32-70f7-11ec-aabc-f47b099bf663"/>
 </diagram>
@@ -3161,7 +3188,7 @@
 <tail-connection>
 <ref refid="e04551fa-7174-11ec-999a-f47b099bf663"/>
 </tail-connection>
-</FlowItem>
+</ControlFlowItem>
 <ControlFlow id="17cbcb90-7175-11ec-999a-f47b099bf663">
 <activity>
 <ref refid="5d98c4ea-7173-11ec-999a-f47b099bf663"/>
@@ -3178,7 +3205,7 @@
 <ref refid="e0452fc2-7174-11ec-999a-f47b099bf663"/>
 </target>
 </ControlFlow>
-<FlowItem id="1e0311bc-7175-11ec-999a-f47b099bf663">
+<ControlFlowItem id="1e0311bc-7175-11ec-999a-f47b099bf663">
 <diagram>
 <ref refid="c67aea32-70f7-11ec-aabc-f47b099bf663"/>
 </diagram>
@@ -3200,7 +3227,7 @@
 <tail-connection>
 <ref refid="01be96d4-7175-11ec-999a-f47b099bf663"/>
 </tail-connection>
-</FlowItem>
+</ControlFlowItem>
 <ControlFlow id="211c8950-7175-11ec-999a-f47b099bf663">
 <activity>
 <ref refid="5d98c4ea-7173-11ec-999a-f47b099bf663"/>
@@ -3239,6 +3266,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 104.0, 154.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -3252,7 +3282,7 @@
 <ref refid="303ed3b6-7175-11ec-999a-f47b099bf663"/>
 </subject>
 <lifetime-length>
-<val>95.0</val>
+<val>145.0</val>
 </lifetime-length>
 </LifelineItem>
 <Interaction id="303f66a0-7175-11ec-999a-f47b099bf663">
@@ -3296,6 +3326,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 358.0, 149.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -3309,7 +3342,7 @@
 <ref refid="4f383852-7175-11ec-999a-f47b099bf663"/>
 </subject>
 <lifetime-length>
-<val>92.0</val>
+<val>142.0</val>
 </lifetime-length>
 </LifelineItem>
 <MessageItem id="78377830-7175-11ec-999a-f47b099bf663">
@@ -3326,7 +3359,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 152.0, 239.0)</val>
 </matrix>
 <points>
-<val>[(2.0, 0.0), (256.0, 0.0)]</val>
+<val>[(-48.0, 0.0), (206.0, 0.0)]</val>
 </points>
 <head-connection>
 <ref refid="303efc9c-7175-11ec-999a-f47b099bf663"/>
@@ -3370,4 +3403,82 @@
 <ref refid="7838c8e8-7175-11ec-999a-f47b099bf663"/>
 </receiveMessage>
 </MessageOccurrenceSpecification>
+<Transition id="3e391fc0-1f86-11ed-bf44-0456e5e540ed">
+<container>
+<ref refid="390e5a58-716a-11ec-999a-f47b099bf663"/>
+</container>
+<guard>
+<ref refid="3e3a282a-1f86-11ed-bf44-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="40ebe11e-716a-11ec-999a-f47b099bf663"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="390d1102-716a-11ec-999a-f47b099bf663"/>
+</source>
+<target>
+<ref refid="3abce6ee-716a-11ec-999a-f47b099bf663"/>
+</target>
+</Transition>
+<Constraint id="3e3a282a-1f86-11ed-bf44-0456e5e540ed">
+<transition>
+<ref refid="3e391fc0-1f86-11ed-bf44-0456e5e540ed"/>
+</transition>
+</Constraint>
+<Transition id="46b8c6b4-1f86-11ed-bf44-0456e5e540ed">
+<container>
+<ref refid="390e5a58-716a-11ec-999a-f47b099bf663"/>
+</container>
+<guard>
+<ref refid="46ba10aa-1f86-11ed-bf44-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="4fe38da2-716a-11ec-999a-f47b099bf663"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="3abce6ee-716a-11ec-999a-f47b099bf663"/>
+</source>
+<target>
+<ref refid="4998f9fa-716a-11ec-999a-f47b099bf663"/>
+</target>
+</Transition>
+<Constraint id="46ba10aa-1f86-11ed-bf44-0456e5e540ed">
+<specification>
+<val>Turn On</val>
+</specification>
+<transition>
+<ref refid="46b8c6b4-1f86-11ed-bf44-0456e5e540ed"/>
+</transition>
+</Constraint>
+<Transition id="4ddc31b0-1f86-11ed-bf44-0456e5e540ed">
+<container>
+<ref refid="390e5a58-716a-11ec-999a-f47b099bf663"/>
+</container>
+<guard>
+<ref refid="4ddde1d6-1f86-11ed-bf44-0456e5e540ed"/>
+</guard>
+<presentation>
+<reflist>
+<ref refid="91665f70-716a-11ec-999a-f47b099bf663"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="4998f9fa-716a-11ec-999a-f47b099bf663"/>
+</source>
+<target>
+<ref refid="3abce6ee-716a-11ec-999a-f47b099bf663"/>
+</target>
+</Transition>
+<Constraint id="4ddde1d6-1f86-11ed-bf44-0456e5e540ed">
+<specification>
+<val>Turn Off</val>
+</specification>
+<transition>
+<ref refid="4ddc31b0-1f86-11ed-bf44-0456e5e540ed"/>
+</transition>
+</Constraint>
 </gaphor>

--- a/gaphor/templates/sysml.gaphor
+++ b/gaphor/templates/sysml.gaphor
@@ -1334,9 +1334,6 @@
 </region>
 </StateMachine>
 <Region id="390e5a58-716a-11ec-999a-f47b099bf663">
-<name>
-<val>Default Region</val>
-</name>
 <stateMachine>
 <ref refid="390dcd04-716a-11ec-999a-f47b099bf663"/>
 </stateMachine>

--- a/gaphor/ui/namespacemodel.py
+++ b/gaphor/ui/namespacemodel.py
@@ -327,6 +327,4 @@ def sort_func(model, iter_a, iter_b, userdata):
     b = (format(vb) or "").lower()
     if a == b:
         return 0
-    if a > b:
-        return 1
-    return -1
+    return 1 if a > b else -1

--- a/gaphor/ui/namespacemodel.py
+++ b/gaphor/ui/namespacemodel.py
@@ -310,9 +310,7 @@ def change_owner(new_parent, element):
     if element.owner:
         ungroup(element.owner, element)
 
-    group(new_parent, element)
-
-    return element.owner is new_parent
+    return group(new_parent, element)
 
 
 def sort_func(model, iter_a, iter_b, userdata):

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -11741,8 +11741,8 @@
 <reflist>
 <ref refid="DCE:DF527520-4B32-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:81F41A0A-4B32-11D7-B391-02BBFE4396CE"/>
-<ref refid="DCE:53659F26-E81E-11DD-BD54-000D936B094A"/>
 <ref refid="DCE:BCEB8FB0-4B32-11D7-B391-02BBFE4396CE"/>
+<ref refid="DCE:53659F26-E81E-11DD-BD54-000D936B094A"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -18419,6 +18419,7 @@
 <reflist>
 <ref refid="DCE:40EA50FC-A41A-11D8-A88E-00061BC22919"/>
 <ref refid="DCE:B0D3389E-4B35-11D7-B391-02BBFE4396CE"/>
+<ref refid="DCE:BCEBC220-4B32-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:2889D960-6693-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:F1CF4FA4-4B33-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:99FBA804-4B35-11D7-B391-02BBFE4396CE"/>
@@ -18429,7 +18430,6 @@
 <ref refid="DCE:3EEBCC18-6698-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="e9507590-e962-11ea-87d1-cbf2d1fcaed0"/>
 <ref refid="DCE:BFC7B66E-4B37-11D7-B391-02BBFE4396CE"/>
-<ref refid="DCE:BCEBC220-4B32-11D7-B391-02BBFE4396CE"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -33233,10 +33233,10 @@ directly in a model.</val>
 <val>(0.0, 0.0)</val>
 </top-left>
 <width>
-<val>173.0</val>
+<val>163.5</val>
 </width>
 <height>
-<val>68.0</val>
+<val>67.68752421999193</val>
 </height>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
@@ -33309,7 +33309,7 @@ directly in a model.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 368.48212461695607, 455.0)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (0.0, -80.0), (516.5178753830439, -80.0)]</val>
+<val>[(-7.879076207289472, 0.0), (-7.879076207289472, -80.0), (516.5178753830439, -80.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:3C0B3598-4588-11DA-A04F-00123FE76EBE"/>
@@ -33335,7 +33335,7 @@ directly in a model.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 247.00699300699307, 390.8253968253968)</val>
 </matrix>
 <points>
-<val>[(0.0, 64.17460317460319), (0.4741101595033683, 0.0)]</val>
+<val>[(-1.2084764946036728, 64.17460317460319), (0.4741101595033683, 0.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:3C0B3598-4588-11DA-A04F-00123FE76EBE"/>
@@ -33370,7 +33370,7 @@ directly in a model.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 398.0, 482.39999999999986)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (972.0, 0.09947212837852248)]</val>
+<val>[(-9.5, -0.12590935841501505), (972.0, 0.09947212837852248)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:3C0B3598-4588-11DA-A04F-00123FE76EBE"/>
@@ -33405,7 +33405,7 @@ directly in a model.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 398.0, 521.0)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (972.0, 3.7386613175674484)]</val>
+<val>[(-9.5, -0.30328531589020713), (972.0, 3.7386613175674484)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:3C0B3598-4588-11DA-A04F-00123FE76EBE"/>
@@ -33445,7 +33445,7 @@ directly in a model.</val>
 </ClassItem>
 <ClassItem id="DCE:55BD8230-4589-11DA-A04F-00123FE76EBE">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 178.5625, 619.890625)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 197.1030484096666, 728.2485795454545)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -33474,7 +33474,7 @@ directly in a model.</val>
 </ClassItem>
 <ClassItem id="DCE:6DE2C9B8-4589-11DA-A04F-00123FE76EBE">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 137.5625, 747.26171875)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 416.37506103515625, 656.5838068181818)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -33518,7 +33518,7 @@ directly in a model.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 294.0, 523.0)</val>
 </matrix>
 <points>
-<val>[(-31.0, 96.890625), (-32.0, 0.0)]</val>
+<val>[(-34.031791907514446, 205.2485795454545), (-34.031791907514446, -0.3124757800080715)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:55BD8230-4589-11DA-A04F-00123FE76EBE"/>
@@ -33531,9 +33531,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
 </diagram>
-<horizontal>
-<val>1</val>
-</horizontal>
 <orthogonal>
 <val>1</val>
 </orthogonal>
@@ -33544,7 +33541,7 @@ directly in a model.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 368.55859375, 523.0)</val>
 </matrix>
 <points>
-<val>[(-143.55859375, 224.26171875), (-143.55859375, 224.26171875), (-143.55859375, 0.0)]</val>
+<val>[(135.25396728515625, 133.58380681818176), (135.25396728515625, 102.84765625), (-68.05859375, 102.84765625), (-68.05859375, -0.3124757800080715)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:6DE2C9B8-4589-11DA-A04F-00123FE76EBE"/>
@@ -33564,7 +33561,7 @@ directly in a model.</val>
 <val>1</val>
 </horizontal>
 <orthogonal>
-<val>0</val>
+<val>1</val>
 </orthogonal>
 <show_direction>
 <val>0</val>
@@ -33579,7 +33576,7 @@ directly in a model.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 253.16015625, 751.26171875)</val>
 </matrix>
 <points>
-<val>[(-58.59765625, -4.0), (-56.595107505256806, -59.37109375)]</val>
+<val>[(163.21490478515625, -82.31435032894751), (62.33984375, -82.31435032894751), (62.33984375, -23.013139204545496)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:6DE2C9B8-4589-11DA-A04F-00123FE76EBE"/>
@@ -33595,11 +33592,8 @@ directly in a model.</val>
 <head_subject>
 <ref refid="DCE:B0FB3B10-4589-11DA-A04F-00123FE76EBE"/>
 </head_subject>
-<horizontal>
-<val>1</val>
-</horizontal>
 <orthogonal>
-<val>0</val>
+<val>1</val>
 </orthogonal>
 <show_direction>
 <val>0</val>
@@ -33614,7 +33608,7 @@ directly in a model.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 243.27436440677965, 672.890625)</val>
 </matrix>
 <points>
-<val>[(9.725635593220346, 19.0), (9.725635593220346, 74.37109375)]</val>
+<val>[(118.22563559322035, 55.357954545454504), (118.22563559322035, 29.609375), (173.1006966283766, 29.609375)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:55BD8230-4589-11DA-A04F-00123FE76EBE"/>
@@ -33649,7 +33643,7 @@ directly in a model.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 909.0, 182.1228070175439)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (-831.0, 0.0), (-831.0, 466.13145434609237), (-730.4375, 466.13145434609237)]</val>
+<val>[(0.0, 0.0), (-831.0, 0.0), (-831.0, 582.1257725279106), (-711.8969515903334, 582.1257725279106)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:DC96AD76-4586-11DA-A04F-00123FE76EBE"/>
@@ -33704,7 +33698,7 @@ directly in a model.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 398.0, 523.0)</val>
 </matrix>
 <points>
-<val>[(459.0, 102.84765625), (459.0, 85.9609375), (0.0, 85.9609375), (0.0, 0.0)]</val>
+<val>[(494.49993896484375, 102.84765625), (494.49993896484375, 85.9609375), (-57.0, 85.9609375), (-57.0, -0.3124757800080715)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:BE1502CE-458A-11DA-A04F-00123FE76EBE"/>
@@ -33727,10 +33721,10 @@ directly in a model.</val>
 <ref refid="DCE:DED93278-458A-11DA-A04F-00123FE76EBE"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 949.138705927935, 591.8253968253969)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 946.2209679123666, 591.8253968253969)</val>
 </matrix>
 <points>
-<val>[(-20.720967912366632, 34.022259424603135), (-27.47089009163608, 3.0)]</val>
+<val>[(-24.553152076067704, 34.022259424603135), (-24.553152076067704, 3.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:BE1502CE-458A-11DA-A04F-00123FE76EBE"/>
@@ -33762,7 +33756,7 @@ directly in a model.</val>
 <ref refid="DCE:1B23E296-458B-11DA-A04F-00123FE76EBE"/>
 </tail_subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 729.9999999999997, 439.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 730.0, 439.0)</val>
 </matrix>
 <points>
 <val>[(248.0, -47.0), (248.49710854092564, 186.84765625)]</val>
@@ -33800,7 +33794,7 @@ directly in a model.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 362.5625, 657.73046875)</val>
 </matrix>
 <points>
-<val>[(0.0, 4.824928977272748), (494.4375, 0.83984375)]</val>
+<val>[(18.5405484096666, 106.5181107954545), (494.4375, 106.5181107954545)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:55BD8230-4589-11DA-A04F-00123FE76EBE"/>
@@ -33832,10 +33826,10 @@ directly in a model.</val>
 <ref refid="DCE:C311E502-458B-11DA-A04F-00123FE76EBE"/>
 </tail_subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 421.16015625, 769.2617187499999)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 421.16015625, 762.8643860479796)</val>
 </matrix>
 <points>
-<val>[(-58.59765625, -3.0526315789473983), (435.83984375, -1.8144728535352215)]</val>
+<val>[(220.21490478515625, -87.33321080874532), (435.83984375, -93.91701762692708)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:6DE2C9B8-4589-11DA-A04F-00123FE76EBE"/>
@@ -34872,8 +34866,8 @@ directly in a model.</val>
 <ownedAttribute>
 <reflist>
 <ref refid="DCE:95532C40-4589-11DA-A04F-00123FE76EBE"/>
-<ref refid="DCE:F3C62FAC-4589-11DA-A04F-00123FE76EBE"/>
 <ref refid="DCE:5BAB3116-458B-11DA-A04F-00123FE76EBE"/>
+<ref refid="DCE:F3C62FAC-4589-11DA-A04F-00123FE76EBE"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -34896,9 +34890,9 @@ directly in a model.</val>
 </name>
 <ownedAttribute>
 <reflist>
+<ref refid="DCE:C311E502-458B-11DA-A04F-00123FE76EBE"/>
 <ref refid="DCE:B0FB3B10-4589-11DA-A04F-00123FE76EBE"/>
 <ref refid="DCE:A1B83AC0-4589-11DA-A04F-00123FE76EBE"/>
-<ref refid="DCE:C311E502-458B-11DA-A04F-00123FE76EBE"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -35176,6 +35170,7 @@ directly in a model.</val>
 <ref refid="DCE:28F9BC3C-4663-11DA-A766-00123FE76EBE"/>
 <ref refid="DCE:F0F4E0C2-4663-11DA-A766-00123FE76EBE"/>
 <ref refid="DCE:BD317F98-46F4-11DA-91FC-00123FE76EBE"/>
+<ref refid="DCE:1B22B6DC-458B-11DA-A04F-00123FE76EBE"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -35225,11 +35220,6 @@ directly in a model.</val>
 <ref refid="DCE:1B23E296-458B-11DA-A04F-00123FE76EBE"/>
 </reflist>
 </memberEnd>
-<ownedEnd>
-<reflist>
-<ref refid="DCE:1B22B6DC-458B-11DA-A04F-00123FE76EBE"/>
-</reflist>
-</ownedEnd>
 <package>
 <ref refid="DCE:A1A5A3A2-4586-11DA-A04F-00123FE76EBE"/>
 </package>
@@ -35251,12 +35241,12 @@ directly in a model.</val>
 <association>
 <ref refid="DCE:1B2210D8-458B-11DA-A04F-00123FE76EBE"/>
 </association>
+<class_>
+<ref refid="DCE:BE153618-458A-11DA-A04F-00123FE76EBE"/>
+</class_>
 <name>
 <val>region</val>
 </name>
-<owningAssociation>
-<ref refid="DCE:1B2210D8-458B-11DA-A04F-00123FE76EBE"/>
-</owningAssociation>
 <type>
 <ref refid="DCE:446B73FC-4587-11DA-A04F-00123FE76EBE"/>
 </type>
@@ -36924,6 +36914,13 @@ directly in a model.</val>
 </presentation>
 </Class>
 <Stereotype id="a38a6700-3fe1-11de-8375-00224128e79d">
+<instanceSpecification>
+<reflist>
+<ref refid="c878f240-3470-11e0-b5fb-0021e9e5a3cd"/>
+<ref refid="b2d601cc-ec89-11ea-96dc-bf74f1f80424"/>
+<ref refid="bdd2b5de-ec89-11ea-96dc-bf74f1f80424"/>
+</reflist>
+</instanceSpecification>
 <name>
 <val>SimpleAttribute</val>
 </name>
@@ -38622,6 +38619,382 @@ swimlanes</val>
 </upperValue>
 </Property>
 <Stereotype id="16f6b5f4-fa90-11de-bd51-00224128e79d">
+<instanceSpecification>
+<reflist>
+<ref refid="16f88e24-fa90-11de-bd51-00224128e79d"/>
+<ref refid="16f98e50-fa90-11de-bd51-00224128e79d"/>
+<ref refid="16fa3af8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="16fad68e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="16fb1590-fa90-11de-bd51-00224128e79d"/>
+<ref refid="16fc55ae-fa90-11de-bd51-00224128e79d"/>
+<ref refid="16fcf270-fa90-11de-bd51-00224128e79d"/>
+<ref refid="16fd30dc-fa90-11de-bd51-00224128e79d"/>
+<ref refid="16fdcc2c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="16fe7ffa-fa90-11de-bd51-00224128e79d"/>
+<ref refid="16ffc770-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17000500-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1700a1ae-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17014582-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17017f84-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1701c43a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1701fe82-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17023992-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17027326-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17030db8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1703ac0a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17044c1e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170502e4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1705ab9a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1705e8b2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17073898-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1707d280-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17081830-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1708fb60-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17099958-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1709d486-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170b4d98-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170c4518-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170c7fb0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170d19e8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170db790-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170df1f6-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170e2ee6-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170e6910-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170ea36c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170f3d72-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170f78be-fa90-11de-bd51-00224128e79d"/>
+<ref refid="170fb432-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17105cca-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1711013e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1712389c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1712d48c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17130f2e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1713bbfe-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1713f830-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17149704-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1714d1ce-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17150cd4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1715b3d2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1715ed66-fa90-11de-bd51-00224128e79d"/>
+<ref refid="171756b0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17179224-fa90-11de-bd51-00224128e79d"/>
+<ref refid="171831b6-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17186b40-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1719097e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1719a316-fa90-11de-bd51-00224128e79d"/>
+<ref refid="171a3c0e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="171ad830-fa90-11de-bd51-00224128e79d"/>
+<ref refid="171b12aa-fa90-11de-bd51-00224128e79d"/>
+<ref refid="171b4d60-fa90-11de-bd51-00224128e79d"/>
+<ref refid="171b887a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="171d444e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="171de502-fa90-11de-bd51-00224128e79d"/>
+<ref refid="171e8570-fa90-11de-bd51-00224128e79d"/>
+<ref refid="171f6b48-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17200c6a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1720a9c2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17215034-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1721e968-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172355be-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17245126-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1724f446-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17252fb0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17256b38-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1725a878-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1725eb62-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1726c5a0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172709f2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1727a538-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1728470e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17294bc2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172a2e34-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172a6dcc-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172aa972-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172ae50e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172b2122-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172b5f8e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172bffc0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172c3bac-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172cd9a4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172d14a0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172d5258-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172d8c14-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172dc738-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172e02ca-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172f32f8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="172fd294-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17300e94-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17304ba2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="173085a4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1730c096-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17315e16-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1731fcf4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17329664-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1732d2aa-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17330e1e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1733ada6-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17344ec8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1734fc7e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17354a94-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17358496-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17362914-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1736d1de-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17376f5e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17381242-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1738b440-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17395364-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17398e56-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1739ca42-fa90-11de-bd51-00224128e79d"/>
+<ref refid="173a05d4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="173bb5b4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="173c57a8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="173cf53c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="173d325e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="173dce44-fa90-11de-bd51-00224128e79d"/>
+<ref refid="173ecfce-fa90-11de-bd51-00224128e79d"/>
+<ref refid="173f6a74-fa90-11de-bd51-00224128e79d"/>
+<ref refid="173fa61a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17404502-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17419f42-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1741e02e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17421abc-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174255e0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1742fba8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174340a4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17437cc2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1743b7a0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1743f274-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174491f2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174530bc-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17456e1a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1745aa6a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17464790-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1747a266-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17484c98-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17488a46-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1748c506-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17490174-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174949cc-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17498a7c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174a2914-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174ac6ee-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174bbae0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174c5874-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174d0ad0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174d4c0c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174df436-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174e3176-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174ed536-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174f147e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174fb000-fa90-11de-bd51-00224128e79d"/>
+<ref refid="174fed04-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17502922-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1750c882-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175163be-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175204a4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1752aa08-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1753a732-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1753e74c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17548332-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1754cae0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17551158-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17555122-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17558cb4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1755d084-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17560ba8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1756a91e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1757ec48-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17583270-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17587352-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1759b6e0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1759f66e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175a3a84-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175ae1e6-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175b1f08-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175b5be4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175bfc34-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175c9d1a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175cd76c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175d746a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175e176c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175e52e0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175e926e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175ed60c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175f1342-fa90-11de-bd51-00224128e79d"/>
+<ref refid="175fc026-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17606742-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1760a1b2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17613dc0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1761eb58-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17622636-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17626056-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17630d8a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1763b230-fa90-11de-bd51-00224128e79d"/>
+<ref refid="176453e8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1764c990-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17691e28-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1769c206-fa90-11de-bd51-00224128e79d"/>
+<ref refid="176a601c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="176c11fa-fa90-11de-bd51-00224128e79d"/>
+<ref refid="176ccbcc-fa90-11de-bd51-00224128e79d"/>
+<ref refid="176d6884-fa90-11de-bd51-00224128e79d"/>
+<ref refid="176e4e02-fa90-11de-bd51-00224128e79d"/>
+<ref refid="176f47da-fa90-11de-bd51-00224128e79d"/>
+<ref refid="176fee1a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17708fb4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1770cd26-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1771181c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17720970-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1772450c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17728404-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1772bff0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1772fe98-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1773406a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17737d96-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1773be6e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1774604e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17750706-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177661aa-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17769efe-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1777fbfa-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17789e8e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17793be6-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1779d7ea-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177a1bc4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177a5940-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177a94d2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177b8ec8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177bd3a6-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177c10a0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177c4b06-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177c8864-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177cc43c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177d0604-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177ec002-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177efc02-fa90-11de-bd51-00224128e79d"/>
+<ref refid="177f990a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17809b48-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1780d61c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17811794-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1781566e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17819232-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1781cdba-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17820942-fa90-11de-bd51-00224128e79d"/>
+<ref refid="178244e8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="178280de-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1782bd10-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17843c1c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17847740-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1784b50c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1785732a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17861528-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1786b9f6-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1787558c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1787f276-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17889028-fa90-11de-bd51-00224128e79d"/>
+<ref refid="178946b2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1789f3fa-fa90-11de-bd51-00224128e79d"/>
+<ref refid="178ab22c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="178b4fe8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="178bf1b4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="178c906a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="178d2c32-fa90-11de-bd51-00224128e79d"/>
+<ref refid="178dc9d0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="178e6de0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="178f0d40-fa90-11de-bd51-00224128e79d"/>
+<ref refid="179046e2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1790e7aa-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17918692-fa90-11de-bd51-00224128e79d"/>
+<ref refid="179225f2-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1792ccb4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17936fd4-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17940c14-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1794ab9c-fa90-11de-bd51-00224128e79d"/>
+<ref refid="179563ca-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17960afa-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1796bae0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17976a30-fa90-11de-bd51-00224128e79d"/>
+<ref refid="179806c0-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1798a742-fa90-11de-bd51-00224128e79d"/>
+<ref refid="17994c1a-fa90-11de-bd51-00224128e79d"/>
+<ref refid="1799e9b8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="179a88c8-fa90-11de-bd51-00224128e79d"/>
+<ref refid="179b2f4e-fa90-11de-bd51-00224128e79d"/>
+<ref refid="179c81e6-fa90-11de-bd51-00224128e79d"/>
+<ref refid="41c1ec02-3803-11e0-87bf-0021e9e5a3cd"/>
+<ref refid="bff231ea-38fd-11e0-98cd-0021e9e5a3cd"/>
+<ref refid="a60793d6-4066-11e0-b382-0019d2b28af0"/>
+<ref refid="899bd666-40f3-11e0-9acb-0019d2b28af0"/>
+<ref refid="df80e344-40fa-11e0-ad29-0019d2b28af0"/>
+<ref refid="f7462160-40fa-11e0-ad29-0019d2b28af0"/>
+<ref refid="5d660834-40fb-11e0-ad29-0019d2b28af0"/>
+<ref refid="881f61b0-40fb-11e0-ad29-0019d2b28af0"/>
+<ref refid="cd80d232-c907-11e9-97bf-90784199a5ed"/>
+<ref refid="03a92558-c908-11e9-97bf-90784199a5ed"/>
+<ref refid="db3ce42e-54f3-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="a6c9263e-54f4-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="74741aaa-5561-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="8717be6e-5561-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="a528cf18-5563-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="fdc1e0ce-5563-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="1347b3c4-5564-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="23fdfe4e-5564-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="35346744-55b8-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="48582f18-55b8-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="8678ec7a-611a-11ea-b792-718e3bcfaa5c"/>
+<ref refid="5fa0e88c-909f-11ea-85c4-7f4489bdcce3"/>
+<ref refid="6804cbba-909f-11ea-85c4-7f4489bdcce3"/>
+<ref refid="9cd32fb2-909f-11ea-85c4-7f4489bdcce3"/>
+<ref refid="a379eb1c-909f-11ea-85c4-7f4489bdcce3"/>
+<ref refid="2de9d91e-e187-11ea-b7ab-f5b4c130f24e"/>
+<ref refid="1a3b368a-e89c-11ea-96dc-bf74f1f80424"/>
+<ref refid="13849f76-e963-11ea-87d1-cbf2d1fcaed0"/>
+<ref refid="1d39fdfe-e963-11ea-87d1-cbf2d1fcaed0"/>
+<ref refid="1199e8ce-e968-11ea-96dc-bf74f1f80424"/>
+<ref refid="6a53816a-e96c-11ea-96dc-bf74f1f80424"/>
+<ref refid="6fe2f796-e96c-11ea-96dc-bf74f1f80424"/>
+<ref refid="fcf3eb6a-e96f-11ea-96dc-bf74f1f80424"/>
+<ref refid="238cf14a-e970-11ea-96dc-bf74f1f80424"/>
+<ref refid="0a6f4a58-ea03-11ea-96dc-bf74f1f80424"/>
+<ref refid="13740e40-ea03-11ea-96dc-bf74f1f80424"/>
+<ref refid="042a36f2-ec84-11ea-96dc-bf74f1f80424"/>
+<ref refid="549472ba-ec84-11ea-96dc-bf74f1f80424"/>
+<ref refid="5932a5bc-ec84-11ea-96dc-bf74f1f80424"/>
+<ref refid="c1bd2806-ec88-11ea-96dc-bf74f1f80424"/>
+<ref refid="3c94f390-ecfe-11ea-96dc-bf74f1f80424"/>
+<ref refid="4a28731a-ecfe-11ea-96dc-bf74f1f80424"/>
+<ref refid="1de265ac-00f1-11eb-8f71-7fd0147881a5"/>
+<ref refid="90a8f398-62d1-11eb-9492-9757bcbe474b"/>
+<ref refid="6641ae6e-62d2-11eb-9492-9757bcbe474b"/>
+<ref refid="7bde042a-62d2-11eb-9492-9757bcbe474b"/>
+<ref refid="a8cd3a82-62d2-11eb-9492-9757bcbe474b"/>
+<ref refid="afd3631a-62d2-11eb-9492-9757bcbe474b"/>
+<ref refid="83324452-63c7-11eb-9492-9757bcbe474b"/>
+<ref refid="8b241b22-63c7-11eb-9492-9757bcbe474b"/>
+<ref refid="90a4a634-63c7-11eb-9492-9757bcbe474b"/>
+<ref refid="95ba27e8-63c7-11eb-9492-9757bcbe474b"/>
+<ref refid="d749b4d2-6528-11eb-9492-9757bcbe474b"/>
+<ref refid="2feec6c2-6529-11eb-9492-9757bcbe474b"/>
+<ref refid="0c8675aa-ebec-11eb-8d68-2d4b211d5079"/>
+<ref refid="1973521a-ebec-11eb-8d68-2d4b211d5079"/>
+<ref refid="9924ae1e-ebec-11eb-8d68-2d4b211d5079"/>
+<ref refid="a3a6b710-ebec-11eb-8d68-2d4b211d5079"/>
+<ref refid="ec6c6e51-3c13-11ec-949b-bb4d014c6009"/>
+<ref refid="ed6f2ab6-3c13-11ec-be24-bb4d014c6009"/>
+<ref refid="911142dc-4c90-11ec-8c4e-0456e5e540ed"/>
+<ref refid="659e28da-9a43-11ec-8e48-0456e5e540ed"/>
+<ref refid="d83a545e-b339-11ec-940a-0456e5e540ed"/>
+<ref refid="2efc8a32-b33a-11ec-940a-0456e5e540ed"/>
+<ref refid="fcc475fc-bb63-11ec-a9db-0456e5e540ed"/>
+<ref refid="e300c0fc-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="f4029664-bb64-11ec-a9db-0456e5e540ed"/>
+<ref refid="06129d7c-bb65-11ec-a9db-0456e5e540ed"/>
+<ref refid="c4841624-bd99-11ec-8a35-0456e5e540ed"/>
+<ref refid="cd212038-bd99-11ec-8a35-0456e5e540ed"/>
+<ref refid="d649e438-bd99-11ec-8a35-0456e5e540ed"/>
+<ref refid="df5dd30e-bd99-11ec-8a35-0456e5e540ed"/>
+</reflist>
+</instanceSpecification>
 <name>
 <val>Tagged</val>
 </name>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

State machines are only created implicitly to hold states.

Issue Number: #1654 

### What is the new behavior?

- [x] State machines can be created from the toolbox
- [x] (pseudo)states can be moved between state machines
- [x] Region support in Statemachine (state / pseudostate / transition)
- [x] Region support in (composite) State
- [x] property page for regions (create / remove) - how to deal with elements in the region? 
- [x] create state / pseudostate / transition from toolbox places it in the right region

### Other

This PR contains a changes where stereotype watch and compartment code is directly imported from the stereotype module.