### PR TITLE
Add Sourcery as a pre-commit hook

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -33,6 +33,10 @@ jobs:
         uses: actions/setup-python@v4.3.1
         with:
           python-version: ${{ env.python_version }}
+      - name: Install sourcery-cli
+        run: pip install sourcery-cli
+      - name: Login to sourcery
+        run: sourcery login --token ${{ secrets.SOURCERY_TOKEN }}
       - name: Lint with Pre-commit
         uses: pre-commit/action@v3.0.0
       - name: Check translations

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,8 @@ repos:
   rev: v3.2.2
   hooks:
   - id: pyupgrade
+- repo: https://github.com/sourcery-ai/sourcery
+  rev: v1.0.1
+  hooks:
+  - id: sourcery
+    args: [--diff=git diff HEAD, --no-summary]


### PR DESCRIPTION
This should reduce Sourcery making PRs against our changes by ensuring that commited changes already have sourcery refactorings included.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
