### PR TITLE
Fix Translations on Windows, macOS, and AppImage

### DIFF
--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -27,11 +27,13 @@ glade_files = [
 ui_files = [
     (str(p), str(Path(*p.parts[1:-1]))) for p in Path("../gaphor").rglob("*.ui")
 ]
+mo_files = [
+    (str(p), str(Path(*p.parts[1:-1]))) for p in Path("../gaphor/locale").rglob("*.mo")
+]
 
 
 def get_version() -> str:
     project_dir = Path.cwd().parent
-    print(project_dir.resolve())
     f = project_dir / "pyproject.toml"
     return str(tomllib.loads(f.read_text())["tool"]["poetry"]["version"])
 
@@ -76,6 +78,7 @@ a = Analysis(
     ]
     + glade_files
     + ui_files
+    + mo_files
     + copy_metadata("gaphor")
     + copy_metadata("gaphas"),
     hiddenimports=collect_entry_points(

--- a/gaphor/i18n.py
+++ b/gaphor/i18n.py
@@ -7,10 +7,18 @@ __all__ = ["gettext"]
 import functools
 import gettext as _gettext
 import importlib.resources
+import locale
 import logging
+import os
+import sys
 import xml.etree.ElementTree as etree
 
 log = logging.getLogger(__name__)
+
+if sys.platform == "win32" and os.getenv("LANG") is None:
+    language, _ = locale.getlocale()
+    if language:
+        os.environ["LANG"] = language
 
 try:
     localedir = importlib.resources.files("gaphor") / "locale"


### PR DESCRIPTION
This PR fixes two major issues with translations:

1. PyInstaller wasn't collecting any .mo translation files, so they weren't available in any of the packaged apps built using PyInstaller.
2. On Windows, Gaphor wasn't automatically setting the language based on the locale Windows was running with, so translations weren't working without manually setting the LANG environmental variable

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
App translations aren't working with packaged apps on Windows, macOS, and Linux with AppImage

Issue Number: #1969 

### What is the new behavior?
Translations are working on all platforms

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
