### PR TITLE
Fix key modifiers for delete element shortcut

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -44,7 +44,7 @@ sudo apt-get install -y python3-dev python3-gi python3-gi-cairo
 gir1.2-gtk-4.0 libgirepository1.0-dev libcairo2-dev libgtksourceview-5-dev
 ```
 
-Install Poetry using [pipx](https://pypa.github.io/pipx/):
+Install [Poetry](https://python-poetry.org) using [pipx](https://pypa.github.io/pipx/):
 ```bash
 pipx install poetry
 ```
@@ -60,6 +60,14 @@ poetry env use 3.x # ensures poetry /consistently/ uses latest major release
 poetry config virtualenvs.in-project true
 poetry install
 poetry run gaphor
+```
+
+NOTE: Gaphor starts with a GTK 4 UI by default. It works best with GTK >=4.8 and libadwaita >=1.2.
+
+To start with a GTK+3 UI, run:
+
+```bash
+GAPHOR_USE_GTK=3 poetry run gaphor
 ```
 
 ## Create a Flatpak Package
@@ -81,7 +89,7 @@ repository](https://github.com/flathub/org.gaphor.Gaphor).
 
 1. Install the GNOME SDK
 
-       flatpak install flathub org.gnome.Sdk 42
+       flatpak install flathub org.gnome.Sdk 43
 
 1. Clone the Flathub repository and install the necessary SDK:
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,6 +1,6 @@
 # Gaphor on macOS
 
-The latest release of Gaphor can be downloaded from the [Gaphor download page](https://gaphor.org/download.html#macos).
+The latest release of Gaphor can be downloaded from the [Gaphor download page](https://gaphor.org/download.html#macos). Gaphor can also be installed as a [Homebrew cask](https://formulae.brew.sh/cask/gaphor).
 
 Older releases are available from [GitHub](https://github.com/gaphor/gaphor/releases).
 
@@ -10,12 +10,12 @@ Older releases are available from [GitHub](https://github.com/gaphor/gaphor/rele
 ## Development Environment
 
 To setup a development environment with macOS:
-1. Install [homebrew](https://brew.sh)
+1. Install [Homebrew](https://brew.sh)
 1. Open a terminal and execute:
 ```bash
 brew install python3 gobject-introspection gtk+3 gtksourceview4 adwaita-icon-theme gtk-mac-integration
 ```
-Install Poetry using [pipx](https://pypa.github.io/pipx/):
+Install [Poetry](https://python-poetry.org) using [pipx](https://pypa.github.io/pipx/):
 ```bash
 pipx install poetry
 ```

--- a/gaphor/diagram/tools/shortcut.py
+++ b/gaphor/diagram/tools/shortcut.py
@@ -21,9 +21,7 @@ def on_delete(ctrl, keyval, keycode, state, event_manager):
     otherwise this key will confuse the text edit stuff.
     """
     view: GtkView = ctrl.get_widget()
-    if keyval in (Gdk.KEY_Delete, Gdk.KEY_BackSpace) and (
-        state == 0 or state & Gdk.ModifierType.MOD2_MASK
-    ):
+    if keyval in (Gdk.KEY_Delete, Gdk.KEY_BackSpace):
         delete_selected_items(view, event_manager)
         return True
     return False


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

1. When deleting, it checks if there are no modifiers or the META modifier is pressed. However, keys like _caps lock_ and _scroll lock_ are also modifiers -> deletion will not work.
2. The modifier masdk `MOD2_MASK` is no longer available in GTK4.

Issue Number: #1788 

### What is the new behavior?

The Delete element shortcut works without checking modifier keys.

### Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
