### PR TITLE
Another attempt at fixing the packaged data dirs

### DIFF
--- a/.github/actions/linux_appimage/action.yml
+++ b/.github/actions/linux_appimage/action.yml
@@ -19,6 +19,7 @@ runs:
       run: |
         jhbuild shell
         poetry run poe package
+        glib-compile-schemas _packaging/dist/gaphor/share/glib-2.0/schemas
         cd _packaging/appimage
         make dist
       shell: bash

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -133,6 +133,7 @@ class SelfTest(Service):
                 "Could not find schemas in data dirs: %s",
                 ":".join(GLib.get_system_data_dirs()),
             )
+            log.info("Schemas found: %s %s", *source.list_schemas(True))
 
     @test
     def test_auto_layout(self, status):

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -1,6 +1,5 @@
 import importlib.resources
 import logging
-import os
 import platform
 import sys
 import textwrap
@@ -8,7 +7,7 @@ import time
 
 import cairo
 import gi
-from gi.repository import Gdk, GLib, Gtk, Pango
+from gi.repository import Gdk, Gio, GLib, Gtk, Pango
 
 from gaphor.abc import Service
 from gaphor.application import Application, distribution
@@ -65,15 +64,8 @@ class SelfTest(Service):
         windows_console_output_workaround()
         self.init_timer(gtk_app, timeout=20)
         self.test_library_versions()
+        self.test_gsettings_schemas()
         self.test_new_session()
-        if not (
-            os.getenv("CI")
-            and sys.platform == "darwin"
-            and Gtk.get_major_version() == 4
-        ):
-            # Skip this test for Darwin in CI (GTK 4.8): it's causing
-            # all interaction to freeze. May be fixed in GTK 4.10.
-            self.test_file_dialog()
         self.test_auto_layout()
 
     def init_timer(self, gtk_app, timeout):
@@ -128,21 +120,19 @@ class SelfTest(Service):
         GLib.idle_add(check_new_session, session, priority=GLib.PRIORITY_LOW)
 
     @test
-    def test_file_dialog(self, status):
-        log.info("Data dirs: %s", ", ".join(GLib.get_system_data_dirs()))
-        session = self.application.new_session()
-        file_manager = session.get_service("file_manager")
-        dialog = file_manager.action_save_as()
-        assert dialog
-
-        def check_file_dialog(dialog):
-            if dialog.get_visible():
-                status.complete()
-                return GLib.SOURCE_REMOVE
-            else:
-                return GLib.SOURCE_CONTINUE
-
-        GLib.idle_add(check_file_dialog, dialog, priority=GLib.PRIORITY_LOW)
+    def test_gsettings_schemas(self, status):
+        source = Gio.settings_schema_source_get_default()
+        if source.lookup("org.gtk.gtk4.Settings.FileChooser", recursive=True):
+            log.info(
+                "Schemas found in data dirs: %s",
+                ":".join(GLib.get_system_data_dirs()),
+            )
+            status.complete()
+        else:
+            log.error(
+                "Could not find schemas in data dirs: %s",
+                ":".join(GLib.get_system_data_dirs()),
+            )
 
     @test
     def test_auto_layout(self, status):

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -64,7 +64,8 @@ class SelfTest(Service):
         windows_console_output_workaround()
         self.init_timer(gtk_app, timeout=20)
         self.test_library_versions()
-        self.test_gsettings_schemas()
+        if Gtk.get_major_version() != 3:
+            self.test_gsettings_schemas()
         self.test_new_session()
         self.test_auto_layout()
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

AppImage does not start because of missing data dirs.
It's not taking into account the `share/` folder in our deliverables.

Follow up of #2016 
Issue Number: #2015

The problem is that we source schema files from 2 locations. Whichever location is copied last copies its `gschemas.compiled` file.

From the docker image:
```
~/jhbuild/install# ls share/glib-2.0/schemas/
gschema.dtd                org.gtk.gtk4.Settings.ColorChooser.gschema.xml  org.gtk.gtk4.Settings.FileChooser.gschema.xml
gschemas.compiled          org.gtk.gtk4.Settings.Debug.gschema.xml
org.gtk.Demo4.gschema.xml  org.gtk.gtk4.Settings.EmojiChooser.gschema.xml
~/jhbuild/install# ls /usr/share/glib-2.0/schemas/
10_gsettings-desktop-schemas.gschema.override       org.gnome.desktop.notifications.gschema.xml
gschema.dtd                                         org.gnome.desktop.peripherals.gschema.xml
gschemas.compiled                                   org.gnome.desktop.privacy.gschema.xml
org.gnome.desktop.a11y.applications.gschema.xml     org.gnome.desktop.screensaver.gschema.xml
org.gnome.desktop.a11y.gschema.xml                  org.gnome.desktop.search-providers.gschema.xml
org.gnome.desktop.a11y.keyboard.gschema.xml         org.gnome.desktop.session.gschema.xml
...
```

In most cases the files from `/usr/share` were copied last, hence the `org.gtk.gtk4.*` schemas were not compiled in and avaiable to the application.

### What is the new behavior?

All schemas bundled are compiled (for AppImage).

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

We should check there this functionaity resides in PyInstaller and make sure PyInstaller does the compilation at the right time.