### PR TITLE
Show something when no diagrams are opened

### DIFF
--- a/gaphor/ui/diagrams.ui
+++ b/gaphor/ui/diagrams.ui
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <requires lib="adw" version="1.2"/>
+  <object class="GtkStack" id="stack">
+    <child>
+      <object class="GtkStackPage">
+        <property name="name">notebook</property>
+        <property name="child">
+          <object class="GtkBox">
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="AdwTabBar">
+                <property name="view">notebook</property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwTabView" id="notebook">
+                <property name="vexpand">1</property>
+              </object>
+            </child>
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkStackPage">
+        <property name="name">empty</property>
+        <property name="child">
+          <object class="AdwStatusPage">
+            <property name="icon-name">gaphor-new-diagram-symbolic</property>
+            <property name="title" translatable="yes">Open a Diagram</property>
+            <property name="description" translatable="yes">Open a diagram from the model browser, or
+create a new diagram from the New diagram menu.</property>
+          </object>
+        </property>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/gaphor/ui/mainwindow.ui
+++ b/gaphor/ui/mainwindow.ui
@@ -61,7 +61,7 @@
           <object class="GtkMenuButton">
             <property name="icon_name">gaphor-new-diagram-symbolic</property>
             <property name="popover">diagram-types</property>
-            <property name="tooltip-text" translatable="true">Open diagram menu</property>
+            <property name="tooltip-text" translatable="true">New diagram menu</property>
           </object>
         </child>
         <child type="end">


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

If no diagrams are open, and no tab bar is shown, it's pretty empty. It's hard to tell if there's an empty diagram opened or nothing at all.

### What is the new behavior?

If no diagrams are shown, a status widget is shown that directs users to opening/creating diagrams.

![image](https://user-images.githubusercontent.com/96249/211805118-98232d5f-c94e-457f-90b0-ffc9bcaea742.png)

NB. Title capitalization is fixed. Now it reads **Open a Diagram**.
GTK4 only.