### PR TITLE
Fix coredumps on Flatpak

### DIFF
--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -363,6 +363,9 @@ def save_changes_before_closing_dialog(window: Gtk.Window, handler) -> None:
         dialog.set_close_response("cancel")
 
     def response(dialog, answer):
+        # Unset transient window: it can cause crashes on flatpak
+        # when all windows are destroyed at once.
+        dialog.set_transient_for(None)
         dialog.destroy()
         handler(answer)
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Locally, Gaphor throws some warnings when it's exiting. On flatpak it just dumps core.

Issue Number: #1962

### What is the new behavior?

Somehow it works better if the final dialog is not transient to the window.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Given I do not see warnings anymore locally, I expect this change to fix flatpak.
