### PR TITLE
Fix doc build failure due to New Diagram icon missing

### DIFF
--- a/docs/first_model.md
+++ b/docs/first_model.md
@@ -5,21 +5,21 @@ In this tutorial we refer to the different parts of the gaphor interface:
 {ref}`Model Browser <getting_started:model browser>`, [Toolbox](getting_started:toolbox),
 {ref}`Property Editor <getting_started:property editor>`.
 
-Although the names should speak for themselves, you can check out the [Getting Started](getting_started) page
-for more information about those sections.
+Although the names should speak for themselves, you can check out the [Getting
+Started](getting_started) page for more information about those sections.
 ```
 
-Once Gaphor is started and you can start a new model with the _Generic_ template. The
+Once Gaphor is started, and you can start a new model with the _Generic_ template. The
 initial diagram is already open in the Diagram section.
 
-Select an element you want to place, in this case a Class (![new class](../gaphor/ui/icons/hicolor/scalable/actions/gaphor-class-symbolic.svg))
-by clicking on the icon in the Toolbox and click on the diagram.
-This will place a new Class item instance
-on the diagram and add a new Class to the model -- it shows up in the Model Browser.
-The selected tool will reset itself to the Pointer tool after the element is placed
-on the diagram.
+Select an element you want to place, in this case a Class (![new
+class](../gaphor/ui/icons/hicolor/scalable/actions/gaphor-class-symbolic.svg))
+by clicking on the icon in the Toolbox and click on the diagram. This will place
+a new Class item instance on the diagram and add a new Class to the model -- it
+shows up in the Model Browser. The selected tool will reset itself to the
+Pointer tool after the element is placed on the diagram.
 
-The Propety Editor on the right side will show you details about the newly added
+The Property Editor on the right side will show you details about the newly added
 class, such as its name (_New Class_), attributes and operations (methods).
 
 ![image](images/first-model-class.png)
@@ -33,19 +33,23 @@ diagrams, Sequence diagrams. But Gaphor does not place any restrictions.
 
 ## Adding Relations
 
-Add another Class. Change the names to `Shape` and `Circle`. Let's define that `Circle` is a sub-type of `Shape`. You can do this
-by selecting one and changing the name in the Property Editor, or by double-clicking the element.
+Add another Class. Change the names to `Shape` and `Circle`. Let's define that
+`Circle` is a sub-type of `Shape`. You can do this by selecting one and changing
+the name in the Property Editor, or by double-clicking the element.
 
-Select Generalization (![new generalization](../gaphor/ui/icons/hicolor/scalable/actions/gaphor-generalization-symbolic.svg)).
+Select Generalization (![new
+generalization](../gaphor/ui/icons/hicolor/scalable/actions/gaphor-generalization-symbolic.svg)).
 
-Move the mouse cursor over `Shape`. Click, hold and drag the line end over `Circle`. Release the mouse button
-and you should have your relationship between `Shape` and `Circle`. You can see both ends of the relation are red,
-indicating they are connected to their class.
+Move the mouse cursor over `Shape`. Click, hold and drag the line end over
+`Circle`. Release the mouse button, and you should have your relationship between
+`Shape` and `Circle`. You can see both ends of the relation are red, indicating
+they are connected to their class.
 
 ![image](images/first-model-generalization.png)
 
-Optionally you can run the auto-layouting (![open menu](images/open-menu-symbolic.svg) → Tools → Auto Layout) to align the elements
-on the diagram.
+Optionally you can run the auto-layout (![open
+menu](images/open-menu-symbolic.svg) → Tools → Auto Layout) to align the
+elements on the diagram.
 
 ## Creating New Diagrams
 
@@ -59,15 +63,18 @@ the header bar.
 
 Select _New Generic Diagram_ and a new diagram is created.
 
-Now drag the elements from the Model Browser onto the new diagram. First the classes `Shape` and `Circle`. Add the generalization
-last. Drop it somewhere between the two classes. The relation will be created to the diagram.
+Now drag the elements from the Model Browser onto the new diagram. First the
+classes `Shape` and `Circle`. Add the generalization last. Drop it somewhere
+between the two classes. The relation will be created to the diagram.
 
-Now change the name of class `Circle` to `Ellipse`. Check the other diagram. The name has been changed there as well.
+Now change the name of class `Circle` to `Ellipse`. Check the other diagram. The
+name has been changed there as well.
 
 
 ```{important}
-Elements in a diagram are only a _representation_ of the elements in the underlaying model. The model is what you see in the
-Model Browser.
+Elements in a diagram are only a _representation_ of the elements in the
+underlaying model. The model is what you see in the Model Browser.
 
-Elements in the model are automatically removed when there are no more representations in any of the diagrams.
+Elements in the model are automatically removed when there are no more
+representations in any of the diagrams.
 ```

--- a/docs/first_model.md
+++ b/docs/first_model.md
@@ -51,7 +51,9 @@ on the diagram.
 
 To create a new diagram, use the Model Browser. Select the element that should
 contain the new diagram. For now, select _New Model_.
-Click the ![new diagram](../gaphor/ui/icons/hicolor/scalable/actions/gaphor-new-diagram-symbolic.svg) in the header bar.
+Click the ![new
+diagram](../gaphor/ui/icons/Adwaita/scalable/actions/list-add-symbolic.svg) in
+the header bar.
 
 ![image](/images/first-model-new-diagram-popup.png)
 

--- a/gaphor/ui/icons/Adwaita/scalable/actions/list-add-symbolic.svg
+++ b/gaphor/ui/icons/Adwaita/scalable/actions/list-add-symbolic.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg height="16px" viewBox="0 0 16 16" width="16px" xmlns="http://www.w3.org/2000/svg">
+    <path d="m 7 1 v 6 h -6 v 2 h 6 v 6 h 2 v -6 h 6 v -2 h -6 v -6 z m 0 0" fill="#2e3436"/>
+</svg>

--- a/gaphor/ui/mainwindow.glade
+++ b/gaphor/ui/mainwindow.glade
@@ -179,7 +179,7 @@
             <child>
               <object class="GtkImage">
                 <property name="visible">1</property>
-                <property name="icon-name">gaphor-new-diagram-symbolic</property>
+                <property name="icon-name">list-add-symbolic</property>
               </object>
             </child>
             <style>


### PR DESCRIPTION
This PR updates the docs to use the updated New Diagram icon. I pulled the Adwaita icon in to the project for our docs to reference, is there a better way to do this?

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
