### PR TITLE
Update Message Dialogs to libadwaita

### DIFF
--- a/gaphor/ui/appfilemanager.py
+++ b/gaphor/ui/appfilemanager.py
@@ -3,6 +3,11 @@ import os.path
 
 from gi.repository import Gtk
 
+if Gtk.get_major_version() == 4:
+    from gi.repository import Adw
+
+from pathlib import Path
+
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import action, gettext
 from gaphor.ui.filedialog import open_file_dialog
@@ -40,24 +45,44 @@ class AppFileManager(Service, ActionProvider):
         def open_files(filenames):
             for filename in filenames:
                 if self.application.has_session(filename):
-                    dialog = Gtk.MessageDialog(
-                        message_type=Gtk.MessageType.QUESTION,
-                        buttons=Gtk.ButtonsType.YES_NO,
-                        text=gettext(
-                            "{filename} is already opened. Do you want to switch to the opened window instead?"
-                        ).format(filename=filename),
-                    )
-                    dialog.set_transient_for(self.parent_window)
+                    name = Path(filename).name
+                    title = gettext("Switch to {name}?").format(name=name)
+                    body = gettext(
+                        "{name} is already opened. Do you want to switch to the opened window instead?"
+                    ).format(name=name)
+                    if Gtk.get_major_version() == 3:
+                        dialog = Gtk.MessageDialog(
+                            message_type=Gtk.MessageType.QUESTION,
+                            buttons=Gtk.ButtonsType.YES_NO,
+                            text=title,
+                            secondary_text=body,
+                        )
+                        dialog.set_transient_for(self.parent_window)
+
+                        dialog.set_modal(True)
+                    else:
+                        dialog = Adw.MessageDialog.new(
+                            self.parent_window,
+                            title,
+                        )
+                        dialog.set_body(body)
+                        dialog.add_response("open", gettext("Open Again"))
+                        dialog.add_response("switch", gettext("Switch"))
+                        dialog.set_response_appearance(
+                            "switch", Adw.ResponseAppearance.SUGGESTED
+                        )
+                        dialog.set_default_response("switch")
+                        dialog.set_close_response("open")
 
                     def response(dialog, answer):
-                        force_new_session = answer != Gtk.ResponseType.YES
+                        # Gtk.ResponseType.NO is for GTK3, open is for GTK4
+                        force_new_session = answer in [Gtk.ResponseType.NO, "open"]
                         dialog.destroy()
                         self.application.new_session(
                             filename=filename, force=force_new_session
                         )
 
                     dialog.connect("response", response)
-                    dialog.set_modal(True)
                     dialog.show()
                 else:
                     self.application.new_session(filename=filename)

--- a/gaphor/ui/errorhandler.py
+++ b/gaphor/ui/errorhandler.py
@@ -19,7 +19,7 @@ from gaphor.i18n import gettext
 def error_handler(message, secondary_message="", window=None):
     exc_type, exc_value, exc_traceback = sys.exc_info()
 
-    debug_message = (f"{secondary_message}\n\n" if secondary_message else "") + gettext(
+    body = (f"{secondary_message}\n\n" if secondary_message else "") + gettext(
         "It looks like Gaphor is started from the command line. Do you want to open a debug session?"
     )
     if Gtk.get_major_version() == 3:
@@ -27,7 +27,7 @@ def error_handler(message, secondary_message="", window=None):
         dialog.set_transient_for(window)
 
         if __debug__ and exc_traceback and sys.stdin.isatty():
-            dialog.props.secondary_text = debug_message
+            dialog.props.secondary_text = body
             dialog.add_buttons(gettext("Close"), 0, gettext("Start Debug Session"), 100)
         else:
             dialog.props.secondary_text = secondary_message
@@ -38,7 +38,7 @@ def error_handler(message, secondary_message="", window=None):
             window,
             message,
         )
-        dialog.set_body(debug_message)
+        dialog.set_body(body)
         if __debug__ and exc_traceback and sys.stdin.isatty():
             dialog.add_response("close", gettext("Close"))
             dialog.add_response("debug", gettext("Start Debug Session"))

--- a/gaphor/ui/errorhandler.py
+++ b/gaphor/ui/errorhandler.py
@@ -1,7 +1,7 @@
 """A generic way to handle errors in GUI applications.
 
 This module also contains a ErrorHandlerAspect, which can be easily
-attached to a class' method and will raise the error dialog when the
+attached to a class method and will raise the error dialog when the
 method exits with an exception.
 """
 
@@ -10,31 +10,48 @@ import sys
 
 from gi.repository import Gtk
 
+if Gtk.get_major_version() == 4:
+    from gi.repository import Adw
+
 from gaphor.i18n import gettext
 
 
 def error_handler(message, secondary_message="", window=None):
     exc_type, exc_value, exc_traceback = sys.exc_info()
 
-    dialog = Gtk.MessageDialog(message_type=Gtk.MessageType.ERROR, text=message)
-    dialog.set_transient_for(window)
+    debug_message = (f"{secondary_message}\n\n" if secondary_message else "") + gettext(
+        "It looks like Gaphor is started from the command line. Do you want to open a debug session?"
+    )
+    if Gtk.get_major_version() == 3:
+        dialog = Gtk.MessageDialog(message_type=Gtk.MessageType.ERROR, text=message)
+        dialog.set_transient_for(window)
 
-    if __debug__ and exc_traceback and sys.stdin.isatty():
-        dialog.props.secondary_text = (
-            f"{secondary_message}\n\n" if secondary_message else ""
-        ) + gettext(
-            "It looks like Gaphor is started from the command line. Do you want to open a debug session?"
-        )
-        dialog.add_buttons(gettext("Close"), 0, gettext("Start debug session"), 100)
+        if __debug__ and exc_traceback and sys.stdin.isatty():
+            dialog.props.secondary_text = debug_message
+            dialog.add_buttons(gettext("Close"), 0, gettext("Start Debug Session"), 100)
+        else:
+            dialog.props.secondary_text = secondary_message
+            dialog.add_button(gettext("Close"), 0)
+        dialog.set_modal(True)
     else:
-        dialog.props.secondary_text = secondary_message
-        dialog.add_button(gettext("Close"), 0)
+        dialog = Adw.MessageDialog.new(
+            window,
+            message,
+        )
+        dialog.set_body(debug_message)
+        if __debug__ and exc_traceback and sys.stdin.isatty():
+            dialog.add_response("close", gettext("Close"))
+            dialog.add_response("debug", gettext("Start Debug Session"))
+            dialog.set_default_response("debug")
+        else:
+            dialog.add_response("close", gettext("Close"))
+            dialog.set_default_response("close")
+        dialog.set_close_response("close")
 
     def response(dialog, answer):
         dialog.destroy()
-        if exc_traceback and answer == 100:
+        if exc_traceback and answer in [100, "debug"]:
             pdb.post_mortem(exc_traceback)
 
     dialog.connect("response", response)
-    dialog.set_modal(True)
     dialog.show()


### PR DESCRIPTION
This PR uses one of the new features in libadwaita 1.2 to update the Message Dialogs.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Gaphor uses Gtk.MessageDialogs for asking the user a question:
![image](https://user-images.githubusercontent.com/10014976/197420006-1ed931cd-73f5-450b-8d32-d5947543f362.png)
![image](https://user-images.githubusercontent.com/10014976/197420036-2f57a931-3689-4ba6-87dc-27d459ee1da1.png)
![image](https://user-images.githubusercontent.com/10014976/197420066-b432758e-3ea0-482b-b63f-f52332e8cd48.png)

Issue Number: N/A

### What is the new behavior?
Gaphor uses the new Adw.MessageDialogs:
![image](https://user-images.githubusercontent.com/10014976/197419912-2213c39e-4ec6-41b3-a51a-24078dd9eb24.png)
![image](https://user-images.githubusercontent.com/10014976/197419950-52b99b6d-7910-4f19-8bce-bc3021ade713.png)
![image](https://user-images.githubusercontent.com/10014976/197419933-60a79e78-edad-43c4-8a4a-9afaceb8893b.png)


### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

### Other information
This requires GNOME 43 and libadwaita 1.2
