### PR TITLE
Regression: line handles should snap to elements when moved around

### DIFF
--- a/gaphor/UML/actions/activitymove.py
+++ b/gaphor/UML/actions/activitymove.py
@@ -4,7 +4,7 @@ from gaphas.move import Move
 from gaphas.types import Pos
 
 from gaphor.diagram.presentation import connect
-from gaphor.diagram.tools.grayout import GrayOutLineHandleMoveMixin
+from gaphor.diagram.tools.handlemove import GrayOutLineHandleMoveMixin
 from gaphor.UML.actions.activity import ActivityParameterNodeItem
 
 

--- a/gaphor/diagram/tools/__init__.py
+++ b/gaphor/diagram/tools/__init__.py
@@ -2,7 +2,7 @@
 from gaphas.tool import hover_tool, rubberband_tool, view_focus_tool, zoom_tools
 from gi.repository import Gtk
 
-import gaphor.diagram.tools.grayout
+import gaphor.diagram.tools.handlemove
 import gaphor.diagram.tools.segment
 from gaphor.diagram.tools.dnd import drop_target_tool
 from gaphor.diagram.tools.dropzone import drop_zone_tool

--- a/gaphor/diagram/tools/itemtool.py
+++ b/gaphor/diagram/tools/itemtool.py
@@ -1,12 +1,6 @@
-from gaphas.handlemove import HandleMove, ItemHandleMove
 from gaphas.tool import item_tool as _item_tool
-from gaphas.types import Pos
 from gaphas.view import GtkView
 from gi.repository import Gtk
-
-from gaphor.core.modeling import Presentation
-from gaphor.diagram.connectors import ItemTemporaryDisconnected
-from gaphor.diagram.presentation import LinePresentation
 
 
 def item_tool(view: GtkView) -> Gtk.GestureDrag:
@@ -18,18 +12,3 @@ def item_tool(view: GtkView) -> Gtk.GestureDrag:
 def on_drag_end(gesture, _offset_x, _offset_y):
     view = gesture.get_widget()
     view.selection.dropzone_item = None
-
-
-@HandleMove.register(Presentation)
-@HandleMove.register(LinePresentation)
-class PresentationHandleMove(ItemHandleMove):
-    def start_move(self, pos: Pos) -> None:
-        super().start_move(pos)
-        model = self.view.model
-        assert model
-        if cinfo := model.connections.get_connection(self.handle):
-            self.item.handle(
-                ItemTemporaryDisconnected(
-                    cinfo.item, cinfo.handle, cinfo.connected, cinfo.port
-                )
-            )

--- a/gaphor/diagram/tools/tests/test_handlemove.py
+++ b/gaphor/diagram/tools/tests/test_handlemove.py
@@ -1,0 +1,49 @@
+from gaphas.handlemove import HandleMove
+
+from gaphor.core import event_handler
+from gaphor.core.modeling import Comment
+from gaphor.diagram.connectors import ItemTemporaryDisconnected
+from gaphor.diagram.general import CommentItem, CommentLineItem
+from gaphor.diagram.presentation import LinePresentation
+from gaphor.diagram.tests.fixtures import connect
+
+
+def test_handle_move_has_guides(create, view):
+    line = create(LinePresentation)
+
+    handle_move = HandleMove(line, line.handles()[0], view)
+
+    handle_move.start_move((0, 0))
+    handle_move.move((0, 0))
+
+    assert view.guides
+
+
+def test_handle_move_has_gray_out(create, view):
+    line = create(CommentLineItem)
+    line2 = create(CommentLineItem)
+
+    handle_move = HandleMove(line, line.handles()[0], view)
+
+    handle_move.start_move((0, 0))
+
+    assert line2 in view.selection.grayed_out_items
+
+
+def test_handle_move_sends_disconnect_event(create, view, event_manager):
+    comment = create(CommentItem, element_class=Comment)
+    line = create(CommentLineItem)
+    connect(line, line.handles()[0], comment)
+
+    events = []
+
+    @event_handler(ItemTemporaryDisconnected)
+    def handler(e):
+        events.append(e)
+
+    event_manager.subscribe(handler)
+
+    handle_move = HandleMove(line, line.handles()[0], view)
+    handle_move.start_move((0, 0))
+
+    assert events


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

* items a line handle can't connect to are not grayed out
* guides do not work

Issue Number: N/A

### What is the new behavior?

Before mentioned functionality has been restored.

All logic (mixins) related to line handle movement is now in one place, which makes it less likely issues occur.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
