### PR TITLE
Prevent deleting an element in a diagram also deleting the diagram itself

### DIFF
--- a/gaphor/diagram/tools/__init__.py
+++ b/gaphor/diagram/tools/__init__.py
@@ -58,6 +58,6 @@ def apply_placement_tool_set(
 def add_basic_tools(view, modeling_language, event_manager):
     view.add_controller(zoom_tool(view))
     view.add_controller(view_focus_tool(view))
-    view.add_controller(shortcut_tool(view, modeling_language, event_manager))
+    view.add_controller(shortcut_tool(view, event_manager))
     if Gtk.get_major_version() != 3:
         view.add_controller(drop_target_tool(modeling_language, event_manager))

--- a/gaphor/diagram/tools/shortcut.py
+++ b/gaphor/diagram/tools/shortcut.py
@@ -2,7 +2,7 @@ from gaphas.view import GtkView
 from gi.repository import Gdk, Gtk
 
 from gaphor.core import Transaction
-from gaphor.core.modeling import Presentation
+from gaphor.core.modeling import Presentation, self_and_owners
 
 
 def shortcut_tool(view, event_manager):
@@ -33,7 +33,7 @@ def delete_selected_items(view: GtkView, event_manager):
     with Transaction(event_manager):
         items = view.selection.selected_items
         for i in list(items):
-            if isinstance(i, Presentation):
-                i.unlink()
-            elif i.diagram:
-                i.diagram.remove(i)
+            assert isinstance(i, Presentation)
+            if i.subject and i.subject in self_and_owners(i.diagram):
+                del i.diagram.element
+            i.unlink()

--- a/gaphor/diagram/tools/shortcut.py
+++ b/gaphor/diagram/tools/shortcut.py
@@ -5,7 +5,7 @@ from gaphor.core import Transaction
 from gaphor.core.modeling import Presentation
 
 
-def shortcut_tool(view, modeling_language, event_manager):
+def shortcut_tool(view, event_manager):
     if Gtk.get_major_version() == 3:
         ctrl = Gtk.EventControllerKey.new(view)
     else:

--- a/gaphor/diagram/tools/tests/test_shortcut.py
+++ b/gaphor/diagram/tools/tests/test_shortcut.py
@@ -1,0 +1,32 @@
+from gaphas.selection import Selection
+
+from gaphor import UML
+from gaphor.diagram.tools.shortcut import delete_selected_items
+from gaphor.UML.diagramitems import PackageItem
+
+
+class MockView:
+    def __init__(self):
+        self.selection = Selection()
+
+
+def test_delete_selected_items(create, diagram, event_manager):
+    package_item = create(PackageItem, UML.Package)
+    view = MockView()
+    view.selection.select_items(package_item)
+
+    delete_selected_items(view, event_manager)
+
+    assert not diagram.ownedPresentation
+
+
+def test_delete_selected_owner(create, diagram, event_manager):
+    package_item = create(PackageItem, UML.Package)
+    diagram.element = package_item.subject
+    view = MockView()
+    view.selection.select_items(package_item)
+
+    delete_selected_items(view, event_manager)
+
+    assert not diagram.ownedPresentation
+    assert diagram.element is None


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

A diagram can be automatically deleted when you delete an item that's also an owner of the diagram. Although this is correct, according to Gaphor's inner workings, it's quite surprising for a user to see his diagram gone spontaneously.

Issue Number: #1747

### What is the new behavior?

The diagram is moved to toplevel before the owner element is removed. This avoids surprising removal.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

I initially tried to fix it in the `SanitizerService`. However, then we should determine what to do while the item is halfway unlinking. Then it's not possible to determine if an element is an owner element reliably.
