### PR TITLE
Toggle the "no tabs" background based on notebook activity

### DIFF
--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -177,6 +177,9 @@ class Diagrams(UIComponent, ActionProvider):
                     if diagram := page.diagram_page.get_diagram():
                         yield diagram.id
 
+        self._stack.set_visible_child_name(
+            "notebook" if notebook.get_n_pages() else "empty"
+        )
         self.properties.set("opened-diagrams", list(diagram_ids()))
 
     def _on_current_page_changed(self, _notebook_or_tab_page, _gparam):
@@ -310,8 +313,6 @@ class Diagrams(UIComponent, ActionProvider):
 
         for action_name in ["win.zoom-in", "win.zoom-out", "win.zoom-100"]:
             self.event_manager.handle(ActionEnabled(action_name, enabled))
-
-        self._stack.set_visible_child_name("notebook" if enabled else "empty")
 
     @event_handler(AttributeUpdated)
     def _on_name_change(self, event):

--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -154,18 +154,6 @@ class Diagrams(UIComponent, ActionProvider):
             )
         )
 
-    def _on_notebook_destroy(self, notebook):
-        for id in self._page_handler_ids:
-            notebook.disconnect(id)
-
-    def _on_switch_page(self, notebook, page, new_page_num):
-        view = page.diagram_page.view
-        self.event_manager.handle(
-            DiagramSelectionChanged(
-                view, view.selection.focused_item, view.selection.selected_items
-            )
-        )
-
     def _on_page_changed(self, notebook, _page, _page_num):
         def diagram_ids():
             notebook = self._notebook
@@ -335,29 +323,6 @@ def apply_tool_select_controller(widget, toolbox):
         toolbox.activate_shortcut(keyval, state)
 
     ctrl.connect("key-pressed", on_shortcut)
-
-
-def tab_label(title, widget, event_manager):
-    tab_box = Gtk.Box.new(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
-    button = Gtk.Button()
-    button.get_style_context().add_class("flat")
-    button.set_focus_on_click(False)
-
-    button.connect(
-        "clicked",
-        lambda _button: event_manager.handle(
-            DiagramClosed(widget.diagram_page.get_diagram())
-        ),
-    )
-
-    label = Gtk.Label.new(title)
-    tab_box.append(label)
-    close_image = Gtk.Image.new_from_icon_name("window-close-symbolic")
-    button.set_child(close_image)
-    tab_box.append(button)
-    tab_box.show()
-
-    return tab_box
 
 
 def get_widgets_on_pages(notebook):

--- a/gaphor/ui/diagrams.ui
+++ b/gaphor/ui/diagrams.ui
@@ -5,6 +5,19 @@
   <object class="GtkStack" id="stack">
     <child>
       <object class="GtkStackPage">
+        <property name="name">empty</property>
+        <property name="child">
+          <object class="AdwStatusPage">
+            <property name="icon-name">gaphor-bw</property>
+            <property name="title" translatable="yes">Open a Diagram</property>
+            <property name="description" translatable="yes">Open a diagram from the model browser, or
+create a new diagram from the New diagram menu.</property>
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkStackPage">
         <property name="name">notebook</property>
         <property name="child">
           <object class="GtkBox">
@@ -19,19 +32,6 @@
                 <property name="vexpand">1</property>
               </object>
             </child>
-          </object>
-        </property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkStackPage">
-        <property name="name">empty</property>
-        <property name="child">
-          <object class="AdwStatusPage">
-            <property name="icon-name">gaphor-bw</property>
-            <property name="title" translatable="yes">Open a Diagram</property>
-            <property name="description" translatable="yes">Open a diagram from the model browser, or
-create a new diagram from the New diagram menu.</property>
           </object>
         </property>
       </object>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When opening the SysML template, no diagrams are opened, but the tabview is in front. It should show the "Open a diagram" stack page.

Issue Number: N/A

### What is the new behavior?

Show the "Open a diagram" emblem whenever all diagrams are closed.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
