### PR TITLE
Add diagrams in diagrams

### DIFF
--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -517,28 +517,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
     </style>
   </object>
 
-  <object class="GtkBox" id="named-element-editor">
-    <property name="orientation">vertical</property>
-    <property name="baseline-position">top</property>
-    <child>
-      <object class="GtkLabel" id="label1">
-        <property name="label" translatable="yes">Name</property>
-        <property name="xalign">0</property>
-        <style>
-          <class name="title"/>
-        </style>
-      </object>
-    </child>
-    <child>
-      <object class="GtkEntry" id="name-entry">
-        <property name="focusable">1</property>
-      </object>
-    </child>
-    <style>
-      <class name="propertypage"/>
-    </style>
-  </object>
-
   <object class="GtkExpander" id="operations-editor">
     <property name="focusable">1</property>
     <property name="expanded">1</property>

--- a/gaphor/UML/tests/test_diagramitems.py
+++ b/gaphor/UML/tests/test_diagramitems.py
@@ -42,6 +42,7 @@ def test_all_diagram_items_have_a_model_element_mapping(item_class):
 
 
 NAMED_EXCLUSIONS = [
+    diagramitems.DiagramItem,
     diagramitems.ExecutionSpecificationItem,
     diagramitems.PartitionItem,
 ]

--- a/gaphor/diagram/event.py
+++ b/gaphor/diagram/event.py
@@ -5,3 +5,8 @@ class ToolCompleted:
 class DiagramItemPlaced(ToolCompleted):
     def __init__(self, item):
         self.item = item
+
+
+class DiagramOpened:
+    def __init__(self, diagram):
+        self.diagram = diagram

--- a/gaphor/diagram/general/__init__.py
+++ b/gaphor/diagram/general/__init__.py
@@ -1,7 +1,16 @@
 from gaphor.diagram.general import connectors
 from gaphor.diagram.general.comment import CommentItem
 from gaphor.diagram.general.commentline import CommentLineItem
+from gaphor.diagram.general.diagramitem import DiagramItem
 from gaphor.diagram.general.simpleitem import Box, Ellipse, Line
 from gaphor.diagram.general.metadata import MetadataItem
 
-__all__ = ["CommentItem", "CommentLineItem", "Box", "Ellipse", "Line", "MetadataItem"]
+__all__ = [
+    "CommentItem",
+    "CommentLineItem",
+    "DiagramItem",
+    "Box",
+    "Ellipse",
+    "Line",
+    "MetadataItem",
+]

--- a/gaphor/diagram/general/diagramitem.py
+++ b/gaphor/diagram/general/diagramitem.py
@@ -3,14 +3,14 @@ An item representing a diagram.
 """
 
 from gaphor.core.modeling.diagram import Diagram
-from gaphor.diagram.presentation import ElementPresentation
+from gaphor.diagram.presentation import ElementPresentation, Named
 from gaphor.diagram.shapes import IconBox, Text, Box, stroke, draw_border
 from gaphor.diagram.support import represents
 from gaphor.diagram.text import FontWeight
 
 
 @represents(Diagram)
-class DiagramItem(ElementPresentation):
+class DiagramItem(ElementPresentation, Named):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=30, height=30)
         for h in self.handles():

--- a/gaphor/diagram/general/diagramitem.py
+++ b/gaphor/diagram/general/diagramitem.py
@@ -1,0 +1,49 @@
+"""
+An item representing a diagram.
+"""
+
+from gaphor.core.modeling.diagram import Diagram
+from gaphor.diagram.presentation import ElementPresentation
+from gaphor.diagram.shapes import IconBox, Text, Box, stroke, draw_border
+from gaphor.diagram.support import represents
+from gaphor.diagram.text import FontWeight
+
+
+@represents(Diagram)
+class DiagramItem(ElementPresentation):
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id, width=30, height=30)
+        for h in self.handles():
+            h.movable = False
+
+        self.shape = IconBox(
+            Box(
+                Box(draw=draw_diagram),
+                style={
+                    "padding": (4, 4, 4, 4),
+                    "border-radius": 4,
+                },
+                draw=draw_border,
+            ),
+            Text(
+                text=lambda: self.subject and self.subject.diagramType or "",
+                style={
+                    "font-weight": FontWeight.BOLD,
+                },
+            ),
+            Text(text=lambda: self.subject and self.subject.name or ""),
+        )
+
+        self.watch("subject[Diagram].name")
+        self.watch("subject[Diagram].diagramType")
+
+
+def draw_diagram(box, context, bounding_box):
+    cr = context.cairo
+
+    cr.rectangle(5, 13, 8, 12)
+    cr.rectangle(18, 5, 8, 12)
+    cr.move_to(17, 9)
+    cr.line_to(8, 9)
+    cr.line_to(8, 12)
+    stroke(context)

--- a/gaphor/diagram/group.py
+++ b/gaphor/diagram/group.py
@@ -53,6 +53,7 @@ class GroupPreconditions:
 group: FunctionDispatcher[Callable[[Element, Element], bool]] = GroupPreconditions(
     multidispatch(object, object)(no_group)
 )
+group.register(None, object)(no_group)
 
 
 def can_group(parent: Element, element_or_type: Element | type[Element]) -> bool:

--- a/gaphor/diagram/propertypages.ui
+++ b/gaphor/diagram/propertypages.ui
@@ -28,6 +28,28 @@
     </style>
   </object>
 
+  <object class="GtkBox" id="name-editor">
+    <property name="orientation">vertical</property>
+    <property name="baseline-position">top</property>
+    <child>
+      <object class="GtkLabel" id="label1">
+        <property name="label" translatable="yes">Name</property>
+        <property name="xalign">0</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkEntry" id="name-entry">
+        <property name="focusable">1</property>
+      </object>
+    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
   <object class="GtkExpander" id="line-editor">
     <property name="expanded">1</property>
     <child type="label">

--- a/gaphor/diagram/tests/test_propertypages.py
+++ b/gaphor/diagram/tests/test_propertypages.py
@@ -1,6 +1,21 @@
+from gaphor.core.modeling import Diagram
 from gaphor.diagram.general import Line
-from gaphor.diagram.propertypages import LineStylePage, NotePropertyPage
+from gaphor.diagram.propertypages import (
+    LineStylePage,
+    NamePropertyPage,
+    NotePropertyPage,
+)
 from gaphor.diagram.tests.fixtures import find
+
+
+def test_name_page(element_factory):
+    diagram = element_factory.create(Diagram)
+    property_page = NamePropertyPage(diagram)
+    widget = property_page.construct()
+    name = find(widget, "name-entry")
+    name.set_text("A new note")
+
+    assert diagram.name == "A new note"
 
 
 def test_line_style_page_rectilinear(diagram):

--- a/gaphor/diagram/tools/textedit.py
+++ b/gaphor/diagram/tools/textedit.py
@@ -1,5 +1,7 @@
 from gi.repository import Gdk, Gtk
 
+from gaphor.core.modeling import Diagram
+from gaphor.diagram.event import DiagramOpened
 from gaphor.diagram.instanteditors import instant_editor
 
 
@@ -22,6 +24,11 @@ def on_key_pressed(controller, keyval, keycode, state, event_manager):
 def on_double_click(gesture, n_press, x, y, event_manager):
     view = gesture.get_widget()
     item = view.selection.hovered_item
-    if item and n_press == 2:
+    if not item or n_press != 2:
+        return
+
+    if isinstance(item.subject, Diagram):
+        event_manager.handle(DiagramOpened(item.subject))
+    else:
         ix, iy = view.get_matrix_v2i(item).transform_point(x, y)
         return instant_editor(item, view, event_manager, (ix, iy))

--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -15,6 +15,7 @@ from gaphor.core.modeling import (
     StyleSheet,
 )
 from gaphor.diagram.drop import drop
+from gaphor.diagram.event import DiagramOpened
 from gaphor.event import ActionEnabled
 from gaphor.i18n import translated_ui_string
 from gaphor.transaction import Transaction
@@ -23,7 +24,6 @@ from gaphor.ui.diagrampage import DiagramPage, GtkView
 from gaphor.ui.event import (
     CurrentDiagramChanged,
     DiagramClosed,
-    DiagramOpened,
     DiagramSelectionChanged,
     ElementOpened,
 )

--- a/gaphor/ui/event.py
+++ b/gaphor/ui/event.py
@@ -6,11 +6,6 @@ class ElementOpened:
         self.element = element
 
 
-class DiagramOpened:
-    def __init__(self, diagram):
-        self.diagram = diagram
-
-
 class DiagramClosed:
     def __init__(self, diagram):
         self.diagram = diagram

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -18,12 +18,13 @@ from gaphor.core.modeling import (
     ModelFlushed,
     ModelReady,
 )
+from gaphor.diagram.event import DiagramOpened
 from gaphor.diagram.tools.dnd import ElementDragData
 from gaphor.i18n import gettext, translated_ui_string
 from gaphor.transaction import Transaction
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.actiongroup import create_action_group
-from gaphor.ui.event import DiagramOpened, DiagramSelectionChanged, ElementOpened
+from gaphor.ui.event import DiagramSelectionChanged, ElementOpened
 from gaphor.diagram.group import change_owner
 from gaphor.ui.treemodel import (
     RelationshipItem,

--- a/gaphor/ui/tests/test_elementeditor.py
+++ b/gaphor/ui/tests/test_elementeditor.py
@@ -40,8 +40,8 @@ def test_create_pages(event_manager, element_factory, diagrams, create):
     editor.open()
     editor.editors.create_pages(package_item)
 
-    assert find(editor.editors.vbox, "named-element-editor")
+    assert find(editor.editors.vbox, "name-editor")
 
     editor.editors.clear_pages()
 
-    assert not find(editor.editors.vbox, "named-element-editor")
+    assert not find(editor.editors.vbox, "name-editor")

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -10,10 +10,10 @@ from gaphor import UML
 from gaphor.core.modeling import Comment, Diagram
 from gaphor.diagram._connector import PresentationConnector
 from gaphor.diagram.connectors import Connector
+from gaphor.diagram.event import DiagramOpened
 from gaphor.diagram.general.comment import CommentItem
 from gaphor.diagram.general.commentline import CommentLineItem
 from gaphor.ui.diagrams import Diagrams
-from gaphor.ui.event import DiagramOpened
 from gaphor.ui.toolbox import Toolbox
 from gaphor.UML.usecases.actor import ActorItem
 

--- a/gaphor/ui/tests/test_mainwindow.py
+++ b/gaphor/ui/tests/test_mainwindow.py
@@ -2,8 +2,9 @@ import pytest
 
 from gaphor.application import Session
 from gaphor.core.modeling import Comment, Diagram
+from gaphor.diagram.event import DiagramOpened
 from gaphor.ui.abc import UIComponent
-from gaphor.ui.event import DiagramOpened, ElementOpened
+from gaphor.ui.event import ElementOpened
 
 
 @pytest.fixture

--- a/tests/test_diagram_tools.py
+++ b/tests/test_diagram_tools.py
@@ -2,7 +2,7 @@ import pytest
 
 from gaphor.application import Session
 from gaphor.core.modeling import Diagram
-from gaphor.ui.event import DiagramOpened
+from gaphor.diagram.event import DiagramOpened
 
 
 @pytest.fixture


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

You cannot add a diagram as an element to another diagram, for example to reference it.

Issue Number: #2124 

### What is the new behavior?

You can add diagrams to diagrams.

Double clicking the diagram will open it. `F2` can (still) be used to edit the diagram name.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

Models can become incompatible due to new presentation item.

### Other information

![image](https://user-images.githubusercontent.com/96249/227709957-a26389d9-23d8-46ec-9a13-ac79cc1e2c56.png)

* Name editor has been moved to `gaphor.diagram`, so we can also edit diagram names
* `DiagramOpened` event has been moved to `gaphor.diagram.event`, so an open event can be emitted from the diagram tools