### PR TITLE
Update gvsbuild to 2022.4.1 to fix zlib error

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -257,9 +257,9 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
     env:
-      gvsbuild_version: 2022.4.0
+      gvsbuild_version: 2022.4.1
       # Bump this number if you want to force a rebuild of gvsbuild with the same revision
-      gvsbuild_update: 3
+      gvsbuild_update: 1
     outputs:
       cachekey: ${{ steps.output.outputs.cachekey }}
     steps:


### PR DESCRIPTION
Our build was failing due to a zlib download error. This PR updates to the new version which uses a zlib link that won't if a new version is released.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Build is failing

Issue Number: N/A

### What is the new behavior?
Build is passing

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
