### PR TITLE
Properly unsubscribe when property page is removed

### DIFF
--- a/gaphor/C4Model/propertypages.glade
+++ b/gaphor/C4Model/propertypages.glade
@@ -21,7 +21,6 @@ renderers and such.</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
     <property name="baseline-position">top</property>
-    <signal name="destroy" handler="container-destroyed" swapped="no"/>
     <child>
       <object class="GtkLabel" id="label2">
         <property name="visible">1</property>

--- a/gaphor/C4Model/propertypages.py
+++ b/gaphor/C4Model/propertypages.py
@@ -7,6 +7,7 @@ from gaphor.diagram.propertypages import (
     PropertyPages,
     handler_blocking,
     new_resource_builder,
+    unsubscribe_all_on_destroy,
 )
 
 
@@ -32,9 +33,6 @@ class DescriptionPropertyPage(PropertyPageBase):
         builder = new_builder(
             "description-editor",
             "description-text-buffer",
-            signals={
-                "container-destroyed": (self.watcher.unsubscribe_all,),
-            },
         )
         subject = self.subject
 
@@ -51,7 +49,9 @@ class DescriptionPropertyPage(PropertyPageBase):
 
         self.watcher.watch("description", text_handler)
 
-        return builder.get_object("description-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("description-editor"), self.watcher
+        )
 
     @transactional
     def _on_description_changed(self, buffer):

--- a/gaphor/C4Model/propertypages.ui
+++ b/gaphor/C4Model/propertypages.ui
@@ -6,7 +6,6 @@
 
   <object class="GtkBox" id="description-editor">
     <property name="orientation">vertical</property>
-    <signal name="destroy" handler="container-destroyed" swapped="no"/>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Description</property>

--- a/gaphor/SysML/propertypages.glade
+++ b/gaphor/SysML/propertypages.glade
@@ -241,7 +241,6 @@ renderers and such.</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
     <property name="baseline-position">top</property>
-    <signal name="destroy" handler="requirement-destroyed" swapped="no"/>
     <child>
       <object class="GtkLabel" id="label1">
         <property name="visible">1</property>

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -1,6 +1,7 @@
 from gaphor import UML
 from gaphor.core import transactional
 from gaphor.diagram.propertypages import (
+    unsubscribe_all_on_destroy,
     PropertyPageBase,
     PropertyPages,
     combo_box_text_auto_complete,
@@ -36,7 +37,6 @@ class RequirementPropertyPage(PropertyPageBase):
             "requirement-text-buffer",
             signals={
                 "requirement-id-changed": (self._on_id_changed,),
-                "requirement-destroyed": (self.watcher.unsubscribe_all,),
             },
         )
         subject = self.subject
@@ -57,7 +57,9 @@ class RequirementPropertyPage(PropertyPageBase):
 
         self.watcher.watch("text", text_handler)
 
-        return builder.get_object("requirement-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("requirement-editor"), self.watcher
+        )
 
     @transactional
     def _on_id_changed(self, entry):

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -172,7 +172,6 @@
 
   <object class="GtkBox" id="requirement-editor">
     <property name="orientation">vertical</property>
-    <signal name="destroy" handler="requirement-destroyed" swapped="no" />
     <child>
       <object class="GtkLabel" id="label1">
         <property name="label" translatable="yes">Id</property>

--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -7,6 +7,7 @@ from gaphor.diagram.propertypages import (
     PropertyPages,
     handler_blocking,
     new_resource_builder,
+    unsubscribe_all_on_destroy,
 )
 from gaphor.UML.actions.activitynodes import DecisionNodeItem, ForkNodeItem
 from gaphor.UML.actions.objectnode import ObjectNodeItem
@@ -174,9 +175,6 @@ class FlowPropertyPageAbstract(PropertyPageBase):
 
         builder = new_builder(
             "transition-editor",
-            signals={
-                "transition-destroy": (self.watcher.unsubscribe_all,),
-            },
         )
 
         guard = builder.get_object("guard")
@@ -190,7 +188,9 @@ class FlowPropertyPageAbstract(PropertyPageBase):
 
         self.watcher.watch("guard", handler)
 
-        return builder.get_object("transition-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("transition-editor"), self.watcher
+        )
 
     @transactional
     def _on_guard_change(self, entry):

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -11,6 +11,7 @@ from gaphor.diagram.propertypages import (
     help_link,
     new_resource_builder,
     on_text_cell_edited,
+    unsubscribe_all_on_destroy,
 )
 from gaphor.UML.actions.activity import ActivityItem
 from gaphor.UML.classes.classespropertypages import on_keypress_event
@@ -77,7 +78,6 @@ class ActivityItemPage(PropertyPageBase):
             signals={
                 "parameter-edited": (on_text_cell_edited, self.model, 0),
                 "parameters-info-clicked": (self.on_parameters_info_clicked),
-                "tree-view-destroy": (self.watcher.unsubscribe_all,),
             },
         )
 
@@ -96,7 +96,9 @@ class ActivityItemPage(PropertyPageBase):
             tree_view.add_controller(controller)
         controller.connect("key-pressed", on_keypress_event, tree_view)
 
-        return builder.get_object("activity-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("activity-editor"), self.watcher
+        )
 
     def on_parameters_info_clicked(self, image, event):
         self.info.show()

--- a/gaphor/UML/actions/propertypages.glade
+++ b/gaphor/UML/actions/propertypages.glade
@@ -289,7 +289,6 @@ renderers and such.</property>
     <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
-    <signal name="destroy" handler="transition-destroy" swapped="no"/>
     <child>
       <object class="GtkLabel">
         <property name="visible">1</property>
@@ -340,7 +339,6 @@ renderers and such.</property>
             <property name="enable-search">0</property>
             <property name="show-expanders">0</property>
             <property name="enable-grid-lines">horizontal</property>
-            <signal name="destroy" handler="tree-view-destroy" swapped="no"/>
             <child internal-child="selection">
               <object class="GtkTreeSelection"/>
             </child>

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -217,7 +217,6 @@
 
   <object class="GtkBox" id="transition-editor">
     <property name="orientation">vertical</property>
-    <signal name="destroy" handler="transition-destroy" swapped="no"/>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Guard</property>
@@ -261,7 +260,6 @@
                 <property name="enable-search">0</property>
                 <property name="show-expanders">0</property>
                 <property name="enable-grid-lines">horizontal</property>
-                <signal name="destroy" handler="tree-view-destroy" swapped="no"/>
                 <child internal-child="selection">
                   <object class="GtkTreeSelection"/>
                 </child>

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -3,7 +3,12 @@ from gi.repository import Gtk
 from gaphor import UML
 from gaphor.core.format import format, parse
 from gaphor.diagram.hoversupport import widget_add_hover_support
-from gaphor.diagram.propertypages import PropertyPageBase, PropertyPages, help_link
+from gaphor.diagram.propertypages import (
+    PropertyPageBase,
+    PropertyPages,
+    help_link,
+    unsubscribe_all_on_destroy,
+)
 from gaphor.transaction import transactional
 from gaphor.UML.classes.association import AssociationItem
 from gaphor.UML.classes.classespropertypages import new_builder
@@ -104,7 +109,6 @@ class AssociationPropertyPage(PropertyPageBase):
                 "tail-navigation-changed": (self._on_end_navigability_change, tail),
                 "tail-aggregation-changed": (self._on_end_aggregation_change, tail),
                 "tail-info-clicked": (self._on_association_info_clicked,),
-                "association-editor-destroy": (self.watcher.unsubscribe_all,),
                 **head_signal_handlers,
                 **tail_signal_handlers,
             },
@@ -143,7 +147,9 @@ class AssociationPropertyPage(PropertyPageBase):
             restore_nav_handler,
         )
 
-        return builder.get_object("association-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("association-editor"), self.watcher
+        )
 
     @transactional
     def _on_show_direction_change(self, button, gparam):

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -15,6 +15,7 @@ from gaphor.diagram.propertypages import (
     new_resource_builder,
     on_bool_cell_edited,
     on_text_cell_edited,
+    unsubscribe_all_on_destroy,
 )
 from gaphor.UML.classes.datatype import DataTypeItem
 from gaphor.UML.classes.interface import Folded, InterfaceItem
@@ -207,9 +208,6 @@ class NamedElementPropertyPage(PropertyPageBase):
         assert self.watcher
         builder = new_builder(
             "named-element-editor",
-            signals={
-                "name-entry-destroyed": (self.watcher.unsubscribe_all,),
-            },
         )
 
         subject = self.subject
@@ -224,7 +222,9 @@ class NamedElementPropertyPage(PropertyPageBase):
 
         self.watcher.watch("name", handler)
 
-        return builder.get_object("named-element-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("named-element-editor"), self.watcher
+        )
 
     @transactional
     def _on_name_changed(self, entry):
@@ -322,7 +322,6 @@ class AttributesPage(PropertyPageBase):
                 "show-attributes-changed": (self._on_show_attributes_change,),
                 "attributes-name-edited": (on_text_cell_edited, self.model, 0),
                 "attributes-static-edited": (on_bool_cell_edited, self.model, 1),
-                "tree-view-destroy": (self.watcher.unsubscribe_all,),
                 "attributes-info-clicked": (self.on_attributes_info_clicked),
             },
         )
@@ -369,7 +368,9 @@ class AttributesPage(PropertyPageBase):
             "ownedAttribute.typeValue", handler
         )
 
-        return builder.get_object("attributes-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("attributes-editor"), self.watcher
+        )
 
     @transactional
     def _on_show_attributes_change(self, button, gparam):
@@ -409,7 +410,6 @@ class OperationsPage(PropertyPageBase):
                 "operations-name-edited": (on_text_cell_edited, self.model, 0),
                 "operations-abstract-edited": (on_bool_cell_edited, self.model, 1),
                 "operations-static-edited": (on_bool_cell_edited, self.model, 2),
-                "tree-view-destroy": (self.watcher.unsubscribe_all,),
                 "operations-info-clicked": (self.on_operations_info_clicked),
             },
         )
@@ -458,7 +458,9 @@ class OperationsPage(PropertyPageBase):
             "ownedOperation.ownedParameter.defaultValue", handler
         )
 
-        return builder.get_object("operations-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("operations-editor"), self.watcher
+        )
 
     @transactional
     def _on_show_operations_change(self, button, gparam):

--- a/gaphor/UML/classes/dependencypropertypages.py
+++ b/gaphor/UML/classes/dependencypropertypages.py
@@ -1,5 +1,10 @@
 from gaphor import UML
-from gaphor.diagram.propertypages import ComboModel, PropertyPageBase, PropertyPages
+from gaphor.diagram.propertypages import (
+    ComboModel,
+    PropertyPageBase,
+    PropertyPages,
+    unsubscribe_all_on_destroy,
+)
 from gaphor.i18n import gettext
 from gaphor.transaction import transactional
 from gaphor.UML.classes.classespropertypages import new_builder
@@ -28,7 +33,6 @@ class DependencyPropertyPage(PropertyPageBase):
             signals={
                 "dependency-type-changed": (self._on_dependency_type_change,),
                 "automatic-changed": (self._on_auto_dependency_change,),
-                "dependency-type-destroy": (self.watcher.unsubscribe_all,),
             },
         )
 
@@ -44,7 +48,9 @@ class DependencyPropertyPage(PropertyPageBase):
 
         self.watcher.watch("subject", self._on_subject_change)
 
-        return self.builder.get_object("dependency-editor")
+        return unsubscribe_all_on_destroy(
+            self.builder.get_object("dependency-editor"), self.watcher
+        )
 
     def _on_subject_change(self, event):
         self.update()

--- a/gaphor/UML/classes/enumerationpropertypages.py
+++ b/gaphor/UML/classes/enumerationpropertypages.py
@@ -8,6 +8,7 @@ from gaphor.diagram.propertypages import (
     PropertyPages,
     help_link,
     on_text_cell_edited,
+    unsubscribe_all_on_destroy,
 )
 from gaphor.transaction import transactional
 from gaphor.UML.classes.classespropertypages import (
@@ -45,7 +46,6 @@ class EnumerationPage(PropertyPageBase):
             signals={
                 "show-enumerations-changed": (self._on_show_enumerations_change,),
                 "enumerations-name-edited": (on_text_cell_edited, self.model, 0),
-                "tree-view-destroy": (self.watcher.unsubscribe_all,),
                 "enumerations-info-clicked": (self.on_enumerations_info_clicked),
             },
         )
@@ -78,7 +78,9 @@ class EnumerationPage(PropertyPageBase):
 
         self.watcher.watch("ownedLiteral.name", handler)
 
-        return builder.get_object("enumerations-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("enumerations-editor"), self.watcher
+        )
 
     @transactional
     def _on_show_enumerations_change(self, button, gparam):

--- a/gaphor/UML/classes/propertypages.glade
+++ b/gaphor/UML/classes/propertypages.glade
@@ -18,7 +18,6 @@ renderers and such.</property>
     <property name="visible">1</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
-    <signal name="destroy" handler="association-editor-destroy" swapped="no"/>
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
@@ -387,7 +386,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
                 <property name="enable-search">0</property>
                 <property name="show-expanders">0</property>
                 <property name="enable-grid-lines">horizontal</property>
-                <signal name="destroy" handler="tree-view-destroy" swapped="no"/>
                 <child internal-child="selection">
                   <object class="GtkTreeSelection"/>
                 </child>
@@ -618,7 +616,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
       <object class="GtkEntry" id="name-entry">
         <property name="visible">1</property>
         <property name="can-focus">1</property>
-        <signal name="destroy" handler="name-entry-destroyed" swapped="no"/>
       </object>
       <packing>
         <property name="position">1</property>
@@ -672,7 +669,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
                 <property name="enable-search">0</property>
                 <property name="show-expanders">0</property>
                 <property name="enable-grid-lines">horizontal</property>
-                <signal name="destroy" handler="tree-view-destroy" swapped="no"/>
                 <child internal-child="selection">
                   <object class="GtkTreeSelection"/>
                 </child>
@@ -826,7 +822,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
                 <property name="enable-search">0</property>
                 <property name="show-expanders">0</property>
                 <property name="enable-grid-lines">horizontal</property>
-                <signal name="destroy" handler="tree-view-destroy" swapped="no"/>
                 <child internal-child="selection">
                   <object class="GtkTreeSelection"/>
                 </child>

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -4,7 +4,6 @@
 
   <object class="GtkBox" id="association-editor">
     <property name="orientation">vertical</property>
-    <signal name="destroy" handler="association-editor-destroy" swapped="no"/>
     <child>
       <object class="GtkBox">
         <child>
@@ -342,7 +341,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
                 <property name="enable-search">0</property>
                 <property name="show-expanders">0</property>
                 <property name="enable-grid-lines">horizontal</property>
-                <signal name="destroy" handler="tree-view-destroy" swapped="no"/>
                 <child internal-child="selection">
                   <object class="GtkTreeSelection"/>
                 </child>
@@ -534,7 +532,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
     <child>
       <object class="GtkEntry" id="name-entry">
         <property name="focusable">1</property>
-        <signal name="destroy" handler="name-entry-destroyed" swapped="no"/>
       </object>
     </child>
     <style>
@@ -583,7 +580,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
                 <property name="enable-search">0</property>
                 <property name="show-expanders">0</property>
                 <property name="enable-grid-lines">horizontal</property>
-                <signal name="destroy" handler="tree-view-destroy" swapped="no"/>
                 <child internal-child="selection">
                   <object class="GtkTreeSelection"/>
                 </child>
@@ -720,7 +716,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
                 <property name="enable-search">0</property>
                 <property name="show-expanders">0</property>
                 <property name="enable-grid-lines">horizontal</property>
-                <signal name="destroy" handler="tree-view-destroy" swapped="no"/>
                 <child internal-child="selection">
                   <object class="GtkTreeSelection"/>
                 </child>

--- a/gaphor/UML/profiles/metaclasspropertypage.py
+++ b/gaphor/UML/profiles/metaclasspropertypage.py
@@ -1,6 +1,7 @@
 from gaphor import UML
 from gaphor.core import transactional
 from gaphor.diagram.propertypages import (
+    unsubscribe_all_on_destroy,
     PropertyPageBase,
     PropertyPages,
     combo_box_text_auto_complete,
@@ -35,7 +36,7 @@ class MetaclassPropertyPage(PropertyPageBase):
         if _issubclass(getattr(UML, c), UML.Element) and c != "Stereotype"
     )
 
-    def __init__(self, subject):
+    def __init__(self, subject: UML.Class):
         self.subject = subject
         self.watcher = subject.watcher()
 
@@ -47,7 +48,6 @@ class MetaclassPropertyPage(PropertyPageBase):
             "metaclass-editor",
             signals={
                 "metaclass-combo-changed": (self._on_name_changed,),
-                "metaclass-combo-destroy": (self.watcher.unsubscribe_all,),
             },
         )
 
@@ -65,7 +65,9 @@ class MetaclassPropertyPage(PropertyPageBase):
 
         self.watcher.watch("name", handler)
 
-        return builder.get_object("metaclass-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("metaclass-editor"), self.watcher
+        )
 
     @transactional
     def _on_name_changed(self, combo):

--- a/gaphor/UML/profiles/propertypages.glade
+++ b/gaphor/UML/profiles/propertypages.glade
@@ -33,7 +33,6 @@ renderers and such.</property>
       <object class="GtkComboBoxText" id="metaclass-combo">
         <property name="visible">1</property>
         <property name="has-entry">1</property>
-        <signal name="destroy" handler="metaclass-combo-destroy" swapped="no"/>
       </object>
       <packing>
         <property name="position">1</property>

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -16,7 +16,6 @@
     <child>
       <object class="GtkComboBoxText" id="metaclass-combo">
         <property name="has-entry">1</property>
-        <signal name="destroy" handler="metaclass-combo-destroy" swapped="no"/>
       </object>
     </child>
     <style>

--- a/gaphor/UML/states/propertypages.glade
+++ b/gaphor/UML/states/propertypages.glade
@@ -173,7 +173,6 @@ renderers and such.</property>
     <property name="margin-top">6</property>
     <property name="orientation">vertical</property>
     <property name="spacing">6</property>
-    <signal name="destroy" handler="transition-destroy" swapped="no"/>
     <child>
       <object class="GtkLabel">
         <property name="visible">1</property>

--- a/gaphor/UML/states/propertypages.py
+++ b/gaphor/UML/states/propertypages.py
@@ -13,6 +13,7 @@ from gaphor.diagram.propertypages import (
     PropertyPages,
     handler_blocking,
     new_resource_builder,
+    unsubscribe_all_on_destroy,
 )
 from gaphor.UML.states.state import StateItem
 from gaphor.UML.states.statemachine import StateMachineItem
@@ -39,9 +40,6 @@ class TransitionPropertyPage(PropertyPageBase):
 
         builder = new_builder(
             "transition-editor",
-            signals={
-                "transition-destroy": (self.watcher.unsubscribe_all,),
-            },
         )
 
         guard = builder.get_object("guard")
@@ -55,7 +53,9 @@ class TransitionPropertyPage(PropertyPageBase):
 
         self.watcher.watch("guard[Constraint].specification", handler)
 
-        return builder.get_object("transition-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("transition-editor"), self.watcher
+        )
 
     @transactional
     def _on_guard_change(self, entry):

--- a/gaphor/UML/states/propertypages.ui
+++ b/gaphor/UML/states/propertypages.ui
@@ -60,7 +60,6 @@
 
   <object class="GtkBox" id="transition-editor">
     <property name="orientation">vertical</property>
-    <signal name="destroy" handler="transition-destroy"/>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Guard</property>

--- a/gaphor/diagram/general/generalpropertypages.py
+++ b/gaphor/diagram/general/generalpropertypages.py
@@ -7,6 +7,7 @@ from gaphor.diagram.propertypages import (
     PropertyPages,
     handler_blocking,
     new_builder,
+    unsubscribe_all_on_destroy,
 )
 
 
@@ -38,9 +39,10 @@ class CommentPropertyPage(PropertyPageBase):
                 buffer.set_text(event.new_value or "")
 
         self.watcher.watch("body", handler)
-        text_view.connect("destroy", self.watcher.unsubscribe_all)
 
-        return builder.get_object("comment-editor")
+        return unsubscribe_all_on_destroy(
+            builder.get_object("comment-editor"), self.watcher
+        )
 
     @transactional
     def _on_body_change(self, buffer):

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -290,6 +290,19 @@ def handler_blocking(widget, event_name, widget_handler):
     return handler_wrapper
 
 
+def _do_unparent(widget, _pspec, watcher):
+    if not widget.props.parent:
+        watcher.unsubscribe_all()
+
+
+def unsubscribe_all_on_destroy(widget, watcher):
+    if Gtk.get_major_version() == 3:
+        widget.connect("destroy", watcher.unsubscribe_all)
+    else:
+        widget.connect("notify::parent", _do_unparent, watcher)
+    return widget
+
+
 @PropertyPages.register(gaphas.item.Line)
 class LineStylePage(PropertyPageBase):
     """Basic line style properties: color, orthogonal, etc."""


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Event handlers "leak" in GTK 4.

Issue Number: N/A

### What is the new behavior?

Add a function to unsubscribe watchers. It appeared handlers were not properly removed in GTK4, since in GTK4 widgets are not "destroyed", but only use reference counting.

### Information

Added a function to `gaphor.diagram.propertypages` to unsubscribe automatically on widget `destroy` (gtk3) or `unparent` (gtk4).