### PR TITLE
Merge editor now compare incoming changes with common ancestor commit

### DIFF
--- a/docs/merge_conflicts.md
+++ b/docs/merge_conflicts.md
@@ -13,19 +13,25 @@ the incoming model or merge changes manually via the Merge Editor.
 
 ![merge dialog](images/merge-dialog.png)
 
-If you choose *Open Merge Editor*, both models will be loaded and the differences will be calculated.
-The differences are added to the model, so you can save the file and continue merge conflict resolution
-at a later point.
+If you choose *Open Merge Editor*, both models will be loaded. The current model remains as is.
+In addition, the changes made to the incoming model are calculated. Those changes are stored as _pending change_ objects in the model.
 
-The Merge Editor is shown on the right side, replacing the (normal) element editor.
+```{tip}
+Pending changes are part of the model, you can save the model with changes and resolve those at a later point.
+```
+
+The Merge Editor is shown on the right side, replacing the (normal) Property Editor.
 
 ![merge conflict window](images/merge-conflict-window.png)
 
 Merge actions are grouped by diagram, where possible.
+When you apply a change, all changes listed as children are also applied.
 Once changes are applied, they can only be reverted by undoing the change (hit _Undo_).
 
 ```{note}
-If you accept all changes, you’ll end up with the incoming model.
+The Merge Editor replaces the Property Editor, as long as there are pending changes in the model.
+
+It is concidered good practice to resolve the merge conflict before you continue modeling.
 ```
 
 When all conflicts have been resolved, press *Resolve* to finish merge conflict resolution.

--- a/gaphor/storage/mergeconflict.py
+++ b/gaphor/storage/mergeconflict.py
@@ -11,7 +11,10 @@ def in_git_repository(filename: Path) -> bool:
 
 
 def split_ours_and_theirs(
-    filename: Path, current: io.BufferedIOBase, incoming: io.BufferedIOBase
+    filename: Path,
+    ancestor: io.BufferedIOBase,
+    current: io.BufferedIOBase,
+    incoming: io.BufferedIOBase,
 ) -> bool:
     """For a file name, find the current (ours) and incoming (theirs) file and serialize those
     to the respected files.
@@ -25,6 +28,7 @@ def split_ours_and_theirs(
     if conflicts := repo.index.conflicts:
         for common, ours, theirs in conflicts:
             if work_path / common.path == filename:
+                ancestor.write(repo.get(common.id).read_raw())
                 current.write(repo.get(ours.id).read_raw())
                 incoming.write(repo.get(theirs.id).read_raw())
                 return True

--- a/gaphor/storage/tests/test_mergeconflict.py
+++ b/gaphor/storage/tests/test_mergeconflict.py
@@ -19,10 +19,12 @@ def test_split_git_repo(tmp_path):
         their_text="Branch commit",
     )
 
+    ancestor = io.BytesIO()
     ours = io.BytesIO()
     theirs = io.BytesIO()
-    result = split_ours_and_theirs(test_file, ours, theirs)
+    result = split_ours_and_theirs(test_file, ancestor, ours, theirs)
 
     assert result
+    assert ancestor.getbuffer() == b"Initial commit"
     assert ours.getbuffer() == b"Second commit"
     assert theirs.getbuffer() == b"Branch commit"

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -222,13 +222,17 @@ class FileManager(Service, ActionProvider):
 
     def resolve_merge_conflict(self, filename: Path):
         temp_dir = tempfile.TemporaryDirectory()
+        ancestor_filename = Path(temp_dir.name) / f"ancestor-{filename.name}"
         current_filename = Path(temp_dir.name) / f"current-{filename.name}"
         incoming_filename = Path(temp_dir.name) / f"incoming-{filename.name}"
         with (
+            ancestor_filename.open("wb") as ancestor_file,
             current_filename.open("wb") as current_file,
             incoming_filename.open("wb") as incoming_file,
         ):
-            split = split_ours_and_theirs(filename, current_file, incoming_file)
+            split = split_ours_and_theirs(
+                filename, ancestor_file, current_file, incoming_file
+            )
 
         def done():
             nonlocal temp_dir

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import tempfile
+from functools import partial
 from pathlib import Path
 from typing import Callable
 
@@ -138,6 +139,7 @@ class FileManager(Service, ActionProvider):
 
     def merge(
         self,
+        ancestor_filename: Path,
         current_filename: Path,
         incoming_filename: Path,
         on_load_done: Callable[[], None] | None = None,
@@ -148,21 +150,30 @@ class FileManager(Service, ActionProvider):
             parent=self.parent_window,
         )
 
+        ancestor_element_factory = ElementFactory()
         incoming_element_factory = ElementFactory()
 
-        def current_progress(percentage):
-            status_window.progress(percentage / 2)
-
-        def incoming_progress(percentage):
-            status_window.progress(50 + percentage / 2)
+        def progress(percentage, completed=0):
+            status_window.progress(completed + percentage / 3)
 
         # Make this callback async, so we can call _load_async again: it's a generator and we can only run one at a time
         @g_async()
         def current_done():
+            log.debug("Loading ancestor model from %s", ancestor_filename)
+            for _ in self._load_async(
+                ancestor_filename,
+                partial(progress, completed=33),
+                ancestor_done,
+                element_factory=ancestor_element_factory,
+            ):
+                pass
+
+        @g_async()
+        def ancestor_done():
             log.debug("Loading incoming model from %s", incoming_filename)
             for _ in self._load_async(
                 incoming_filename,
-                incoming_progress,
+                partial(progress, completed=66),
                 incoming_done,
                 element_factory=incoming_element_factory,
             ):
@@ -172,7 +183,13 @@ class FileManager(Service, ActionProvider):
             try:
                 log.debug("Comparing models")
                 with self.element_factory.block_events():
-                    list(compare(self.element_factory, incoming_element_factory))
+                    list(
+                        compare(
+                            self.element_factory,
+                            ancestor_element_factory,
+                            incoming_element_factory,
+                        )
+                    )
 
                 if on_load_done:
                     on_load_done()
@@ -180,7 +197,7 @@ class FileManager(Service, ActionProvider):
                 status_window.destroy()
 
         log.debug("Loading current model from %s", current_filename)
-        for _ in self._load_async(current_filename, current_progress, current_done):
+        for _ in self._load_async(current_filename, progress, current_done):
             pass
 
     @g_async()
@@ -248,7 +265,12 @@ class FileManager(Service, ActionProvider):
             elif answer == "incoming":
                 self.load(incoming_filename, on_load_done=done)
             elif answer == "manual":
-                self.merge(current_filename, incoming_filename, on_load_done=done)
+                self.merge(
+                    ancestor_filename,
+                    current_filename,
+                    incoming_filename,
+                    on_load_done=done,
+                )
             else:
                 raise ValueError(f"Unknown resolution for merge conflict: {answer}")
 

--- a/gaphor/ui/modelmerge/organize.py
+++ b/gaphor/ui/modelmerge/organize.py
@@ -82,17 +82,18 @@ def organize_changes(element_factory, modeling_language):
             element_type = modeling_language.lookup_element(element_change.element_name)
             assert element_type
             return element_type
-        else:
-            raise ValueError("Can’t resolve id {element_id} to a type")
+        return None
 
     def composite(change: RefChange):
         element_type = lookup_element(change.element_id)
+        if not element_type:
+            return False
         prop = getattr(element_type, change.property_name, None)
         return prop and prop.composite
 
     def not_presentation(change: RefChange):
         element_type = lookup_element(change.property_ref)
-        return not issubclass(element_type, (Diagram, Presentation))
+        return element_type and not issubclass(element_type, (Diagram, Presentation))
 
     def composite_and_not_presentation(change: RefChange):
         return composite(change) and not_presentation(change)

--- a/gaphor/ui/modelmerge/tests/test_organize.py
+++ b/gaphor/ui/modelmerge/tests/test_organize.py
@@ -253,6 +253,34 @@ def test_add_diagram_with_reference(element_factory, modeling_language, change):
     assert ref in tree[0].children[0].elements
 
 
+def test_unresolvable_reference_element_id(element_factory, modeling_language, change):
+    change(
+        RefChange,
+        op="add",
+        element_id="12345",
+        property_name="element",
+    )
+
+    tree = list(organize_changes(element_factory, modeling_language))
+
+    assert not tree
+
+
+def test_unresolvable_reference_property_ref(
+    element_factory, modeling_language, change
+):
+    change(
+        RefChange,
+        op="add",
+        property_name="element",
+        property_ref="12345",
+    )
+
+    tree = list(organize_changes(element_factory, modeling_language))
+
+    assert not tree
+
+
 def test_add_diagram_contains_presentation(element_factory, modeling_language, change):
     add_diagram = change(ElementChange, op="add", element_name="Diagram")
     add_class_item = change(ElementChange, op="add", element_name="ClassItem")

--- a/gaphor/ui/modelmerge/tests/test_organize_uml.py
+++ b/gaphor/ui/modelmerge/tests/test_organize_uml.py
@@ -42,7 +42,7 @@ def test_class_with_members(element_factory, modeling_language, create):
     parse(class_item.subject.ownedOperation[0], "+ to_string(arg: int): str")
 
     current = ElementFactory()
-    all(compare(current, element_factory))
+    all(compare(current, current, element_factory))
     tree = list(organize_changes(current, modeling_language))
 
     assert len(tree) == 1
@@ -57,7 +57,7 @@ def test_association(element_factory, modeling_language, create):
     connect(association, association.tail, tail_class_item)
 
     current = ElementFactory()
-    all(compare(current, element_factory))
+    all(compare(current, current, element_factory))
     tree = list(organize_changes(current, modeling_language))
 
     assert len(tree) == 1
@@ -74,7 +74,7 @@ def test_association_with_existing_classes(element_factory, modeling_language, c
     current = ElementFactory()
     current.create_as(UML.Class, head_class_item.subject.id)
     current.create_as(UML.Class, tail_class_item.subject.id)
-    all(compare(current, element_factory))
+    all(compare(current, current, element_factory))
     tree = list(organize_changes(current, modeling_language))
 
     assert len(tree) == 3
@@ -89,7 +89,7 @@ def test_extension(element_factory, modeling_language, create):
     connect(extension, extension.tail, stereotype_item)
 
     current = ElementFactory()
-    all(compare(current, element_factory))
+    all(compare(current, current, element_factory))
     tree = list(organize_changes(current, modeling_language))
 
     assert len(tree) == 1
@@ -103,7 +103,7 @@ def test_activity_with_parameter_node(element_factory, modeling_language, create
     activity.subject.node = node
 
     current = ElementFactory()
-    all(compare(current, element_factory))
+    all(compare(current, current, element_factory))
     tree = list(organize_changes(current, modeling_language))
 
     assert len(tree) == 1
@@ -121,7 +121,7 @@ def test_partition_with_swim_lanes(element_factory, modeling_language, create):
     partition.partition[1].activity = partition.subject.activity
 
     current = ElementFactory()
-    all(compare(current, element_factory))
+    all(compare(current, current, element_factory))
     tree = list(organize_changes(current, modeling_language))
 
     # Create diagram + extra Activity
@@ -140,7 +140,7 @@ def test_connector_with_item_flow(element_factory, modeling_language, create):
     create_item_flow(connector_item.subject)
 
     current = ElementFactory()
-    all(compare(current, element_factory))
+    all(compare(current, current, element_factory))
     tree = list(organize_changes(current, modeling_language))
 
     assert len(tree) == 1
@@ -153,7 +153,7 @@ def test_state_with_entry_do_exit_criteria(element_factory, modeling_language, c
     state_item.subject.doActivity = element_factory.create(UML.Activity)
 
     current = ElementFactory()
-    all(compare(current, element_factory))
+    all(compare(current, current, element_factory))
     tree = list(organize_changes(current, modeling_language))
 
     assert len(tree) == 1
@@ -168,7 +168,7 @@ def test_transition_with_guard(element_factory, modeling_language, create):
     connect(transition_item, transition_item.tail, tail_state_item)
 
     current = ElementFactory()
-    all(compare(current, element_factory))
+    all(compare(current, current, element_factory))
     tree = list(organize_changes(current, modeling_language))
 
     assert transition_item.subject.guard
@@ -182,7 +182,7 @@ def test_applied_stereotype(element_factory, modeling_language, create):
     apply_stereotype(class_item.subject, stereotype)
 
     current = ElementFactory()
-    all(compare(current, element_factory))
+    all(compare(current, current, element_factory))
     tree = list(organize_changes(current, modeling_language))
 
     # Create Stereotype + create diagram


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The list of changes in the merge editor is long and not easy to comprehend.

Issue Number: #388 

### What is the new behavior?

Instead of comparing the incoming with the current model, the incoming model is compared with a common ancestor node. As a result, the change set only contains the changes made in the incoming branch. Those changes can be applied to the model.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
