### PR TITLE
Update gvsbuild to upgrade cairo in Windows

### DIFF
--- a/.github/actions/setup_and_test/action.yml
+++ b/.github/actions/setup_and_test/action.yml
@@ -22,7 +22,9 @@ runs:
       shell: bash
     - name: Windows specific overrides
       if: runner.os == 'Windows'
-      run: poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\*.whl)
+      run: |
+        poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\PyGObject*.whl)
+        poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\pycairo*.whl)
       shell: pwsh
     - name: Compile translations
       run: poetry run poe gettext-mo

--- a/.github/actions/setup_and_test/action.yml
+++ b/.github/actions/setup_and_test/action.yml
@@ -20,6 +20,10 @@ runs:
     - name: Install Python Dependencies
       run: poetry install --no-interaction
       shell: bash
+    - name: Windows specific overrides
+      if: runner.os == 'Windows'
+      run: poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\*.whl)
+      shell: pwsh
     - name: Compile translations
       run: poetry run poe gettext-mo
       shell: bash

--- a/.github/actions/windows_executables/action.yml
+++ b/.github/actions/windows_executables/action.yml
@@ -23,7 +23,9 @@ runs:
       run: poetry install --only main,packaging --no-interaction
       shell: bash
     - name: Windows specific overrides
-      run: poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\*.whl)
+      run: |
+        poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\PyGObject*.whl)
+        poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\pycairo*.whl)
       shell: pwsh
     - name: Create Windows Installers
       env:

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -235,9 +235,9 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
     env:
-      gvsbuild_version: 2022.5.0
-      # Bump this number if you want to force a rebuild of gvsbuild with the same revision
-      gvsbuild_update: 4
+      gvsbuild_version: 2022.6.0
+      # Bump this number if you want to force a rebuild of gvsbuild with the same version
+      gvsbuild_update: 1
     outputs:
       cachekey: ${{ steps.output.outputs.cachekey }}
     steps:
@@ -264,12 +264,9 @@ jobs:
         run: python -m pip install gvsbuild==${{ env.gvsbuild_version }}
       - name: GTK binaries run gvsbuild
         if: steps.cache.outputs.cache-hit != 'true'
-        run: >
-          gvsbuild build --ninja-opts -j2 --enable-gi --py-wheel gobject-introspection gtk4 libadwaita pycairo pygobject
+        run: > # j2 option resolves out of memory issues while linking on GitHub Actions runners
+          gvsbuild build --ninja-opts -j2 --enable-gi gobject-introspection gtk4 libadwaita
           gtksourceview5 adwaita-icon-theme hicolor-icon-theme
-      - name: Copy wheels to cached directory
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: cp (Resolve-Path C:\gtk-build\build\x64\release\pygobject\dist\*.whl) C:\gtk-build\gtk\x64\release\
       - name: GTK binaries restore git binary
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
@@ -284,7 +281,7 @@ jobs:
     runs-on: windows-latest
     env:
       GAPHOR_USE_GTK: 4
-      INCLUDE: C:\gtk-build\gtk\x64\release\lib\glib-2.0\include;C:\gtk-build\gtk\x64\release\include;C:\gtk-build\gtk\x64\release\include\gobject-introspection-1.0;C:\gtk-build\gtk\x64\release\include\cairo;C:\gtk-build\gtk\x64\release\include\glib-2.0
+      INCLUDE: C:\gtk-build\gtk\x64\release\include;C:\gtk-build\gtk\x64\release\include\cairo;C:\gtk-build\gtk\x64\release\include\glib-2.0;C:\gtk-build\gtk\x64\release\include\gobject-introspection-1.0;C:\gtk-build\gtk\x64\release\lib\glib-2.0\include;
       LIB: C:\gtk-build\gtk\x64\release\lib
     permissions:
       contents: write

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -237,7 +237,7 @@ jobs:
     env:
       gvsbuild_version: 2022.6.0
       # Bump this number if you want to force a rebuild of gvsbuild with the same version
-      gvsbuild_update: 1
+      gvsbuild_update: 2
     outputs:
       cachekey: ${{ steps.output.outputs.cachekey }}
     steps:
@@ -266,8 +266,13 @@ jobs:
       - name: GTK binaries run gvsbuild
         if: steps.cache.outputs.cache-hit != 'true'
         run: >
-          gvsbuild build --ninja-opts -j2 --enable-gi gobject-introspection gtk4 libadwaita
-          gtksourceview5 adwaita-icon-theme hicolor-icon-theme
+          gvsbuild build --ninja-opts -j2 --enable-gi --py-wheel gobject-introspection
+          gtk4 libadwaita gtksourceview5 pycairo pygobject adwaita-icon-theme hicolor-icon-theme
+      - name: Copy wheels to cached directory
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: >
+          Get-ChildItem C:\gtk-build\build\x64\release\*\dist\*.whl |
+          ForEach-Object -process { cp $_ C:\gtk-build\gtk\x64\release\ }
       - name: GTK binaries restore git binary
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -262,9 +262,10 @@ jobs:
       - name: Install gvsbuild
         if: steps.cache.outputs.cache-hit != 'true'
         run: python -m pip install gvsbuild==${{ env.gvsbuild_version }}
+        # j2 option resolves out of memory issues while linking on GitHub Actions runners
       - name: GTK binaries run gvsbuild
         if: steps.cache.outputs.cache-hit != 'true'
-        run: > # j2 option resolves out of memory issues while linking on GitHub Actions runners
+        run: >
           gvsbuild build --ninja-opts -j2 --enable-gi gobject-introspection gtk4 libadwaita
           gtksourceview5 adwaita-icon-theme hicolor-icon-theme
       - name: GTK binaries restore git binary

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -124,7 +124,7 @@ pipx install gvsbuild
 In the same PowerShell terminal, execute:
 
 ```PowerShell
-gvsbuild build --enable-gi gobject-introspection gtk4 libadwaita gtksourceview5 adwaita-icon-theme hicolor-icon-theme
+gvsbuild build --enable-gi --py-wheel gobject-introspection gtk4 libadwaita gtksourceview5 pygobject pycairo adwaita-icon-theme hicolor-icon-theme
 ```
 Grab a coffee, the build will take a few minutes to complete.
 
@@ -143,24 +143,26 @@ pipx install poetry
 poetry config virtualenvs.in-project true
 ```
 
-Install Gaphor's other dependencies
-```PowerShell
-poetry install
-```
-
 Add GTK to your environmental variables:
 ```PowerShell
-$gtk_path = "C:\gtk-build\gtk\x64\release"
-$env:Path = $gtk_path + "\bin;" + $env:Path
-$env:LIB = $gtk_path + "\lib"
-$gtk_include = $gtk_path + "\include"
-$env:INCLUDE = $gtk_include + "\cairo;" + $gtk_include + "\glib-2.0;"
-$env:INCLUDE = $gtk_include + "\gobject-introspection-1.0;" + $env:INCLUDE
-$env:INCLUDE = $gtk_path + "\lib\glib-2.0\include;" + $gtk_include + ";" + $env:INCLUDE
+$env:Path = $env:Path + "C:\gtk-build\gtk\x64\release\bin;"
+$env:LIB = "C:\gtk-build\gtk\x64\release\lib"
+$env:INCLUDE = "C:\gtk-build\gtk\x64\release\include;C:\gtk-build\gtk\x64\release\include\cairo;C:\gtk-build\gtk\x64\release\include\glib-2.0;C:\gtk-build\gtk\x64\release\include\gobject-introspection-1.0;C:\gtk-build\gtk\x64\release\lib\glib-2.0\include;"
 ```
 
 You can also edit your account's Environmental Variables to persist across
 PowerShell sessions.
+
+Install Gaphor's dependencies
+```PowerShell
+poetry install
+```
+
+Reinstall PyGObject and pycairo using gvsbuild wheels
+```PowerShell
+poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\build\x64\release\pygobject\dist\PyGObject*.whl)
+poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\build\x64\release\pycairo\dist\pycairo*.whl)
+```
 
 Launch Gaphor!
 ```PowerShell

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -105,7 +105,7 @@ pipx install gvsbuild
 In the same PowerShell terminal, execute:
 
 ```PowerShell
-gvsbuild build --enable-gi --py-wheel gobject-introspection gtk4 libadwaita pycairo pygobject gtksourceview5 adwaita-icon-theme hicolor-icon-theme
+gvsbuild build --enable-gi gobject-introspection gtk4 libadwaita gtksourceview5 adwaita-icon-theme hicolor-icon-theme
 ```
 Grab a coffee, the build will take a few minutes to complete.
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -70,26 +70,45 @@ choco install visualstudio2022-workload-vctools
 
 #### Install the Latest Python
 
-Download and install the latest version of Python:
+In Windows, The full installer contains all the Python components and is the
+best option for developers using Python for any kind of project.
+
+For more information on how to use the official installer, please see the
+[full installer instructions](https://docs.python.org/3/using/windows.html#windows-full).
+The default installation options should be fine for use with Gaphor.
+
+1. Install the latest Python version using the
+[official installer](https://www.python.org/downloads/windows/).
+
+2. Open a PowerShell terminal as a normal user and check the python version:
+
+   ```PowerShell
+   py -3.11 --version
+   ```
+
+#### Install Graphviz
+
+Graphviz is used by Gaphor for automatic diagram formatting.
 
 1. Install from Chocolately with administrator PowerShell:
 
    ```PowerShell
-   choco install python
+   choco install graphviz
    ```
 
-2. Restart your PowerShell terminal as a normal user and check  the python version:
+2. Restart your PowerShell terminal as a normal user and check that the dot
+   command is available:
 
    ```PowerShell
-   python --version
+   dot -?
    ```
 
 #### Install pipx
 
 From the regular user PowerShell terminal execute:
 ```PowerShell
-python -m pip install --user pipx
-python -m pipx ensurepath
+py -3.11 -m pip install --user pipx
+py -3.11 -m pipx ensurepath
 ```
 
 #### Install gvsbuild
@@ -119,7 +138,7 @@ cd gaphor
 ```
 
 Install Poetry
-```bash
+```PowerShell
 pipx install poetry
 poetry config virtualenvs.in-project true
 ```
@@ -139,6 +158,9 @@ $env:INCLUDE = $gtk_include + "\cairo;" + $gtk_include + "\glib-2.0;"
 $env:INCLUDE = $gtk_include + "\gobject-introspection-1.0;" + $env:INCLUDE
 $env:INCLUDE = $gtk_path + "\lib\glib-2.0\include;" + $gtk_include + ";" + $env:INCLUDE
 ```
+
+You can also edit your account's Environmental Variables to persist across
+PowerShell sessions.
 
 Launch Gaphor!
 ```PowerShell

--- a/gaphor/RAAML/fta/majorityvotegate.py
+++ b/gaphor/RAAML/fta/majorityvotegate.py
@@ -2,7 +2,6 @@
 
 from math import pi
 
-import cairo
 from gaphas.geometry import Rectangle
 
 from gaphor.core import gettext
@@ -91,7 +90,6 @@ def draw_majority_vote_gate(box, context: DrawContext, bounding_box: Rectangle):
     cr.restore()
 
     # Draw "m"
-    cr.select_font_face("Sans", cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_NORMAL)
     text = "m"
     if bounding_box.height > 3 * bounding_box.width:
         cr.set_font_size(32 * bounding_box.width / DEFAULT_WIDTH)

--- a/poetry.lock
+++ b/poetry.lock
@@ -24,7 +24,7 @@ python-versions = "*"
 
 [[package]]
 name = "asttokens"
-version = "2.2.0"
+version = "2.2.1"
 description = "Annotate AST trees with source code positions"
 category = "main"
 optional = false
@@ -245,15 +245,15 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 
 [[package]]
 name = "filelock"
-version = "3.8.0"
+version = "3.8.2"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
-testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2022.9.29)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
+testing = ["covdefaults (>=2.2.2)", "coverage (>=6.5)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "future"
@@ -513,7 +513,7 @@ testing = ["coverage", "ipykernel", "jupytext", "matplotlib", "nbdime", "nbforma
 
 [[package]]
 name = "jupyter-client"
-version = "7.4.7"
+version = "7.4.8"
 description = "Jupyter protocol implementation and client libraries"
 category = "main"
 optional = true
@@ -602,7 +602,7 @@ traitlets = "*"
 
 [[package]]
 name = "mdit-py-plugins"
-version = "0.3.1"
+version = "0.3.3"
 description = "Collection of plugins for markdown-it-py"
 category = "main"
 optional = true
@@ -844,7 +844,7 @@ virtualenv = ">=20.0.8"
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.33"
+version = "3.0.36"
 description = "Library for building powerful interactive command lines in Python"
 category = "main"
 optional = false
@@ -893,7 +893,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycairo"
-version = "1.22.0"
+version = "1.23.0"
 description = "Python interface for cairo"
 category = "main"
 optional = false
@@ -1451,7 +1451,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.17.0"
+version = "20.17.1"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -1522,7 +1522,7 @@ docs = ["sphinx", "sphinx-rtd-theme", "sphinx-copybutton", "myst-nb"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<3.12"
-content-hash = "344b932d5f017473d420f1b1dbabe8108dcb6ae47f7bacb29adaddb60b10ebc1"
+content-hash = "e7a4120455c4e7f96a20cdc86d382c8e55047470ed1399fac240e8074b1f80b8"
 
 [metadata.files]
 alabaster = [
@@ -1538,8 +1538,8 @@ appnope = [
     {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
 ]
 asttokens = [
-    {file = "asttokens-2.2.0-py2.py3-none-any.whl", hash = "sha256:c56caef774a929923696f09ceea0eadcb95c94b30e8ee4f9fc4f5867096caaeb"},
-    {file = "asttokens-2.2.0.tar.gz", hash = "sha256:e27b1f115daebfafd4d1826fc75f9a72f0b74bd3ae4ee4d9380406d74d35e52c"},
+    {file = "asttokens-2.2.1-py2.py3-none-any.whl", hash = "sha256:6b0ac9e93fb0335014d382b8fa9b3afa7df546984258005da0b9e7095b3deb1c"},
+    {file = "asttokens-2.2.1.tar.gz", hash = "sha256:4622110b2a6f30b77e1473affaa97e711bc2f07d3f10848420ff1898edbe94f3"},
 ]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
@@ -1558,6 +1558,7 @@ backcall = [
 ]
 better-exceptions = [
     {file = "better_exceptions-0.3.3-py3-none-any.whl", hash = "sha256:9c70b1c61d5a179b84cd2c9d62c3324b667d74286207343645ed4306fdaad976"},
+    {file = "better_exceptions-0.3.3-py3.8.egg", hash = "sha256:bf111d0c9994ac1123f29c24907362bed2320a86809c85f0d858396000667ce2"},
     {file = "better_exceptions-0.3.3.tar.gz", hash = "sha256:e4e6bc18444d5f04e6e894b10381e5e921d3d544240418162c7db57e9eb3453b"},
 ]
 certifi = [
@@ -1751,8 +1752,8 @@ fastjsonschema = [
     {file = "fastjsonschema-2.16.2.tar.gz", hash = "sha256:01e366f25d9047816fe3d288cbfc3e10541daf0af2044763f3d0ade42476da18"},
 ]
 filelock = [
-    {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
-    {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
+    {file = "filelock-3.8.2-py3-none-any.whl", hash = "sha256:8df285554452285f79c035efb0c861eb33a4bcfa5b7a137016e32e6a90f9792c"},
+    {file = "filelock-3.8.2.tar.gz", hash = "sha256:7565f628ea56bfcd8e54e42bdc55da899c85c1abfe1b5bcfd147e9188cebb3b2"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
@@ -1876,8 +1877,8 @@ jupyter-cache = [
     {file = "jupyter_cache-0.5.0-py3-none-any.whl", hash = "sha256:642e434b9b75c4b94dc8346eaf5a639c8926a0673b87e5e8ef6460d5cf2c9516"},
 ]
 jupyter-client = [
-    {file = "jupyter_client-7.4.7-py3-none-any.whl", hash = "sha256:df56ae23b8e1da1b66f89dee1368e948b24a7f780fa822c5735187589fc4c157"},
-    {file = "jupyter_client-7.4.7.tar.gz", hash = "sha256:330f6b627e0b4bf2f54a3a0dd9e4a22d2b649c8518168afedce2c96a1ceb2860"},
+    {file = "jupyter_client-7.4.8-py3-none-any.whl", hash = "sha256:d4a67ae86ee014bcb96bd8190714f6af921f2b0f52f4208b086aa5acfd9f8d65"},
+    {file = "jupyter_client-7.4.8.tar.gz", hash = "sha256:109a3c33b62a9cf65aa8325850a0999a795fac155d9de4f7555aef5f310ee35a"},
 ]
 jupyter-core = [
     {file = "jupyter_core-5.1.0-py3-none-any.whl", hash = "sha256:f5740d99606958544396914b08e67b668f45e7eff99ab47a7f4bcead419c02f4"},
@@ -1938,8 +1939,8 @@ matplotlib-inline = [
     {file = "matplotlib_inline-0.1.6-py3-none-any.whl", hash = "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311"},
 ]
 mdit-py-plugins = [
-    {file = "mdit-py-plugins-0.3.1.tar.gz", hash = "sha256:3fc13298497d6e04fe96efdd41281bfe7622152f9caa1815ea99b5c893de9441"},
-    {file = "mdit_py_plugins-0.3.1-py3-none-any.whl", hash = "sha256:606a7f29cf56dbdfaf914acb21709b8f8ee29d857e8f29dcc33d8cb84c57bfa1"},
+    {file = "mdit-py-plugins-0.3.3.tar.gz", hash = "sha256:5cfd7e7ac582a594e23ba6546a2f406e94e42eb33ae596d0734781261c251260"},
+    {file = "mdit_py_plugins-0.3.3-py3-none-any.whl", hash = "sha256:36d08a29def19ec43acdcd8ba471d3ebab132e7879d442760d963f19913e04b9"},
 ]
 mdurl = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
@@ -2009,8 +2010,8 @@ pre-commit = [
     {file = "pre_commit-2.20.0.tar.gz", hash = "sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.33-py3-none-any.whl", hash = "sha256:ced598b222f6f4029c0800cefaa6a17373fb580cd093223003475ce32805c35b"},
-    {file = "prompt_toolkit-3.0.33.tar.gz", hash = "sha256:535c29c31216c77302877d5120aef6c94ff573748a5b5ca5b1b1f76f5e700c73"},
+    {file = "prompt_toolkit-3.0.36-py3-none-any.whl", hash = "sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305"},
+    {file = "prompt_toolkit-3.0.36.tar.gz", hash = "sha256:3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63"},
 ]
 psutil = [
     {file = "psutil-5.9.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c1ca331af862803a42677c120aff8a814a804e09832f166f226bfd22b56feee8"},
@@ -2041,17 +2042,17 @@ py = [
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycairo = [
-    {file = "pycairo-1.22.0-cp310-cp310-win32.whl", hash = "sha256:5a62cf1d2c6339028709a600d83c0c24111feedeef3cf977bca333fbb94a79c8"},
-    {file = "pycairo-1.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:62ce5e8c97eeee70170ba9a74845a0ded4bde9b7f1701d88957cbadf8cb1ccd6"},
-    {file = "pycairo-1.22.0-cp311-cp311-win32.whl", hash = "sha256:356c9fc665e8522f497b6cbe026ad8decacbb04c93e13fd5d145956433f3d471"},
-    {file = "pycairo-1.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:b85807ec65a8b7966aca7aa41c39016b72515d6401a874a4b52c314471b31865"},
-    {file = "pycairo-1.22.0-cp37-cp37m-win32.whl", hash = "sha256:9fbe26b3fbe85fde063070e543b4a5f3609569ca8f79680867cecb837d5be29c"},
-    {file = "pycairo-1.22.0-cp37-cp37m-win_amd64.whl", hash = "sha256:00c8a6b92c5075ee3be7ea1d33f676d259f11f92cad7e37077dd193437c8c27c"},
-    {file = "pycairo-1.22.0-cp38-cp38-win32.whl", hash = "sha256:47aed13e950345c8248f77c8a51bff52188bef7afd3d5169584e0eddc21ba341"},
-    {file = "pycairo-1.22.0-cp38-cp38-win_amd64.whl", hash = "sha256:e81189414c11340134bffa6dcb06a378976cb87a6742f39aaefc79cb27612250"},
-    {file = "pycairo-1.22.0-cp39-cp39-win32.whl", hash = "sha256:e31a5b70664c425f4d1b71ba8aaf259920de6937a9490132ffabadad2a89764f"},
-    {file = "pycairo-1.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:007ae728c56b9a0962d8c5513ae967a4fceff03e022940383c20f4f3d4c48dbe"},
-    {file = "pycairo-1.22.0.tar.gz", hash = "sha256:b34517abdf619d4c7f0274f012b398d9b03bab7adc3efd2912bf36be3f911f3f"},
+    {file = "pycairo-1.23.0-cp310-cp310-win32.whl", hash = "sha256:564601e5f528531c6caec1c0177c3d0709081e1a2a5cccc13561f715080ae535"},
+    {file = "pycairo-1.23.0-cp310-cp310-win_amd64.whl", hash = "sha256:e7cde633986435d87a86b6118b7b6109c384266fd719ef959883e2729f6eafae"},
+    {file = "pycairo-1.23.0-cp311-cp311-win32.whl", hash = "sha256:3a71f758e461180d241e62ef52e85499c843bd2660fd6d87cec99c9833792bfa"},
+    {file = "pycairo-1.23.0-cp311-cp311-win_amd64.whl", hash = "sha256:2dec5378133778961993fb59d66df16070e03f4d491b67eb695ca9ad7a696008"},
+    {file = "pycairo-1.23.0-cp37-cp37m-win32.whl", hash = "sha256:d6bacff15d688ed135b4567965a4b664d9fb8de7417a7865bb138ad612043c9f"},
+    {file = "pycairo-1.23.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ec305fc7f2f0299df78aadec0eaf6eb9accb90eda242b5d3492544d3f2b28027"},
+    {file = "pycairo-1.23.0-cp38-cp38-win32.whl", hash = "sha256:1a6d8e0f353062ad92954784e33dbbaf66c880c9c30e947996c542ed9748aaaf"},
+    {file = "pycairo-1.23.0-cp38-cp38-win_amd64.whl", hash = "sha256:82e335774a17870bc038e0c2fb106c1e5e7ad0c764662023886dfcfce5bb5a52"},
+    {file = "pycairo-1.23.0-cp39-cp39-win32.whl", hash = "sha256:a4b1f525bbdf637c40f4d91378de36c01ec2b7f8ecc585b700a079b9ff83298e"},
+    {file = "pycairo-1.23.0-cp39-cp39-win_amd64.whl", hash = "sha256:87efd62a7b7afad9a0a420f05b6008742a6cfc59077697be65afe8dc73ae15ad"},
+    {file = "pycairo-1.23.0.tar.gz", hash = "sha256:9b61ac818723adc04367301317eb2e814a83522f07bbd1f409af0dada463c44c"},
 ]
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -2174,13 +2175,6 @@ pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
-    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
-    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -2429,8 +2423,8 @@ urllib3 = [
     {file = "urllib3-1.26.13.tar.gz", hash = "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.17.0-py3-none-any.whl", hash = "sha256:40a7e06a98728fd5769e1af6fd1a706005b4bb7e16176a272ed4292473180389"},
-    {file = "virtualenv-20.17.0.tar.gz", hash = "sha256:7d6a8d55b2f73b617f684ee40fd85740f062e1f2e379412cb1879c7136f05902"},
+    {file = "virtualenv-20.17.1-py3-none-any.whl", hash = "sha256:ce3b1684d6e1a20a3e5ed36795a97dfc6af29bc3970ca8dab93e11ac6094b3c4"},
+    {file = "virtualenv-20.17.1.tar.gz", hash = "sha256:f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ exclude = ["**/tests", "gaphor/conftest.py" ]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-pycairo = "<1.23"
+pycairo = "^1.23"
 PyGObject = "^3.30"
 gaphas = "^3.1.0"
 generic = "^1.0.0"

--- a/tests/test_gaphorconvert.py
+++ b/tests/test_gaphorconvert.py
@@ -1,3 +1,5 @@
+import importlib
+
 import pytest
 
 from gaphor.plugins.diagramexport import gaphorconvert
@@ -16,8 +18,13 @@ def test_help_output(capsys):
     assert "--regex=regex" in captured.out
 
 
-def test_export_pdf(tmp_path):
-    gaphorconvert.main(["-v", "-d", str(tmp_path), "test-models/all-elements.gaphor"])
+@pytest.fixture
+def model():
+    return importlib.resources.files("test-models") / "all-elements.gaphor"
+
+
+def test_export_pdf(tmp_path, model):
+    gaphorconvert.main(["-v", "-d", str(tmp_path), str(model)])
 
     model_path = tmp_path / "New model"
 
@@ -25,10 +32,8 @@ def test_export_pdf(tmp_path):
     assert (model_path / "main.pdf").exists()
 
 
-def test_export_png(tmp_path):
-    gaphorconvert.main(
-        ["-v", "-f", "png", "-d", str(tmp_path), "test-models/all-elements.gaphor"]
-    )
+def test_export_png(tmp_path, model):
+    gaphorconvert.main(["-v", "-f", "png", "-d", str(tmp_path), str(model)])
 
     model_path = tmp_path / "New model"
 
@@ -36,10 +41,8 @@ def test_export_png(tmp_path):
     assert (model_path / "main.png").exists()
 
 
-def test_export_svg(tmp_path):
-    gaphorconvert.main(
-        ["-v", "-f", "svg", "-d", str(tmp_path), "test-models/all-elements.gaphor"]
-    )
+def test_export_svg(tmp_path, model):
+    gaphorconvert.main(["-v", "-f", "svg", "-d", str(tmp_path), str(model)])
 
     model_path = tmp_path / "New model"
 


### PR DESCRIPTION
This PR fixes Windows build issues by:
- Upgrading gvsbuild to version 2022.6.0
- Update the Windows docs to use the official Python installer and install wheels from gvsbuild
- Fix an issue with `test_gaphorconvert` where it was using relative file paths, updated to use importlib

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
