### PR TITLE
Added extra port below text for actor

### DIFF
--- a/gaphor/UML/usecases/actor.py
+++ b/gaphor/UML/usecases/actor.py
@@ -2,6 +2,13 @@
 
 from math import pi
 
+from gaphas.constraint import constraint
+from gaphas.geometry import distance_line_point
+from gaphas.item import SE, SW
+from gaphas.port import LinePort
+from gaphas.position import Position
+from gaphas.solver import REQUIRED, STRONG, variable
+
 from gaphor import UML
 from gaphor.diagram.presentation import Classified, ElementPresentation
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
@@ -23,8 +30,39 @@ class ActorItem(Classified, ElementPresentation):
     future.
     """
 
+    text_height = variable(strength=REQUIRED, varname="_text_height")
+
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=ARM * 2, height=HEAD + NECK + BODY + ARM)
+
+        # Allow to connect to the bottom of the actor, below the actor name
+        self._sub_text_port = LinePort(
+            Position(0, 0, strength=STRONG), Position(0, 0, strength=STRONG)
+        )
+        self._ports.append(self._sub_text_port)
+
+        self.text_height = 20.0
+
+        add = diagram.connections.add_constraint
+        add(
+            self,
+            constraint(
+                horizontal=(self._handles[SW].pos, self._sub_text_port.start),
+                delta=self.text_height,
+            ),
+        )
+        add(
+            self,
+            constraint(vertical=(self._handles[SW].pos, self._sub_text_port.start)),
+        )
+        add(
+            self,
+            constraint(
+                horizontal=(self._handles[SE].pos, self._sub_text_port.end),
+                delta=self.text_height,
+            ),
+        )
+        add(self, constraint(vertical=(self._handles[SE].pos, self._sub_text_port.end)))
 
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
@@ -48,6 +86,23 @@ class ActorItem(Classified, ElementPresentation):
                 },
             ),
         )
+
+    def update(self, context):
+        super().update(context)
+        _xs, ys = list(zip(*self.shape.sizes))
+        self.text_height = sum(ys)
+
+    def point(self, x: float, y: float) -> float:
+        return min(  # type: ignore[no-any-return]
+            super().point(x, y),
+            distance_line_point(
+                self._sub_text_port.start, self._sub_text_port.end, (x, y)
+            )[0],
+        )
+
+    def postload(self):
+        super().postload()
+        self.diagram.connections.solve()
 
 
 def draw_actor(box, context, bounding_box):

--- a/gaphor/UML/usecases/tests/test_actor.py
+++ b/gaphor/UML/usecases/tests/test_actor.py
@@ -1,0 +1,53 @@
+from gaphor import UML
+from gaphor.core.modeling import Diagram
+from gaphor.diagram.general import CommentLineItem
+from gaphor.diagram.tests.fixtures import connect
+from gaphor.UML.usecases.actor import ActorItem
+
+
+def test_create_actor(create, diagram):
+    actor_item = create(ActorItem, UML.Actor)
+    actor_item.subject.name = "Actor"
+
+    diagram.update_now({actor_item})
+
+
+def test_connect_to_lower_port(create, diagram):
+    actor_item = create(ActorItem, UML.Actor)
+    actor_item.subject.name = "Actor Name"
+    line_item = create(CommentLineItem)
+    line_head, line_tail = line_item.handles()
+    line_head.pos = (50, 100)
+    line_tail.pos = (50, 100)
+
+    diagram.update_now({actor_item, line_item})
+
+    connect(line_item, line_head, actor_item)
+
+    cinfo = diagram.connections.get_connection(line_head)
+    assert cinfo.port is actor_item.ports()[-1]
+
+
+def test_save_and_load(create, diagram, element_factory, saver, loader):
+    actor_item = create(ActorItem, UML.Actor)
+    actor_item.subject.name = "Actor Name"
+    line_item = create(CommentLineItem)
+    line_head, line_tail = line_item.handles()
+    line_head.pos = (50, 100)
+    line_tail.pos = (50, 100)
+
+    diagram.update_now({actor_item, line_item})
+
+    connect(line_item, line_head, actor_item)
+
+    diagram.update_now({actor_item, line_item})
+
+    data = saver()
+    loader(data)
+
+    new_diagram = next(element_factory.select(Diagram))
+    new_actor_item = next(element_factory.select(ActorItem))
+    new_line_item = next(element_factory.select(CommentLineItem))
+    cinfo = new_diagram.connections.get_connection(new_line_item.head)
+
+    assert cinfo.port is new_actor_item.ports()[-1]


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

If you attach a relation (association, dependency) to the bottom of an Actor, the relation crosses the actor name.

Issue Number: #1231, #1854

### What is the new behavior?

An extra port has been added below the name of the actor. You can attach your associations and dependencies there.

![image](https://user-images.githubusercontent.com/96249/200884525-d2ecbc36-59db-4a0f-b3aa-8ff10a5069f6.png)

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
