### PR TITLE
Use native file chooser on Windows

### DIFF
--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -17,7 +17,7 @@ def new_filter(name, pattern, mime_type=None):
     f = Gtk.FileFilter.new()
     f.set_name(name)
     f.add_pattern(pattern)
-    if mime_type:
+    if mime_type and sys.platform != "win32":
         f.add_mime_type(mime_type)
     return f
 


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Windows build falls back to `GtkFileChooserDialog` instead of using its native file chooser.

See https://docs.gtk.org/gtk4/class.FileChooserNative.html#win32-details

Issue Number: N/A

### What is the new behavior?
Use of `GtkFileChooserNative` on Windows.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->