### PR TITLE
Load GI modules lazily for modeling languages

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -46,7 +46,6 @@ In versions before 2.13, an `EventManager` is required. In later versions, the
 
 
 ```{code-cell} ipython3
-from sphinx.ext.autodoc.mock import mock
 from gaphor.core.eventmanager import EventManager
 from gaphor.services.modelinglanguage import ModelingLanguageService
 from gaphor.storage import storage
@@ -54,8 +53,7 @@ from gaphor.storage import storage
 event_manager = EventManager()
 
 # Avoid loading GTK by using Sphinx’s mock function
-with mock(["gi.repository.Gtk", "gi.repository.Gdk"]):
-    modeling_language = ModelingLanguageService(event_manager=event_manager)
+modeling_language = ModelingLanguageService(event_manager=event_manager)
 
 storage.load(
     "../models/Core.gaphor",

--- a/gaphor/UML/actions/__init__.py
+++ b/gaphor/UML/actions/__init__.py
@@ -2,7 +2,7 @@ from gaphor.UML.actions import (
     actionseditors,
     actionsgroup,
     actionspropertypages,
-    activityconnect,
+    # activityconnect,
     activitypropertypage,
     copypaste,
     flowconnect,

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -1,9 +1,5 @@
-from gaphor import UML
-from gaphor.core import transactional
-from gaphor.core.format import format, parse
 from gaphor.diagram.hoversupport import widget_add_hover_support
 from gaphor.diagram.propertypages import (
-    EditableTreeModel,
     PropertyPageBase,
     PropertyPages,
     help_link,
@@ -17,43 +13,6 @@ from gaphor.UML.classes.classespropertypages import on_keypress_event
 new_builder = new_resource_builder("gaphor.UML.actions")
 
 
-class ActivityParameters(EditableTreeModel):
-    """GTK tree model to edit class attributes."""
-
-    def __init__(self, item):
-        super().__init__(item, cols=(str, object))
-
-    def get_rows(self):
-        for node in self._item.subject.node:
-            if isinstance(node, UML.ActivityParameterNode):
-                yield [format(node.parameter), node]
-
-    def create_object(self):
-        model = self._item.model
-        node = model.create(UML.ActivityParameterNode)
-        node.parameter = model.create(UML.Parameter)
-        self._item.subject.node = node
-        return node
-
-    @transactional
-    def set_object_value(self, row, col, value):
-        node = row[-1]
-        if col == 0:
-            parse(node.parameter, value)
-            row[0] = format(node.parameter)
-        elif col == 1:
-            # Value in attribute object changed:
-            row[0] = format(node.parameter)
-
-    def swap_objects(self, o1, o2):
-        return self._item.subject.node.swap(o1, o2)
-
-    def sync_model(self, new_order):
-        self._item.subject.node.order(
-            lambda key: new_order.index(key) if key in new_order else -1
-        )
-
-
 @PropertyPages.register(ActivityItem)
 class ActivityItemPage(PropertyPageBase):
 
@@ -64,6 +23,8 @@ class ActivityItemPage(PropertyPageBase):
         self.watcher = item.subject and item.subject.watcher()
 
     def construct(self):
+        from gaphor.UML.actions.gtkmodels import ActivityParameters
+
         subject = self.item.subject
 
         if not subject:

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -1,5 +1,3 @@
-from gi.repository import Gtk
-
 from gaphor import UML
 from gaphor.core import transactional
 from gaphor.core.format import format, parse
@@ -12,6 +10,7 @@ from gaphor.diagram.propertypages import (
     new_resource_builder,
     on_text_cell_edited,
 )
+from gaphor.lazygi import Gtk
 from gaphor.UML.actions.activity import ActivityItem
 from gaphor.UML.classes.classespropertypages import on_keypress_event
 

--- a/gaphor/UML/actions/gtkmodels.py
+++ b/gaphor/UML/actions/gtkmodels.py
@@ -1,0 +1,41 @@
+from gaphor import UML
+from gaphor.core.format import format, parse
+from gaphor.diagram.gtkmodels import EditableTreeModel
+from gaphor.transaction import transactional
+
+
+class ActivityParameters(EditableTreeModel):
+    """GTK tree model to edit class attributes."""
+
+    def __init__(self, item):
+        super().__init__(item, cols=(str, object))
+
+    def get_rows(self):
+        for node in self._item.subject.node:
+            if isinstance(node, UML.ActivityParameterNode):
+                yield [format(node.parameter), node]
+
+    def create_object(self):
+        model = self._item.model
+        node = model.create(UML.ActivityParameterNode)
+        node.parameter = model.create(UML.Parameter)
+        self._item.subject.node = node
+        return node
+
+    @transactional
+    def set_object_value(self, row, col, value):
+        node = row[-1]
+        if col == 0:
+            parse(node.parameter, value)
+            row[0] = format(node.parameter)
+        elif col == 1:
+            # Value in attribute object changed:
+            row[0] = format(node.parameter)
+
+    def swap_objects(self, o1, o2):
+        return self._item.subject.node.swap(o1, o2)
+
+    def sync_model(self, new_order):
+        self._item.subject.node.order(
+            lambda key: new_order.index(key) if key in new_order else -1
+        )

--- a/gaphor/UML/actions/partitionpage.py
+++ b/gaphor/UML/actions/partitionpage.py
@@ -1,7 +1,3 @@
-"""Activity partition property page."""
-
-from gi.repository import Gtk
-
 from gaphor import UML
 from gaphor.core import gettext, transactional
 from gaphor.diagram.propertypages import (
@@ -10,6 +6,7 @@ from gaphor.diagram.propertypages import (
     combo_box_text_auto_complete,
     new_resource_builder,
 )
+from gaphor.lazygi import Gtk
 from gaphor.UML.actions.partition import PartitionItem
 
 new_builder = new_resource_builder("gaphor.UML.actions")

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -1,9 +1,8 @@
-from gi.repository import Gtk
-
 from gaphor import UML
 from gaphor.core.format import format, parse
 from gaphor.diagram.hoversupport import widget_add_hover_support
 from gaphor.diagram.propertypages import PropertyPageBase, PropertyPages, help_link
+from gaphor.lazygi import Gtk
 from gaphor.transaction import transactional
 from gaphor.UML.classes.association import AssociationItem
 from gaphor.UML.classes.classespropertypages import new_builder

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -2,10 +2,9 @@ import logging
 
 from gaphor import UML
 from gaphor.core import gettext, transactional
-from gaphor.core.format import format, parse
+from gaphor.core.format import format
 from gaphor.diagram.hoversupport import widget_add_hover_support
 from gaphor.diagram.propertypages import (
-    EditableTreeModel,
     PropertyPageBase,
     PropertyPages,
     handler_blocking,
@@ -45,122 +44,6 @@ def on_keypress_event(ctrl, keyval, keycode, state, tree):
         model.swap(iter, model.iter_previous(iter))
         return True
     return False
-
-
-class ClassAttributes(EditableTreeModel):
-    """GTK tree model to edit class attributes."""
-
-    def __init__(self, item):
-        super().__init__(item, cols=(str, bool, object))
-
-    def get_rows(self):
-        for attr in self._item.subject.ownedAttribute:
-            if not attr.association:
-                yield [format(attr, note=True), attr.isStatic, attr]
-
-    def create_object(self):
-        attr = self._item.model.create(UML.Property)
-        self._item.subject.ownedAttribute = attr
-        return attr
-
-    @transactional
-    def set_object_value(self, row, col, value):
-        attr = row[-1]
-        if col == 0:
-            parse(attr, value)
-            row[0] = format(attr, note=True)
-        elif col == 1:
-            attr.isStatic = not attr.isStatic
-            row[1] = attr.isStatic
-        elif col == 2:
-            # Value in attribute object changed:
-            row[0] = format(attr, note=True)
-            row[1] = attr.isStatic
-
-    def swap_objects(self, o1, o2):
-        return self._item.subject.ownedAttribute.swap(o1, o2)
-
-    def sync_model(self, new_order):
-        self._item.subject.ownedAttribute.order(
-            lambda e: new_order.index(e) if e in new_order else len(new_order)
-        )
-
-
-class ClassOperations(EditableTreeModel):
-    """GTK tree model to edit class operations."""
-
-    def __init__(self, item):
-        super().__init__(item, cols=(str, bool, bool, object))
-
-    def get_rows(self):
-        for operation in self._item.subject.ownedOperation:
-            yield [
-                format(operation, note=True),
-                operation.isAbstract,
-                operation.isStatic,
-                operation,
-            ]
-
-    def create_object(self):
-        operation = self._item.model.create(UML.Operation)
-        self._item.subject.ownedOperation = operation
-        return operation
-
-    @transactional
-    def set_object_value(self, row, col, value):
-        operation = row[-1]
-        if col == 0:
-            parse(operation, value)
-            row[0] = format(operation, note=True)
-        elif col == 1:
-            operation.isAbstract = not operation.isAbstract
-            row[1] = operation.isAbstract
-        elif col == 2:
-            operation.isStatic = not operation.isStatic
-            row[2] = operation.isStatic
-        elif col == 3:
-            row[0] = format(operation, note=True)
-            row[1] = operation.isAbstract
-            row[2] = operation.isStatic
-
-    def swap_objects(self, o1, o2):
-        return self._item.subject.ownedOperation.swap(o1, o2)
-
-    def sync_model(self, new_order):
-        self._item.subject.ownedOperation.order(new_order.index)
-
-
-class ClassEnumerationLiterals(EditableTreeModel):
-    """GTK tree model to edit enumeration literals."""
-
-    def __init__(self, item):
-        super().__init__(item, cols=(str, object))
-
-    def get_rows(self):
-        for literal in self._item.subject.ownedLiteral:
-            yield [format(literal), literal]
-
-    def create_object(self):
-        literal = self._item.model.create(UML.EnumerationLiteral)
-        self._item.subject.ownedLiteral = literal
-        literal.enumeration = self._item.subject
-        return literal
-
-    @transactional
-    def set_object_value(self, row, col, value):
-        literal = row[-1]
-        if col == 0:
-            parse(literal, value)
-            row[0] = format(literal)
-        elif col == 1:
-            # Value in attribute object changed:
-            row[0] = format(literal)
-
-    def swap_objects(self, o1, o2):
-        return self._item.subject.ownedLiteral.swap(o1, o2)
-
-    def sync_model(self, new_order):
-        self._item.subject.ownedLiteral.order(new_order.index)
 
 
 def tree_view_column_tooltips(tree_view, tooltips):
@@ -309,6 +192,8 @@ class AttributesPage(PropertyPageBase):
         self.watcher = item.subject and item.subject.watcher()
 
     def construct(self):
+        from gaphor.UML.classes.gtkmodels import ClassAttributes
+
         if not self.item.subject:
             return
 
@@ -394,6 +279,8 @@ class OperationsPage(PropertyPageBase):
         self.watcher = item.subject and item.subject.watcher()
 
     def construct(self):
+        from gaphor.UML.classes.gtkmodels import ClassOperations
+
         if not self.item.subject:
             return
 

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -1,7 +1,5 @@
 import logging
 
-from gi.repository import Gdk, Gtk
-
 from gaphor import UML
 from gaphor.core import gettext, transactional
 from gaphor.core.format import format, parse
@@ -16,6 +14,7 @@ from gaphor.diagram.propertypages import (
     on_bool_cell_edited,
     on_text_cell_edited,
 )
+from gaphor.lazygi import Gdk, Gtk
 from gaphor.UML.classes.datatype import DataTypeItem
 from gaphor.UML.classes.interface import Folded, InterfaceItem
 from gaphor.UML.classes.klass import ClassItem

--- a/gaphor/UML/classes/dependencypropertypages.py
+++ b/gaphor/UML/classes/dependencypropertypages.py
@@ -1,5 +1,5 @@
 from gaphor import UML
-from gaphor.diagram.propertypages import ComboModel, PropertyPageBase, PropertyPages
+from gaphor.diagram.propertypages import PropertyPageBase, PropertyPages
 from gaphor.i18n import gettext
 from gaphor.transaction import transactional
 from gaphor.UML.classes.classespropertypages import new_builder
@@ -33,6 +33,8 @@ class DependencyPropertyPage(PropertyPageBase):
         )
 
     def construct(self):
+        from gaphor.diagram.gtkmodels import ComboModel
+
         dependency_combo = self.builder.get_object("dependency-combo")
         model = ComboModel(self.DEPENDENCY_TYPES)
         dependency_combo.set_model(model)

--- a/gaphor/UML/classes/enumerationpropertypages.py
+++ b/gaphor/UML/classes/enumerationpropertypages.py
@@ -11,7 +11,6 @@ from gaphor.lazygi import Gtk
 from gaphor.transaction import transactional
 from gaphor.UML.classes.classespropertypages import (
     AttributesPage,
-    ClassEnumerationLiterals,
     OperationsPage,
     new_resource_builder,
     on_keypress_event,
@@ -33,6 +32,8 @@ class EnumerationPage(PropertyPageBase):
         self.watcher = item.subject and item.subject.watcher()
 
     def construct(self):
+        from gaphor.UML.classes.gtkmodels import ClassEnumerationLiterals
+
         if not isinstance(self.item.subject, UML.Enumeration):
             return
 

--- a/gaphor/UML/classes/enumerationpropertypages.py
+++ b/gaphor/UML/classes/enumerationpropertypages.py
@@ -1,5 +1,3 @@
-from gi.repository import Gtk
-
 from gaphor import UML
 from gaphor.core.format import format
 from gaphor.diagram.hoversupport import widget_add_hover_support
@@ -9,6 +7,7 @@ from gaphor.diagram.propertypages import (
     help_link,
     on_text_cell_edited,
 )
+from gaphor.lazygi import Gtk
 from gaphor.transaction import transactional
 from gaphor.UML.classes.classespropertypages import (
     AttributesPage,

--- a/gaphor/UML/classes/gtkmodels.py
+++ b/gaphor/UML/classes/gtkmodels.py
@@ -1,0 +1,126 @@
+"""GTK-based types.
+
+Thos module is normally imported in the method where it's used to avoid
+the need for a global import of GTK.
+"""
+
+from gaphor import UML
+from gaphor.core.format import format, parse
+from gaphor.diagram.gtkmodels import EditableTreeModel
+from gaphor.transaction import transactional
+
+
+class ClassAttributes(EditableTreeModel):
+    """GTK tree model to edit class attributes."""
+
+    def __init__(self, item):
+        super().__init__(item, cols=(str, bool, object))
+
+    def get_rows(self):
+        for attr in self._item.subject.ownedAttribute:
+            if not attr.association:
+                yield [format(attr, note=True), attr.isStatic, attr]
+
+    def create_object(self):
+        attr = self._item.model.create(UML.Property)
+        self._item.subject.ownedAttribute = attr
+        return attr
+
+    @transactional
+    def set_object_value(self, row, col, value):
+        attr = row[-1]
+        if col == 0:
+            parse(attr, value)
+            row[0] = format(attr, note=True)
+        elif col == 1:
+            attr.isStatic = not attr.isStatic
+            row[1] = attr.isStatic
+        elif col == 2:
+            # Value in attribute object changed:
+            row[0] = format(attr, note=True)
+            row[1] = attr.isStatic
+
+    def swap_objects(self, o1, o2):
+        return self._item.subject.ownedAttribute.swap(o1, o2)
+
+    def sync_model(self, new_order):
+        self._item.subject.ownedAttribute.order(
+            lambda e: new_order.index(e) if e in new_order else len(new_order)
+        )
+
+
+class ClassOperations(EditableTreeModel):
+    """GTK tree model to edit class operations."""
+
+    def __init__(self, item):
+        super().__init__(item, cols=(str, bool, bool, object))
+
+    def get_rows(self):
+        for operation in self._item.subject.ownedOperation:
+            yield [
+                format(operation, note=True),
+                operation.isAbstract,
+                operation.isStatic,
+                operation,
+            ]
+
+    def create_object(self):
+        operation = self._item.model.create(UML.Operation)
+        self._item.subject.ownedOperation = operation
+        return operation
+
+    @transactional
+    def set_object_value(self, row, col, value):
+        operation = row[-1]
+        if col == 0:
+            parse(operation, value)
+            row[0] = format(operation, note=True)
+        elif col == 1:
+            operation.isAbstract = not operation.isAbstract
+            row[1] = operation.isAbstract
+        elif col == 2:
+            operation.isStatic = not operation.isStatic
+            row[2] = operation.isStatic
+        elif col == 3:
+            row[0] = format(operation, note=True)
+            row[1] = operation.isAbstract
+            row[2] = operation.isStatic
+
+    def swap_objects(self, o1, o2):
+        return self._item.subject.ownedOperation.swap(o1, o2)
+
+    def sync_model(self, new_order):
+        self._item.subject.ownedOperation.order(new_order.index)
+
+
+class ClassEnumerationLiterals(EditableTreeModel):
+    """GTK tree model to edit enumeration literals."""
+
+    def __init__(self, item):
+        super().__init__(item, cols=(str, object))
+
+    def get_rows(self):
+        for literal in self._item.subject.ownedLiteral:
+            yield [format(literal), literal]
+
+    def create_object(self):
+        literal = self._item.model.create(UML.EnumerationLiteral)
+        self._item.subject.ownedLiteral = literal
+        literal.enumeration = self._item.subject
+        return literal
+
+    @transactional
+    def set_object_value(self, row, col, value):
+        literal = row[-1]
+        if col == 0:
+            parse(literal, value)
+            row[0] = format(literal)
+        elif col == 1:
+            # Value in attribute object changed:
+            row[0] = format(literal)
+
+    def swap_objects(self, o1, o2):
+        return self._item.subject.ownedLiteral.swap(o1, o2)
+
+    def sync_model(self, new_order):
+        self._item.subject.ownedLiteral.order(new_order.index)

--- a/gaphor/UML/classes/tests/test_classespropertypages.py
+++ b/gaphor/UML/classes/tests/test_classespropertypages.py
@@ -4,13 +4,13 @@ from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
 from gaphor.UML.classes.classespropertypages import (
     AttributesPage,
-    ClassAttributes,
     ClassifierPropertyPage,
     Folded,
     InterfacePropertyPage,
     NamedElementPropertyPage,
     OperationsPage,
 )
+from gaphor.UML.classes.gtkmodels import ClassAttributes
 
 
 @pytest.fixture

--- a/gaphor/UML/classes/tests/test_propertypages.py
+++ b/gaphor/UML/classes/tests/test_propertypages.py
@@ -2,10 +2,7 @@ from gi.repository import Gtk
 
 from gaphor import UML
 from gaphor.UML.classes import ClassItem, EnumerationItem
-from gaphor.UML.classes.classespropertypages import (
-    ClassAttributes,
-    ClassEnumerationLiterals,
-)
+from gaphor.UML.classes.gtkmodels import ClassAttributes, ClassEnumerationLiterals
 
 
 def test_attribute_editing(create):

--- a/gaphor/UML/interactions/interactionspropertypages.py
+++ b/gaphor/UML/interactions/interactionspropertypages.py
@@ -1,6 +1,5 @@
 from gaphor.core import transactional
 from gaphor.diagram.propertypages import (
-    ComboModel,
     PropertyPageBase,
     PropertyPages,
     new_resource_builder,
@@ -34,6 +33,8 @@ class MessagePropertyPage(PropertyPageBase):
         self.item = item
 
     def construct(self):
+        from gaphor.diagram.gtkmodels import ComboModel
+
         item = self.item
         subject = item.subject
 

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -1,10 +1,8 @@
-"""Stereotype property page."""
-from gi.repository import Gtk
-
 from gaphor import UML
 from gaphor.core import transactional
 from gaphor.core.modeling.element import Element
 from gaphor.diagram.propertypages import PropertyPageBase, PropertyPages
+from gaphor.lazygi import Gtk
 from gaphor.UML.profiles.metaclasspropertypage import new_builder
 
 

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gaphor import UML
 from gaphor.core import transactional
 from gaphor.core.modeling.element import Element

--- a/gaphor/diagram/general/generaleditors.py
+++ b/gaphor/diagram/general/generaleditors.py
@@ -1,7 +1,6 @@
-from gi.repository import Gdk, Gtk
-
 from gaphor.diagram.general.comment import CommentItem
 from gaphor.diagram.instanteditors import instant_editor, show_popover
+from gaphor.lazygi import Gdk, Gtk
 from gaphor.transaction import Transaction
 
 

--- a/gaphor/diagram/general/generalpropertypages.py
+++ b/gaphor/diagram/general/generalpropertypages.py
@@ -1,5 +1,3 @@
-from gi.repository import Gtk
-
 from gaphor.core import transactional
 from gaphor.core.modeling import Comment
 from gaphor.diagram.propertypages import (
@@ -8,6 +6,7 @@ from gaphor.diagram.propertypages import (
     handler_blocking,
     new_builder,
 )
+from gaphor.lazygi import Gtk
 
 
 @PropertyPages.register(Comment)

--- a/gaphor/diagram/gtkmodels.py
+++ b/gaphor/diagram/gtkmodels.py
@@ -1,0 +1,154 @@
+"""GTK-based types.
+
+Thos module is normally imported in the method where it's used to avoid
+the need for a global import of GTK.
+"""
+
+from gi.repository import Gtk
+
+from gaphor.core import transactional
+
+
+class EditableTreeModel(Gtk.ListStore):
+    """Editable GTK tree model based on ListStore model.
+
+    Every row is represented by a list of editable values. Last column
+    contains an object, which is being edited (this column is not
+    displayed). When editable value in first column is set to empty string
+    then object is deleted.
+
+    Last row is empty and contains no object to edit. It allows to enter
+    new values.
+    """
+
+    def __init__(self, item, cols):
+        """Create new model.
+
+        Args:
+          item (Presentation): diagram item owning tree model
+          cols (tuple): model column types, defaults to [str, object]
+        """
+        super().__init__(*cols)
+        self._item = item
+
+        for data in self.get_rows():
+            self.append(data)
+        self._add_empty()
+        self.connect_after("row-inserted", self.on_row_inserted)
+
+    def on_row_inserted(self, model, path, iter):
+        """This method is called when new elements are added and when a row is
+        moved via DnD."""
+        new_order = [row[-1] for row in self if row[-1]]
+        self.sync_model(new_order)
+
+    def get_rows(self):
+        """Return rows to be edited.
+
+        Last column has to contain object being edited.
+        """
+
+        raise NotImplementedError
+
+    def create_object(self):
+        """Create new object."""
+        raise NotImplementedError
+
+    def set_object_value(self, row, col, value):
+        """Update row's column with a value."""
+        raise NotImplementedError
+
+    def swap_objects(self, o1, o2):
+        """Swap two objects.
+
+        If objects are swapped, then return ``True``.
+        """
+        raise NotImplementedError
+
+    def _get_object(self, iter):
+        """Get object from ``iter``."""
+        path = self.get_path(iter)
+        return self[path][-1]
+
+    def swap(self, a, b):
+        """
+        Swap two list rows.
+        Parameters:
+        - a: path to first row
+        - b: path to second row
+        """
+        if not (a and b):
+            return
+        o1 = self[a][-1]
+        o2 = self[b][-1]
+        if o1 and o2 and self.swap_objects(o1, o2):
+            super().swap(a, b)
+
+    def _add_empty(self):
+        """Add empty row to the end of the model."""
+        self.append([None] * self.get_n_columns())
+
+    @transactional
+    def update(self, iter, col, value):
+        row = self[iter]
+
+        if col == 0 and not value and row[-1]:
+            # delete row and object if text of first column is empty
+            self.remove(iter)
+
+        elif col == 0 and value and not row[-1]:
+            # create new object
+            obj = self.create_object()
+            row[-1] = obj
+            self.set_object_value(row, col, value)
+            self._add_empty()
+
+        elif row[-1]:
+            self.set_object_value(row, col, value)
+
+    def remove(self, iter):
+        """Remove object from GTK model and destroy it."""
+        if obj := self._get_object(iter):
+            obj.unlink()
+            return super().remove(iter)
+        else:
+            return iter
+
+
+class ComboModel(Gtk.ListStore):
+    """combo box model.
+
+    Model allows to easily create a combo box with values and their labels,
+    for example
+
+        label1  ->  value1
+        label2  ->  value2
+        label3  ->  value3
+
+    Labels are displayed by combo box and programmer has easy access to
+    values associated with given label.
+
+    Attributes:
+
+    - _data: model data
+    - _indices: dictionary of values' indices
+    """
+
+    def __init__(self, data):
+        super().__init__(str)
+
+        self._indices: dict[tuple[str, str], int] = {}
+        self._data = data
+
+        # add labels to underlying model and store index information
+        for i, (label, value) in enumerate(data):
+            self.append([label])
+            self._indices[value] = i
+
+    def get_index(self, value):
+        """Return index of a ``value``."""
+        return self._indices[value]
+
+    def get_value(self, index):
+        """Get value for given ``index``."""
+        return self._data[index][1]

--- a/gaphor/diagram/hoversupport.py
+++ b/gaphor/diagram/hoversupport.py
@@ -1,4 +1,4 @@
-from gi.repository import Gdk, Gtk
+from gaphor.lazygi import Gdk, Gtk
 
 
 def widget_add_hover_support(widget):

--- a/gaphor/diagram/instanteditors.py
+++ b/gaphor/diagram/instanteditors.py
@@ -4,9 +4,9 @@ from functools import singledispatch
 
 from gaphas import Item
 from gaphas.geometry import Rectangle
-from gi.repository import Gdk, Gtk
 
 from gaphor.diagram.presentation import LinePresentation, Named
+from gaphor.lazygi import Gdk, Gtk
 from gaphor.transaction import Transaction
 
 

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -9,11 +9,11 @@ from typing import Callable, Dict, Iterable, List, Tuple, Type
 
 import gaphas.item
 from gaphas.segment import Segment
-from gi.repository import Gtk
 
 from gaphor.core import transactional
 from gaphor.core.modeling import Element
 from gaphor.i18n import translated_ui_string
+from gaphor.lazygi import Gtk
 
 
 def new_resource_builder(package, property_pages="propertypages"):

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -4,8 +4,10 @@ To register property pages implemented in this module, it is imported in
 gaphor.adapter package.
 """
 
+from __future__ import annotations
+
 import abc
-from typing import Callable, Dict, Iterable, List, Tuple, Type
+from typing import Callable, Iterable
 
 import gaphas.item
 from gaphas.segment import Segment
@@ -45,8 +47,8 @@ class _PropertyPages:
     """
 
     def __init__(self) -> None:
-        self.pages: List[
-            Tuple[Type[Element], Callable[[Element], PropertyPageBase]]
+        self.pages: list[
+            tuple[type[Element], Callable[[Element], PropertyPageBase]]
         ] = []
 
     def register(self, subject_type):
@@ -81,112 +83,6 @@ class PropertyPageBase(metaclass=abc.ABCMeta):
         """
 
 
-class EditableTreeModel(Gtk.ListStore):
-    """Editable GTK tree model based on ListStore model.
-
-    Every row is represented by a list of editable values. Last column
-    contains an object, which is being edited (this column is not
-    displayed). When editable value in first column is set to empty string
-    then object is deleted.
-
-    Last row is empty and contains no object to edit. It allows to enter
-    new values.
-    """
-
-    def __init__(self, item, cols):
-        """Create new model.
-
-        Args:
-          item (Presentation): diagram item owning tree model
-          cols (tuple): model column types, defaults to [str, object]
-        """
-        super().__init__(*cols)
-        self._item = item
-
-        for data in self.get_rows():
-            self.append(data)
-        self._add_empty()
-        self.connect_after("row-inserted", self.on_row_inserted)
-
-    def on_row_inserted(self, model, path, iter):
-        """This method is called when new elements are added and when a row is
-        moved via DnD."""
-        new_order = [row[-1] for row in self if row[-1]]
-        self.sync_model(new_order)
-
-    def get_rows(self):
-        """Return rows to be edited.
-
-        Last column has to contain object being edited.
-        """
-
-        raise NotImplementedError
-
-    def create_object(self):
-        """Create new object."""
-        raise NotImplementedError
-
-    def set_object_value(self, row, col, value):
-        """Update row's column with a value."""
-        raise NotImplementedError
-
-    def swap_objects(self, o1, o2):
-        """Swap two objects.
-
-        If objects are swapped, then return ``True``.
-        """
-        raise NotImplementedError
-
-    def _get_object(self, iter):
-        """Get object from ``iter``."""
-        path = self.get_path(iter)
-        return self[path][-1]
-
-    def swap(self, a, b):
-        """
-        Swap two list rows.
-        Parameters:
-        - a: path to first row
-        - b: path to second row
-        """
-        if not (a and b):
-            return
-        o1 = self[a][-1]
-        o2 = self[b][-1]
-        if o1 and o2 and self.swap_objects(o1, o2):
-            super().swap(a, b)
-
-    def _add_empty(self):
-        """Add empty row to the end of the model."""
-        self.append([None] * self.get_n_columns())
-
-    @transactional
-    def update(self, iter, col, value):
-        row = self[iter]
-
-        if col == 0 and not value and row[-1]:
-            # delete row and object if text of first column is empty
-            self.remove(iter)
-
-        elif col == 0 and value and not row[-1]:
-            # create new object
-            obj = self.create_object()
-            row[-1] = obj
-            self.set_object_value(row, col, value)
-            self._add_empty()
-
-        elif row[-1]:
-            self.set_object_value(row, col, value)
-
-    def remove(self, iter):
-        """Remove object from GTK model and destroy it."""
-        if obj := self._get_object(iter):
-            obj.unlink()
-            return super().remove(iter)
-        else:
-            return iter
-
-
 @transactional
 def on_text_cell_edited(renderer, path, value, model, col=0):
     """Update editable tree model based on fresh user input."""
@@ -201,45 +97,6 @@ def on_bool_cell_edited(renderer, path, model, col):
 
     iter = model.get_iter(path)
     model.update(iter, col, renderer.get_active())
-
-
-class ComboModel(Gtk.ListStore):
-    """combo box model.
-
-    Model allows to easily create a combo box with values and their labels,
-    for example
-
-        label1  ->  value1
-        label2  ->  value2
-        label3  ->  value3
-
-    Labels are displayed by combo box and programmer has easy access to
-    values associated with given label.
-
-    Attributes:
-
-    - _data: model data
-    - _indices: dictionary of values' indices
-    """
-
-    def __init__(self, data):
-        super().__init__(str)
-
-        self._indices: Dict[Tuple[str, str], int] = {}
-        self._data = data
-
-        # add labels to underlying model and store index information
-        for i, (label, value) in enumerate(data):
-            self.append([label])
-            self._indices[value] = i
-
-    def get_index(self, value):
-        """Return index of a ``value``."""
-        return self._indices[value]
-
-    def get_value(self, index):
-        """Get value for given ``index``."""
-        return self._data[index][1]
 
 
 def combo_box_text_auto_complete(

--- a/gaphor/extensions/sphinx.py
+++ b/gaphor/extensions/sphinx.py
@@ -7,7 +7,6 @@ import sphinx.util.docutils
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives import images
-from sphinx.ext.autodoc.mock import mock
 from sphinx.util import logging
 
 from gaphor.core.modeling import Diagram, ElementFactory
@@ -119,8 +118,7 @@ class DiagramDirective(sphinx.util.docutils.SphinxDirective):
 def load_model(model_file: str) -> ElementFactory:
     element_factory = ElementFactory()
 
-    with mock(["gi.repository.Gtk", "gi.repository.Gdk"]):
-        modeling_language = ModelingLanguageService()
+    modeling_language = ModelingLanguageService()
 
     storage.load(
         model_file,

--- a/gaphor/lazygi.py
+++ b/gaphor/lazygi.py
@@ -1,0 +1,34 @@
+"""This module provides a little wrapper around the Gtk, and UI related
+modules.
+
+This basically allows you to import Gaphor modules
+without Gtk, which is very convenient in notebooks
+and CI environments.
+
+It's remotely related to https://peps.python.org/pep-0690/.
+
+`importlib.util.LazyLoader` does not work, since `gi.repository`
+modules are already dynamically loaded.
+"""
+
+import importlib
+from typing import Any
+
+import gi
+
+
+class LazyGIModule:
+    def __init__(self, gi_name):
+        self._gi_name = gi_name
+        self._module = None
+
+    def __getattr__(self, name):
+        if not gi.get_required_version(self._gi_name):
+            raise ImportError(f"No required version set for {self._gi_name}")
+        if not self._module:
+            self._module = importlib.import_module(f"gi.repository.{self._gi_name}")
+        return getattr(self._module, name)
+
+
+Gdk: Any = LazyGIModule("Gdk")  # type: ignore[misc]
+Gtk: Any = LazyGIModule("Gtk")  # type: ignore[misc]

--- a/gaphor/tests/test_lazygi.py
+++ b/gaphor/tests/test_lazygi.py
@@ -1,0 +1,4 @@
+def test_lazy_gi():
+    from gaphor.lazygi import Gtk
+
+    assert Gtk.Widget


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

If you use a notebook, or generate docs with Sphinx, you'll either need to have GTK installed or explicitly mock the `Gtk` and `Gdk` modules.

Issue Number: #1746 

### What is the new behavior?

GTK and GDK modules are loaded lazy, only when the first element is loaded. Now you can use Gaphor without worrying about GTK.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

This approach is not working: we're including modules that have a close interaction with the view, for guided lines and such.