### PR TITLE
Fix Instant editor focus on GTK4

### DIFF
--- a/docs/modeling_language.md
+++ b/docs/modeling_language.md
@@ -112,7 +112,7 @@ When you double click on an item in a diagram, a popup can show up so you can ea
 By default this works for any named element. You can register your own inline editor function if you need to.
 
 ```{eval-rst}
-.. function:: gaphor.diagram.instanteditors.InstantEditor(item: Item, view, event_manager, pos: Optional[Tuple[int, int]] = None) -> bool
+.. function:: gaphor.diagram.instanteditors.instant_editor(item: Item, view, event_manager, pos: Optional[Tuple[int, int]] = None) -> bool
 
    Show a small editor popup in the diagram. Makes for
    easy editing without resorting to the Element editor.

--- a/gaphor/UML/actions/actionseditors.py
+++ b/gaphor/UML/actions/actionseditors.py
@@ -1,10 +1,10 @@
-from gaphor.diagram.instanteditors import InstantEditor, popup_entry, show_popover
+from gaphor.diagram.instanteditors import instant_editor, popup_entry, show_popover
 from gaphor.transaction import Transaction
 from gaphor.UML.actions.activity import ActivityParameterNodeItem
 from gaphor.UML.actions.activitynodes import ForkNodeItem
 
 
-@InstantEditor.register(ForkNodeItem)
+@instant_editor.register(ForkNodeItem)
 def fork_node_item_editor(item, view, event_manager, pos=None) -> bool:
     """Text edit support for Named items."""
 
@@ -24,7 +24,7 @@ def fork_node_item_editor(item, view, event_manager, pos=None) -> bool:
     return True
 
 
-@InstantEditor.register(ActivityParameterNodeItem)
+@instant_editor.register(ActivityParameterNodeItem)
 def activity_parameter_node_item_editor(
     item: ActivityParameterNodeItem, view, event_manager, pos=None
 ) -> bool:

--- a/gaphor/UML/classes/classeseditors.py
+++ b/gaphor/UML/classes/classeseditors.py
@@ -1,12 +1,12 @@
 from gaphas.geometry import Rectangle, distance_point_point_fast
 
 from gaphor.core.format import format, parse
-from gaphor.diagram.instanteditors import InstantEditor, popup_entry, show_popover
+from gaphor.diagram.instanteditors import instant_editor, popup_entry, show_popover
 from gaphor.transaction import Transaction
 from gaphor.UML.classes.association import AssociationItem
 
 
-@InstantEditor.register(AssociationItem)
+@instant_editor.register(AssociationItem)
 def association_item_editor(item, view, event_manager, pos=None) -> bool:
     """Text edit support for Named items."""
 

--- a/gaphor/diagram/general/generaleditors.py
+++ b/gaphor/diagram/general/generaleditors.py
@@ -1,11 +1,11 @@
 from gi.repository import Gdk, Gtk
 
 from gaphor.diagram.general.comment import CommentItem
-from gaphor.diagram.instanteditors import InstantEditor, show_popover
+from gaphor.diagram.instanteditors import instant_editor, show_popover
 from gaphor.transaction import Transaction
 
 
-@InstantEditor.register(CommentItem)
+@instant_editor.register(CommentItem)
 def CommentItemEditor(item, view, event_manager, pos=None) -> bool:
     def update_text():
         text = buffer.get_text(

--- a/gaphor/diagram/instanteditors.py
+++ b/gaphor/diagram/instanteditors.py
@@ -11,7 +11,7 @@ from gaphor.transaction import Transaction
 
 
 @singledispatch
-def InstantEditor(
+def instant_editor(
     item: Item, view, event_manager, pos: tuple[int, int] | None = None
 ) -> bool:
     """Show a small editor popup in the diagram. Makes for easy editing without
@@ -23,7 +23,7 @@ def InstantEditor(
     return False
 
 
-@InstantEditor.register(Named)
+@instant_editor.register(Named)
 def named_item_editor(item, view, event_manager, pos=None) -> bool:
     """Text edit support for Named items."""
 

--- a/gaphor/diagram/instanteditors.py
+++ b/gaphor/diagram/instanteditors.py
@@ -81,6 +81,7 @@ def show_popover(widget, view, box, commit):
     def on_closed(popover):
         if should_commit:
             commit()
+        view.grab_focus()
 
     popover.connect("closed", on_closed)
 

--- a/gaphor/diagram/tools/placement.py
+++ b/gaphor/diagram/tools/placement.py
@@ -11,7 +11,7 @@ from gaphor.core.eventmanager import EventManager
 from gaphor.diagram.diagramtoolbox import ItemFactory
 from gaphor.diagram.event import DiagramItemPlaced
 from gaphor.diagram.group import group
-from gaphor.diagram.instanteditors import InstantEditor
+from gaphor.diagram.instanteditors import instant_editor
 from gaphor.diagram.presentation import ElementPresentation
 from gaphor.diagram.tools.dropzone import grow_parent
 
@@ -114,4 +114,4 @@ def on_drag_end(gesture, offset_x, offset_y, placement_state):
 @g_async(priority=GLib.PRIORITY_LOW)
 def open_editor(item, view, event_manager):
     if isinstance(item, ElementPresentation):
-        InstantEditor(item, view, event_manager)
+        instant_editor(item, view, event_manager)

--- a/gaphor/diagram/tools/textedit.py
+++ b/gaphor/diagram/tools/textedit.py
@@ -1,6 +1,6 @@
 from gi.repository import Gdk, Gtk
 
-from gaphor.diagram.instanteditors import InstantEditor
+from gaphor.diagram.instanteditors import instant_editor
 
 
 def text_edit_tools(view, event_manager):
@@ -20,7 +20,7 @@ def on_key_pressed(controller, keyval, keycode, state, event_manager):
     view = controller.get_widget()
     item = view.selection.hovered_item
     if item and keyval == Gdk.KEY_F2:
-        return InstantEditor(item, view, event_manager)
+        return instant_editor(item, view, event_manager)
 
 
 def on_double_click(gesture, n_press, x, y, event_manager):
@@ -28,4 +28,4 @@ def on_double_click(gesture, n_press, x, y, event_manager):
     item = view.selection.hovered_item
     if item and n_press == 2:
         ix, iy = view.get_matrix_v2i(item).transform_point(x, y)
-        return InstantEditor(item, view, event_manager, (ix, iy))
+        return instant_editor(item, view, event_manager, (ix, iy))


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When an instant editor closes, focus is not automatically returned to the diagram. This causes users to do an extra click, before (for example) shortcuts can be used again

### What is the new behavior?

Instant editors work in GTK4 the same as GTK3.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
