### PR TITLE
Fail CI build if Windows certificate signing fails

### DIFF
--- a/.github/actions/windows_executables/action.yml
+++ b/.github/actions/windows_executables/action.yml
@@ -46,7 +46,13 @@ runs:
         $certificatePath = Join-Path -Path $currentDirectory -ChildPath 'certificate.pfx'
         [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
         & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe' sign /f 'certificate.pfx' /tr $env:timestampUrl /td sha256 /fd sha256 /p $env:password $env:installer $env:portable
-        Remove-Item 'certificate.pfx'
+        if (0 -eq $LASTEXITCODE) {
+          Remove-Item 'certificate.pfx'
+        } else {
+          Remove-Item 'certificate.pfx'
+          "Signing failed"
+          Exit 1
+        }
       shell: PowerShell
     - name: Upload gaphor-${{ inputs.version }}-installer.exe
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
I have updated the project secrets with the new PFX file and updated password for the Windows certificate. The new cert is good until 2025-10-04, so we need to order a new one beginning of September.

The certificate signing was previously failing semi-silently, where it gave an error but didn't cause the build to fail. This PR fixes this by forcing an Exit 1 if the signing fails.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Windows binaries are unsigned

Issue Number: #1756 

### What is the new behavior?
Windows binaries are now signed

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

### Other information
