### PR TITLE
A quick fix for crashes in the CSS editor

### DIFF
--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -20,11 +20,6 @@ from gaphor.core.modeling.event import (
 from gaphor.diagram.propertypages import PropertyPages, new_resource_builder
 from gaphor.i18n import localedir
 from gaphor.ui.abc import UIComponent
-from gaphor.ui.csscompletion import (
-    CssFunctionCompletionProvider,
-    CssNamedColorsCompletionProvider,
-    CssPropertyCompletionProvider,
-)
 from gaphor.ui.event import DiagramSelectionChanged
 from gaphor.ui.modelmerge import ModelMerge
 from gaphor.event import ModelLoaded
@@ -319,10 +314,10 @@ class PreferencesStack:
             self.lang_manager.get_language("gaphorcss")
         )
 
-        view_completion = self.style_sheet_view.get_completion()
-        view_completion.add_provider(CssFunctionCompletionProvider())
-        view_completion.add_provider(CssNamedColorsCompletionProvider())
-        view_completion.add_provider(CssPropertyCompletionProvider())
+        # view_completion = self.style_sheet_view.get_completion()
+        # view_completion.add_provider(CssFunctionCompletionProvider())
+        # view_completion.add_provider(CssNamedColorsCompletionProvider())
+        # view_completion.add_provider(CssPropertyCompletionProvider())
         assert self.style_manager
         self._notify_dark_id = self.style_manager.connect(
             "notify::dark", self._on_notify_dark


### PR DESCRIPTION
Remove the completion code for now. This is a quick fix/workaround.

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Gaphor crashes as soon as you enter something in the CSS editor

Issue Number: #2242

### What is the new behavior?

Disable auto-complete for now.

We can do a bugfix release after this change, so Gaphor does not crash.