### PR TITLE
Fix macOS shortcuts on GTK 4

### DIFF
--- a/gaphor/ui/help/__init__.py
+++ b/gaphor/ui/help/__init__.py
@@ -3,6 +3,8 @@
 (help browser anyone?)
 """
 
+import sys
+
 from gi.repository import Gtk
 
 from gaphor.abc import ActionProvider, Service
@@ -47,7 +49,12 @@ class HelpService(Service, ActionProvider):
     @action(name="app.shortcuts")
     def shortcuts(self):
         builder = Gtk.Builder()
-        builder.add_from_string(translated_ui_string("gaphor.ui.help", "shortcuts.ui"))
+        ui = translated_ui_string("gaphor.ui.help", "shortcuts.ui")
+        if Gtk.get_major_version() != 3:
+            modifier = "Meta" if sys.platform == "darwin" else "Control"
+            ui = ui.replace("&lt;Primary&gt;", f"&lt;{modifier}&gt;")
+
+        builder.add_from_string(ui)
 
         shortcuts = builder.get_object("shortcuts-gaphor")
         shortcuts.set_modal(True)

--- a/gaphor/ui/macosshim.py
+++ b/gaphor/ui/macosshim.py
@@ -1,6 +1,6 @@
 try:
     import gi
-    from gi.repository import Gtk
+    from gi.repository import GLib, Gtk
 
     if Gtk.get_major_version() == 3:
         gi.require_version("GtkosxApplication", "1.0")
@@ -33,3 +33,100 @@ else:
         macos_app.connect(
             "NSApplicationBlockTermination", block_termination, application
         )
+
+
+if Gtk.get_major_version != 3:
+
+    def new_shortcut_with_args(shortcut, name, *args):
+        shortcut = Gtk.Shortcut.new(
+            trigger=Gtk.ShortcutTrigger.parse_string(shortcut),
+            action=Gtk.SignalAction.new(name),
+        )
+        if args:
+            shortcut.set_arguments(GLib.Variant.new_tuple(*args))
+        return shortcut
+
+    # MacOS specific key bindings:
+    # Command–a: Select all.
+    # Command–Shift-a: Unselect all.
+    # Command–Up Arrow: Move the insertion point to the beginning of the document.
+    # Command–Down Arrow: Move the insertion point to the end of the document.
+    # Command–Left Arrow: Move the insertion point to the beginning of the current line.
+    # Command–Right Arrow: Move the insertion point to the end of the current line.
+    # Option–Left Arrow: Move the insertion point to the beginning of the previous word.
+    # Option–Right Arrow: Move the insertion point to the end of the next word.
+
+    # Control-H: Delete the character to the left of the insertion point. Or use Delete.
+    # Control-D: Delete the character to the right of the insertion point. Or use Fn-Delete.
+
+    # Gtk.Text
+
+    Gtk.Text.add_shortcut(
+        Gtk.Shortcut.new(
+            trigger=Gtk.ShortcutTrigger.parse_string("<Meta>a"),
+            action=Gtk.CallbackAction.new(lambda self, data: self.select_region(0, -1)),
+        )
+    )
+    Gtk.Text.add_shortcut(
+        new_shortcut_with_args(
+            "<Meta><Shift>a",
+            "move-cursor",
+            GLib.Variant.new_int32(Gtk.MovementStep.VISUAL_POSITIONS),
+            GLib.Variant.new_int32(0),
+            GLib.Variant.new_boolean(False),
+        )
+    )
+
+    Gtk.Text.add_shortcut(
+        new_shortcut_with_args(
+            "<Meta>Up",
+            "move-cursor",
+            GLib.Variant.new_int32(Gtk.MovementStep.VISUAL_POSITIONS),
+            GLib.Variant.new_int32(0),
+            GLib.Variant.new_boolean(False),
+        )
+    )
+    Gtk.Text.add_shortcut(
+        new_shortcut_with_args(
+            "<Meta>Down",
+            "move-cursor",
+            GLib.Variant.new_int32(Gtk.MovementStep.VISUAL_POSITIONS),
+            GLib.Variant.new_int32(-1),
+            GLib.Variant.new_boolean(False),
+        )
+    )
+
+    # Gtk.TextView
+
+    Gtk.TextView.add_shortcut(
+        new_shortcut_with_args("<Meta>a", "select-all", GLib.Variant.new_boolean(True))
+    )
+    Gtk.TextView.add_shortcut(
+        new_shortcut_with_args(
+            "<Meta><Shift>a", "select-all", GLib.Variant.new_boolean(False)
+        )
+    )
+
+    for cls in (Gtk.Text, Gtk.TextView):
+        for shortcut, signal in [
+            ("<Meta>x", "cut-clipboard"),
+            ("<Meta>c", "copy-clipboard"),
+            ("<Meta>v", "paste-clipboard"),
+        ]:
+            cls.add_shortcut(
+                Gtk.Shortcut.new(
+                    trigger=Gtk.ShortcutTrigger.parse_string(shortcut),
+                    action=Gtk.SignalAction.new(signal),
+                )
+            )
+
+        for shortcut, action in [
+            ("<Meta>z", "text.undo"),
+            ("<Meta><Shift>z", "text.redo"),
+        ]:
+            cls.add_shortcut(
+                Gtk.Shortcut.new(
+                    trigger=Gtk.ShortcutTrigger.parse_string(shortcut),
+                    action=Gtk.NamedAction.new(action),
+                )
+            )


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

On GTK4 no magic mapping is done for us on macOS, where `Command` serves as primary modifier.

Issue Number: #1839

### What is the new behavior?

We remap the `Primary` modifier on macOS to the `Meta` key (`Command`).

<img width="284" alt="image" src="https://user-images.githubusercontent.com/96249/205724600-29a08178-2251-4355-bf3f-ec4737b1d038.png">