### PR TITLE
Update folded interface shape when connecting dependency

### DIFF
--- a/gaphor/UML/classes/interfaceconnect.py
+++ b/gaphor/UML/classes/interfaceconnect.py
@@ -32,6 +32,7 @@ class DependencyInterfaceConnect(DependencyConnect):
             self.element.side = port.side
             self.element.request_update()
             self.line.request_update()
+            self.element.update_shapes()
 
     def disconnect(self, handle):
         """If dependency item is no longer connected to an interface, then draw


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When connecting a dependency to a folded interface, the visual for the interface does not show the socket.

![Screenshot from 2022-11-04 16-36-05](https://user-images.githubusercontent.com/85876381/200015605-c74621f9-aa4c-4287-a4db-c07fa59b3c40.png)

### What is the new behavior?

The visual is updated to show the socket.

Before connecting:
![Screenshot from 2022-11-04 16-33-04](https://user-images.githubusercontent.com/85876381/200015101-890a5071-2e9c-4baf-8055-3af26442fec0.png)

After connecting:
![Screenshot from 2022-11-04 16-33-12](https://user-images.githubusercontent.com/85876381/200015121-17d24d88-5e7f-4ce7-b570-d5ff9f6d3f8d.png)


### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
