### PR TITLE
Fix file not found for about and keyboard shortcut dialogs

### DIFF
--- a/gaphor/ui/help/__init__.py
+++ b/gaphor/ui/help/__init__.py
@@ -14,9 +14,7 @@ from gaphor.i18n import translated_ui_string
 def new_builder(ui_file):
     builder = Gtk.Builder()
     ui_file = f"{ui_file}.glade" if Gtk.get_major_version() == 3 else f"{ui_file}.ui"
-    builder.add_from_string(
-        translated_ui_string("gaphor.services.helpservice", ui_file)
-    )
+    builder.add_from_string(translated_ui_string("gaphor.ui.help", ui_file))
     return builder
 
 
@@ -49,9 +47,7 @@ class HelpService(Service, ActionProvider):
     @action(name="win.shortcuts")
     def shortcuts(self):
         builder = Gtk.Builder()
-        builder.add_from_string(
-            translated_ui_string("gaphor.services.helpservice", "shortcuts.ui")
-        )
+        builder.add_from_string(translated_ui_string("gaphor.ui.help", "shortcuts.ui"))
 
         shortcuts = builder.get_object("shortcuts-gaphor")
         shortcuts.set_modal(True)


### PR DESCRIPTION
This fixes a bug introduced by #1871. When opening the about and keyboard shortcuts dialog, a FileNotFoundError was thrown.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
About and Keyboard Shortcut dialogs won't load

Issue Number: N/A

### What is the new behavior?
Dialogs are working properly

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
