### PR TITLE
Support Generic<Type> syntax

### DIFF
--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -27,7 +27,7 @@ mult_subpat = r"\s*(?P<has_mult>\[\s*((?P<mult_l>[0-9]+)\s*\.\.)?\s*(?P<mult_u>(
 multa_subpat = r"\s*(\[?((?P<mult_l>[0-9]+)\s*\.\.)?\s*(?P<mult_u>([0-9]+|\*))\]?)?"
 
 # Type and multiplicity (optional) ::= ':' type
-type_subpat = r"\s*(:\s*(?P<type>[a-zA-Z_]\w*( +\w+| *\| *\w+)*))?"
+type_subpat = r"\s*(:\s*(?P<type>[a-zA-Z_]\w*( +\w+| *\| *\w+| *<[\w\| ]*>)*))?"
 
 # default value (optional) ::= '=' default
 default_subpat = r"\s*(=\s*(?P<default>\S+))?"


### PR DESCRIPTION
For attributes and operations (parameters).

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Currently syntax like `attr: Generic<Type>` is not supported.

Issue Number: #1720

### What is the new behavior?

The `<Type>` bit is parsed as part of the type value. No special meaning is provided. This is the same as it currently works for union types.
