### PR TITLE
Use normal `+` icon for new diagram dropdown

### DIFF
--- a/gaphor/ui/mainwindow.ui
+++ b/gaphor/ui/mainwindow.ui
@@ -54,14 +54,14 @@
           <object class="GtkMenuButton" id="modeling-language-name">
             <property name="focus_on_click">0</property>
             <property name="popover">select-modeling-language</property>
-            <property name="icon_name">pan-down-symbolic</property>
           </object>
         </child>
         <child>
           <object class="GtkMenuButton">
-            <property name="icon_name">gaphor-new-diagram-symbolic</property>
+            <property name="icon_name">list-add-symbolic</property>
             <property name="popover">diagram-types</property>
             <property name="tooltip-text" translatable="true">New diagram menu</property>
+            <property name="always-show-arrow">1</property>
           </object>
         </child>
         <child type="end">


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

It seems the create diagram icon is a bit confusing.

Issue Number: #1927

### What is the new behavior?

The add-functionality is now a simple `+`. This gives us the freedom to add other elements as well, if we want (like Packages).

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


### Other information

![image](https://user-images.githubusercontent.com/96249/215359739-bb7fcbfb-4c3c-40ed-894f-1df7312df99d.png)
