### PR TITLE
Append colon and space when inserting CSS props

### DIFF
--- a/gaphor/ui/csscompletion.py
+++ b/gaphor/ui/csscompletion.py
@@ -104,7 +104,8 @@ class CssPropertyCompletionProvider(GObject.GObject, GtkSource.CompletionProvide
         has_selection, begin, end = context.get_bounds()
         if has_selection:
             buffer.delete(begin, end)
-        buffer.insert(begin, proposal.text, len(proposal.text))
+        text = proposal.text + ': '
+        buffer.insert(begin, text, len(text))
         buffer.end_user_action()
 
     def do_display(

--- a/gaphor/ui/csscompletion.py
+++ b/gaphor/ui/csscompletion.py
@@ -104,7 +104,7 @@ class CssPropertyCompletionProvider(GObject.GObject, GtkSource.CompletionProvide
         has_selection, begin, end = context.get_bounds()
         if has_selection:
             buffer.delete(begin, end)
-        text = proposal.text + ': '
+        text = proposal.text + ": "
         buffer.insert(begin, text, len(text))
         buffer.end_user_action()
 

--- a/gaphor/ui/csscompletion.py
+++ b/gaphor/ui/csscompletion.py
@@ -104,7 +104,7 @@ class CssPropertyCompletionProvider(GObject.GObject, GtkSource.CompletionProvide
         has_selection, begin, end = context.get_bounds()
         if has_selection:
             buffer.delete(begin, end)
-        text = proposal.text + ": "
+        text = f"{proposal.text}: "
         buffer.insert(begin, text, len(text))
         buffer.end_user_action()
 


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?
Appends `: ` when inserting CSS properties. Example `border` gets inserted as `border: `.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
