### PR TITLE
Allow sequence diagram messages on lifeline body

### DIFF
--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -2,9 +2,6 @@
 
 from typing import Optional
 
-from gaphas.connector import ConnectionSink, ItemConnectionSink
-from gaphas.types import Pos, SupportsFloatPos
-
 from gaphor import UML
 from gaphor.core.modeling import Element, Presentation
 from gaphor.diagram.connectors import BaseConnector, Connector
@@ -281,25 +278,3 @@ class ExecutionSpecificationExecutionSpecificationConnect(BaseConnector):
 
         for cinfo in self.diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).disconnect(cinfo.handle)
-
-
-@ConnectionSink.register(LifelineItem)
-class LifelineConnectionSink(ItemConnectionSink):
-    def glue(
-        self, pos: SupportsFloatPos, secondary_pos: Optional[SupportsFloatPos] = None
-    ) -> Optional[Pos]:
-        """Glue a line to the lifeline item, have a preference for the lifetime
-        line."""
-        assert isinstance(self.item, LifelineItem)
-        glue_pos = super().glue(pos, secondary_pos)
-
-        lifetime = self.item.lifetime
-        if lifetime.visible and self.port is not lifetime.port:  # type: ignore[has-type]
-            g, d = lifetime.port.glue(pos)
-            if d < self.distance:
-                self.port = lifetime.port
-                glue_pos = g
-
-            return glue_pos
-
-        return glue_pos

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -254,9 +254,10 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
             cr = context.cairo
             with cairo_state(cr):
                 cr.set_dash((7.0, 5.0), 0)
+                x = self._handles[SW].pos.x
                 top = self._lifetime.top
-                cr.move_to(top.pos.x, top.pos.y)
-                cr.line_to(bottom.pos.x, bottom.pos.y)
+                cr.move_to(top.pos.x - x, top.pos.y)
+                cr.line_to(bottom.pos.x - x, bottom.pos.y)
                 stroke(context, dash=False)
 
             # draw destruction event

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -216,10 +216,13 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
 
     def save(self, save_func):
         super().save(save_func)
-        save_func("lifetime-length", self._lifetime.length)
+        save_func("lifetime-y", float(self._lifetime.bottom.pos.y))
 
     def load(self, name, value):
-        if name == "lifetime-length":
+        if name == "lifetime-y":
+            self._lifetime.bottom.pos.y = float(value)
+        elif name == "lifetime-length":
+            # For gaphor < 2.12
             self._lifetime.bottom.pos.y = self.height + float(value)
         else:
             super().load(name, value)
@@ -227,7 +230,7 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
         # Force update the lifetime position,
         # so message items can connect properly.
         if name in ("top-left", "width"):
-            self.lifetime.top.pos.x = self.lifetime.bottom.pos.x = (
+            self._lifetime.top.pos.x = self._lifetime.bottom.pos.x = (
                 self._handles[NW].pos.x + self.width / 2
             )
 

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -19,14 +19,14 @@ bottom of the lifeline's lifetime when delete message is connected to a
 lifeline.
 """
 
-from gaphas.connector import Handle, Port
+from gaphas.connector import Handle
 from gaphas.constraint import CenterConstraint, EqualsConstraint, LessThanConstraint
 from gaphas.geometry import distance_line_point
 from gaphas.item import NW, SE, SW
-from gaphas.position import MatrixProjection, Position
+from gaphas.port import LinePort
+from gaphas.position import MatrixProjection
 from gaphas.solver import VERY_STRONG, MultiConstraint
 from gaphas.solver.constraint import BaseConstraint
-from gaphas.types import Pos, SupportsFloatPos
 
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
@@ -63,20 +63,8 @@ class BetweenConstraint(BaseConstraint):
             self.v.value = upper
 
 
-class BetweenPort(Port):
+class BetweenPort(LinePort):
     """Port defined as a line between two handles."""
-
-    def __init__(self, start: Position, end: Position) -> None:
-        super().__init__()
-
-        self.start = start
-        self.end = end
-
-    def glue(self, pos: SupportsFloatPos) -> tuple[Pos, float]:
-        d, pl = distance_line_point(
-            self.start.tuple(), self.end.tuple(), (float(pos[0]), float(pos[1]))
-        )
-        return pl, d
 
     def constraint(self, item, handle, glue_item):
         """Create connection line constraint between item's handle and the

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -22,7 +22,7 @@ lifeline.
 from gaphas.connector import Handle, Port
 from gaphas.constraint import CenterConstraint, EqualsConstraint, LessThanConstraint
 from gaphas.geometry import distance_line_point
-from gaphas.item import SE, SW
+from gaphas.item import NW, SE, SW
 from gaphas.position import MatrixProjection, Position
 from gaphas.solver import VERY_STRONG, MultiConstraint
 from gaphas.solver.constraint import BaseConstraint
@@ -170,7 +170,7 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
         self._handles.append(bottom)
         self.watch_handle(top)
         self.watch_handle(bottom)
-        self._ports.append(self._lifetime.port)
+        self._ports.insert(0, self._lifetime.port)
 
         self.shape = Box(
             Text(
@@ -223,6 +223,13 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
             self._lifetime.bottom.pos.y = self.height + float(value)
         else:
             super().load(name, value)
+
+        # Force update the lifetime position,
+        # so message items can connect properly.
+        if name in ("top-left", "width"):
+            self.lifetime.top.pos.x = self.lifetime.bottom.pos.x = (
+                self._handles[NW].pos.x + self.width / 2
+            )
 
     def draw_lifeline(self, box, context, bounding_box):
         """Draw lifeline.

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -131,12 +131,6 @@ class LifetimeItem:
 
     min_length = property(lambda s: s._c_min_length.delta, _set_min_length)
 
-    def _set_connectable(self, connectable):
-        self.port.connectable = connectable
-        self.bottom.movable = connectable
-
-    connectable = property(lambda s: s.port.connectable, _set_connectable)
-
     def _is_visible(self):
         return self.length > self.MIN_LENGTH
 

--- a/gaphor/UML/interactions/message.py
+++ b/gaphor/UML/interactions/message.py
@@ -228,7 +228,7 @@ class MessageItem(Named, LinePresentation[UML.Message]):
             c1
             and isinstance(c1.connected, LifelineItem)
             and not c1.connected.lifetime.visible
-            or c2
+            and c2
             and isinstance(c2.connected, LifelineItem)
             and not c2.connected.lifetime.visible
         )

--- a/gaphor/UML/interactions/tests/test_messageconnect.py
+++ b/gaphor/UML/interactions/tests/test_messageconnect.py
@@ -22,17 +22,6 @@ def test_head_glue(diagram):
     assert glued
 
 
-def test_invisible_lifetime_glue(diagram):
-    """Test message to invisible lifetime glue."""
-    ll = diagram.create(LifelineItem)
-    msg = diagram.create(MessageItem)
-
-    glued = allow(msg, msg.head, ll, ll.lifetime.port)
-
-    assert not ll.lifetime.visible
-    assert not glued
-
-
 def test_visible_lifetime_glue(diagram):
     """Test message to visible lifetime glue."""
     ll = diagram.create(LifelineItem)
@@ -205,81 +194,26 @@ def test_disconnection(diagram):
     assert msg.subject is None, f"{msg.subject}"
 
 
-def test_lifetime_connectivity_on_head(diagram, element_factory):
-    """Test lifeline's lifetime connectivity change on head connection."""
-    ll = diagram.create(LifelineItem, subject=element_factory.create(UML.Lifeline))
-    msg = diagram.create(MessageItem)
+def test_communication_diagram_message_head_glue(diagram):
+    communication = diagram.create(LifelineItem)
+    sequence = diagram.create(LifelineItem)
+    sequence.lifetime.visible = True
+    message = diagram.create(MessageItem)
 
-    # connect message to lifeline's head, lifeline's lifetime
-    # visibility and connectivity should change
-    connect(msg, msg.head, ll)
-    assert not ll.lifetime.visible
-    assert not ll.lifetime.connectable
-    assert ll.lifetime.MIN_LENGTH == ll.lifetime.min_length
+    connect(message, message.tail, sequence)
 
-    # ... and disconnection
-    disconnect(msg, msg.head)
-    assert ll.lifetime.connectable
-    assert ll.lifetime.MIN_LENGTH == ll.lifetime.min_length
+    assert allow(message, message.head, communication, communication.lifetime.port)
 
 
-def test_lifetime_connectivity_on_lifetime(diagram, element_factory):
-    """Test lifeline's lifetime connectivity change on lifetime connection."""
-    ll = diagram.create(LifelineItem, subject=element_factory.create(UML.Lifeline))
-    ll.lifetime.visible = True
-    ll.handles()[-1].pos.y = 500
-    msg = diagram.create(MessageItem)
-    msg.head.pos.y = 400
-
-    # connect message to lifeline's lifetime, lifeline's lifetime
-    # visibility and connectivity should be unchanged
-    connect(msg, msg.head, ll)
-
-    assert diagram.connections.get_connection(msg.head).port is ll.ports()[-1]
-    assert ll.lifetime.connectable
-    assert ll.lifetime.MIN_LENGTH_VISIBLE == ll.lifetime.min_length
-
-    # ... and disconnection
-    disconnect(msg, msg.head)
-    assert ll.lifetime.connectable
-    assert ll.lifetime.visible
-    assert ll.lifetime.MIN_LENGTH == ll.lifetime.min_length
-
-
-def test_message_glue_cd(diagram):
-    """Test gluing message on communication diagram."""
-
+def test_communication_diagram_message_tail_glue(diagram):
     lifeline1 = diagram.create(LifelineItem)
     lifeline2 = diagram.create(LifelineItem)
     message = diagram.create(MessageItem)
 
-    # make second lifeline to be in sequence diagram mode
     lifeline2.lifetime.visible = True
-
-    # connect head of message to lifeline's head
     connect(message, message.head, lifeline1)
 
-    glued = allow(message, message.tail, lifeline2, lifeline2.lifetime.port)
-    # no connection possible as 2nd lifeline is in sequence diagram
-    # mode
-    assert not glued
-
-
-def test_message_glue_sd(diagram):
-    """Test gluing message on sequence diagram."""
-
-    msg = diagram.create(MessageItem)
-    ll1 = diagram.create(LifelineItem)
-    ll2 = diagram.create(LifelineItem)
-
-    # 1st lifeline - communication diagram
-    # 2nd lifeline - sequence diagram
-    ll2.lifetime.visible = True
-
-    # connect lifetime of message to lifeline's lifetime
-    connect(msg, msg.head, ll1, ll1.lifetime.port)
-
-    assert not allow(msg, msg.tail, ll2)
+    assert allow(message, message.tail, lifeline2, lifeline2.lifetime.port)
 
 
 def test_message_glue_from_lifetimee_to_head(diagram):

--- a/gaphor/UML/interactions/tests/test_messageconnect.py
+++ b/gaphor/UML/interactions/tests/test_messageconnect.py
@@ -259,10 +259,22 @@ def test_message_glue_sd(diagram):
     # connect lifetime of message to lifeline's lifetime
     connect(msg, msg.head, ll1, ll1.lifetime.port)
 
-    glued = allow(msg, msg.tail, ll2)
-    # no connection possible as 2nd lifeline is in communication
-    # diagram mode
-    assert not glued
+    assert not allow(msg, msg.tail, ll2)
+
+
+def test_message_glue_from_lifetimee_to_head(diagram):
+    """Test gluing message on communication diagram."""
+
+    lifeline1 = diagram.create(LifelineItem)
+    lifeline2 = diagram.create(LifelineItem)
+    message = diagram.create(MessageItem)
+
+    lifeline1.lifetime.visible = True
+
+    # connect head of message to lifeline's head
+    connect(message, message.head, lifeline1)
+
+    assert allow(message, message.tail, lifeline2, lifeline2.lifetime.port)
 
 
 def test_messages_disconnect_cd(diagram, element_factory):

--- a/gaphor/UML/interactions/tests/test_messageconnect.py
+++ b/gaphor/UML/interactions/tests/test_messageconnect.py
@@ -132,6 +132,26 @@ def test_lifetime_connection(diagram):
     assert msg.subject.messageKind == "complete"
 
 
+def test_lifetime_connect_disconnect(diagram):
+    """Test messages' lifetimes connection."""
+    msg = diagram.create(MessageItem)
+    ll1 = diagram.create(LifelineItem)
+    ll2 = diagram.create(LifelineItem)
+
+    # make lifelines to be in sequence diagram mode
+    ll1.lifetime.visible = True
+    ll2.lifetime.visible = True
+    assert ll1.lifetime.visible and ll2.lifetime.visible
+
+    # connect lifetimes with messages message to lifeline's head
+    connect(msg, msg.head, ll1, ll1.lifetime.port)
+    connect(msg, msg.tail, ll2, ll2.lifetime.port)
+    disconnect(msg, msg.tail)
+
+    assert msg.subject is not None
+    assert msg.subject.messageKind == "lost"
+
+
 @pytest.mark.parametrize("end_name", ["head", "tail"])
 def test_message_is_owned_by_implicit_interaction_connecting_to_head(
     diagram, element_factory, end_name


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Issue Number: #1599 

### What is the new behavior?

* Messages can be connected everywhere on a lifeline object
* The timeline can now always be extracted (used to be blocked when a message was connected to the body)
* Saving and loading has been fixed to support connecting to body as well as timeline
* Only if a message is connected between two lifeline elements without timeline (timeline is collapsed), a communication diagram style message will be shown.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

Timeline length is saved differently.
