### PR TITLE
Move PyPI publish to last step of CI pipeline

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -43,6 +43,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     if: "!contains(github.event.head_commit.message, 'skip ci')"
+    outputs:
+      sdist: dist/gaphor-${{ steps.setup_and_test.outputs.version }}-tar.gz
+      wheel: dist/gaphor-${{ steps.setup_and_test.outputs.version }}-py3-none-any.whl
     steps:
       - uses: actions/checkout@v3.2.0
         with:
@@ -79,9 +82,6 @@ jobs:
         with:
           name: gaphor-${{ steps.setup_and_test.outputs.version }}-py3-none-any.whl
           path: dist/gaphor-${{ steps.setup_and_test.outputs.version }}-py3-none-any.whl
-      - name: Publish to PyPI (release only)
-        if: github.event_name == 'release'
-        run: poetry publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}
 
   linux-flatpak-devel:
     needs: lint
@@ -150,6 +150,27 @@ jobs:
         run: |
           chmod +x ${{ needs.linux-appimage.outputs.appimage }}
           xvfb-run ./${{ needs.linux-appimage.outputs.appimage }} --self-test
+
+  linux-pypi-publish:
+    needs: [check-linux-appimage, check-windows-installer, check-macos-app]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    if: github.event_name == 'release'
+    steps:
+      - name: Download sdist
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.linux-gtk4.outputs.sdist }}
+          path: dist
+      - name: Download wheel
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.linux-gtk4.outputs.sdist }}
+          path: dist
+      - name: Install Poetry
+        run: python3 -m pip install poetry==1.3.1
+      - name: Publish to PyPI
+        run: poetry publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}
 
   macos:
     needs: lint


### PR DESCRIPTION
During the release of version 2.14.1, notarization failed of the macOS app due to a network issue. Unfortunately, the PyPI publish had already occurred, which is not reversible. This PR moves the publish PyPI routine to the last step of the pipeline, only if the platform checks are all complete.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
PyPI publish happens during the linux-gtk4 step, which is one of the first ones to finish

Issue Number: N/A

### What is the new behavior?
PyPI publish always happens last and won't happen at all unless all preceding steps have passed

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
