### PR TITLE
Interact with models without GTK

### DIFF
--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -78,7 +78,10 @@ a = Analysis(
     + copy_metadata("gaphor")
     + copy_metadata("gaphas"),
     hiddenimports=collect_entry_points(
-        "gaphor.services", "gaphor.appservices", "gaphor.modelinglanguages"
+        "gaphor.services",
+        "gaphor.appservices",
+        "gaphor.modelinglanguages",
+        "gaphor.modules",
     ),
     hooksconfig={
         "gi": {

--- a/docs/gaphor-services.md
+++ b/docs/gaphor-services.md
@@ -41,9 +41,6 @@ Now let's create a class in our model for every service.
 ```{code-cell} ipython3
 from gaphor import UML
 from gaphor.core.modeling import ElementFactory
-from gaphor.services.modelinglanguage import ModelingLanguageService
-
-modeling_language = ModelingLanguageService()
 
 element_factory = ElementFactory()
 

--- a/docs/gaphor-services.md
+++ b/docs/gaphor-services.md
@@ -39,10 +39,11 @@ entry_points
 Now let's create a class in our model for every service.
 
 ```{code-cell} ipython3
-import inspect
-
-from gaphor.core.modeling import ElementFactory
 from gaphor import UML
+from gaphor.core.modeling import ElementFactory
+from gaphor.services.modelinglanguage import ModelingLanguageService
+
+modeling_language = ModelingLanguageService()
 
 element_factory = ElementFactory()
 
@@ -59,6 +60,8 @@ With all components mapped, we can create dependencies between those components,
 based on the constructor parameter names.
 
 ```{code-cell} ipython3
+import inspect
+
 for name, cls in entry_points.items():
     for param_name in inspect.signature(cls).parameters:
         if param_name not in components:
@@ -93,7 +96,7 @@ from gaphor.extensions.ipython import auto_layout, draw
 
 auto_layout(diagram)
 
-draw(diagram)
+draw(diagram, format="svg")
 ```
 
 That's all. As you can see from the diagram, a lot of services rely on

--- a/docs/modeling_language.md
+++ b/docs/modeling_language.md
@@ -26,15 +26,21 @@ language implementation can offer?
 * [Connectors](#connectors), allow diagram items to connect
 * [Copy/paste](#copy-and-paste) behavior when element copying is not trivial,
   for example with more than one element is involved
-* [Editor pages](#editor-property-pages), shown in the collapsible pane on the right side
 * [Grouping](#grouping), allow elements to be nested in one another
 * [Dropping](#dropping), allow elements to be dragged from the tree view onto a diagram
 * [Automatic cleanup rules](#automated-model-cleanup) to keep the model consistent
-* [Instant (diagram) editor popups](#instant-diagram-editor-popups)
 
 The first three by functionalities are exposed by the `ModelingLanguage` class.
 The other functionalities can be extended by adding handlers to the respective
 generic functions.
+
+Modeling languages can also provide new UI components. Those components are not loaded
+directly when you import a modeling language package. Instead they should be imported via
+the `gaphor.modules` entrypoint.
+
+* [Editor pages](#editor-property-pages), shown in the collapsible pane on the right side
+* [Instant (diagram) editor popups](#instant-diagram-editor-popups)
+* Special diagram interactions
 
 
 ```{eval-rst}
@@ -101,18 +107,6 @@ To serialize the copied elements and deserialize them again, there are two funct
    ``lookup`` function is used to resolve references to other elements.
 ```
 
-## Editor property pages
-
-The editor page is constructed from snippets. For example: almost each element has a name,
-so there is a UI snippet that allows you to edit a name.
-
-Each property page (snippet) should inherit from `PropertyPageBase`.
-
-```{eval-rst}
-.. autoclass:: gaphor.diagram.propertypages.PropertyPageBase
-   :members:
-```
-
 ## Grouping
 
 Grouping is done by dragging one item on top of another, in a diagram or in the tree view.
@@ -162,6 +156,18 @@ A little dispatch function is used to determine if a model element can be remove
 .. function:: gaphor.diagram.deletable.deletable(element: Element) -> bool
 
    Determine if a model element can safely be removed.
+```
+
+## Editor property pages
+
+The editor page is constructed from snippets. For example: almost each element has a name,
+so there is a UI snippet that allows you to edit a name.
+
+Each property page (snippet) should inherit from `PropertyPageBase`.
+
+```{eval-rst}
+.. autoclass:: gaphor.diagram.propertypages.PropertyPageBase
+   :members:
 ```
 
 ## Instant (diagram) editor popups

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -46,7 +46,6 @@ In versions before 2.13, an `EventManager` is required. In later versions, the
 
 
 ```{code-cell} ipython3
-from sphinx.ext.autodoc.mock import mock
 from gaphor.core.eventmanager import EventManager
 from gaphor.services.modelinglanguage import ModelingLanguageService
 from gaphor.storage import storage
@@ -54,8 +53,7 @@ from gaphor.storage import storage
 event_manager = EventManager()
 
 # Avoid loading GTK by using Sphinx’s mock function
-with mock(["gi.repository.Gtk", "gi.repository.Gdk"]):
-    modeling_language = ModelingLanguageService(event_manager=event_manager)
+modeling_language = ModelingLanguageService(event_manager=event_manager)
 
 storage.load(
     "../models/Core.gaphor",

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -52,7 +52,6 @@ from gaphor.storage import storage
 
 event_manager = EventManager()
 
-# Avoid loading GTK by using Sphinx’s mock function
 modeling_language = ModelingLanguageService(event_manager=event_manager)
 
 storage.load(
@@ -65,10 +64,10 @@ storage.load(
 At this point the model is loaded in the `element_factory` and can be queried.
 
 ```{note}
-A modeling language consists of the model elements, diagram items, and graphical
-components required to interact with the elements through the GUI. As a rule of
-thumb, you’ll need to have GTK (the GUI toolkit we use) installed to load a full
-featured modeling language.
+A modeling language consists of the model elements, and diagram items.
+Graphical components are loaded separately.
+For the most basic manupilations, GTK (the GUI toolkit we use) is not required,
+but you may run into situations where Gaphor tries to load the GTK library.
 
 One trick to avoid this (when generating Sphinx docs at least) is to use
 autodoc’s mock function to mock out the GTK and GDK libraries. However, Pango

--- a/gaphor/C4Model/__init__.py
+++ b/gaphor/C4Model/__init__.py
@@ -1,0 +1,2 @@
+import gaphor.C4Model.iconname
+import gaphor.C4Model.modelinglanguage

--- a/gaphor/C4Model/modelinglanguage.py
+++ b/gaphor/C4Model/modelinglanguage.py
@@ -3,7 +3,6 @@
 from typing import Iterable
 
 import gaphor.C4Model.iconname  # noqa
-import gaphor.C4Model.propertypages  # noqa
 from gaphor.abc import ModelingLanguage
 from gaphor.C4Model import c4model, diagramitems
 from gaphor.C4Model.toolbox import c4model_diagram_types, c4model_toolbox_actions

--- a/gaphor/C4Model/modelinglanguage.py
+++ b/gaphor/C4Model/modelinglanguage.py
@@ -2,7 +2,6 @@
 
 from typing import Iterable
 
-import gaphor.C4Model.iconname  # noqa
 from gaphor.abc import ModelingLanguage
 from gaphor.C4Model import c4model, diagramitems
 from gaphor.C4Model.toolbox import c4model_diagram_types, c4model_toolbox_actions

--- a/gaphor/C4Model/propertypages.py
+++ b/gaphor/C4Model/propertypages.py
@@ -9,6 +9,11 @@ from gaphor.diagram.propertypages import (
     new_resource_builder,
 )
 
+
+def init():
+    pass
+
+
 new_builder = new_resource_builder("gaphor.C4Model")
 
 

--- a/gaphor/RAAML/__init__.py
+++ b/gaphor/RAAML/__init__.py
@@ -1,0 +1,1 @@
+import gaphor.RAAML.modelinglanguage

--- a/gaphor/RAAML/modelinglanguage.py
+++ b/gaphor/RAAML/modelinglanguage.py
@@ -3,7 +3,6 @@ assets."""
 
 from typing import Iterable
 
-import gaphor.SysML.propertypages  # noqa
 from gaphor.abc import ModelingLanguage
 from gaphor.core import gettext
 from gaphor.diagram.diagramtoolbox import DiagramType, ToolboxDefinition

--- a/gaphor/RAAML/stpa/__init__.py
+++ b/gaphor/RAAML/stpa/__init__.py
@@ -1,3 +1,4 @@
+import gaphor.RAAML.stpa.block
 from gaphor.RAAML.stpa.controlaction import ControlActionItem
 from gaphor.RAAML.stpa.operationalsituation import OperationalSituationItem
 from gaphor.RAAML.stpa.relationships import RelevantToItem

--- a/gaphor/RAAML/stpa/block.py
+++ b/gaphor/RAAML/stpa/block.py
@@ -1,0 +1,8 @@
+from gaphor.diagram.support import represents
+from gaphor.RAAML import raaml
+from gaphor.SysML.blocks import BlockItem
+
+represents(raaml.Situation)(BlockItem)
+represents(raaml.Loss)(BlockItem)
+represents(raaml.Hazard)(BlockItem)
+represents(raaml.ControlStructure)(BlockItem)

--- a/gaphor/SysML/__init__.py
+++ b/gaphor/SysML/__init__.py
@@ -1,0 +1,2 @@
+import gaphor.SysML.drop
+import gaphor.SysML.modelinglanguage

--- a/gaphor/SysML/blocks/__init__.py
+++ b/gaphor/SysML/blocks/__init__.py
@@ -1,4 +1,5 @@
 import gaphor.SysML.blocks.connectors
+import gaphor.SysML.blocks.datatype
 import gaphor.SysML.blocks.group
 from gaphor.SysML.blocks.block import BlockItem
 from gaphor.SysML.blocks.property import PropertyItem

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -15,7 +15,6 @@ from gaphor.diagram.shapes import (
 )
 from gaphor.diagram.support import represents
 from gaphor.diagram.text import FontStyle, FontWeight
-from gaphor.RAAML import raaml
 from gaphor.SysML.sysml import Block, ValueType
 from gaphor.UML.classes.klass import attribute_watches
 from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
@@ -24,10 +23,6 @@ from gaphor.UML.umlfmt import format_property
 
 
 @represents(Block)
-@represents(raaml.Situation)
-@represents(raaml.Loss)
-@represents(raaml.Hazard)
-@represents(raaml.ControlStructure)
 class BlockItem(Classified, ElementPresentation[Block]):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
@@ -57,6 +52,8 @@ class BlockItem(Classified, ElementPresentation[Block]):
     show_values: attribute[int] = attribute("show_values", int, default=False)
 
     def additional_stereotypes(self):
+        from gaphor.RAAML import raaml
+
         if isinstance(self.subject, raaml.Situation):
             return [gettext("Situation")]
         elif isinstance(self.subject, raaml.ControlStructure):

--- a/gaphor/SysML/blocks/datatype.py
+++ b/gaphor/SysML/blocks/datatype.py
@@ -1,0 +1,5 @@
+from gaphor.diagram.support import represents
+from gaphor.SysML import sysml
+from gaphor.UML.classes.datatype import DataTypeItem
+
+represents(sysml.ValueType)(DataTypeItem)

--- a/gaphor/SysML/modelinglanguage.py
+++ b/gaphor/SysML/modelinglanguage.py
@@ -3,7 +3,6 @@ assets."""
 
 from typing import Iterable
 
-import gaphor.SysML.drop  # noqa
 from gaphor.abc import ModelingLanguage
 from gaphor.core import gettext
 from gaphor.diagram.diagramtoolbox import DiagramType, ToolboxDefinition

--- a/gaphor/SysML/modelinglanguage.py
+++ b/gaphor/SysML/modelinglanguage.py
@@ -4,7 +4,6 @@ assets."""
 from typing import Iterable
 
 import gaphor.SysML.drop  # noqa
-import gaphor.SysML.propertypages  # noqa
 from gaphor.abc import ModelingLanguage
 from gaphor.core import gettext
 from gaphor.diagram.diagramtoolbox import DiagramType, ToolboxDefinition

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -12,6 +12,11 @@ from gaphor.SysML.blocks.block import BlockItem
 from gaphor.SysML.requirements.requirement import RequirementItem
 from gaphor.UML.classes.classespropertypages import AttributesPage, OperationsPage
 
+
+def init():
+    pass
+
+
 new_builder = new_resource_builder("gaphor.SysML")
 
 

--- a/gaphor/UML/__init__.py
+++ b/gaphor/UML/__init__.py
@@ -1,8 +1,10 @@
 # Here, order matters
 import gaphor.UML.umloverrides
 from gaphor.UML.uml import *
+import gaphor.UML.copypaste
 import gaphor.UML.deletable
 import gaphor.UML.drop
 import gaphor.UML.iconname
 import gaphor.UML.group
+import gaphor.UML.modelinglanguage
 from gaphor.UML import recipes

--- a/gaphor/UML/actions/__init__.py
+++ b/gaphor/UML/actions/__init__.py
@@ -1,12 +1,8 @@
 from gaphor.UML.actions import (
-    actionseditors,
     actionsgroup,
-    actionspropertypages,
     activityconnect,
-    activitypropertypage,
     copypaste,
     flowconnect,
-    partitionpage,
     pinconnect,
 )
 from gaphor.UML.actions.action import (

--- a/gaphor/UML/actions/activityconnect.py
+++ b/gaphor/UML/actions/activityconnect.py
@@ -1,12 +1,6 @@
 from gaphas.connector import Handle, Port
-from gaphas.guide import GuidedItemHandleMoveMixin
-from gaphas.handlemove import HandleMove, ItemHandleMove
-from gaphas.move import Move
-from gaphas.types import Pos
 
 from gaphor.diagram.connectors import Connector
-from gaphor.diagram.presentation import connect
-from gaphor.diagram.tools.grayout import GrayOutLineHandleMoveMixin
 from gaphor.UML.actions.activity import ActivityItem, ActivityParameterNodeItem
 
 
@@ -33,28 +27,3 @@ class ActivityParameterNodeConnector:
 
     def disconnect(self, handle: Handle) -> None:
         pass
-
-
-@HandleMove.register(ActivityParameterNodeItem)
-class ActivityParameterNodeItemHandleMove(
-    GrayOutLineHandleMoveMixin, GuidedItemHandleMoveMixin, ItemHandleMove
-):
-    """We use a custom tool for moving parameter nodes.
-
-    Parameter nodes always connect to their parent (Activity).
-    """
-
-    def connect(self, pos: Pos) -> None:
-        item = self.item
-        connect(item, self.handle, item.parent)
-        self.view.model.request_update(item)
-
-
-@Move.register(ActivityParameterNodeItem)
-def activity_parameter_node_move(item, view):
-    """We use a custom tool for moving parameter nodes.
-
-    They can be moved while handle is connected and will automatically
-    connect to a side of its parent.
-    """
-    return ActivityParameterNodeItemHandleMove(item, item.handles()[0], view)

--- a/gaphor/UML/actions/activitymove.py
+++ b/gaphor/UML/actions/activitymove.py
@@ -1,0 +1,33 @@
+from gaphas.guide import GuidedItemHandleMoveMixin
+from gaphas.handlemove import HandleMove, ItemHandleMove
+from gaphas.move import Move
+from gaphas.types import Pos
+
+from gaphor.diagram.presentation import connect
+from gaphor.diagram.tools.grayout import GrayOutLineHandleMoveMixin
+from gaphor.UML.actions.activity import ActivityParameterNodeItem
+
+
+@HandleMove.register(ActivityParameterNodeItem)
+class ActivityParameterNodeItemHandleMove(
+    GrayOutLineHandleMoveMixin, GuidedItemHandleMoveMixin, ItemHandleMove
+):
+    """We use a custom tool for moving parameter nodes.
+
+    Parameter nodes always connect to their parent (Activity).
+    """
+
+    def connect(self, pos: Pos) -> None:
+        item = self.item
+        connect(item, self.handle, item.parent)
+        self.view.model.request_update(item)
+
+
+@Move.register(ActivityParameterNodeItem)
+def activity_parameter_node_move(item, view):
+    """We use a custom tool for moving parameter nodes.
+
+    They can be moved while handle is connected and will automatically
+    connect to a side of its parent.
+    """
+    return ActivityParameterNodeItemHandleMove(item, item.handles()[0], view)

--- a/gaphor/UML/classes/__init__.py
+++ b/gaphor/UML/classes/__init__.py
@@ -1,10 +1,5 @@
 from gaphor.UML.classes import (
     classconnect,
-    classeseditors,
-    classespropertypages,
-    associationpropertypages,
-    dependencypropertypages,
-    enumerationpropertypages,
     containmentconnect,
     copypaste,
     interfaceconnect,

--- a/gaphor/UML/classes/datatype.py
+++ b/gaphor/UML/classes/datatype.py
@@ -11,7 +11,6 @@ from gaphor.diagram.presentation import (
 )
 from gaphor.diagram.shapes import Box, Text, draw_border
 from gaphor.diagram.support import represents
-from gaphor.SysML import sysml
 from gaphor.UML.classes.klass import (
     attribute_watches,
     attributes_compartment,
@@ -25,7 +24,6 @@ log = logging.getLogger(__name__)
 
 @represents(UML.DataType)
 @represents(UML.PrimitiveType)
-@represents(sysml.ValueType)
 class DataTypeItem(Classified, ElementPresentation[UML.DataType]):
     """This item visualizes a Data Type instance.
 
@@ -53,6 +51,8 @@ class DataTypeItem(Classified, ElementPresentation[UML.DataType]):
     show_operations: attribute[int] = attribute("show_operations", int, default=True)
 
     def additional_stereotypes(self):
+        from gaphor.SysML import sysml
+
         if isinstance(self.subject, UML.PrimitiveType):
             return [gettext("primitive")]
         elif isinstance(self.subject, sysml.ValueType):

--- a/gaphor/UML/deployments/__init__.py
+++ b/gaphor/UML/deployments/__init__.py
@@ -1,7 +1,6 @@
 from gaphor.UML.deployments import (
     connectorconnect,
     copypaste,
-    deploymentpropertypage,
     deploymentsgroup,
 )
 from gaphor.UML.deployments.artifact import ArtifactItem

--- a/gaphor/UML/interactions/__init__.py
+++ b/gaphor/UML/interactions/__init__.py
@@ -2,7 +2,6 @@ from gaphor.UML.interactions import (
     copypaste,
     interactionsconnect,
     interactionsgroup,
-    interactionspropertypages,
 )
 from gaphor.UML.interactions.executionspecification import ExecutionSpecificationItem
 from gaphor.UML.interactions.interaction import InteractionItem

--- a/gaphor/UML/modelinglanguage.py
+++ b/gaphor/UML/modelinglanguage.py
@@ -6,7 +6,7 @@ from typing import Iterable
 from gaphor.abc import ModelingLanguage
 from gaphor.core import gettext
 from gaphor.diagram.diagramtoolbox import DiagramType, ToolboxDefinition
-from gaphor.UML import copypaste, diagramitems, uml  # noqa F401
+from gaphor.UML import diagramitems, uml
 from gaphor.UML.toolbox import uml_diagram_types, uml_toolbox_actions
 
 

--- a/gaphor/UML/profiles/__init__.py
+++ b/gaphor/UML/profiles/__init__.py
@@ -1,7 +1,5 @@
 from gaphor.UML.profiles import (
     extensionconnect,
-    metaclasspropertypage,
-    stereotypepropertypages,
 )
 from gaphor.UML.profiles.extension import ExtensionItem
 from gaphor.UML.profiles.packageimport import PackageImportItem

--- a/gaphor/UML/states/__init__.py
+++ b/gaphor/UML/states/__init__.py
@@ -1,4 +1,4 @@
-from gaphor.UML.states import copypaste, group, propertypages, vertexconnect, dropzone
+from gaphor.UML.states import copypaste, group, vertexconnect
 from gaphor.UML.states.finalstate import FinalStateItem
 from gaphor.UML.states.pseudostates import PseudostateItem
 from gaphor.UML.states.state import StateItem

--- a/gaphor/UML/uicomponents.py
+++ b/gaphor/UML/uicomponents.py
@@ -1,0 +1,24 @@
+# flake8: noqa F401
+
+from gaphor.UML.actions import (
+    actionseditors,
+    actionspropertypages,
+    activitymove,
+    activitypropertypage,
+    partitionpage,
+)
+from gaphor.UML.classes import (
+    associationpropertypages,
+    classeseditors,
+    classespropertypages,
+    dependencypropertypages,
+    enumerationpropertypages,
+)
+from gaphor.UML.deployments import deploymentpropertypage
+from gaphor.UML.interactions import interactionspropertypages
+from gaphor.UML.profiles import metaclasspropertypage, stereotypepropertypages
+from gaphor.UML.states import dropzone, propertypages
+
+
+def init():
+    """Allow this module to be loaded from an entrypoint."""

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -2,7 +2,7 @@
 from gaphor.event import ServiceEvent
 
 
-class RevertibeEvent:
+class RevertibleEvent:
     """Base type for all events that can be reversed.
 
     This event can be used as "low level" event for anything that should

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 from gaphas.item import Matrices
 
 from gaphor.core.modeling.element import Element, Id, UnlinkEvent
-from gaphor.core.modeling.event import RevertibeEvent
+from gaphor.core.modeling.event import RevertibleEvent
 from gaphor.core.modeling.properties import relation_many, relation_one
 
 if TYPE_CHECKING:
@@ -138,7 +138,7 @@ class Presentation(Matrices, Element, Generic[S]):
             self.handle(MatrixUpdated(self, old_value))
 
 
-class MatrixUpdated(RevertibeEvent):
+class MatrixUpdated(RevertibleEvent):
     def __init__(self, element, old_value):
         super().__init__(element)
         self.old_value = old_value

--- a/gaphor/diagram/__init__.py
+++ b/gaphor/diagram/__init__.py
@@ -4,5 +4,7 @@ diagram)."""
 
 import gi
 
+import gaphor.diagram._connector
+
 gi.require_version("Pango", "1.0")
 gi.require_version("PangoCairo", "1.0")

--- a/gaphor/diagram/_connector.py
+++ b/gaphor/diagram/_connector.py
@@ -8,8 +8,6 @@ import logging
 
 from gaphas.connector import Connector as ConnectorAspect
 from gaphas.connector import ItemConnector, LineConnector
-from gaphas.handlemove import HandleMove, ItemHandleMove
-from gaphas.types import Pos
 
 from gaphor.core import transactional
 from gaphor.core.modeling import Presentation
@@ -18,7 +16,6 @@ from gaphor.diagram.connectors import (
     ItemConnected,
     ItemDisconnected,
     ItemReconnected,
-    ItemTemporaryDisconnected,
 )
 from gaphor.diagram.presentation import ElementPresentation, LinePresentation
 
@@ -85,21 +82,6 @@ class PresentationConnector(ItemConnector):
 @ConnectorAspect.register(LinePresentation)
 class LinePresentationConnector(PresentationConnector, LineConnector):
     pass
-
-
-@HandleMove.register(Presentation)
-@HandleMove.register(LinePresentation)
-class PresentationHandleMove(ItemHandleMove):
-    def start_move(self, pos: Pos) -> None:
-        super().start_move(pos)
-        model = self.view.model
-        assert model
-        if cinfo := model.connections.get_connection(self.handle):
-            self.item.handle(
-                ItemTemporaryDisconnected(
-                    cinfo.item, cinfo.handle, cinfo.connected, cinfo.port
-                )
-            )
 
 
 class DisconnectHandle:

--- a/gaphor/diagram/_connector.py
+++ b/gaphor/diagram/_connector.py
@@ -1,3 +1,9 @@
+"""Gaphas connectors.
+
+This module ties connectors in Gaphas -- on presentation -- to model
+level connectors (gaphor.connectors).
+"""
+
 import logging
 
 from gaphas.connector import Connector as ConnectorAspect

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -17,7 +17,7 @@ from gaphas.connector import Handle, Port
 from generic.multidispatch import FunctionDispatcher, multidispatch
 
 from gaphor.core.modeling import Diagram, Element, Presentation
-from gaphor.core.modeling.event import RevertibeEvent
+from gaphor.core.modeling.event import RevertibleEvent
 from gaphor.core.modeling.properties import association, redefine, relation
 from gaphor.diagram.copypaste import copy, paste
 from gaphor.diagram.presentation import ElementPresentation, LinePresentation
@@ -432,7 +432,7 @@ def paste_model(copy_data, diagram) -> Iterator[Element]:
     return iter(new_elements.values())
 
 
-class ItemConnected(RevertibeEvent):
+class ItemConnected(RevertibleEvent):
     def __init__(self, element, handle, connected, port):
         super().__init__(element)
         self.handle_index = element.handles().index(handle)
@@ -450,7 +450,7 @@ class ItemConnected(RevertibeEvent):
         connector.disconnect()
 
 
-class ItemDisconnected(RevertibeEvent):
+class ItemDisconnected(RevertibleEvent):
     def __init__(self, element, handle, connected, port):
         super().__init__(element)
         self.handle_index = element.handles().index(handle)
@@ -471,7 +471,7 @@ class ItemDisconnected(RevertibeEvent):
         target.handle(ItemConnected(target, handle, sink.item, sink.port))
 
 
-class ItemTemporaryDisconnected(RevertibeEvent):
+class ItemTemporaryDisconnected(RevertibleEvent):
     def __init__(self, element, handle, connected, port):
         super().__init__(element)
         self.handle_index = element.handles().index(handle)
@@ -491,7 +491,7 @@ class ItemTemporaryDisconnected(RevertibeEvent):
         target.handle(ItemReconnected(target, handle))
 
 
-class ItemReconnected(RevertibeEvent):
+class ItemReconnected(RevertibleEvent):
     def __init__(self, element, handle):
         super().__init__(element)
         self.handle_index = element.handles().index(handle)

--- a/gaphor/diagram/general/__init__.py
+++ b/gaphor/diagram/general/__init__.py
@@ -1,4 +1,4 @@
-from gaphor.diagram.general import connectors, generaleditors, generalpropertypages
+from gaphor.diagram.general import connectors
 from gaphor.diagram.general.comment import CommentItem
 from gaphor.diagram.general.commentline import CommentLineItem
 from gaphor.diagram.general.simpleitem import Box, Ellipse, Line

--- a/gaphor/diagram/general/uicomponents.py
+++ b/gaphor/diagram/general/uicomponents.py
@@ -1,0 +1,8 @@
+# flake8: noqa F401
+
+import gaphor.diagram.general.generaleditors
+import gaphor.diagram.general.generalpropertypages
+
+
+def init():
+    """Allows this module to be loaded from an entrypoint."""

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -12,7 +12,7 @@ from gaphas.geometry import Rectangle, distance_rectangle_point
 from gaphas.solver.constraint import BaseConstraint
 
 from gaphor.core.modeling.diagram import Diagram
-from gaphor.core.modeling.event import RevertibeEvent
+from gaphor.core.modeling.event import RevertibleEvent
 from gaphor.core.modeling.presentation import Presentation, S, literal_eval
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import Style, merge_styles
@@ -69,7 +69,7 @@ def postload_connect(item: gaphas.Item, handle: gaphas.Handle, target: gaphas.It
     connect(item, handle, target)
 
 
-class HandlePositionEvent(RevertibeEvent):
+class HandlePositionEvent(RevertibleEvent):
 
     requires_transaction = False
 

--- a/gaphor/diagram/tools/__init__.py
+++ b/gaphor/diagram/tools/__init__.py
@@ -2,7 +2,6 @@
 from gaphas.tool import hover_tool, rubberband_tool, view_focus_tool, zoom_tools
 from gi.repository import Gtk
 
-import gaphor.diagram.tools.connector
 import gaphor.diagram.tools.grayout
 import gaphor.diagram.tools.segment
 from gaphor.diagram.tools.dnd import drop_target_tool

--- a/gaphor/diagram/tools/itemtool.py
+++ b/gaphor/diagram/tools/itemtool.py
@@ -1,6 +1,12 @@
+from gaphas.handlemove import HandleMove, ItemHandleMove
 from gaphas.tool import item_tool as _item_tool
+from gaphas.types import Pos
 from gaphas.view import GtkView
 from gi.repository import Gtk
+
+from gaphor.core.modeling import Presentation
+from gaphor.diagram.connectors import ItemTemporaryDisconnected
+from gaphor.diagram.presentation import LinePresentation
 
 
 def item_tool(view: GtkView) -> Gtk.GestureDrag:
@@ -12,3 +18,18 @@ def item_tool(view: GtkView) -> Gtk.GestureDrag:
 def on_drag_end(gesture, _offset_x, _offset_y):
     view = gesture.get_widget()
     view.selection.dropzone_item = None
+
+
+@HandleMove.register(Presentation)
+@HandleMove.register(LinePresentation)
+class PresentationHandleMove(ItemHandleMove):
+    def start_move(self, pos: Pos) -> None:
+        super().start_move(pos)
+        model = self.view.model
+        assert model
+        if cinfo := model.connections.get_connection(self.handle):
+            self.item.handle(
+                ItemTemporaryDisconnected(
+                    cinfo.item, cinfo.handle, cinfo.connected, cinfo.port
+                )
+            )

--- a/gaphor/diagram/tools/segment.py
+++ b/gaphor/diagram/tools/segment.py
@@ -1,7 +1,7 @@
 from gaphas.connector import ConnectionSink, Connector
 from gaphas.segment import LineSegment, Segment
 
-from gaphor.core.modeling.event import RevertibeEvent
+from gaphor.core.modeling.event import RevertibleEvent
 from gaphor.diagram.connectors import ItemTemporaryDisconnected
 from gaphor.diagram.presentation import LinePresentation
 
@@ -47,7 +47,7 @@ class PresentationSegment(LineSegment):
             connector.connect(sink)
 
 
-class LineSplitSegmentEvent(RevertibeEvent):
+class LineSplitSegmentEvent(RevertibleEvent):
     def __init__(self, element, segment, count):
         super().__init__(element)
         self.segment = segment
@@ -58,7 +58,7 @@ class LineSplitSegmentEvent(RevertibeEvent):
         segment.merge_segment(self.segment, self.count)
 
 
-class LineMergeSegmentEvent(RevertibeEvent):
+class LineMergeSegmentEvent(RevertibleEvent):
     def __init__(self, element, segment, count):
         super().__init__(element)
         self.segment = segment

--- a/gaphor/diagram/tools/segment.py
+++ b/gaphor/diagram/tools/segment.py
@@ -2,8 +2,8 @@ from gaphas.connector import ConnectionSink, Connector
 from gaphas.segment import LineSegment, Segment
 
 from gaphor.core.modeling.event import RevertibeEvent
+from gaphor.diagram.connectors import ItemTemporaryDisconnected
 from gaphor.diagram.presentation import LinePresentation
-from gaphor.diagram.tools.connector import ItemTemporaryDisconnected
 
 
 @Segment.register(LinePresentation)

--- a/gaphor/extensions/sphinx.py
+++ b/gaphor/extensions/sphinx.py
@@ -7,7 +7,6 @@ import sphinx.util.docutils
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives import images
-from sphinx.ext.autodoc.mock import mock
 from sphinx.util import logging
 
 from gaphor.core.modeling import Diagram, ElementFactory
@@ -119,8 +118,7 @@ class DiagramDirective(sphinx.util.docutils.SphinxDirective):
 def load_model(model_file: str) -> ElementFactory:
     element_factory = ElementFactory()
 
-    with mock(["gi.repository.Gtk", "gi.repository.Gdk"]):
-        modeling_language = ModelingLanguageService()
+    modeling_language = ModelingLanguageService()
 
     storage.load(
         model_file,

--- a/gaphor/plugins/autolayout/pydot.py
+++ b/gaphor/plugins/autolayout/pydot.py
@@ -13,13 +13,13 @@ from gaphas.segment import Segment
 from gaphor.abc import ActionProvider, Service
 from gaphor.action import action
 from gaphor.core.modeling import Diagram, Element, Presentation
+from gaphor.diagram.connectors import ItemTemporaryDisconnected
 from gaphor.diagram.presentation import (
     AttachedPresentation,
     ElementPresentation,
     HandlePositionEvent,
     LinePresentation,
 )
-from gaphor.diagram.tools.connector import ItemTemporaryDisconnected
 from gaphor.i18n import gettext
 from gaphor.transaction import Transaction
 from gaphor.UML import NamedElement

--- a/gaphor/services/moduleloader.py
+++ b/gaphor/services/moduleloader.py
@@ -1,0 +1,12 @@
+from gaphor.abc import Service
+from gaphor.entrypoint import initialize
+
+
+class ModuleLoader(Service):
+    def __init__(self):
+        """Load modules defined in entrypoints `[gaphor.modules]`."""
+
+        initialize("gaphor.modules")
+
+    def shutdown(self):
+        pass

--- a/gaphor/services/tests/test_moduleloader.py
+++ b/gaphor/services/tests/test_moduleloader.py
@@ -1,0 +1,12 @@
+import sys
+
+from gaphor.services.moduleloader import ModuleLoader
+
+
+def test_module_loader():
+    ModuleLoader()
+
+    assert "gaphor.diagram.general.uicomponents" in sys.modules
+    assert "gaphor.UML.uicomponents" in sys.modules
+    assert "gaphor.SysML.propertypages" in sys.modules
+    assert "gaphor.C4Model.propertypages" in sys.modules

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -26,7 +26,7 @@ from gaphor.core.modeling.event import (
     ElementCreated,
     ElementDeleted,
     ModelReady,
-    RevertibeEvent,
+    RevertibleEvent,
 )
 from gaphor.core.modeling.presentation import Presentation
 from gaphor.core.modeling.properties import association as association_property
@@ -296,8 +296,8 @@ class UndoManager(Service, ActionProvider):
         self.event_manager.unsubscribe(self.undo_association_add_event)
         self.event_manager.unsubscribe(self.undo_association_delete_event)
 
-    @event_handler(RevertibeEvent)
-    def undo_reversible_event(self, event: RevertibeEvent):
+    @event_handler(RevertibleEvent)
+    def undo_reversible_event(self, event: RevertibleEvent):
         element_id = event.element.id
 
         def undo_reversible_event():

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -8,10 +8,10 @@ from gi.repository import GLib, Gtk
 
 from gaphor import UML
 from gaphor.core.modeling import Comment, Diagram
+from gaphor.diagram._connector import PresentationConnector
 from gaphor.diagram.connectors import Connector
 from gaphor.diagram.general.comment import CommentItem
 from gaphor.diagram.general.commentline import CommentLineItem
-from gaphor.diagram.tools.connector import PresentationConnector
 from gaphor.ui.diagrams import Diagrams
 from gaphor.ui.event import DiagramOpened
 from gaphor.ui.toolbox import Toolbox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,13 @@ gaphorconvert = "gaphor.plugins.diagramexport.gaphorconvert:main"
 "greeter" = "gaphor.ui.greeter:Greeter"
 "self_test" = "gaphor.ui.selftest:SelfTest"
 "error_reports" = "gaphor.plugins.errorreports:ErrorReports"
+"module_loader" = "gaphor.services.moduleloader:ModuleLoader"
+
+[tool.poetry.plugins."gaphor.modules"]
+"general_ui_components" = "gaphor.diagram.general.uicomponents:init"
+"uml_ui_components" = "gaphor.UML.uicomponents:init"
+"sysml_property_pages" = "gaphor.SysML.propertypages:init"
+"c4model_property_pages" = "gaphor.C4Model.propertypages:init"
 
 [tool.poetry.plugins."gaphor.services"]
 "component_registry" = "gaphor.services.componentregistry:ComponentRegistry"


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Currently, when using Gaphor as a library, you'll need to have GTK and the GTK introspection bindings on your system. GTK depends on X11 and wayland libraries, which are also installed, making the installation bigger than needed.

```bash
# apt install gir1.2-gtk-4.0              
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  adwaita-icon-theme dbus dbus-user-session dconf-gsettings-backend dconf-service dmsetup gir1.2-gdkpixbuf-2.0 gir1.2-graphene-1.0 gtk-update-icon-cache hicolor-icon-theme
  humanity-icon-theme iso-codes libapparmor1 libargon2-1 libavahi-client3 libavahi-common-data libavahi-common3 libcairo-gobject2 libcairo-script-interpreter2 libcolord2
  libcryptsetup12 libcups2 libdbus-1-3 libdconf1 libdevmapper1.02.1 libepoxy0 libgdk-pixbuf-2.0-0 libgdk-pixbuf2.0-bin libgdk-pixbuf2.0-common libgraphene-1.0-0 libgtk-4-1
  libgtk-4-bin libgtk-4-common libip4tc2 libjson-c5 libkmod2 liblcms2-2 liblzo2-2 libnss-systemd libpam-systemd librsvg2-2 librsvg2-common libwayland-client0 libwayland-egl1
  libxcursor1 libxdamage1 libxfixes3 libxi6 libxinerama1 libxkbcommon0 libxrandr2 networkd-dispatcher python3-dbus systemd systemd-sysv systemd-timesyncd ubuntu-mono xkb-data
```

Issue Number: N/A

### What is the new behavior?

The code has been restructured a little to not require GTK, unless it's really needed.

For this, a new entry point has been introduced: `gaphor.modules`. Those entry points are simply modules. These modules are used to populate the single-/multidispatch functions required for the GUI, such as property pages and instant editors.

Cyclic dependencies between UML and SysML, and SysML and RAAML have been broken.

All functionalities required for scripting are loaded as soon as the module is loaded (connectors, grouping, etc.). This makes it easier to use.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
