### PR TITLE
Fix event-controller warning on GTK4

### DIFF
--- a/gaphor/plugins/console/console.py
+++ b/gaphor/plugins/console/console.py
@@ -226,7 +226,7 @@ class GTKInterpreterConsole(Gtk.ScrolledWindow):
         buffer = self.text.get_buffer()
         input_mark = buffer.get_mark("input")
         self.text.scroll_to_mark(input_mark, 0, True, 1, 1)
-        return False
+        return GLib.SOURCE_REMOVE
 
     def push(self, line):
         self.buffer.append(line)

--- a/gaphor/ui/statuswindow.py
+++ b/gaphor/ui/statuswindow.py
@@ -124,7 +124,7 @@ def progress_idle_handler(progress_bar, queue):
         pass
     if percentage:
         progress_bar.set_fraction(min(percentage, 100.0) / 100.0)
-    return True
+    return GLib.SOURCE_CONTINUE
 
 
 def remove_idle_handler(window, idle_id):

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -7,14 +7,13 @@ import functools
 import logging
 from typing import Optional, Tuple
 
-from gi.repository import Gdk, GObject, Gtk
+from gi.repository import Gdk, GLib, GObject, Gtk
 
 from gaphor.core.eventmanager import EventManager, event_handler
 from gaphor.diagram.diagramtoolbox import ToolboxDefinition
 from gaphor.diagram.event import ToolCompleted
 from gaphor.diagram.hoversupport import flowbox_add_hover_support
 from gaphor.diagram.tools.dnd import ToolboxActionDragData
-from gaphor.event import TransactionCommit
 from gaphor.services.modelinglanguage import (
     ModelingLanguageChanged,
     ModelingLanguageService,
@@ -187,9 +186,10 @@ class Toolbox(UIComponent):
                     return
 
     @event_handler(ToolCompleted)
-    def _on_diagram_item_placed(self, event: TransactionCommit) -> None:
+    def _on_diagram_item_placed(self, event) -> None:
         if self.properties.get("reset-tool-after-create", True):
-            self.select_tool("toolbox-pointer")
+            # Select tool from an idle handler, so the original tool can complete propertly.
+            GLib.idle_add(self.select_tool, "toolbox-pointer")
 
     @event_handler(ModelingLanguageChanged)
     def _on_modeling_language_changed(self, event: ModelingLanguageChanged) -> None:


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When you create a new item on a diagram, a warning is printed to stdout:

```
(gaphor:2109098): Gtk-CRITICAL **: 21:57:18.331: gtk_event_controller_get_propagation_phase: assertion 'GTK_IS_EVENT_CONTROLLER (controller)' failed
```

### What is the new behavior?

This warning is fixed: a new set of controllers is set from an idle handler.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
