### PR TITLE
Model browser multi select

### DIFF
--- a/gaphor/diagram/tools/dnd.py
+++ b/gaphor/diagram/tools/dnd.py
@@ -9,7 +9,7 @@ from gaphor.transaction import Transaction
 
 
 class ElementDragData(GObject.Object):
-    element = GObject.Property(type=object)
+    elements = GObject.Property(type=object)
 
 
 class ToolboxActionDragData(GObject.Object):
@@ -27,10 +27,21 @@ def drop_target_tool(modeling_language, event_manager) -> Gtk.EventController:
 def on_drop(target, source_value, x, y, modeling_language, event_manager):
     view = target.get_widget()
     if isinstance(source_value, ElementDragData):
-        element = source_value.element
+        elements = source_value.elements
         x, y = view.matrix.inverse().transform_point(x, y)
         with Transaction(event_manager):
-            if item := drop(element, view.model, x, y):
+            items = []
+            for element in elements:
+                if item := drop(element, view.model, x, y):
+                    x += 20
+                    y += 20
+                    items.append(item)
+
+            if len(items) > 1:
+                view.selection.unselect_all()
+                view.selection.select_items(*items)
+                return True
+            if items:
                 view.selection.unselect_all()
                 view.selection.focused_item = item
                 return True

--- a/gaphor/ui/styling-gtk4.css
+++ b/gaphor/ui/styling-gtk4.css
@@ -60,6 +60,7 @@ frame > textview {
 }
 
 #model_browser box {
+  padding: 2px 0;
   border-top: 0 solid @shade_color;
   transition: border 200ms;
 }

--- a/gaphor/ui/styling-gtk4.css
+++ b/gaphor/ui/styling-gtk4.css
@@ -59,8 +59,17 @@ frame > textview {
   background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
+#model_browser box {
+  border-top: 0 solid @shade_color;
+  transition: border 200ms;
+}
+
 #model_browser .move-element-above {
-  border-top: 12px solid lighter(@insensitive_fg_color);
+  border-top-width: 12px;
+}
+
+#model_browser .move-element-above:drop(active) {
+  box-shadow: none;
 }
 
 #elementeditor {

--- a/gaphor/ui/tests/test_treecomponent.py
+++ b/gaphor/ui/tests/test_treecomponent.py
@@ -201,6 +201,7 @@ def test_create_diagram(tree_component, element_factory):
 def test_create_package(tree_component, element_factory):
     parent = element_factory.create(UML.Package)
     parent.name = "root"
+    tree_component.select_element(parent)
     tree_component.tree_view_create_package()
 
     package = next(p for p in element_factory.select(UML.Package) if p.name != "root")
@@ -222,7 +223,7 @@ def test_create_toplevel_package(tree_component, element_factory):
 @skip_if_gtk3
 def test_delete_element(tree_component, element_factory):
     klass = element_factory.create(UML.Class)
-    assert tree_component.get_selected_element() is klass
+    tree_component.select_element(klass)
 
     tree_component.tree_view_delete()
 
@@ -235,9 +236,7 @@ def test_search_next(tree_component, element_factory):
     class_a.name = "a"
     class_b = element_factory.create(UML.Class)
     class_b.name = "b"
-
     search_engine = SearchEngine(tree_component.model, tree_component.tree_view)
-    assert tree_component.get_selected_element() is class_a
 
     search_engine.search_next("b")
 
@@ -252,7 +251,7 @@ def test_search_text_changed(tree_component, element_factory):
     class_b.name = "b"
 
     search_engine = SearchEngine(tree_component.model, tree_component.tree_view)
-    assert tree_component.get_selected_element() is class_a
+    # assert tree_component.get_selected_element() is class_a
 
     search_engine.text_changed("b")
 

--- a/gaphor/ui/tests/test_treecomponent.py
+++ b/gaphor/ui/tests/test_treecomponent.py
@@ -3,7 +3,13 @@ from gi.repository import Gtk
 
 from gaphor import UML
 from gaphor.core.modeling import Diagram
-from gaphor.ui.treecomponent import SearchEngine, TreeComponent
+from gaphor.ui.treecomponent import (
+    ElementDragData,
+    SearchEngine,
+    TreeComponent,
+    get_first_selected_item,
+    list_item_drop_drop,
+)
 
 skip_if_gtk3 = pytest.mark.skipif(
     Gtk.get_major_version() == 3, reason="Gtk.ListView is not supported by GTK 3"
@@ -224,6 +230,7 @@ def test_create_toplevel_package(tree_component, element_factory):
 def test_delete_element(tree_component, element_factory):
     klass = element_factory.create(UML.Class)
     tree_component.select_element(klass)
+    assert tree_component.get_selected_element() is klass
 
     tree_component.tree_view_delete()
 
@@ -236,7 +243,10 @@ def test_search_next(tree_component, element_factory):
     class_a.name = "a"
     class_b = element_factory.create(UML.Class)
     class_b.name = "b"
+
     search_engine = SearchEngine(tree_component.model, tree_component.tree_view)
+    tree_component.select_element(class_a)
+    assert tree_component.get_selected_element() is class_a
 
     search_engine.search_next("b")
 
@@ -251,7 +261,8 @@ def test_search_text_changed(tree_component, element_factory):
     class_b.name = "b"
 
     search_engine = SearchEngine(tree_component.model, tree_component.tree_view)
-    # assert tree_component.get_selected_element() is class_a
+    tree_component.select_element(class_a)
+    assert tree_component.get_selected_element() is class_a
 
     search_engine.text_changed("b")
 
@@ -274,3 +285,49 @@ def test_generalization_text(tree_component, element_factory):
     assert tree_item
     assert branch.relationships[0].element is generalization
     assert branch.relationships[0].text == "general: General"
+
+
+@skip_if_gtk3
+def test_drop_multiple_elements(tree_component, element_factory, event_manager):
+    class_a = element_factory.create(UML.Class)
+    class_a.name = "a"
+    class_b = element_factory.create(UML.Class)
+    class_b.name = "b"
+    gen = element_factory.create(UML.Generalization)
+    gen.general = class_a
+    gen.specific = class_b
+    orig = element_factory.create(UML.Package)
+    class_a.package = orig
+    class_b.package = orig
+    package = element_factory.create(UML.Package)
+
+    drag_data = ElementDragData(elements=[class_a, class_b])
+    tree_component.select_element(class_a)
+    list_item = MockRowItem(get_first_selected_item(tree_component.selection))
+    tree_component.select_element(package)
+    target = MockDropTarget()
+    list_item_drop_drop(target, drag_data, 0, 0, list_item, event_manager)
+
+    assert class_b not in tree_component.get_selected_elements()
+    assert class_a not in tree_component.get_selected_elements()
+
+
+class MockRowItem:
+    def __init__(self, list_item):
+        self.list_item = list_item
+
+    def get_item(self):
+        return self.list_item
+
+
+class MockDropTarget:
+    def get_widget(self):
+        class Widget:
+            def get_style_context(self):
+                return StyleContext()
+
+        class StyleContext:
+            def remove_class(self, _):
+                pass
+
+        return Widget()

--- a/gaphor/ui/treecomponent.py
+++ b/gaphor/ui/treecomponent.py
@@ -82,7 +82,8 @@ class TreeComponent(UIComponent, ActionProvider):
         self.tree_view.set_vexpand(True)
 
         def list_view_activate(list_view, position):
-            list_view.activate_action("tree-view.open", None)
+            element = self.selection.get_item(position).get_item().element
+            self.open_element(element)
 
         self.tree_view.connect("activate", list_view_activate)
 
@@ -135,15 +136,19 @@ class TreeComponent(UIComponent, ActionProvider):
 
     def get_selected_element(self) -> Element | None:
         assert self.model
-        return next(self.get_selected_elements(), None)  # type: ignore[no-any-return,call-overload]
+        return next(iter(self.get_selected_elements()), None)
 
-    @action(name="tree-view.open")
-    def tree_view_open_selected(self):
-        element = self.get_selected_element()
+    def open_element(self, element):
+        assert element
         if isinstance(element, Diagram):
             self.event_manager.handle(DiagramOpened(element))
         else:
             self.event_manager.handle(ElementOpened(element))
+
+    @action(name="tree-view.open")
+    def tree_view_open_selected(self):
+        element = self.get_selected_element()
+        self.open_element(element)
 
     @action(name="tree-view.show-in-diagram")
     def tree_view_show_in_diagram(self, diagram_id: str) -> None:


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Only one element can be selected in the model browser. 

Issue Number:  #2022

### What is the new behavior?

- [x] Allow to select multiple elements
- [ ] Drag multiple elements and drop in a diagram
- [ ] Drag multiple elements and drop in the model browser

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

This PR requires #2047.

Also updated drag-between styling (now animates) and padding on tree items (#2053).

Drag source controllers are still attached to the individual rows. Adding it to the ListView resulted in a bad UX: if you wanted to drag an item you had to select it first before it could be dragged.