### PR TITLE
Fix resource lookup for packaged Gaphor

### DIFF
--- a/_packaging/use_gtk_4.py
+++ b/_packaging/use_gtk_4.py
@@ -1,3 +1,5 @@
 import os
+import sys
 
 os.environ["GAPHOR_USE_GTK"] = "4"
+os.environ["XDG_DATA_DIRS"] = os.path.join(sys._MEIPASS, "share")  # type: ignore[attr-defined]

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -22,7 +22,7 @@ def new_filter(name, pattern, mime_type=None):
     return f
 
 
-def _file_dialog_with_filters(title, parent, action, filters):
+def _file_dialog_with_filters(title, parent, action, filters) -> Gtk.FileChooserNative:
     dialog = Gtk.FileChooserNative.new(title, parent, action, None, None)
 
     if parent:
@@ -75,7 +75,7 @@ def save_file_dialog(
     filename=None,
     extension=None,
     filters=None,
-) -> None:
+) -> Gtk.FileChooser:
     if filters is None:
         filters = []
     dialog = _file_dialog_with_filters(
@@ -124,3 +124,4 @@ def save_file_dialog(
             dialog.set_current_folder(Gio.File.parse_name(str(filename.parent)))
     dialog.set_modal(True)
     dialog.show()
+    return dialog

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -296,12 +296,9 @@ class FileManager(Service, ActionProvider):
     @action(name="file-save-as", shortcut="<Primary><Shift>s")
     def action_save_as(self):
         """Save the model in the element_factory by allowing the user to select
-        a file name.
+        a file name."""
 
-        Returns True if the saving actually happened.
-        """
-
-        save_file_dialog(
+        return save_file_dialog(
             gettext("Save Gaphor Model As"),
             self.save,
             parent=self.parent_window,

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -65,6 +65,7 @@ class SelfTest(Service):
         self.init_timer(gtk_app, timeout=20)
         self.test_library_versions()
         self.test_new_session()
+        self.test_file_dialog()
         self.test_auto_layout()
 
     def init_timer(self, gtk_app, timeout):
@@ -117,6 +118,22 @@ class SelfTest(Service):
                 return GLib.SOURCE_CONTINUE
 
         GLib.idle_add(check_new_session, session, priority=GLib.PRIORITY_LOW)
+
+    @test
+    def test_file_dialog(self, status):
+        session = self.application.new_session()
+        file_manager = session.get_service("file_manager")
+        dialog = file_manager.action_save_as()
+        assert dialog
+
+        def check_file_dialog(dialog):
+            if dialog.get_visible():
+                status.complete()
+                return GLib.SOURCE_REMOVE
+            else:
+                return GLib.SOURCE_CONTINUE
+
+        GLib.idle_add(check_file_dialog, dialog, priority=GLib.PRIORITY_LOW)
 
     @test
     def test_auto_layout(self, status):

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -1,5 +1,6 @@
 import importlib.resources
 import logging
+import os
 import platform
 import sys
 import textwrap
@@ -65,7 +66,14 @@ class SelfTest(Service):
         self.init_timer(gtk_app, timeout=20)
         self.test_library_versions()
         self.test_new_session()
-        self.test_file_dialog()
+        if not (
+            os.getenv("CI")
+            and sys.platform == "darwin"
+            and Gtk.get_major_version() == 4
+        ):
+            # Skip this test for Darwin in CI (GTK 4.8): it's causing
+            # all interaction to freeze. May be fixed in GTK 4.10.
+            self.test_file_dialog()
         self.test_auto_layout()
 
     def init_timer(self, gtk_app, timeout):

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -129,6 +129,7 @@ class SelfTest(Service):
 
     @test
     def test_file_dialog(self, status):
+        log.info("Data dirs: %s", ", ".join(GLib.get_system_data_dirs()))
         session = self.application.new_session()
         file_manager = session.get_service("file_manager")
         dialog = file_manager.action_save_as()

--- a/gaphor/ui/tests/test_selftest.py
+++ b/gaphor/ui/tests/test_selftest.py
@@ -1,7 +1,10 @@
+import logging
+
 from gaphor.ui import main
 
 
-def test_self_test():
+def test_self_test(caplog):
+    caplog.set_level(logging.INFO)
     exit_code = main(["--self-test"])
 
-    assert exit_code == 0
+    assert exit_code == 0, caplog.text


### PR DESCRIPTION
### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the [Code of Conduct](https://github.com/gaphor/gaphor/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

AppImage crashes when GTK4 is not installed on the system.

This is because it's looking for GSettings schema's only in system folders (e.g. `/usr/share`). Instead it should look in our package (`sys._MEIPASS/share`).

Issue Number: #2015 

### What is the new behavior?

Resources are looked up in the right data directory. 
