### PR TITLE
macOS: cursor shortcuts

### DIFF
--- a/gaphor/ui/macosshim.py
+++ b/gaphor/ui/macosshim.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 log = logging.getLogger(__name__)
 
 
-if sys.platform != "darwin" and Gtk.get_major_version() == 3:
+if sys.platform != "darwin" and Gtk.get_major_version() == 3:  # noqa C901
     import gi
 
     macos_app = None
@@ -43,55 +43,69 @@ if sys.platform != "darwin" and Gtk.get_major_version() == 3:
             "NSApplicationBlockTermination", block_termination, application
         )
 
-elif sys.platform == "darwin" and Gtk.get_major_version == 4:
+elif sys.platform == "darwin" and Gtk.get_major_version() == 4:
 
     from gi.repository import GLib
 
-    def new_shortcut_with_args(shortcut, name, *args):
+    def new_shortcut_with_args(shortcut, signal, *args):
         shortcut = Gtk.Shortcut.new(
             trigger=Gtk.ShortcutTrigger.parse_string(shortcut),
-            action=Gtk.SignalAction.new(name),
+            action=Gtk.SignalAction.new(signal),
         )
         if args:
             shortcut.set_arguments(GLib.Variant.new_tuple(*args))
         return shortcut
 
-    # MacOS specific key bindings:
-    # Command–a: Select all.
-    # Command–Shift-a: Unselect all.
-    # Command–Up Arrow: Move the insertion point to the beginning of the document.
-    # Command–Down Arrow: Move the insertion point to the end of the document.
-    # Command–Left Arrow: Move the insertion point to the beginning of the current line.
-    # Command–Right Arrow: Move the insertion point to the end of the current line.
-    # Option–Left Arrow: Move the insertion point to the beginning of the previous word.
-    # Option–Right Arrow: Move the insertion point to the end of the next word.
+    def add_move_binding(widget_class, shortcut, step, count):
 
-    # Control-H: Delete the character to the left of the insertion point. Or use Delete.
-    # Control-D: Delete the character to the right of the insertion point. Or use Fn-Delete.
+        widget_class.add_shortcut(
+            new_shortcut_with_args(
+                shortcut,
+                "move-cursor",
+                GLib.Variant.new_int32(step),
+                GLib.Variant.new_int32(count),
+                GLib.Variant.new_boolean(False),
+            )
+        )
 
-    for cls in (Gtk.Text, Gtk.TextView):
+        widget_class.add_shortcut(
+            new_shortcut_with_args(
+                "|".join(f"<Shift>{s}" for s in shortcut.split("|")),
+                "move-cursor",
+                GLib.Variant.new_int32(step),
+                GLib.Variant.new_int32(count),
+                GLib.Variant.new_boolean(True),
+            )
+        )
+
+    for widget_class in (Gtk.Text, Gtk.TextView):
         for shortcut, signal in [
             ("<Meta>x", "cut-clipboard"),
             ("<Meta>c", "copy-clipboard"),
             ("<Meta>v", "paste-clipboard"),
         ]:
-            cls.add_shortcut(
-                Gtk.Shortcut.new(
-                    trigger=Gtk.ShortcutTrigger.parse_string(shortcut),
-                    action=Gtk.SignalAction.new(signal),
-                )
-            )
+            widget_class.add_shortcut(new_shortcut_with_args(shortcut, signal))
 
         for shortcut, action in [
             ("<Meta>z", "text.undo"),
             ("<Meta><Shift>z", "text.redo"),
         ]:
-            cls.add_shortcut(
+            widget_class.add_shortcut(
                 Gtk.Shortcut.new(
                     trigger=Gtk.ShortcutTrigger.parse_string(shortcut),
                     action=Gtk.NamedAction.new(action),
                 )
             )
+
+        for shortcut, step, count in [
+            ("<Meta>Up|<Meta>KP_Up", Gtk.MovementStep.BUFFER_ENDS, -1),
+            ("<Meta>Down|<Meta>KP_Down", Gtk.MovementStep.BUFFER_ENDS, 1),
+            ("<Meta>Left|<Meta>KP_Left", Gtk.MovementStep.DISPLAY_LINE_ENDS, -1),
+            ("<Meta>Right|<Meta>KP_Right", Gtk.MovementStep.DISPLAY_LINE_ENDS, 1),
+            ("<Alt>Left|<Alt>KP_Left", Gtk.MovementStep.WORDS, -1),
+            ("<Alt>Right|<Alt>KP_Right", Gtk.MovementStep.WORDS, 1),
+        ]:
+            add_move_binding(widget_class, shortcut, step, count)
 
     # Gtk.Text
 
@@ -107,25 +121,6 @@ elif sys.platform == "darwin" and Gtk.get_major_version == 4:
             "move-cursor",
             GLib.Variant.new_int32(Gtk.MovementStep.VISUAL_POSITIONS),
             GLib.Variant.new_int32(0),
-            GLib.Variant.new_boolean(False),
-        )
-    )
-
-    Gtk.Text.add_shortcut(
-        new_shortcut_with_args(
-            "<Meta>Up",
-            "move-cursor",
-            GLib.Variant.new_int32(Gtk.MovementStep.VISUAL_POSITIONS),
-            GLib.Variant.new_int32(0),
-            GLib.Variant.new_boolean(False),
-        )
-    )
-    Gtk.Text.add_shortcut(
-        new_shortcut_with_args(
-            "<Meta>Down",
-            "move-cursor",
-            GLib.Variant.new_int32(Gtk.MovementStep.VISUAL_POSITIONS),
-            GLib.Variant.new_int32(-1),
             GLib.Variant.new_boolean(False),
         )
     )


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Cursor shortcuts (`Cmd+Left`, etc.) do not work.

Issue Number: #1839

### What is the new behavior?

Cursor shortcuts work as expected.

I reworked the code a little, so shortcuts are only loaded for macOS.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


### Other information

I think this is the last change related to macOS keyboard shortcuts in GTK4.