### PR TITLE
Improve Windows build reliability by limiting cores to 2

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -237,7 +237,7 @@ jobs:
     env:
       gvsbuild_version: 2022.5.0
       # Bump this number if you want to force a rebuild of gvsbuild with the same revision
-      gvsbuild_update: 2
+      gvsbuild_update: 4
     outputs:
       cachekey: ${{ steps.output.outputs.cachekey }}
     steps:
@@ -265,8 +265,8 @@ jobs:
       - name: GTK binaries run gvsbuild
         if: steps.cache.outputs.cache-hit != 'true'
         run: >
-          gvsbuild build --enable-gi --py-wheel gobject-introspection gtk4 libadwaita pycairo pygobject gtksourceview5
-          adwaita-icon-theme hicolor-icon-theme
+          gvsbuild build --ninja-opts -j2 --enable-gi --py-wheel gobject-introspection gtk4 libadwaita pycairo pygobject
+          gtksourceview5 adwaita-icon-theme hicolor-icon-theme
       - name: Copy wheels to cached directory
         if: steps.cache.outputs.cache-hit != 'true'
         run: cp (Resolve-Path C:\gtk-build\build\x64\release\pygobject\dist\*.whl) C:\gtk-build\gtk\x64\release\

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -105,7 +105,7 @@ pipx install gvsbuild
 In the same PowerShell terminal, execute:
 
 ```PowerShell
-gvsbuild build --enable-gi --py-wheel gobject-introspection gtk3 pycairo pygobject gtksourceview4 adwaita-icon-theme hicolor-icon-theme
+gvsbuild build --enable-gi --py-wheel gobject-introspection gtk4 libadwaita pycairo pygobject gtksourceview5 adwaita-icon-theme hicolor-icon-theme
 ```
 Grab a coffee, the build will take a few minutes to complete.
 


### PR DESCRIPTION
This PR limits the number of cores to 2 during the Windows build and updates the Windows build command in the docs for GTK4.

This should help get rid of out of memory errors while linking GTK4.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
