### PR TITLE
Fix socket hang up error during release upload

### DIFF
--- a/.github/actions/linux_appimage/action.yml
+++ b/.github/actions/linux_appimage/action.yml
@@ -31,8 +31,8 @@ runs:
         name: Gaphor-${{ inputs.version }}-x86_64.AppImage
         path: _packaging/dist/Gaphor-${{ inputs.version }}-x86_64.AppImage
     - name: Upload Assets (release only)
-      uses: AButler/upload-release-assets@v2.0
       if: github.event_name == 'release'
-      with:
-        files: "_packaging/dist/*"
-        repo-token: ${{ inputs.github_token }}
+      run: |
+        echo ${{ inputs.github_token }} | gh auth login --with-token
+        gh release upload ${{ inputs.version }} "_packaging/dist/*"
+      shell: bash

--- a/.github/actions/macos_dmg/action.yml
+++ b/.github/actions/macos_dmg/action.yml
@@ -98,11 +98,11 @@ runs:
         name: Gaphor-${{ inputs.version }}.dmg
         path: _packaging/dist/Gaphor-${{ inputs.version }}.dmg
     - name: Upload Assets (release only)
-      uses: AButler/upload-release-assets@v2.0
       if: github.event_name == 'release'
-      with:
-        files: "_packaging/dist/Gaphor-${{ inputs.version }}.dmg"
-        repo-token: ${{ inputs.github_token }}
+      run: |
+        echo ${{ inputs.github_token }} | gh auth login --with-token
+        gh release upload ${{ inputs.version }} "_packaging/dist/Gaphor-${{ inputs.version }}.dmg"
+      shell: bash
     - name: Zip app
       id: zip
       if: inputs.mainline_build != 'true'

--- a/.github/actions/windows_executables/action.yml
+++ b/.github/actions/windows_executables/action.yml
@@ -67,8 +67,8 @@ runs:
         name: gaphor-${{ inputs.version }}-portable.exe
         path: _packaging/dist/gaphor-${{ inputs.version }}-portable.exe
     - name: Upload Assets (release only)
-      uses: AButler/upload-release-assets@v2.0
       if: github.event_name == 'release'
-      with:
-        files: "_packaging/dist/*.exe"
-        repo-token: ${{ inputs.github_token }}
+      run: |
+        echo ${{ inputs.github_token }} | gh auth login --with-token
+        gh release upload ${{ inputs.version }} "_packaging/dist/*.exe"
+      shell: pwsh


### PR DESCRIPTION
In run https://github.com/gaphor/gaphor/actions/runs/3824238322/jobs/6520647088 we are getting a socket hangup error when trying to upload final release assets from Windows. We have seen this in the past with Linux as well when we were uploading the sdist and wheel.

This PR replaces use of https://github.com/AButler/upload-release-assets with the gh CLI. Others who have seen this error have reported success with this method.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Intermittent socket hang up errors with CI

Issue Number: N/A

### What is the new behavior?
No socket hang up

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
