### PR TITLE
Fix loading error

### DIFF
--- a/gaphor/UML/classes/classconnect.py
+++ b/gaphor/UML/classes/classconnect.py
@@ -79,12 +79,15 @@ class AssociationConnect(RelationshipConnect):
         subject = line.subject
 
         def member_ends_match(subject):
-            return (
-                head_subject is subject.memberEnd[0].type
-                and tail_subject is subject.memberEnd[1].type
-            ) or (
-                head_subject is subject.memberEnd[1].type
-                and tail_subject is subject.memberEnd[0].type
+            return len(subject.memberEnd) >= 2 and (
+                (
+                    head_subject is subject.memberEnd[0].type
+                    and tail_subject is subject.memberEnd[1].type
+                )
+                or (
+                    head_subject is subject.memberEnd[1].type
+                    and tail_subject is subject.memberEnd[0].type
+                )
             )
 
         # First check if the right subject is already connected:

--- a/gaphor/core/eventmanager.py
+++ b/gaphor/core/eventmanager.py
@@ -24,6 +24,7 @@ class EventManager(Service):
 
     def __init__(self) -> None:
         self._events = _Manager()
+        self._priority = _Manager()
         self._queue: deque[Event] = deque()
         self._handling = False
 
@@ -36,12 +37,26 @@ class EventManager(Service):
         Handlers are triggered (executed) when specific events are
         emitted through the handle() method.
         """
+        self._subscribe(handler, self._events)
+
+    def priority_subscribe(self, handler: Handler) -> None:
+        """Register a handler.
+
+        Priority handlers are executed directly. They should not raise
+        other events, cause that can cause a problem in the exection order.
+
+        It's basically to make sure that all events are recorded by the
+        undo manager.
+        """
+        self._subscribe(handler, self._priority)
+
+    def _subscribe(self, handler: Handler, manager: _Manager) -> None:
         event_types = getattr(handler, "__event_types__", None)
         if not event_types:
             raise Exception(f"No event types provided for function {handler}")
 
         for et in event_types:
-            self._events.subscribe(handler, et)
+            manager.subscribe(handler, et)
 
     def unsubscribe(self, handler: Handler) -> None:
         """Unregister a previously registered handler."""
@@ -50,12 +65,16 @@ class EventManager(Service):
             raise Exception(f"No event types provided for function {handler}")
 
         for et in event_types:
+            self._priority.unsubscribe(handler, et)
             self._events.unsubscribe(handler, et)
 
     def handle(self, *events: Event) -> None:
         """Send event notifications to registered handlers."""
         queue = self._queue
         queue.extendleft(events)
+
+        for event in events:
+            self._priority.handle(event)
 
         if not self._handling:
             self._handling = True

--- a/gaphor/core/modeling/tests/test_presentation.py
+++ b/gaphor/core/modeling/tests/test_presentation.py
@@ -40,6 +40,23 @@ def test_should_emit_event_when_unlinked(diagram, event_manager):
     assert events[0].element is presentation
 
 
+def test_should_unlink_more_than_once(diagram, event_manager):
+    presentation = diagram.create(Example)
+    events = []
+
+    @event_handler(ElementDeleted)
+    def handler(event):
+        events.append(event)
+
+    event_manager.subscribe(handler)
+
+    presentation.unlink()
+    presentation.unlink()
+    presentation.unlink()
+
+    assert len(events) == 1
+
+
 def test_presentation_can_not_set_new_diagram(diagram, element_factory):
     presentation = diagram.create(Example)
     new_diagram = element_factory.create(Diagram)

--- a/gaphor/core/tests/test_eventmanager.py
+++ b/gaphor/core/tests/test_eventmanager.py
@@ -1,0 +1,102 @@
+import pytest
+from exceptiongroup import ExceptionGroup
+
+from gaphor.core.eventmanager import event_handler
+
+
+class Event:
+    pass
+
+
+class OtherEvent:
+    pass
+
+
+@event_handler(Event)
+class Subscriber:
+    def __init__(self, exception=None):
+        self.events = []
+        self.exception = exception
+
+    def __call__(self, event):
+        self.events.append(event)
+        if self.exception:
+            raise self.exception()
+
+
+def create_handler(event_type):
+    events = []
+
+    @event_handler(event_type)
+    def handler(event):
+        events.append(event)
+
+    return handler, events
+
+
+@pytest.fixture
+def subscriber(event_manager):
+    s = Subscriber()
+    event_manager.subscribe(s)
+    return s
+
+
+def test_event_manager(event_manager, subscriber):
+    event = Event()
+
+    event_manager.handle(event)
+
+    assert event in subscriber.events
+
+
+def test_error_in_handler(event_manager):
+    event = Event()
+    error = Subscriber(ValueError)
+    after = Subscriber()
+
+    event_manager.subscribe(error)
+    event_manager.subscribe(after)
+
+    with pytest.raises(ExceptionGroup):
+        event_manager.handle(event)
+
+    assert event in error.events
+    assert event in after.events
+
+
+def test_error_in_handler_and_second_event(event_manager):
+    @event_handler(Event)
+    def error_handler(event):
+        event_manager.handle(OtherEvent())
+        raise ValueError()
+
+    other_handler, other_events = create_handler(OtherEvent)
+
+    event_manager.subscribe(error_handler)
+    event_manager.subscribe(other_handler)
+
+    event = Event()
+
+    with pytest.raises(ExceptionGroup):
+        event_manager.handle(event)
+
+    assert not other_events
+
+
+def test_priority_handler_error_in_handler_and_second_event(event_manager):
+    @event_handler(Event)
+    def error_handler(event):
+        event_manager.handle(OtherEvent())
+        raise ValueError()
+
+    other_handler, other_events = create_handler(OtherEvent)
+
+    event_manager.subscribe(error_handler)
+    event_manager.priority_subscribe(other_handler)
+
+    event = Event()
+
+    with pytest.raises(ExceptionGroup):
+        event_manager.handle(event)
+
+    assert other_events

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -99,10 +99,10 @@ class UndoManager(Service, ActionProvider):
         self._current_transaction = None
         self._undoing = 0
 
-        event_manager.subscribe(self.reset)
-        event_manager.subscribe(self.begin_transaction)
-        event_manager.subscribe(self.commit_transaction)
-        event_manager.subscribe(self.rollback_transaction)
+        event_manager.priority_subscribe(self.reset)
+        event_manager.priority_subscribe(self.begin_transaction)
+        event_manager.priority_subscribe(self.commit_transaction)
+        event_manager.priority_subscribe(self.rollback_transaction)
         self._register_undo_handlers()
         self._action_executed()
 

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -184,6 +184,14 @@ def _load_elements_and_canvasitems(
             )
 
         if issubclass(cls, Presentation):
+            if "diagram" not in elem.references:
+                log.warning(
+                    "Removing element %s of type %s without diagram", elem.id, cls
+                )
+                assert not any(elem.id in e.references for e in elements.values())
+                del elements[elem.id]
+                return
+
             diagram_id = elem.references["diagram"]
             diagram_elem = elements[diagram_id]
             create_element(diagram_elem)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

There is still a possibility that a model is saved in a state that can't be loaded.

Issue Number: #1928

### What is the new behavior?

* Add an extra check for presentation elements that lack a diagram reference. We can easily get rid of those *iff* they are not referenced.
* Add an extra check for association connections: do not assume `Association.memberEnd` is always populated.
* Add a priority lane for event handlers. This is mainly to allow Undo Manager to receive all events
    
My hypothesis on why things still can break is because not all events are properly registered at the undo manager. In that case we can no do a full undo, and the model may remain in an inconsistent state. The effect (e.g. a property is set) is applied directly, then we notify by means of an event. That event will eventually be handled, or not, if an exception occurs.

To remedy this, we can basically do two things:

1. delay the (model) change until just before the event is about to be    fired (e.i. change events to commands).
2. Make sure all events are captured by the undo manager.

Option 1. is quite complicated, since a simple relation change canresults in a combination of set and delete events.
Option 2. is a bit hacky as well, since we add a "priotity lane" to the event manager.