### PR TITLE
Disable Recent files if no recent files are present

### DIFF
--- a/gaphor/ui/tests/test_greeter.py
+++ b/gaphor/ui/tests/test_greeter.py
@@ -47,4 +47,4 @@ def test_greeter_with_no_recent_files(event_manager):
     widget = greeter.greeter
     stack = find(widget, "stack")
 
-    assert stack.get_visible_child_name() == "new-model"
+    assert stack.get_visible_child_name() == "recent-files"


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The "Recent Models..." option is always enabled in the menu, even if no recent files are available. It opens the new model dialog which is confusing.

Issue Number: #1829 

### What is the new behavior?

The menu entry is disabled if no recent files are present.

You can test this by removing all recently opened Gaphor files from the "Recent" page in the file explorer (Nautilus).

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
