### PR TITLE
Remove querymixin from modeling lists

### DIFF
--- a/gaphor/codegen/tests/test_coder.py
+++ b/gaphor/codegen/tests/test_coder.py
@@ -281,7 +281,7 @@ def test_replace_simple_attribute(uml_metamodel: ElementFactory):
             lambda e: isinstance(e, UML.Class) and e.name == "InstanceSpecification"
         )
     )
-    a = instancespec.ownedAttribute["it.name == 'specification'"][0]
+    a = next(it for it in instancespec.ownedAttribute if it.name == "specification")
 
     assert a.name == "specification"
     assert a.typeValue == "str"

--- a/gaphor/core/modeling/collection.py
+++ b/gaphor/core/modeling/collection.py
@@ -3,12 +3,12 @@
 from typing import Generic, List, Type, TypeVar, overload
 
 from gaphor.core.modeling.event import AssociationUpdated
-from gaphor.core.modeling.listmixins import querymixin, recursemixin, recurseproxy
+from gaphor.core.modeling.listmixins import recursemixin, recurseproxy
 
 T = TypeVar("T")
 
 
-class collectionlist(recursemixin, querymixin, List[T]):  # type: ignore[misc]
+class collectionlist(recursemixin, List[T]):  # type: ignore[misc]
     """
     >>> c = collectionlist()
     >>> c.append("a")
@@ -39,10 +39,6 @@ class collectionlist(recursemixin, querymixin, List[T]):  # type: ignore[misc]
     <gaphor.core.modeling.listmixins.recurseproxy object at 0x...>
     >>> list(c.ownedOperation[:].ownedParameter.name)
     ['foo', 'bar']
-    >>> c.ownedOperation[0].ownedParameter['it.name=="foo"', 0].name
-    'foo'
-    >>> c.ownedOperation[:].ownedParameter['it.name=="foo"', 0].name
-    'foo'
     """
 
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

We could use string based queries, but never used those.

### What is the new behavior?

Just use a list comprehension:

```python
a = instancespec.ownedAttribute["it.name == 'specification'"][0]
a = next(it for it in instancespec.ownedAttribute if it.name == 'specification')
```

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No
