### PR TITLE
Update diagram directly when partitions change

### DIFF
--- a/gaphor/UML/actions/partitionpage.py
+++ b/gaphor/UML/actions/partitionpage.py
@@ -111,3 +111,5 @@ class PartitionPropertyPage(PropertyPageBase):
 
             last_child = self.partitions.get_last_child()
             self.partitions.remove(last_child)
+
+        self.item.diagram.update_now(self.item.diagram.ownedPresentation)

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -378,7 +378,6 @@ class Diagram(Element):
     def update_now(
         self,
         dirty_items: Sequence[Presentation],
-        dirty_matrix_items: Sequence[Presentation] = (),
     ) -> None:
         """Update the diagram canvas."""
         sort = self.sort

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -167,7 +167,7 @@ def paste_presentation(copy_data: PresentationCopy, diagram, lookup):
     for name, ser in data.items():
         for value in deserialize(ser, lookup):
             item.load(name, value)
-    diagram.update_now((), [item])
+    diagram.update_now((item,))
 
 
 class CopyData(NamedTuple):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Exceptions are thrown when partitions with actions when more swimlanes are added.

Issue Number: #2138 

### What is the new behavior?

Changing partitions may cause actions to be moved around as well, since they should remain in the rigth swimlane.
Now the diagram items are updated as part of changing the swimlanes.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Also fixed the `Diagram.update_now()` interface: matrix-only updates are no longer used.