### PR TITLE
Fix translation warning never logged with missing mo files

### DIFF
--- a/gaphor/i18n.py
+++ b/gaphor/i18n.py
@@ -22,7 +22,7 @@ if sys.platform == "win32" and os.getenv("LANG") is None:
 
 try:
     localedir = importlib.resources.files("gaphor") / "locale"
-    translate = _gettext.translation("gaphor", localedir=str(localedir), fallback=True)
+    translate = _gettext.translation("gaphor", localedir=str(localedir))
     gettext = translate.gettext
 
 except OSError as e:


### PR DESCRIPTION
When fallback is set to True, gettext uses a NullTranslator to return the message and an exception isn't raised if there is an issue with the translation files. We also are using a try-except block to print a warning message. With fallback set, the warning message is never printed.

This PR removes the fallback value, which causes it to default to False.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Warnings are never printed for missing translation files.

Issue Number: N/A

### What is the new behavior?
Warnings are restored.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
