### PR TITLE
Hide New Package menu unless package selected

### DIFF
--- a/gaphor/ui/namespace.py
+++ b/gaphor/ui/namespace.py
@@ -55,7 +55,8 @@ def popup_model(element, modeling_language):
     part.append_submenu(
         gettext("New _Diagram"), create_diagram_types_model(modeling_language)
     )
-    part.append(gettext("New _Package"), "tree-view.create-package")
+    if isinstance(element, UML.Package):
+        part.append(gettext("New _Package"), "tree-view.create-package")
     model.append_section(None, part)
 
     part = Gio.Menu.new()


### PR DESCRIPTION
Fixes #1952 which is an assertion error while creating a package that is nested under a non-package item.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
The New Package option was always visible on the right click menu.

Issue Number: #1952

### What is the new behavior?
The New Package option is disabled unless you are right-clicking on a package.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
