### PR TITLE
Inherited stereotype part 2: attributes from super type

### DIFF
--- a/gaphor/UML/__init__.py
+++ b/gaphor/UML/__init__.py
@@ -5,3 +5,4 @@ import gaphor.UML.deletable
 import gaphor.UML.drop
 import gaphor.UML.iconname
 import gaphor.UML.group
+from gaphor.UML import recipes

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -140,7 +140,7 @@ def all_attributes(stereotype, seen=None):
 @transactional
 def toggle_stereotype(renderer, path, subject, model):
     row = model[path]
-    name, old_value, is_applied, _, _, stereotype, _, _ = row
+    _, _, is_applied, _, _, stereotype, _, _ = row
     value = not is_applied
 
     if value:
@@ -157,7 +157,7 @@ def toggle_stereotype(renderer, path, subject, model):
 def set_value(renderer, path, value, model):
     """Set value of stereotype property applied to an UML element."""
     row = model[path]
-    name, old_value, is_applied, _, _, attr, applied, slot = row
+    _, _, _, _, _, attr, applied, slot = row
     if isinstance(attr, UML.Stereotype):
         return  # don't edit stereotype rows
 

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -178,4 +178,4 @@ def set_value(renderer, path, value, model):
         value = ""
 
     row[1] = value
-    row[5] = slot
+    row[7] = slot

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -62,12 +62,12 @@ def stereotype_model(subject):
         [
             str,  # stereotype/attribute
             str,  # value
-            bool,  # is applied stereotype
-            bool,  # show checkbox (is stereotype)
+            bool,  # active / is applied stereotype
+            bool,  # visible  checkbox (is stereotype)
             bool,  # value editable
             object,  # stereotype / attribute
-            object,  # value editable
-            object,  # slot element
+            object,  # instance specification
+            object,  # slot
         ]
     )
     refresh(subject, model)
@@ -89,18 +89,10 @@ def refresh(subject, model):
             row[:] = row_data
         return new_row
 
-    # shortcut map stereotype -> slot (InstanceSpecification)
-    slots = {}
-    for applied in instances:
-        for slot in applied.slot:
-            slots[slot.definingFeature] = slot
-
     for st_index, st in enumerate(stereotypes):
-        for applied in instances:
-            if st in applied.classifier:
-                break
-        else:
-            applied = None
+        applied = next(
+            (applied for applied in instances if st in applied.classifier), None
+        )
 
         parent = upsert(
             f"{st_index}",
@@ -108,7 +100,14 @@ def refresh(subject, model):
             (st.name, "", bool(applied), True, False, st, None, None),
         )
         for attr_index, attr in enumerate(attr for attr in all_attributes(st)):
-            slot = slots.get(attr)
+            slot = (
+                next(
+                    (slot for slot in applied.slot if slot.definingFeature is attr),
+                    None,
+                )
+                if applied
+                else None
+            )
             value = slot.value if slot else ""
             upsert(
                 f"{st_index}:{attr_index}",

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -107,9 +107,7 @@ def refresh(subject, model):
             None,
             (st.name, "", bool(applied), True, False, st, None, None),
         )
-        for attr_index, attr in enumerate(
-            attr for attr in st.ownedAttribute if not attr.association
-        ):
+        for attr_index, attr in enumerate(attr for attr in all_attributes(st)):
             slot = slots.get(attr)
             value = slot.value if slot else ""
             upsert(
@@ -126,6 +124,17 @@ def refresh(subject, model):
                     slot,
                 ),
             )
+
+
+def all_attributes(stereotype, seen=None):
+    if seen is None:
+        seen = {stereotype}
+
+    for super_type in stereotype.generalization[:].general[:]:
+        if super_type not in seen:
+            seen.add(super_type)
+            yield from all_attributes(super_type)
+    yield from (attr for attr in stereotype.ownedAttribute if not attr.association)
 
 
 @transactional

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -3,6 +3,7 @@ from gi.repository import Gtk
 
 from gaphor import UML
 from gaphor.core import transactional
+from gaphor.core.modeling.element import Element
 from gaphor.diagram.propertypages import PropertyPageBase, PropertyPages
 from gaphor.UML.profiles.metaclasspropertypage import new_builder
 
@@ -75,7 +76,7 @@ def stereotype_model(subject):
     return model, (toggle_stereotype, subject, model), (set_value, model)
 
 
-def refresh(subject, model):
+def refresh(subject: Element, model: Gtk.TreeStore):
     stereotypes = UML.recipes.get_stereotypes(subject)
     instances = subject.appliedStereotype
 

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -100,7 +100,7 @@ def refresh(subject: Element, model: Gtk.TreeStore):
             None,
             (st.name, "", bool(applied), True, False, st, None, None),
         )
-        for attr_index, attr in enumerate(attr for attr in all_attributes(st)):
+        for attr_index, attr in enumerate(all_attributes(st)):
             slot = (
                 next(
                     (slot for slot in applied.slot if slot.definingFeature is attr),
@@ -161,10 +161,10 @@ def set_value(renderer, path, value, model):
     if isinstance(attr, UML.Stereotype):
         return  # don't edit stereotype rows
 
-    if slot is None and not value:
-        return  # nothing to do and don't create slot without value
-
     if slot is None:
+        if not value:
+            return  # nothing to do and don't create slot without value
+
         slot = UML.recipes.add_slot(applied, attr)
 
     assert slot

--- a/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
@@ -74,9 +74,7 @@ def test_inherited_stereotype(diagram, element_factory):
     metaclass, stereotype = metaclass_and_stereotype(element_factory)
     substereotype = element_factory.create(UML.Stereotype)
     substereotype.name = "SubStereotype"
-    generalization: UML.Generalization = element_factory.create(UML.Generalization)
-    generalization.general = stereotype
-    generalization.specific = substereotype
+    UML.recipes.create_generalization(stereotype, substereotype)
 
     property_page = create_property_page(diagram, element_factory)
     model = get_model(property_page)
@@ -94,9 +92,7 @@ def test_inherited_stereotype_with_attributes(diagram, element_factory):
     stereotype.ownedAttribute = attr
     substereotype = element_factory.create(UML.Stereotype)
     substereotype.name = "SubStereotype"
-    generalization: UML.Generalization = element_factory.create(UML.Generalization)
-    generalization.general = stereotype
-    generalization.specific = substereotype
+    UML.recipes.create_generalization(stereotype, substereotype)
 
     property_page = create_property_page(diagram, element_factory)
     model = get_model(property_page)

--- a/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
@@ -85,3 +85,25 @@ def test_inherited_stereotype(diagram, element_factory):
     assert model[(0,)][0] == "Stereotype"
     assert model[(1,)]
     assert model[(1,)][0] == "SubStereotype"
+
+
+def test_inherited_stereotype_with_attributes(diagram, element_factory):
+    metaclass, stereotype = metaclass_and_stereotype(element_factory)
+    attr = element_factory.create(UML.Property)
+    attr.name = "Attr"
+    stereotype.ownedAttribute = attr
+    substereotype = element_factory.create(UML.Stereotype)
+    substereotype.name = "SubStereotype"
+    generalization: UML.Generalization = element_factory.create(UML.Generalization)
+    generalization.general = stereotype
+    generalization.specific = substereotype
+
+    property_page = create_property_page(diagram, element_factory)
+    model = get_model(property_page)
+
+    assert model[(0,)]
+    assert model[(0,)][0] == "Stereotype"
+    assert model[(0, 0)][0] == "Attr"
+    assert model[(1,)]
+    assert model[(1,)][0] == "SubStereotype"
+    assert model[(1, 0)][0] == "Attr"

--- a/gaphor/UML/recipes.py
+++ b/gaphor/UML/recipes.py
@@ -122,7 +122,7 @@ def get_stereotypes(element):
     model = element.model
     # UML specs does not allow to extend stereotypes with stereotypes
     if isinstance(element, Stereotype):
-        return ()
+        return []
 
     cls = type(element)
 

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -190,8 +190,6 @@ def test_extension_deletion_with_2_metaclasses(element_factory):
     metaklass.name = "Class"
     metaiface = create(UML.Class)
     metaiface.name = "Interface"
-    klass = create(UML.Class)
-    iface = create(UML.Interface)
     stereotype = create(UML.Stereotype)
     st_attr = create(UML.Property)
     stereotype.ownedAttribute = st_attr
@@ -199,6 +197,8 @@ def test_extension_deletion_with_2_metaclasses(element_factory):
     UML.recipes.create_extension(metaiface, stereotype)
 
     # Apply stereotype to class and create slot
+    klass = create(UML.Class)
+    iface = create(UML.Interface)
     instspec1 = UML.recipes.apply_stereotype(klass, stereotype)
     instspec2 = UML.recipes.apply_stereotype(iface, stereotype)
     UML.recipes.add_slot(instspec1, st_attr)
@@ -217,13 +217,13 @@ def test_stereotype_deletion(element_factory):
     create = element_factory.create
     metaklass = create(UML.Class)
     metaklass.name = "Class"
-    klass = create(UML.Class)
     stereotype = create(UML.Stereotype)
     st_attr = create(UML.Property)
     stereotype.ownedAttribute = st_attr
     UML.recipes.create_extension(metaklass, stereotype)
 
     # Apply stereotype to class and create slot
+    klass = create(UML.Class)
     instspec = UML.recipes.apply_stereotype(klass, stereotype)
     UML.recipes.add_slot(instspec, st_attr)
 
@@ -232,6 +232,30 @@ def test_stereotype_deletion(element_factory):
     stereotype.unlink()
 
     assert not klass.appliedStereotype
+
+
+def test_extension_generalization_with_attribute_from_super_type(element_factory):
+    create = element_factory.create
+    metaklass = create(UML.Class)
+    metaklass.name = "Class"
+    stereotype = create(UML.Stereotype)
+    UML.recipes.create_extension(metaklass, stereotype)
+    substereotype = create(UML.Stereotype)
+    UML.recipes.create_generalization(stereotype, substereotype)
+
+    # Add attribute to super-stereotype
+    st_attr = create(UML.Property)
+    stereotype.ownedAttribute = st_attr
+
+    # Apply sub-stereotype and assign parent attribute
+    klass = create(UML.Class)
+    instspec = UML.recipes.apply_stereotype(klass, substereotype)
+    UML.recipes.add_slot(instspec, st_attr)
+
+    st_attr.unlink()
+
+    assert substereotype in klass.appliedStereotype[:].classifier
+    assert not klass.appliedStereotype[0].slot
 
 
 def test_diagram_move(element_factory, mocker):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When you inherit a stereotype from another stereotype, the attributes of the super stereotype do not show up in the property editor for the sub type.

Issue Number: #672

### What is the new behavior?

Attributes from a super type also contribute to a sub type

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

![image](https://user-images.githubusercontent.com/96249/188317101-f1b7720c-ea4f-437c-8beb-965a5d4907d5.png)
