### PR TITLE
Windows CI: fix cannot create symlink error

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install Linux Dependencies
       uses: ./.github/actions/linux_dependencies
     - name: Use Python Dependency Cache
-      uses: actions/cache@v3.2.1
+      uses: actions/cache@v3.2.2
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-22.04

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install Linux Dependencies
       uses: ./.github/actions/linux_dependencies
     - name: Use Python Dependency Cache
-      uses: actions/cache@v3.2.0
+      uses: actions/cache@v3.2.1
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-22.04

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.1
+        uses: actions/cache@v3.2.2
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-22.04
@@ -121,7 +121,7 @@ jobs:
       - name: Install Linux Dependencies
         run: apt-get update -qq && apt-get install -qq --no-install-recommends graphviz
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.1
+        uses: actions/cache@v3.2.2
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-container
@@ -177,7 +177,7 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.1
+        uses: actions/cache@v3.2.2
         with:
           path: ~/Library/Caches/pip
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
@@ -240,7 +240,7 @@ jobs:
       - name: Install macOS Dependencies
         uses: ./.github/actions/macos_dependencies
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.1
+        uses: actions/cache@v3.2.2
         with:
           path: ~/Library/Caches/pip
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
@@ -262,7 +262,7 @@ jobs:
       - name: GTK binaries create dir
         run: mkdir C:\gtk-build\gtk\x64\release
       - name: GTK binaries get from cache
-        uses: actions/cache@v3.2.1
+        uses: actions/cache@v3.2.2
         id: cache
         with:
           path: C:\gtk-build\gtk\x64\release\**
@@ -317,7 +317,7 @@ jobs:
       - name: Create GTK binaries dir
         run: mkdir C:\gtk-build\gtk\x64\release
       - name: Get GTK binaries from cache
-        uses: actions/cache/restore@v3.2.1
+        uses: actions/cache/restore@v3.2.2
         id: cache
         with:
           path: C:\gtk-build\gtk\x64\release\**
@@ -340,7 +340,7 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.1
+        uses: actions/cache@v3.2.2
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3.2.1
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-22.04
@@ -121,7 +121,7 @@ jobs:
       - name: Install Linux Dependencies
         run: apt-get update -qq && apt-get install -qq --no-install-recommends graphviz
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3.2.1
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-container
@@ -177,7 +177,7 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3.2.1
         with:
           path: ~/Library/Caches/pip
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
@@ -240,7 +240,7 @@ jobs:
       - name: Install macOS Dependencies
         uses: ./.github/actions/macos_dependencies
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3.2.1
         with:
           path: ~/Library/Caches/pip
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
@@ -255,18 +255,18 @@ jobs:
     env:
       gvsbuild_version: 2022.6.0
       # Bump this number if you want to force a rebuild of gvsbuild with the same version
-      gvsbuild_update: 2
+      gvsbuild_update: 4
     outputs:
       cachekey: ${{ steps.output.outputs.cachekey }}
     steps:
       - name: GTK binaries create dir
         run: mkdir C:\gtk-build\gtk\x64\release
       - name: GTK binaries get from cache
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3.2.1
         id: cache
         with:
           path: C:\gtk-build\gtk\x64\release\**
-          key: gvsbuild-${{ env.gvsbuild_update }}-${{ env.gvsbuild_version }}
+          key: ${{ runner.os }}-gvsbuild-${{ env.gvsbuild_update }}-${{ env.gvsbuild_version }}
       - name: Set up Python
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-python@v4.4.0
@@ -298,7 +298,7 @@ jobs:
           move "C:\Program Files\Git\notbin" "C:\Program Files\Git\bin"
       - name: GTK binaries output cache key
         id: output
-        run: Write-Output "cachekey=gvsbuild-${{ env.gvsbuild_update }}-${{ env.gvsbuild_version }}" >> $env:GITHUB_OUTPUT
+        run: Write-Output "cachekey=${{ runner.os }}-gvsbuild-${{ env.gvsbuild_update }}-${{ env.gvsbuild_version }}" >> $env:GITHUB_OUTPUT
 
   windows:
     needs: [lint, windows-build-gtk]
@@ -317,7 +317,7 @@ jobs:
       - name: Create GTK binaries dir
         run: mkdir C:\gtk-build\gtk\x64\release
       - name: Get GTK binaries from cache
-        uses: actions/cache/restore@v3.2.0
+        uses: actions/cache/restore@v3.2.1
         id: cache
         with:
           path: C:\gtk-build\gtk\x64\release\**
@@ -340,7 +340,7 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3.2.1
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/hypothesis-test.yml
+++ b/.github/workflows/hypothesis-test.yml
@@ -26,13 +26,13 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3.2.1
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-20.04
       - name: Use Hypothesis Cache
         id: restore-cache
-        uses: actions/cache/restore@v3.2.0
+        uses: actions/cache/restore@v3.2.1
         with:
           path: .hypothesis
           key: ${{ runner.os }}-hypothesis
@@ -52,7 +52,7 @@ jobs:
             Test run failed for commit ${{github.sha}}.
             See https://github.com/gaphor/gaphor/actions/workflows/hypothesis-test.yml.
       - name: Save cache
-        uses: actions/cache/save@v3.2.0
+        uses: actions/cache/save@v3.2.1
         if: always()
         with:
           path: .hypothesis

--- a/.github/workflows/hypothesis-test.yml
+++ b/.github/workflows/hypothesis-test.yml
@@ -26,13 +26,13 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
       - name: Use Python Dependency Cache
-        uses: actions/cache@v3.2.1
+        uses: actions/cache@v3.2.2
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-20.04
       - name: Use Hypothesis Cache
         id: restore-cache
-        uses: actions/cache/restore@v3.2.1
+        uses: actions/cache/restore@v3.2.2
         with:
           path: .hypothesis
           key: ${{ runner.os }}-hypothesis
@@ -52,7 +52,7 @@ jobs:
             Test run failed for commit ${{github.sha}}.
             See https://github.com/gaphor/gaphor/actions/workflows/hypothesis-test.yml.
       - name: Save cache
-        uses: actions/cache/save@v3.2.1
+        uses: actions/cache/save@v3.2.2
         if: always()
         with:
           path: .hypothesis


### PR DESCRIPTION
This PR resolves a cannot create symlink error with actions/cache version 3.2.1 by changing the Windows cache key to include the runner os. They reverted the change in version 3.2.2, but it still seems like it a best practice to include the runner os in the key.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Symlink error in CI when upgrading actions/cache versions

Issue Number: N/A

### What is the new behavior?
No errors

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
