### PR TITLE
Use system fonts by default for diagrams

### DIFF
--- a/gaphor/core/modeling/stylesheet.py
+++ b/gaphor/core/modeling/stylesheet.py
@@ -12,7 +12,6 @@ SYSTEM_STYLE_SHEET = textwrap.dedent(
     * {
      background-color: transparent;
      color: black;
-     font-family: sans;
      font-size: 14;
      line-width: 2;
      padding: 0;
@@ -49,13 +48,6 @@ SYSTEM_STYLE_SHEET = textwrap.dedent(
 
 DEFAULT_STYLE_SHEET = textwrap.dedent(
     """\
-    * {
-     background-color: transparent;
-     color: black;
-     font-family: sans;
-     font-size: 14;
-    }
-
     diagram {
      /* line-style: sloppy 0.3; */
     }

--- a/gaphor/core/modeling/stylesheet.py
+++ b/gaphor/core/modeling/stylesheet.py
@@ -60,14 +60,25 @@ class StyleSheet(Element):
 
     def __init__(self, id=None, model=None):
         super().__init__(id, model)
-
+        self._system_font_family = "sans"
         self.compile_style_sheet()
 
     styleSheet: attribute[str] = attribute("styleSheet", str, DEFAULT_STYLE_SHEET)
 
+    @property
+    def system_font_family(self) -> str:
+        return self._system_font_family
+
+    @system_font_family.setter
+    def system_font_family(self, font_family: str):
+        self._system_font_family = font_family
+        self.compile_style_sheet()
+
     def compile_style_sheet(self) -> None:
         self._compiled_style_sheet = CompiledStyleSheet(
-            SYSTEM_STYLE_SHEET, self.styleSheet
+            SYSTEM_STYLE_SHEET,
+            f"* {{ font-family: {self._system_font_family} }}",
+            self.styleSheet,
         )
 
     def match(self, node: StyleNode) -> Style:

--- a/gaphor/core/modeling/tests/test_diagram_style.py
+++ b/gaphor/core/modeling/tests/test_diagram_style.py
@@ -3,12 +3,7 @@ import pytest
 
 from gaphor.core.eventmanager import EventManager
 from gaphor.core.modeling import ElementFactory, Presentation, StyleSheet
-from gaphor.core.modeling.diagram import (
-    FALLBACK_STYLE,
-    Diagram,
-    StyledDiagram,
-    StyledItem,
-)
+from gaphor.core.modeling.diagram import Diagram, StyledDiagram, StyledItem
 
 
 @pytest.fixture
@@ -56,18 +51,4 @@ def test_diagram_has_no_parent(diagram):
 def test_style_sheet_has_default_style():
     style_sheet = StyleSheet()
 
-    assert "* {" in style_sheet.styleSheet
-
-
-def test_system_style_sheet_covers_fallback_styles(diagram):
-    style_sheet = StyleSheet()
-    style_sheet.styleSheet = ""
-    style_sheet.compile_style_sheet()
-
-    item = diagram.create(DemoItem)
-    node = StyledItem(item)
-
-    style = style_sheet.match(node)
-
-    for prop, value in FALLBACK_STYLE.items():
-        assert style[prop] == value
+    assert "diagram {" in style_sheet.styleSheet

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -7,6 +7,8 @@ from gi.repository import Pango, PangoCairo
 
 from gaphor.core.styling import FontStyle, FontWeight, Style, TextAlign, TextDecoration
 
+SYSTEM_FONT = "sans"
+
 
 class Layout:
     def __init__(
@@ -45,7 +47,7 @@ class Layout:
             self.set_alignment(text_align)
 
     def set_font(self, font: Style) -> None:
-        font_family = font.get("font-family")
+        font_family = font.get("font-family", SYSTEM_FONT)
         font_size = font.get("font-size")
         font_weight = font.get("font-weight")
         font_style = font.get("font-style")

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -7,8 +7,6 @@ from gi.repository import Pango, PangoCairo
 
 from gaphor.core.styling import FontStyle, FontWeight, Style, TextAlign, TextDecoration
 
-SYSTEM_FONT = "sans"
-
 
 class Layout:
     def __init__(
@@ -47,7 +45,7 @@ class Layout:
             self.set_alignment(text_align)
 
     def set_font(self, font: Style) -> None:
-        font_family = font.get("font-family", SYSTEM_FONT)
+        font_family = font.get("font-family")
         font_size = font.get("font-size")
         font_weight = font.get("font-weight")
         font_style = font.get("font-style")

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -66,11 +66,11 @@ def main(argv=sys.argv) -> int:
                 "gtk-application-prefer-dark-theme", darkdetect.isDark()
             )
         else:
-            if darkdetect.isDark():
-                color_scheme = Adw.ColorScheme.PREFER_DARK
-            else:
-                color_scheme = Adw.ColorScheme.PREFER_LIGHT
-            Adw.StyleManager.get_default().set_color_scheme(color_scheme)
+            Adw.StyleManager.get_default().set_color_scheme(
+                Adw.ColorScheme.PREFER_DARK
+                if darkdetect.isDark()
+                else Adw.ColorScheme.PREFER_LIGHT
+            )
 
     if has_option("-p", "--profiler"):
 

--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -7,7 +7,13 @@ from gi.repository import Gio, Gtk
 
 from gaphor.abc import ActionProvider
 from gaphor.core import action, event_handler
-from gaphor.core.modeling import AttributeUpdated, Diagram, ModelFlushed, ModelReady
+from gaphor.core.modeling import (
+    AttributeUpdated,
+    Diagram,
+    ModelFlushed,
+    ModelReady,
+    StyleSheet,
+)
 from gaphor.diagram.drop import drop
 from gaphor.event import ActionEnabled
 from gaphor.transaction import Transaction
@@ -324,6 +330,12 @@ class Diagrams(UIComponent, ActionProvider):
     @event_handler(ModelReady)
     def _on_model_ready(self, event=None):
         """Open the toplevel element and load toplevel diagrams."""
+
+        if style_sheet := next(self.element_factory.select(StyleSheet), None):
+            style_sheet.system_font_family = (
+                Gtk.Settings.get_default().props.gtk_font_name.rsplit(" ", 1)[0]
+            )
+
         diagram_ids = self.properties.get("opened-diagrams", [])
         current_diagram_id = self.properties.get("current-diagram", None)
 

--- a/models/SysML.gaphor
+++ b/models/SysML.gaphor
@@ -11036,25 +11036,7 @@ otherwise MRO can not be resolved.</val>
 <val>required</val>
 </name>
 </Property>
-<StyleSheet id="7b071a10-ec8e-11ea-96dc-bf74f1f80424">
-<styleSheet>
-<val>* {
- background-color: transparent;
- color: black;
- font-family: sans;
- font-size: 14;
- highlight-color: rgba(0, 0, 255, 0.4);
- line-width: 2;
- padding: 0;
-}
-
-diagram {
- line-style: normal;
- /* line-style: sloppy 0.3; */
-}
-</val>
-</styleSheet>
-</StyleSheet>
+<StyleSheet id="7b071a10-ec8e-11ea-96dc-bf74f1f80424"/>
 <Extension id="9345730a-ed52-11ea-96dc-bf74f1f80424">
 <memberEnd>
 <reflist>

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -51418,21 +51418,7 @@ Fig. 9.9</val>
 </Generalization>
 <StyleSheet id="a89690ce-e0a8-11ea-b7ab-f5b4c130f24e">
 <styleSheet>
-<val>* {
- background-color: transparent;
- color: black;
- font-family: sans;
- font-size: 14;
- highlight-color: rgba(0, 0, 255, 0.4);
- line-width: 2;
- padding: 0;
-}
-
-diagram {
- line-style: normal;
- /* line-style: sloppy 0.3; */
-}
-
+<val>
 :not([subject], :is(line, box, ellipse, commentline)) {
   color: firebrick;
 }


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

We use the default font `sans`, which looks a bit off.

Issue Number: #1921 

### What is the new behavior?

* The system default UI font is set when the UI is used.
* Fallback to the well known "Sans" font.
* Removed default style from our models

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


### Other information

It looks like the changes in element dimensions are minimal. The fonts have slightly different sizing.


![GNOME Cantarell](https://user-images.githubusercontent.com/96249/207713071-8f0bc46b-220f-4dfb-aae1-4cd93e0246ff.png)
