### PR TITLE
macos: Disable DnD for GTK4

### DIFF
--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -5,6 +5,7 @@ This is the toolbox in the lower left of the screen.
 
 import functools
 import logging
+import sys
 from typing import Optional, Tuple
 
 from gi.repository import Gdk, GLib, GObject, Gtk
@@ -119,7 +120,7 @@ class Toolbox(UIComponent):
                 )
                 flowbox.connect("drag-begin", _flowbox_drag_begin)
                 flowbox.connect("drag-data-get", _flowbox_drag_data_get)
-            else:
+            elif sys.platform != "darwin":
                 drag_source = Gtk.DragSource.new()
                 drag_source.connect("prepare", _flowbox_drag_prepare)
                 flowbox.add_controller(drag_source)

--- a/gaphor/ui/treecomponent.py
+++ b/gaphor/ui/treecomponent.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 from gi.repository import Gdk, GLib, GObject, Gtk
 
 from gaphor import UML
@@ -354,11 +356,12 @@ def list_item_factory_setup(_factory, list_item, event_manager, modeling_languag
     ctrl.connect("pressed", on_show_popup)
     row.add_controller(ctrl)
 
-    drag_source = Gtk.DragSource.new()
-    drag_source.set_actions(Gdk.DragAction.MOVE | Gdk.DragAction.COPY)
-    drag_source.connect("prepare", list_item_drag_prepare, list_item)
-    drag_source.connect("drag-begin", list_item_drag_begin, list_item)
-    row.add_controller(drag_source)
+    if sys.platform != "darwin":
+        drag_source = Gtk.DragSource.new()
+        drag_source.set_actions(Gdk.DragAction.MOVE | Gdk.DragAction.COPY)
+        drag_source.connect("prepare", list_item_drag_prepare, list_item)
+        drag_source.connect("drag-begin", list_item_drag_begin, list_item)
+        row.add_controller(drag_source)
 
     drop_target = Gtk.DropTarget.new(ElementDragData.__gtype__, Gdk.DragAction.COPY)
     drop_target.set_preload(True)


### PR DESCRIPTION
On GTK4/macos DnD does not work. It makes the IU block. Therefore it may be better to disable DnD on macOS, at least until it's properly working.
