### PR TITLE
Add support for CSS variables

### DIFF
--- a/docs/style_sheets.md
+++ b/docs/style_sheets.md
@@ -212,6 +212,33 @@ be provided to set the level of line wobbliness. 0.5 is default, 0.0 is a
 straight line. The value should be between -2.0 and 2.0. Values between 0.0 and
 0.5 make for a subtle effect.
 
+### Variables
+
+Since Gaphor 2.16.0 you can use [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) in your style sheets.
+
+This allows you to define often used values in a more generic way. Think of things
+like line dash style and colors.
+
+The `var()` function has some limitations:
+
+* Values can’t have a default value.
+* Variables can’t have a variable as their value.
+
+Example:
+
+```css
+diagram {
+  --bg-color: whitesmoke;
+  background-color: var(--bg-color);
+}
+
+diagram[diagramType=sd] {
+  --bg-color: rgb(200, 200, 255);
+}
+```
+
+All diagrams have a white background. Sequence diagrams get a blue-ish background.
+
 ## Working with model elements
 
 Gaphor has many model elements. How can you find out which item should be styled?
@@ -277,7 +304,7 @@ diagram[owner.name=drafts] {
   line-style: sloppy 0.3;
 }
 
-diagram[name=draft] * {
+diagram[owner.name=draft] * {
   font-family: Purisa; /* Or use some other font that's installed on your system */
 }
 ```

--- a/gaphor/core/styling/properties.py
+++ b/gaphor/core/styling/properties.py
@@ -43,6 +43,8 @@ class TextDecoration(Enum):
 
 # Style is using SVG properties where possible
 # https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute
+# NB. The Style can also contain variables (start with `--`),
+#     however those are not part of the interface.
 Style = TypedDict(
     "Style",
     {

--- a/gaphor/core/styling/tests/test_css.py
+++ b/gaphor/core/styling/tests/test_css.py
@@ -279,3 +279,12 @@ def test_unknown_variable():
     props = compiled_style_sheet.match(Node("diagram"))
 
     assert props.get("line-width") is None
+
+
+def test_unknown_variable_fallback():
+    css = "* { line-width: 1.0 } diagram { line-width: var(--myvar) }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    props = compiled_style_sheet.match(Node("diagram"))
+
+    assert props.get("line-width") == 1.0

--- a/gaphor/core/styling/tests/test_css.py
+++ b/gaphor/core/styling/tests/test_css.py
@@ -281,10 +281,37 @@ def test_unknown_variable():
     assert props.get("line-width") is None
 
 
-def test_unknown_variable_fallback():
+def test_unknown_variable_should_use_original_value():
     css = "* { line-width: 1.0 } diagram { line-width: var(--myvar) }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
     props = compiled_style_sheet.match(Node("diagram"))
 
     assert props.get("line-width") == 1.0
+
+
+def test_unknown_variable_resolve_original_value():
+    css = "* { line-width: var(--lw); --lw: 1.0 } diagram { line-width: var(--myvar) }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    props = compiled_style_sheet.match(Node("diagram"))
+
+    assert props.get("line-width") == 1.0
+
+
+def test_variable_cannot_contain_a_variable():
+    css = "* { line-width: var(--a); --a: var(--b); --b: 1.0 }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    props = compiled_style_sheet.match(Node("diagram"))
+
+    assert props.get("line-width") is None
+
+
+def test_variable_with_property():
+    css = "* { line-width: var(line-width); }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    props = compiled_style_sheet.match(Node("diagram"))
+
+    assert props.get("line-width") is None

--- a/gaphor/core/styling/tests/test_css.py
+++ b/gaphor/core/styling/tests/test_css.py
@@ -250,3 +250,32 @@ def test_broken_line_style():
     props = compiled_style_sheet.match(Node("mytype"))
 
     assert props.get("line-style") is None
+
+
+def test_variable():
+    css = "diagram { --myvar: 12; line-width: var(--myvar) }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    props = compiled_style_sheet.match(Node("diagram"))
+
+    assert props.get("line-width") == 12
+
+
+def test_variable_color():
+    css = "* { --mycolor: #123456 } diagram { color: var(--mycolor) }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    props = compiled_style_sheet.match(Node("diagram"))
+
+    assert props.get("color") == pytest.approx(
+        (0x12 / 255.0, 0x34 / 255.0, 0x56 / 255.0, 1.0)
+    )
+
+
+def test_unknown_variable():
+    css = "diagram { line-width: var(--myvar) }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    props = compiled_style_sheet.match(Node("diagram"))
+
+    assert props.get("line-width") is None

--- a/gaphor/core/styling/tests/test_properties.py
+++ b/gaphor/core/styling/tests/test_properties.py
@@ -95,3 +95,34 @@ def test_multi_declaration():
 
     assert props["font-weight"] == FontWeight.BOLD
     assert props["color"] == (0, 0, 0, 1)
+
+
+@pytest.mark.parametrize(
+    ["value", "expected"],
+    [
+        ["12", 12],
+        ["white", "white"],
+    ],
+)
+def test_assign_variable(value, expected):
+    css = f"* {{ --my-value: {value} }}"
+
+    props = first_decl_block(css)
+
+    assert props["--my-value"] == expected
+
+
+def test_assign_variable_with_function():
+    css = "* { --my-value: rgb(1, 2, 3) }"
+
+    props = first_decl_block(css)
+
+    assert props["--my-value"].name == "rgb"
+
+
+def test_use_variable():
+    css = "* { line-width: var(--my-value) }"
+
+    props = first_decl_block(css)
+
+    assert props["line-width"].name == "--my-value"


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

If we want to use the same color/line width/... in multiple places, we have to define those explicitly.

Issue Number: #2018

### What is the new behavior?

It is now possible to define variables:

```css

* {
  --bg-color: rgb(12, 12,12);
  --line-width: 2.4;
}

diagram {
  background-color: var(--bg-color);
}

association {
  line-width: var(--line-width);
}
```

See also https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties

Support for default/fallback values has not been implemented. Given our context is quite limited (e.i. we're not making a CSS framework), we can probably do without fallback values.

If variables do not resolve a value from the parent layer is used. E.g. if you provide an invalid variable for color, the default color is used.
