### PR TITLE
Do not auto-layout sequence diagrams

### DIFF
--- a/gaphor/plugins/autolayout/pydot.py
+++ b/gaphor/plugins/autolayout/pydot.py
@@ -10,6 +10,7 @@ from gaphas.item import NW
 from gaphas.matrix import Matrix
 from gaphas.segment import Segment
 
+import gaphor.UML.interactions
 from gaphor.abc import ActionProvider, Service
 from gaphor.action import action
 from gaphor.core.modeling import Diagram, Element, Presentation
@@ -370,3 +371,12 @@ def parse_bb(bb, height: float | None = None) -> Rect:
 
 def strip_quotes(s):
     return s.replace('"', "").replace("\\\n", "")
+
+
+# Do not auto-layout sequence diagrams
+_interaction_items = [i for i in dir(gaphor.UML.interactions) if i.endswith("Item")]
+for _item in _interaction_items:
+    as_pydot.register(getattr(gaphor.UML.interactions, _item))(lambda _: iter(()))
+
+del _interaction_items
+del _item


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Sequence diagrams can be auto-layouted, which guarantees a messed up diagram 

Issue Number: #1899

### What is the new behavior?

Explicitly exclude sequence diagrams from auto-layouting.

