### PR TITLE
Standard keyboard shortcuts

### DIFF
--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -87,7 +87,7 @@ class ElementEditor(UIComponent, ActionProvider):
 
     @action(
         name="show-editors",
-        shortcut="<Primary>e",
+        shortcut="F9",
         state=lambda self: self.properties.get("show-editors", True),  # type: ignore[no-any-return]
     )
     def toggle_editor_visibility(self, active):

--- a/gaphor/ui/greeter.ui
+++ b/gaphor/ui/greeter.ui
@@ -54,6 +54,7 @@
           <object class="GtkMenuButton">
             <property name="popover">hamburger</property>
             <property name="icon_name">open-menu-symbolic</property>
+            <property name="primary">1</property>
           </object>
         </child>
       </object>

--- a/gaphor/ui/help/shortcuts.ui
+++ b/gaphor/ui/help/shortcuts.ui
@@ -36,7 +36,7 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">1</property>
-                <property name="accelerator">&lt;Primary&gt;e</property>
+                <property name="accelerator">F9</property>
                 <property name="title" translatable="yes">Toggle property editor</property>
               </object>
             </child>

--- a/gaphor/ui/mainwindow.ui
+++ b/gaphor/ui/mainwindow.ui
@@ -53,6 +53,7 @@
             <property name="popover">hamburger</property>
             <property name="icon_name">open-menu-symbolic</property>
             <property name="tooltip-text" translatable="true">Open application menu</property>
+            <property name="primary">1</property>
           </object>
         </child>
         <child type="end">


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the new behavior?

Keyboard shortcuts as defined in the [GNOME HIG](https://developer.gnome.org/hig/reference/keyboard.html):

* `F10` Open menu
* `F9` Toggle side pane
