### PR TITLE
Update devcontainer to work on Fedora

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,10 @@
 		"args": { "VARIANT": "jammy" }
 	},
 	"workspaceMount": "",
-	"runArgs": ["--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}:Z"],
+	"runArgs": [
+		"--init",
+		"--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}:Z"
+	],
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
 		"context": "..",
 		"args": { "VARIANT": "jammy" }
 	},
+	"workspaceMount": "",
+	"runArgs": ["--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}:Z"],
 
 	// Configure tool-specific properties.
 	"customizations": {
@@ -38,8 +40,7 @@
 		}
 	},
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+	"forwardPorts": [5901, 6080],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "pipx install poetry && poetry config virtualenvs.in-project true && poetry install",


### PR DESCRIPTION
Fedora uses SELinux. Also I needed to explicitly expose the ports.

Those are a few tweaks I needed to do to get the devcontainer running on my local machine.