### PR TITLE
Move Control Flow line style to CSS

### DIFF
--- a/gaphor/UML/actions/flow.py
+++ b/gaphor/UML/actions/flow.py
@@ -36,7 +36,6 @@ class ControlFlowItem(Named, LinePresentation):
                 ),
                 Text(text=lambda: self.subject.name or ""),
             ),
-            style={"dash-style": (9.0, 3.0)},
         )
 
         self.watch("subject[NamedElement].name")

--- a/gaphor/core/modeling/stylesheet.py
+++ b/gaphor/core/modeling/stylesheet.py
@@ -40,6 +40,10 @@ SYSTEM_STYLE_SHEET = textwrap.dedent(
     interfacerealization[on_folded_interface = true] {
         dash-style: 0;
     }
+
+    controlflow {
+        dash-style: 9 3;
+    }
     """
 )
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Control flow is following the SysML notation. This is fine generally, unless you want (or need) to stricty follow the UML specs, where Control Flow is a solid line.

Issue Number: #1900

### What is the new behavior?

The dashed line style has been moved to the style sheet from an inline style. Now it can be overridden in the model.

If you want a solid line, add the following to the style sheet of your model:

```css
controlflow {
  dash-style: 0;
}
```