### PR TITLE
namespace.py: Actually set properties for rectangle

### DIFF
--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -202,8 +202,12 @@ class Namespace(UIComponent, ActionProvider):
             menu = Gtk.PopoverMenu.new_from_model(
                 popup_model(selected_element, self.modeling_language)
             )
-            menu.set_pointing_to(Gdk.Rectangle(x, y, 1, 1))
-            menu.set_offset(x, y)
+            gdk_rect = Gdk.Rectangle()
+            gdk_rect.x = x
+            gdk_rect.y = y
+            gdk_rect.width = gdk_rect.height = 1
+
+            menu.set_pointing_to(gdk_rect)
             menu.set_has_arrow(False)
             menu.set_parent(self.view)
             menu.popup()


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Gdk.Rectangle doesn't accept arguments, which resulted in the coordinates and width/height not being set.

Issue Number: N/A

### What is the new behavior?

These properties are now set. As a result of this change, 'set_offset' is no longer required.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->