### PR TITLE
Make operations visible on Blocks

### DIFF
--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -15,7 +15,12 @@ from gaphor.diagram.shapes import (
 from gaphor.diagram.support import represents
 from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.SysML.sysml import Block, ValueType
-from gaphor.UML.classes.klass import attribute_watches
+from gaphor.UML.classes.klass import (
+    attribute_watches,
+    attributes_compartment,
+    operation_watches,
+    operations_compartment,
+)
 from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
 from gaphor.UML.recipes import stereotypes_str
 from gaphor.UML.umlfmt import format_property
@@ -31,6 +36,12 @@ class BlockItem(Classified, ElementPresentation[Block]):
         ).watch("show_references", self.update_shapes).watch(
             "show_values", self.update_shapes
         ).watch(
+            "show_operations", self.update_shapes
+        ).watch(
+            "show_attributes", self.update_shapes
+        ).watch(
+            "subject[NamedElement].name"
+        ).watch(
             "subject[NamedElement].name"
         ).watch(
             "subject[NamedElement].namespace.name"
@@ -40,6 +51,7 @@ class BlockItem(Classified, ElementPresentation[Block]):
             "subject[Class].ownedAttribute.aggregation", self.update_shapes
         )
         attribute_watches(self, "Block")
+        operation_watches(self, "Block")
         stereotype_watches(self)
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
@@ -49,6 +61,10 @@ class BlockItem(Classified, ElementPresentation[Block]):
     show_references: attribute[int] = attribute("show_references", int, default=False)
 
     show_values: attribute[int] = attribute("show_values", int, default=False)
+
+    show_attributes: attribute[int] = attribute("show_attributes", int, default=True)
+
+    show_operations: attribute[int] = attribute("show_operations", int, default=True)
 
     def additional_stereotypes(self):
         from gaphor.RAAML import raaml
@@ -121,6 +137,18 @@ class BlockItem(Classified, ElementPresentation[Block]):
                         and a.aggregation == "composite",
                     )
                 ]
+                or []
+            ),
+            *(
+                self.show_attributes
+                and self.subject
+                and [attributes_compartment(self.subject)]
+                or []
+            ),
+            *(
+                self.show_operations
+                and self.subject
+                and [operations_compartment(self.subject)]
                 or []
             ),
             *(self.show_stereotypes and stereotype_compartments(self.subject) or []),

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -54,9 +54,9 @@ class BlockItem(Classified, ElementPresentation[Block]):
 
     show_values: attribute[int] = attribute("show_values", int, default=False)
 
-    show_attributes: attribute[int] = attribute("show_attributes", int, default=True)
+    show_attributes: attribute[int] = attribute("show_attributes", int, default=False)
 
-    show_operations: attribute[int] = attribute("show_operations", int, default=True)
+    show_operations: attribute[int] = attribute("show_operations", int, default=False)
 
     def additional_stereotypes(self):
         from gaphor.RAAML import raaml

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -15,12 +15,7 @@ from gaphor.diagram.shapes import (
 from gaphor.diagram.support import represents
 from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.SysML.sysml import Block, ValueType
-from gaphor.UML.classes.klass import (
-    attribute_watches,
-    attributes_compartment,
-    operation_watches,
-    operations_compartment,
-)
+from gaphor.UML.classes.klass import attributes_compartment, operation_watches
 from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
 from gaphor.UML.recipes import stereotypes_str
 from gaphor.UML.umlfmt import format_property
@@ -38,8 +33,6 @@ class BlockItem(Classified, ElementPresentation[Block]):
         ).watch(
             "show_operations", self.update_shapes
         ).watch(
-            "show_attributes", self.update_shapes
-        ).watch(
             "subject[NamedElement].name"
         ).watch(
             "subject[NamedElement].name"
@@ -50,7 +43,6 @@ class BlockItem(Classified, ElementPresentation[Block]):
         ).watch(
             "subject[Class].ownedAttribute.aggregation", self.update_shapes
         )
-        attribute_watches(self, "Block")
         operation_watches(self, "Block")
         stereotype_watches(self)
 
@@ -148,7 +140,9 @@ class BlockItem(Classified, ElementPresentation[Block]):
             *(
                 self.show_operations
                 and self.subject
-                and [operations_compartment(self.subject)]
+                and [
+                    self.operations_compartment(gettext("operations"), self.subject),
+                ]
                 or []
             ),
             *(self.show_stereotypes and stereotype_compartments(self.subject) or []),
@@ -183,4 +177,28 @@ class BlockItem(Classified, ElementPresentation[Block]):
                 "justify-content": JustifyContent.START,
             },
             draw=draw_top_separator,
+        )
+
+    def operations_compartment(self, name, predicate):
+        def lazy_format(operation):
+            return lambda: format_property(operation) or gettext("unnamed")
+
+        return Box(
+            Text(
+                text=name,
+                style={
+                    "padding": (0, 0, 4, 0),
+                    "font-size": "x-small",
+                    "font-style": FontStyle.ITALIC,
+                },
+            ),
+            *(
+                Text(text=lazy_format(operation), style={"text-align": TextAlign.LEFT})
+                for operation in self.subject.ownedOperation
+            ),
+            style={
+                "padding": (4, 4, 4, 4),
+                "min-height": 8,
+                "justify-content": JustifyContent.START,
+            },
         )

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -141,7 +141,9 @@ class BlockItem(Classified, ElementPresentation[Block]):
                 self.show_operations
                 and self.subject
                 and [
-                    self.operations_compartment(gettext("operations"), self.subject),
+                    self.operations_compartment(
+                        self.diagram.gettext("operations"), self.subject
+                    ),
                 ]
                 or []
             ),
@@ -181,7 +183,7 @@ class BlockItem(Classified, ElementPresentation[Block]):
 
     def operations_compartment(self, name, predicate):
         def lazy_format(operation):
-            return lambda: format_property(operation) or gettext("unnamed")
+            return lambda: format_property(operation) or self.diagram.gettext("unnamed")
 
         return Box(
             Text(

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -71,6 +71,8 @@ class RequirementPropertyPage(PropertyPageBase):
 PropertyPages.register(RequirementItem)(AttributesPage)
 PropertyPages.register(RequirementItem)(OperationsPage)
 
+PropertyPages.register(BlockItem)(OperationsPage)
+
 
 @PropertyPages.register(BlockItem)
 class CompartmentPage(PropertyPageBase):

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -271,7 +271,6 @@ class InterfacePropertyPage(PropertyPageBase):
 @PropertyPages.register(DataTypeItem)
 @PropertyPages.register(ClassItem)
 @PropertyPages.register(InterfaceItem)
-@PropertyPages.register(BlockItem)
 class AttributesPage(PropertyPageBase):
     """An editor for attributes associated with classes and interfaces."""
 

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -18,6 +18,7 @@ from gaphor.diagram.propertypages import (
     on_text_cell_edited,
     unsubscribe_all_on_destroy,
 )
+from gaphor.SysML.blocks import BlockItem
 from gaphor.UML.classes.datatype import DataTypeItem
 from gaphor.UML.classes.interface import Folded, InterfaceItem
 from gaphor.UML.classes.klass import ClassItem
@@ -270,6 +271,7 @@ class InterfacePropertyPage(PropertyPageBase):
 @PropertyPages.register(DataTypeItem)
 @PropertyPages.register(ClassItem)
 @PropertyPages.register(InterfaceItem)
+@PropertyPages.register(BlockItem)
 class AttributesPage(PropertyPageBase):
     """An editor for attributes associated with classes and interfaces."""
 
@@ -350,6 +352,7 @@ class AttributesPage(PropertyPageBase):
 @PropertyPages.register(DataTypeItem)
 @PropertyPages.register(ClassItem)
 @PropertyPages.register(InterfaceItem)
+@PropertyPages.register(BlockItem)
 class OperationsPage(PropertyPageBase):
     """An editor for operations associated with classes and interfaces."""
 

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -18,7 +18,6 @@ from gaphor.diagram.propertypages import (
     on_text_cell_edited,
     unsubscribe_all_on_destroy,
 )
-from gaphor.SysML.blocks import BlockItem
 from gaphor.UML.classes.datatype import DataTypeItem
 from gaphor.UML.classes.interface import Folded, InterfaceItem
 from gaphor.UML.classes.klass import ClassItem
@@ -351,7 +350,6 @@ class AttributesPage(PropertyPageBase):
 @PropertyPages.register(DataTypeItem)
 @PropertyPages.register(ClassItem)
 @PropertyPages.register(InterfaceItem)
-@PropertyPages.register(BlockItem)
 class OperationsPage(PropertyPageBase):
     """An editor for operations associated with classes and interfaces."""
 


### PR DESCRIPTION
This PR enables operations on Blocks so that they are visible on the Block shape and in the Property Editor.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Operations and Attributes are hidden on Blocks

Issue Number: #1953 

### What is the new behavior?
Operations and Attributes are visible on Blocks

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
