### PR TITLE
Show diagram name in header

### DIFF
--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -68,9 +68,10 @@ class SessionShutdown(ServiceEvent):
 
 
 class ModelLoaded:
-    def __init__(self, service, filename: Path | None = None):
+    def __init__(self, service, filename: Path | None = None, modified: bool = False):
         self.service = service
         self.filename = filename
+        self.modified = modified
 
 
 class ModelSaved:

--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -386,9 +386,13 @@ class Diagrams(UIComponent, ActionProvider):
                     self._notebook.set_tab_label(
                         widget, tab_label(event.new_value, widget, self.event_manager)
                     )
+                    if page == self._notebook.get_current_page():
+                        self.event_manager.handle(CurrentDiagramChanged(event.element))
                     return
                 elif event.element is widget.get_child().diagram_page.diagram:
                     widget.set_title(event.new_value or "")
+                    if widget is self._notebook.get_selected_page():
+                        self.event_manager.handle(CurrentDiagramChanged(event.element))
                     return
 
 

--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -376,24 +376,25 @@ class Diagrams(UIComponent, ActionProvider):
 
     @event_handler(AttributeUpdated)
     def _on_name_change(self, event):
-        if event.property is Diagram.name:
-            for page in range(self._notebook.get_n_pages()):
-                widget = self._notebook.get_nth_page(page)
-                if (
-                    Gtk.get_major_version() == 3
-                    and event.element is widget.diagram_page.diagram
-                ):
-                    self._notebook.set_tab_label(
-                        widget, tab_label(event.new_value, widget, self.event_manager)
-                    )
-                    if page == self._notebook.get_current_page():
-                        self.event_manager.handle(CurrentDiagramChanged(event.element))
-                    return
-                elif event.element is widget.get_child().diagram_page.diagram:
-                    widget.set_title(event.new_value or "")
-                    if widget is self._notebook.get_selected_page():
-                        self.event_manager.handle(CurrentDiagramChanged(event.element))
-                    return
+        if event.property is not Diagram.name:
+            return
+        for page in range(self._notebook.get_n_pages()):
+            widget = self._notebook.get_nth_page(page)
+            if (
+                Gtk.get_major_version() == 3
+                and event.element is widget.diagram_page.diagram
+            ):
+                self._notebook.set_tab_label(
+                    widget, tab_label(event.new_value, widget, self.event_manager)
+                )
+                if page == self._notebook.get_current_page():
+                    self.event_manager.handle(CurrentDiagramChanged(event.element))
+                return
+            elif event.element is widget.get_child().diagram_page.diagram:
+                widget.set_title(event.new_value or "")
+                if widget is self._notebook.get_selected_page():
+                    self.event_manager.handle(CurrentDiagramChanged(event.element))
+                return
 
 
 def apply_tool_select_controller(widget, toolbox):

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -128,6 +128,8 @@ class FileManager(Service, ActionProvider):
             status_window.destroy()
             if on_load_done:
                 on_load_done()
+            else:
+                self.event_manager.handle(ModelLoaded(self, filename))
 
         self._load_async(filename, status_window.progress, done)
 
@@ -160,8 +162,6 @@ class FileManager(Service, ActionProvider):
                 except UnicodeDecodeError:
                     # try to load without encoding, for older models saved on windows
                     yield from open_model(encoding=None)
-
-                self.event_manager.handle(ModelLoaded(self, filename))
             except MergeConflictDetected:
                 self.filename = None
                 if Gtk.get_major_version() == 3:
@@ -222,9 +222,7 @@ class FileManager(Service, ActionProvider):
             nonlocal temp_dir
             temp_dir.cleanup()
             self.filename = filename
-            if self.main_window:
-                self.main_window.filename = filename
-                self.main_window.model_changed = True
+            self.event_manager.handle(ModelLoaded(self, filename, modified=True))
 
         if resolution == "current":
             self.load(current_filename, on_load_done=done)

--- a/gaphor/ui/mainwindow.glade
+++ b/gaphor/ui/mainwindow.glade
@@ -79,17 +79,46 @@
             <property name="visible">1</property>
             <property name="orientation">vertical</property>
             <child>
-              <object class="GtkLabel" id="title">
+              <object class="GtkBox">
+                <property name="orientation">horizontal</property>
                 <property name="visible">1</property>
-                <property name="label" translatable="yes">Gaphor</property>
-                <style>
-                  <class name="title"/>
-                </style>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="hexpand">1</property>
+                    <property name="visible">1</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="modified">
+                    <property name="visible">0</property>
+                    <property name="label">•</property>
+                    <property name="margin-end">6</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="title">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">Gaphor</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="hexpand">1</property>
+                    <property name="visible">1</property>
+                  </object>
+                </child>
               </object>
             </child>
             <child>
               <object class="GtkLabel" id="subtitle">
                 <property name="visible">1</property>
+                <property name="label" translatable="yes">New model</property>
                 <style>
                   <class name="subtitle"/>
                 </style>

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -182,8 +182,7 @@ class MainWindow(Service, ActionProvider):
         )
 
         self.title = builder.get_object("title")
-        if Gtk.get_major_version() != 3:
-            self.modified = builder.get_object("modified")
+        self.modified = builder.get_object("modified")
         self.subtitle = builder.get_object("subtitle")
         self.set_title()
 
@@ -210,7 +209,7 @@ class MainWindow(Service, ActionProvider):
 
         self.window.set_resizable(True)
         if Gtk.get_major_version() == 3:
-            self.window.show_all()
+            self.window.show()
             self.window.add_accel_group(shortcuts)
             self.window.connect("delete-event", self._on_window_close_request)
             self.window.connect("size-allocate", self._on_window_size_allocate)
@@ -252,11 +251,7 @@ class MainWindow(Service, ActionProvider):
             else f"{gettext('New model')} - Gaphor"
         )
 
-        if Gtk.get_major_version() == 3:
-            if self.model_changed:
-                title += " [" + gettext("edited") + "]"
-        else:
-            self.modified.set_visible(self.model_changed)
+        self.modified.set_visible(self.model_changed)
 
         self.title.set_text(title)
         self.subtitle.set_text(subtitle)

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -246,6 +246,12 @@ class MainWindow(Service, ActionProvider):
             else gettext("New model")
         )
 
+        window_title = (
+            f"{self.filename.name} ({str(self.filename.parent).replace(str(Path.home()), '~')}) - Gaphor"
+            if self.filename
+            else f"{gettext('New model')} - Gaphor"
+        )
+
         if Gtk.get_major_version() == 3:
             if self.model_changed:
                 title += " [" + gettext("edited") + "]"
@@ -254,7 +260,7 @@ class MainWindow(Service, ActionProvider):
 
         self.title.set_text(title)
         self.subtitle.set_text(subtitle)
-        self.window.set_title(title)
+        self.window.set_title(window_title)
 
     # Signal callbacks:
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

We always show the tab bar. It's better, according to GNOME style guidelines, to hide the tab bar if there's only one tab shown.

However, we want to tell the user which diagram they're editing.

Issue Number: #1955 

### What is the new behavior?

The diagram name is shown in the header bar. The tab bar is hidden if only one diagram is opened.

We can also change this to showing the full path.

Updated window name:
![image](https://user-images.githubusercontent.com/96249/211789303-88b2ad40-1e7a-4b9f-a7ae-9a1dd04835d3.png)

## Other

I did some cleanup on some of the events, and reduced the state maintained by `MainWindow`.