### PR TITLE
Fix encoding warnings for no encoding argument

### DIFF
--- a/gaphor/storage/tests/fixtures.py
+++ b/gaphor/storage/tests/fixtures.py
@@ -13,17 +13,17 @@ def create_merge_conflict(repo, filename, initial_text, our_text, their_text):
 
         return repo.create_commit(ref, author, author, message, tree, parents)
 
-    filename.write_text(initial_text)
+    filename.write_text(initial_text, encoding="utf-8")
     initial_oid = commit_all("Initial commit", parents=[])
     main_ref = repo.head
     branch_ref = repo.references.create("refs/heads/branch", initial_oid)
 
     repo.checkout(branch_ref)
-    filename.write_text(their_text)
+    filename.write_text(their_text, encoding="utf-8")
     branch_oid = commit_all("Branch commit", parents=[initial_oid])
 
     repo.checkout(main_ref)
-    filename.write_text(our_text)
+    filename.write_text(our_text, encoding="utf-8")
     commit_all("Second commit", parents=[initial_oid])
 
     repo.merge(branch_oid)


### PR DESCRIPTION
Fixes PEP597 encoding warnings caused by no encoding argument specified.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Encoding warnings with PYTHONWARNDEFAULTENCODING=true

Issue Number: N/A

### What is the new behavior?
No warnings

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
