### PR TITLE
Auto add skip-changelog label for pre-commit.ci and all-contributors

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,7 +12,7 @@ chore:
   - .flake8
   - pyproject.toml
 python:
-  - '*.py'
+  - gaphor/**/*.py
 skip-changelog:
   - .pre-commit-config.yaml
   - .all-contributorsrc

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,3 +13,6 @@ chore:
   - pyproject.toml
 python:
   - '*.py'
+skip-changelog:
+  - .pre-commit-config.yaml
+  - .all-contributorsrc


### PR DESCRIPTION
Automatically label pre-commit.ci and all-contributor with skip-changelog so that they don't show up in our release drafts.

Also fixes the Python labeler, since it wasn't working except for Python files in the root of the project.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
No labels are applied and they have to be manually added for these two bots

Issue Number: N/A

### What is the new behavior?
skip-changelog label is automatically added

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
