### PR TITLE
Retain save folder - use Path

### DIFF
--- a/gaphor/application.py
+++ b/gaphor/application.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import logging
+from pathlib import Path
 from typing import Iterator, TypeVar, cast
 
 from gaphor import transaction
@@ -81,6 +82,7 @@ class Application(Service, ActionProvider):
         return self._active_session
 
     def new_session(self, *, filename=None, template=None, services=None, force=False):
+        filename = Path(filename) if filename else None
         if filename is None and template is None:
             return self._new_session(services=services)
 
@@ -125,6 +127,7 @@ class Application(Service, ActionProvider):
         return bool(self._active_session)
 
     def has_session(self, filename):
+        filename = Path(filename)
         return any(
             session for session in self._sessions if session.filename == filename
         )

--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -1,6 +1,8 @@
 """Application lifecycle events are managed here."""
 
-from typing import Optional
+from __future__ import annotations
+
+from pathlib import Path
 
 from gaphor.abc import Service
 
@@ -40,13 +42,13 @@ class SessionCreated(ServiceEvent):
         self,
         applicaton: Service,
         session: Service,
-        filename: Optional[str],
-        template: Optional[str],
+        filename: str | Path | None,
+        template: str | None,
     ):
         super().__init__(applicaton)
         self.application = applicaton
         self.session = session
-        self.filename = filename
+        self.filename = Path(filename) if filename else None
         self.template = template
 
 
@@ -66,13 +68,13 @@ class SessionShutdown(ServiceEvent):
 
 
 class ModelLoaded:
-    def __init__(self, service, filename=None):
+    def __init__(self, service, filename: Path | None = None):
         self.service = service
         self.filename = filename
 
 
 class ModelSaved:
-    def __init__(self, service, filename=None):
+    def __init__(self, service, filename: Path | None = None):
         self.service = service
         self.filename = filename
 

--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -106,7 +106,7 @@ class ActionEnabled:
         self.scope, self.name = (
             action_name.split(".", 2) if "." in action_name else ("win", action_name)
         )
-        self.enabled = bool(enabled)
+        self.enabled = enabled
 
 
 class Notification:

--- a/gaphor/plugins/xmiexport/__init__.py
+++ b/gaphor/plugins/xmiexport/__init__.py
@@ -1,6 +1,7 @@
 """This plugin extends Gaphor with XMI export functionality."""
 
 import logging
+from pathlib import Path
 
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import action, gettext
@@ -33,8 +34,11 @@ class XMIExport(Service, ActionProvider):
             except Exception as e:
                 logger.error(f"Error while saving model to file {filename}: {e}")
 
-        filename = self.file_manager.filename
-        filename = filename.replace(".gaphor", ".xmi") if filename else "model.xmi"
+        filename = (
+            self.file_manager.filename.with_suffix(".xmi")
+            if self.file_manager.filename
+            else Path("model.xmi")
+        )
         save_file_dialog(
             gettext("Export model as XMI file"),
             handler,

--- a/gaphor/services/properties.py
+++ b/gaphor/services/properties.py
@@ -45,8 +45,8 @@ def get_cache_dir() -> str:
     return cache_dir
 
 
-def file_hash(filename: str) -> str:
-    return hashlib.blake2b(filename.encode("utf-8"), digest_size=24).hexdigest()
+def file_hash(filename) -> str:
+    return hashlib.blake2b(str(filename).encode("utf-8"), digest_size=24).hexdigest()
 
 
 class PropertyChanged:

--- a/gaphor/tests/test_application.py
+++ b/gaphor/tests/test_application.py
@@ -31,7 +31,7 @@ def test_model_loaded(application):
     session = application.new_session()
     session.event_manager.handle(ModelLoaded(None, Path("some_file_name")))
 
-    assert session.filename == "some_file_name"
+    assert session.filename == Path("some_file_name")
 
 
 def test_model_saved(application):

--- a/gaphor/tests/test_application.py
+++ b/gaphor/tests/test_application.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from gaphor.application import Application
@@ -34,7 +36,7 @@ def test_model_loaded(application):
 
 def test_model_saved(application):
     session = application.new_session()
-    session.event_manager.handle(ModelSaved(None, "some_file_name"))
+    session.event_manager.handle(ModelSaved(None, Path("some_file_name")))
 
     assert session.filename == "some_file_name"
 

--- a/gaphor/tests/test_application.py
+++ b/gaphor/tests/test_application.py
@@ -29,7 +29,7 @@ def test_service_load(application):
 
 def test_model_loaded(application):
     session = application.new_session()
-    session.event_manager.handle(ModelLoaded(None, "some_file_name"))
+    session.event_manager.handle(ModelLoaded(None, Path("some_file_name")))
 
     assert session.filename == "some_file_name"
 
@@ -38,7 +38,7 @@ def test_model_saved(application):
     session = application.new_session()
     session.event_manager.handle(ModelSaved(None, Path("some_file_name")))
 
-    assert session.filename == "some_file_name"
+    assert session.filename == Path("some_file_name")
 
 
 def test_new_session_from_template(application, test_models):

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -63,12 +63,18 @@ def open_file_dialog(title, handler, parent=None, dirname=None, filters=None) ->
             dialog.set_current_folder(dirname)
     else:
         if dirname:
-            dialog.set_current_folder(Gio.File.new_for_path(dirname))
+            dialog.set_current_folder(Gio.File.parse_name(dirname))
     dialog.show()
 
 
 def save_file_dialog(
-    title, handler, parent=None, filename=None, extension=None, filters=None
+    title,
+    handler,
+    parent=None,
+    filename=None,
+    extension=None,
+    dirname=None,
+    filters=None,
 ) -> None:
     if filters is None:
         filters = []
@@ -86,7 +92,7 @@ def save_file_dialog(
         if Gtk.get_major_version() == 3:
             dialog.set_filename(filename)
         else:
-            dialog.set_file(Gio.File.new_for_path(filename))
+            dialog.set_current_name(filename)
 
     def overwrite_check():
         filename = get_filename()
@@ -111,5 +117,10 @@ def save_file_dialog(
         set_filename(filename)
     if Gtk.get_major_version() == 3:
         dialog.set_do_overwrite_confirmation(True)
+        if dirname:
+            dialog.set_current_folder(dirname)
+    else:
+        if dirname:
+            dialog.set_current_folder(Gio.File.parse_name(dirname))
     dialog.set_modal(True)
     dialog.show()

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -95,7 +95,7 @@ def save_file_dialog(
 
     def overwrite_check() -> Path | None:
         filename = get_filename()
-        if extension and not filename.suffix == extension:
+        if extension and filename.suffix != extension:
             filename.with_suffix(extension)
             set_filename(filename)
             return None if filename.exists() else filename

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -1,5 +1,7 @@
 """The main application window."""
 
+from __future__ import annotations
+
 import importlib.resources
 import logging
 from pathlib import Path
@@ -124,7 +126,7 @@ class MainWindow(Service, ActionProvider):
         self.action_group: Gio.ActionGroup = None
         self.title: Gtk.Label = None
         self.subtitle: Gtk.Label = None
-        self.filename = None
+        self.filename: Path | None = None
         self.model_changed = False
         self.layout = None
         self.modeling_language_name = None
@@ -225,7 +227,7 @@ class MainWindow(Service, ActionProvider):
             return
 
         if self.filename:
-            p = Path(self.filename)
+            p = self.filename
             title = p.stem
             subtitle = str(p).replace(str(Path.home()), "~")
         else:
@@ -240,9 +242,11 @@ class MainWindow(Service, ActionProvider):
     # Signal callbacks:
 
     @event_handler(SessionCreated, ModelLoaded, ModelSaved)
-    def _on_file_manager_state_changed(self, event):
+    def _on_file_manager_state_changed(
+        self, event: SessionCreated | ModelLoaded | ModelSaved
+    ):
         self.model_changed = False
-        self.filename = event.filename
+        self.filename = Path(event.filename) if event.filename else None
         self.set_title()
         if self.window:
             self.window.present()

--- a/gaphor/ui/tests/test_filedialog.py
+++ b/gaphor/ui/tests/test_filedialog.py
@@ -1,3 +1,4 @@
+import os.path
 from pathlib import Path
 
 import pytest
@@ -98,7 +99,7 @@ def test_save_dialog(file_chooser):
 
     file_chooser.stub_select_file("/test/path", "model.gaphor")
 
-    assert selected_file.parts == ("/", "test", "path", "model.gaphor")
+    assert selected_file.parts == (os.path.sep, "test", "path", "model.gaphor")
 
 
 def test_save_dialog_with_full_file_name(file_chooser):
@@ -108,16 +109,17 @@ def test_save_dialog_with_full_file_name(file_chooser):
         nonlocal selected_file
         selected_file = f
 
+    filename = Path("/test/path/model.gaphor")
     save_file_dialog(
         "title",
         save_handler,
-        filename=Path("/test/path/model.gaphor"),
+        filename=filename,
         extension=".gaphor",
         filters=[],
     )
 
-    assert file_chooser.stub_current_folder == "/test/path"
-    assert file_chooser.stub_current_name == "model.gaphor"
+    assert file_chooser.stub_current_folder == str(filename.parent)
+    assert file_chooser.stub_current_name == filename.name
 
 
 def test_save_dialog_with_only_file_name(file_chooser):
@@ -127,13 +129,18 @@ def test_save_dialog_with_only_file_name(file_chooser):
         nonlocal selected_file
         selected_file = f
 
+    filename = Path("model.gaphor")
     save_file_dialog(
         "title",
         save_handler,
-        filename=Path("model.gaphor"),
+        filename=filename,
         extension=".gaphor",
         filters=[],
     )
 
-    assert file_chooser.stub_current_folder == "."
-    assert file_chooser.stub_current_name == "model.gaphor"
+    # On GitHub CI, the path is returning the absolute path, both are fine
+    assert file_chooser.stub_current_folder in (
+        str(filename.parent),
+        str(filename.parent.absolute()),
+    )
+    assert file_chooser.stub_current_name == filename.name

--- a/gaphor/ui/tests/test_filedialog.py
+++ b/gaphor/ui/tests/test_filedialog.py
@@ -1,0 +1,139 @@
+from pathlib import Path
+
+import pytest
+from gi.repository import Gio, Gtk
+
+from gaphor.ui.filedialog import save_file_dialog
+
+
+class FileChooserStub:
+    def __init__(self) -> None:
+        self._response_callback = None
+        self._current_name = None
+        self._current_folder = None
+
+    @property
+    def stub_current_name(self):
+        return self._current_name
+
+    @property
+    def stub_current_folder(self):
+        return self._current_folder
+
+    def stub_select_file(self, folder, name):
+        self._current_folder = folder
+        self._current_name = name
+        assert self._response_callback
+        self._response_callback(self, Gtk.ResponseType.ACCEPT)
+
+    def connect(self, signal, callback):
+        assert signal == "response"
+        self._response_callback = callback
+
+    if Gtk.get_major_version() == 3:
+
+        def get_filename(self):
+            return str(Path(self._current_folder, self._current_name))
+
+        def set_filename(self, name):
+            self._current_name = name
+
+        def set_current_folder(self, name):
+            self._current_folder = name
+
+        def set_do_overwrite_confirmation(self, confirm):
+            pass
+
+    else:
+
+        def get_file(self):
+            return Gio.File.new_for_path(self._current_folder).get_child(
+                self._current_name
+            )
+
+        def set_current_name(self, name: str):
+            self._current_name = name
+
+        def set_current_folder(self, name: Gio.File):
+            self._current_folder = name.get_parse_name()
+
+    def add_filter(self, filter):
+        pass
+
+    def set_modal(self, modal):
+        pass
+
+    def show(self):
+        pass
+
+    def destroy(self):
+        pass
+
+
+@pytest.fixture
+def file_chooser(monkeypatch):
+    stub = FileChooserStub()
+
+    def new_file_chooser(title, parent, action, accept_label, cancel_label):
+        return stub
+
+    monkeypatch.setattr("gi.repository.Gtk.FileChooserNative.new", new_file_chooser)
+    return stub
+
+
+def test_save_dialog(file_chooser):
+    selected_file = None
+
+    def save_handler(f):
+        nonlocal selected_file
+        selected_file = f
+
+    save_file_dialog(
+        "title",
+        save_handler,
+        filename=None,
+        extension=".gaphor",
+        filters=[],
+    )
+
+    file_chooser.stub_select_file("/test/path", "model.gaphor")
+
+    assert selected_file.parts == ("/", "test", "path", "model.gaphor")
+
+
+def test_save_dialog_with_full_file_name(file_chooser):
+    selected_file = None
+
+    def save_handler(f):
+        nonlocal selected_file
+        selected_file = f
+
+    save_file_dialog(
+        "title",
+        save_handler,
+        filename=Path("/test/path/model.gaphor"),
+        extension=".gaphor",
+        filters=[],
+    )
+
+    assert file_chooser.stub_current_folder == "/test/path"
+    assert file_chooser.stub_current_name == "model.gaphor"
+
+
+def test_save_dialog_with_only_file_name(file_chooser):
+    selected_file = None
+
+    def save_handler(f):
+        nonlocal selected_file
+        selected_file = f
+
+    save_file_dialog(
+        "title",
+        save_handler,
+        filename=Path("model.gaphor"),
+        extension=".gaphor",
+        filters=[],
+    )
+
+    assert file_chooser.stub_current_folder == "."
+    assert file_chooser.stub_current_name == "model.gaphor"

--- a/gaphor/ui/tests/test_filemanager.py
+++ b/gaphor/ui/tests/test_filemanager.py
@@ -16,7 +16,7 @@ def test_save(element_factory, file_manager: FileManager, tmp_path):
     element_factory.create(UML.Class)
     out_file = tmp_path / "out.gaphor"
 
-    file_manager.save(filename=str(out_file))
+    file_manager.save(filename=out_file)
 
     assert out_file.exists()
 
@@ -30,7 +30,7 @@ def test_model_is_saved_with_utf8_encoding(
     package.name = "안녕하세요 세계"
 
     model_file = tmp_path / "model.gaphor"
-    file_manager.save(str(model_file))
+    file_manager.save(model_file)
 
     with open(model_file, encoding="utf-8") as f:
         f.read()  # raises exception if characters can't be decoded
@@ -48,7 +48,7 @@ def test_model_is_loaded_with_utf8_encoding(
     package.name = package_name
 
     model_file = tmp_path / "model.gaphor"
-    file_manager.save(str(model_file))
+    file_manager.save(model_file)
 
     element_factory.flush()
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When exporting a diagram, the folder always reverted to the current working directory

Issue Number: #1675

### What is the new behavior?

Fix #1675 behavior.

In addition, use `pathlib.Path` for paths internally, instead of `str`.


### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

Some events now contain a `Path` instead of a `str` object.


### Other information
