### PR TITLE
Fix PEP597 Encoding Warnings

### DIFF
--- a/.github/actions/setup_and_test/action.yml
+++ b/.github/actions/setup_and_test/action.yml
@@ -30,5 +30,7 @@ runs:
       run: poetry run poe gettext-mo
       shell: bash
     - name: Test with Pytest
+      env:
+        PYTHONWARNDEFAULTENCODING: 'true'
       run: ${{ runner.os == 'Linux' && 'xvfb-run' || '' }} poetry run pytest --cov=gaphor
       shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,8 @@ repos:
   rev: 6.0.0
   hooks:
   - id: flake8
+    additional_dependencies:
+      - flake8-encodings==0.5.0.post1
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:

--- a/_packaging/windows/build-win-installer.py
+++ b/_packaging/windows/build-win-installer.py
@@ -6,7 +6,7 @@ import subprocess
 from pathlib import Path
 
 version = subprocess.run(
-    ["poetry", "version", "-s"], capture_output=True, text=True
+    ["poetry", "version", "-s"], encoding="utf-8", capture_output=True, text=True
 ).stdout.rstrip()
 
 
@@ -32,6 +32,7 @@ def build_installer(
             f"-DVERSION={version}",
             str(nsi),
         ],
+        encoding="utf-8",
         capture_output=True,
         text=True,
     )
@@ -41,10 +42,10 @@ def build_installer(
 
 def concatenate_files(input_files: list[Path], output_file: Path) -> None:
     print(f"Opening {output_file} for write")
-    with open(output_file, "wb") as writer:
+    with open(output_file, "wb", encoding="utf-8") as writer:
         for input_file in input_files:
             print(f"Writing {input_file}")
-            with open(input_file, "rb") as reader:
+            with open(input_file, "rb", encoding="utf-8") as reader:
                 shutil.copyfileobj(reader, writer)
 
 
@@ -52,10 +53,10 @@ def unix2dos(file_path: Path) -> None:
     win_line_ending = b"\r\n"
     unix_line_ending = b"\n"
 
-    with open(file_path, "rb") as open_file:
+    with open(file_path, "rb", encoding="utf-8") as open_file:
         content = open_file.read()
     content = content.replace(win_line_ending, unix_line_ending)
-    with open(file_path, "wb") as open_file:
+    with open(file_path, "wb", encoding="utf-8") as open_file:
         open_file.write(content)
 
 

--- a/_packaging/windows/build-win-installer.py
+++ b/_packaging/windows/build-win-installer.py
@@ -42,10 +42,10 @@ def build_installer(
 
 def concatenate_files(input_files: list[Path], output_file: Path) -> None:
     print(f"Opening {output_file} for write")
-    with open(output_file, "wb", encoding="utf-8") as writer:
+    with open(output_file, "wb") as writer:
         for input_file in input_files:
             print(f"Writing {input_file}")
-            with open(input_file, "rb", encoding="utf-8") as reader:
+            with open(input_file, "rb") as reader:
                 shutil.copyfileobj(reader, writer)
 
 
@@ -53,10 +53,10 @@ def unix2dos(file_path: Path) -> None:
     win_line_ending = b"\r\n"
     unix_line_ending = b"\n"
 
-    with open(file_path, "rb", encoding="utf-8") as open_file:
+    with open(file_path, "rb") as open_file:
         content = open_file.read()
     content = content.replace(win_line_ending, unix_line_ending)
-    with open(file_path, "wb", encoding="utf-8") as open_file:
+    with open(file_path, "wb") as open_file:
         open_file.write(content)
 
 

--- a/gaphor/UML/actions/tests/test_objectnode.py
+++ b/gaphor/UML/actions/tests/test_objectnode.py
@@ -1,3 +1,5 @@
+import locale
+
 from gaphor import UML
 from gaphor.UML.actions.objectnode import ObjectNodeItem
 
@@ -26,4 +28,6 @@ def test_ordering(create):
     node.subject.ordering = "unordered"
     node.show_ordering = True
 
-    assert "{ ordering = unordered }" == ordering.text()
+    language = locale.getlocale()[0]
+    if language == "en_US":
+        assert "{ ordering = unordered }" == ordering.text()

--- a/gaphor/codegen/coder.py
+++ b/gaphor/codegen/coder.py
@@ -106,14 +106,14 @@ def main(
     )
     overrides = Overrides(overridesfile) if overridesfile else None
 
-    with (open(outfile, "w") if outfile else contextlib.nullcontext(sys.stdout)) as out:  # type: ignore[attr-defined]
+    with (open(outfile, "w", encoding="utf-8") if outfile else contextlib.nullcontext(sys.stdout)) as out:  # type: ignore[attr-defined]
         for line in coder(model, super_models, overrides):
             print(line, file=out)
 
 
 def load_model(modelfile: str, modeling_language: ModelingLanguage) -> ElementFactory:
     element_factory = ElementFactory()
-    with open(modelfile) as file_obj:
+    with open(modelfile, encoding="utf-8") as file_obj:
         storage.load(
             file_obj,
             element_factory,

--- a/gaphor/codegen/override.py
+++ b/gaphor/codegen/override.py
@@ -19,7 +19,7 @@ class Overrides:
         self.overrides = {}
         self.header = ""
         if filename:
-            with open(filename) as fp:
+            with open(filename, encoding="utf-8") as fp:
                 self.read_overrides(fp)
 
     def read_overrides(self, fp):

--- a/gaphor/diagram/tests/test_export.py
+++ b/gaphor/diagram/tests/test_export.py
@@ -14,7 +14,7 @@ def test_export_to_svg(diagram_with_box, tmp_path):
     f = tmp_path / "test.svg"
 
     save_svg(f, diagram_with_box)
-    content = f.read_text()
+    content = f.read_text(encoding="utf-8")
 
     assert "<svg" in content
 

--- a/gaphor/extensions/sphinx.py
+++ b/gaphor/extensions/sphinx.py
@@ -119,7 +119,7 @@ def load_model(model_file: str) -> ElementFactory:
 
     modeling_language = ModelingLanguageService()
 
-    with open(model_file) as file_obj:
+    with open(model_file, encoding="utf-8") as file_obj:
         storage.load(
             file_obj,
             element_factory,

--- a/gaphor/extensions/tests/test_sphinx.py
+++ b/gaphor/extensions/tests/test_sphinx.py
@@ -5,12 +5,12 @@ from gaphor.extensions.sphinx import setup as sphinx_setup
 
 
 def test_setup(tmp_path):
-    (tmp_path / "conf.py").write_text("")
+    (tmp_path / "conf.py").write_text("", encoding="utf-8")
     gen = sphinx.application.Sphinx(
         srcdir="docs",
-        confdir=tmp_path,
-        outdir=tmp_path,
-        doctreedir=tmp_path,
+        confdir=str(tmp_path),
+        outdir=str(tmp_path),
+        doctreedir=str(tmp_path),
         buildername="html",
     )
 
@@ -26,7 +26,8 @@ def test_setup(tmp_path):
 
 def test_setup_load_models(tmp_path):
     (tmp_path / "conf.py").write_text(
-        "gaphor_models = {'style-sheets': 'style-sheet-examples.gaphor'}"
+        "gaphor_models = {'style-sheets': 'style-sheet-examples.gaphor'}",
+        encoding="utf-8",
     )
     gen = sphinx.application.Sphinx(
         srcdir="docs",

--- a/gaphor/plugins/console/consolewindow.py
+++ b/gaphor/plugins/console/consolewindow.py
@@ -36,7 +36,7 @@ class ConsoleWindow(UIComponent, ActionProvider):
 
         console_py = os.path.join(get_config_dir(), "console.py")
         try:
-            with open(console_py) as f:
+            with open(console_py, encoding="utf-8") as f:
                 for line in f:
                     console.push(line)
         except OSError:

--- a/gaphor/plugins/diagramexport/gaphorconvert.py
+++ b/gaphor/plugins/diagramexport/gaphorconvert.py
@@ -91,7 +91,7 @@ def main(argv=sys.argv[1:]):
     # we should have some gaphor files to be processed at this point
     for model in args:
         message(f"loading model {model}")
-        with open(model) as file_obj:
+        with open(model, encoding="utf-8") as file_obj:
             storage.load(file_obj, factory, modeling_language)
         message("ready for rendering")
 

--- a/gaphor/plugins/xmiexport/tests/test_exportmodel.py
+++ b/gaphor/plugins/xmiexport/tests/test_exportmodel.py
@@ -33,6 +33,6 @@ def test_xmi_export(element_factory, tmp_path):
 
     exporter.export(f)
 
-    content = f.read_text()
+    content = f.read_text(encoding="utf-8")
 
     assert '<XMI xmi.version="2.1"' in content

--- a/gaphor/services/properties.py
+++ b/gaphor/services/properties.py
@@ -129,7 +129,7 @@ class Properties(Service):
 
         if os.path.exists(filename) and os.path.isfile(filename):
 
-            data = Path(filename).read_text()
+            data = Path(filename).read_text(encoding="utf-8")
             try:
                 self._properties = ast.literal_eval(data)
             except SyntaxError:

--- a/gaphor/services/tests/test_properties.py
+++ b/gaphor/services/tests/test_properties.py
@@ -35,7 +35,7 @@ def test_load_properties(properties, event_manager):
 def test_load_of_corrupted_properties(properties, event_manager, caplog):
     properties.set("test", 1)
     properties.on_model_saved(ModelSaved(None, "test_load_properties"))
-    Path(properties.filename).write_text("{ invalid content }")
+    Path(properties.filename).write_text("{ invalid content }", encoding="utf-8")
 
     new_properties = gaphor.services.properties.Properties(event_manager)
     new_properties.on_model_loaded(ModelLoaded(None, "test_load_properties"))

--- a/gaphor/storage/tests/test_parser.py
+++ b/gaphor/storage/tests/test_parser.py
@@ -4,7 +4,7 @@ from gaphor.storage.parser import parse
 
 
 def test_parsing_v2_1_model_with_grouped_item(test_models):
-    with open(test_models / "node-component-v2.1.gaphor") as f:
+    with open(test_models / "node-component-v2.1.gaphor", encoding="utf-8") as f:
         elements = parse(f)
 
     diagram = next(e for e in elements.values() if e.type == "Diagram")
@@ -18,7 +18,7 @@ def test_parsing_v2_1_model_with_grouped_item(test_models):
 
 
 def test_parsing_of_open_file(test_models):
-    with (test_models / "test-model.gaphor").open() as model:
+    with (test_models / "test-model.gaphor").open(encoding="utf-8") as model:
         elements = parse(model)
 
     assert elements

--- a/gaphor/storage/tests/test_storage.py
+++ b/gaphor/storage/tests/test_storage.py
@@ -226,7 +226,7 @@ def test_save_and_load_of_association_with_two_connected_classes(
 def test_load_and_save_of_a_model(element_factory, modeling_language, test_models):
     path = test_models / "simple-items.gaphor"
 
-    with open(path) as ifile:
+    with open(path, encoding="utf-8") as ifile:
         storage.load(
             ifile,
             factory=element_factory,
@@ -237,7 +237,7 @@ def test_load_and_save_of_a_model(element_factory, modeling_language, test_model
 
     storage.save(pf, factory=element_factory)
 
-    orig = path.read_text()
+    orig = path.read_text(encoding="utf-8")
     copy = pf.data
 
     expr = re.compile('gaphor-version="[^"]*"')
@@ -254,7 +254,7 @@ def test_can_not_load_models_older_that_0_17_0(
     path = test_models / "old-gaphor-version.gaphor"
 
     def load_old_model():
-        with open(path) as ifile:
+        with open(path, encoding="utf-8") as ifile:
             storage.load(
                 ifile,
                 factory=element_factory,

--- a/gaphor/storage/tests/test_storage_message_item_upgrade.py
+++ b/gaphor/storage/tests/test_storage_message_item_upgrade.py
@@ -5,7 +5,7 @@ from gaphor.UML import diagramitems
 
 
 def test_message_item_upgrade(element_factory, modeling_language, test_models):
-    with (test_models / "multiple-messages.gaphor").open() as f:
+    with (test_models / "multiple-messages.gaphor").open(encoding="utf-8") as f:
         load(f, element_factory, modeling_language)
 
     diagram = element_factory.lselect(Diagram)[0]

--- a/gaphor/tests/test_application.py
+++ b/gaphor/tests/test_application.py
@@ -42,7 +42,7 @@ def test_model_saved(application):
 
 
 def test_new_session_from_template(application, test_models):
-    with (test_models / "test-model.gaphor").open() as model:
+    with (test_models / "test-model.gaphor").open(encoding="utf-8") as model:
         session = application.new_session(template=model)
 
     assert any(session.get_service("element_factory").select())

--- a/gaphor/tests/test_babel.py
+++ b/gaphor/tests/test_babel.py
@@ -2,7 +2,7 @@ from gaphor.babel import extract_gaphor
 
 
 def test_babel(test_models):
-    with (test_models / "test-model.gaphor").open() as model:
+    with (test_models / "test-model.gaphor").open(encoding="utf-8") as model:
         texts = list(extract_gaphor(model, (), (), None))
 
     assert (None, "gettext", "Element", []) in texts

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -191,7 +191,9 @@ class MainWindow(Service, ActionProvider):
         main_content = builder.get_object("main-content")
         deserialize(
             main_content,
-            (importlib.resources.files("gaphor.ui") / "layout.xml").read_text(),
+            (importlib.resources.files("gaphor.ui") / "layout.xml").read_text(
+                encoding="utf-8"
+            ),
             _factory,
             self.properties,
         )

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -122,9 +122,9 @@ class SelfTest(Service):
 
     @test
     def test_new_session(self, status):
-        with (
-            importlib.resources.files("gaphor") / "templates" / "uml.gaphor"
-        ).open() as f:
+        with (importlib.resources.files("gaphor") / "templates" / "uml.gaphor").open(
+            encoding="utf-8"
+        ) as f:
             session = self.application.new_session(template=f)
 
         def check_new_session(session):
@@ -162,4 +162,5 @@ def windows_console_output_workaround():
             filename="gaphor-self-test.txt",
             filemode="w",
             force=True,
+            encoding="utf-8",
         )

--- a/gaphor/ui/uipreview.py
+++ b/gaphor/ui/uipreview.py
@@ -13,7 +13,7 @@ from gaphor.ui.styling import Styling
 
 
 def load_components(ui_filename):
-    with open(ui_filename) as ui_file:
+    with open(ui_filename, encoding="utf-8") as ui_file:
         ui_xml = load_ui_file(ui_file)
 
     builder = Gtk.Builder.new_from_string(ui_xml, -1)

--- a/po/check-babel.py
+++ b/po/check-babel.py
@@ -33,7 +33,7 @@ def check_po_files():
     po_path: Path = Path(__file__).resolve().parent
     have_errors = False
     for path in (path for path in po_path.iterdir() if path.suffix == ".po"):
-        with path.open() as po:
+        with path.open(encoding="utf-8") as po:
             messages = pofile.read_po(po)
 
         for message, error in invalid(messages):

--- a/tests/test_action_issue.py
+++ b/tests/test_action_issue.py
@@ -9,7 +9,7 @@ from gaphor.UML.actions import ActionItem, ControlFlowItem
 class TestActionIssue:
     def test_it(self, element_factory, modeling_language, test_models):
         """Test an issue when loading a freshly created action diagram."""
-        with (test_models / "action-issue.gaphor").open() as f:
+        with (test_models / "action-issue.gaphor").open(encoding="utf-8") as f:
             storage.load(f, element_factory, modeling_language)
 
         actions = element_factory.lselect(UML.Action)

--- a/tests/test_load_model.py
+++ b/tests/test_load_model.py
@@ -13,7 +13,7 @@ from gaphor.UML.classes.association import (
 
 
 def test_association_ends_are_set(element_factory, modeling_language, test_models):
-    with (test_models / "association-ends.gaphor").open() as file_obj:
+    with (test_models / "association-ends.gaphor").open(encoding="utf-8") as file_obj:
         load(file_obj, element_factory, modeling_language)
     composite = next(
         element_factory.select(

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -299,7 +299,7 @@ class ModelConsistency(RuleBasedStateMachine):
             ), f"{self.model.lselect()} != {new_model.lselect()}"
             assert {e.id for e in self.model} == {e.id for e in new_model}
         except Exception:
-            with open("falsifying_model.gaphor", "w") as out:
+            with open("falsifying_model.gaphor", "w", encoding="utf") as out:
                 storage.save(out, self.model)
             raise
 

--- a/tests/test_models_up_to_date.py
+++ b/tests/test_models_up_to_date.py
@@ -28,8 +28,8 @@ def test_core_model(tmp_path):
         outfile=outfile,
     )
 
-    current_model = Path(coremodel.__file__).read_text()
-    generated_model = outfile.read_text()
+    current_model = Path(coremodel.__file__).read_text(encoding="utf-8")
+    generated_model = outfile.read_text(encoding="utf-8")
 
     assert generated_model == current_model
 
@@ -43,8 +43,8 @@ def test_uml_model(tmp_path):
         outfile=outfile,
     )
 
-    current_model = Path(uml.__file__).read_text()
-    generated_model = outfile.read_text()
+    current_model = Path(uml.__file__).read_text(encoding="utf-8")
+    generated_model = outfile.read_text(encoding="utf-8")
 
     assert generated_model == current_model
 
@@ -57,8 +57,8 @@ def test_c4model_model(tmp_path):
         outfile=outfile,
     )
 
-    current_model = Path(c4model.__file__).read_text()
-    generated_model = outfile.read_text()
+    current_model = Path(c4model.__file__).read_text(encoding="utf-8")
+    generated_model = outfile.read_text(encoding="utf-8")
 
     assert generated_model == current_model
 
@@ -74,8 +74,8 @@ def test_sysml_model(tmp_path):
         outfile=outfile,
     )
 
-    current_model = Path(sysml.__file__).read_text()
-    generated_model = outfile.read_text()
+    current_model = Path(sysml.__file__).read_text(encoding="utf-8")
+    generated_model = outfile.read_text(encoding="utf-8")
 
     assert generated_model == current_model
 
@@ -92,7 +92,7 @@ def test_raaml_model(tmp_path):
         outfile=outfile,
     )
 
-    current_model = Path(raaml.__file__).read_text()
-    generated_model = outfile.read_text()
+    current_model = Path(raaml.__file__).read_text(encoding="utf-8")
+    generated_model = outfile.read_text(encoding="utf-8")
 
     assert generated_model == current_model

--- a/tests/test_package_removal.py
+++ b/tests/test_package_removal.py
@@ -23,7 +23,7 @@ def event_manager(session):
 def element_factory(session, test_models):
     element_factory = session.get_service("element_factory")
     modeling_language = session.get_service("modeling_language")
-    with (test_models / "issue_53.gaphor").open() as f:
+    with (test_models / "issue_53.gaphor").open(encoding="utf-8") as f:
         load(f, element_factory, modeling_language)
     yield element_factory
     element_factory.shutdown()


### PR DESCRIPTION
PEP 597 adds encoding warnings and will eventually make UTF-8 the default encoding in Python. This PR fixes encoding warnings to help prevent bugs introduced due to encoding warnings. For example, our `check-babel` module wouldn't run at all in Windows due to an encoding error.

I don't think should be a breaking change, we already try to set encoding to None if opening a model fails due to an encoding error.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
In many places we open and write to files without the encoding specified

Issue Number: N/A

### What is the new behavior?
Encodings are explicitly set to UTF-8

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
