### PR TITLE
Remove GTK3 leftover from element editor

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,12 @@ extensions = [
     "IPython.sphinxext.ipython_console_highlighting",
 ]
 
-autodoc_mock_imports = ["gi.repository.Gdk", "gi.repository.Gtk", "gi.repository.Adw"]
+autodoc_mock_imports = [
+    "gi.repository.Gdk",
+    "gi.repository.Gtk",
+    "gi.repository.Adw",
+    "gi.repository.GtkSource",
+]
 gi.require_version = lambda *_: ...
 
 os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -12,7 +12,7 @@ gi.require_version("Gdk", "4.0")
 gi.require_version("GtkSource", "5")
 gi.require_version("Adw", "1")
 
-from gi.repository import Adw, Gio, GLib, Gtk
+from gi.repository import Adw, Gio, GLib, Gtk, GtkSource
 
 from gaphor.application import Application, Session, distribution
 from gaphor.core import event_handler
@@ -21,6 +21,8 @@ from gaphor.ui.actiongroup import apply_application_actions
 
 APPLICATION_ID = "org.gaphor.Gaphor"
 LOG_FORMAT = "%(name)s %(levelname)s %(message)s"
+
+GtkSource.init()
 
 
 def main(argv=sys.argv) -> int:

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -6,7 +6,7 @@ from typing import Optional
 from unicodedata import normalize
 
 from babel import Locale
-from gi.repository import GLib, Gtk, GtkSource
+from gi.repository import Adw, GLib, Gtk, GtkSource
 
 from gaphor.abc import ActionProvider
 from gaphor.core import Transaction, action, event_handler
@@ -26,11 +26,6 @@ from gaphor.event import ModelLoaded
 
 
 log = logging.getLogger(__name__)
-
-if Gtk.get_major_version() != 3:
-    from gi.repository import Adw
-
-    GtkSource.init()
 
 new_builder = new_resource_builder("gaphor.ui", "elementeditor")
 
@@ -276,9 +271,7 @@ class PreferencesStack:
         self.event_manager = event_manager
         self.element_factory = element_factory
         self.lang_manager = GtkSource.LanguageManager.get_default()
-        self.style_manager = (
-            None if Gtk.get_major_version() == 3 else Adw.StyleManager.get_default()
-        )
+        self.style_manager = Adw.StyleManager.get_default()
         self._notify_dark_id = 0
         self.lang_manager.append_search_path(
             str(importlib.resources.files("gaphor") / "ui" / "language-specs")


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Element editor contains a left-over from the days of GTK 3.

### What is the new behavior?

It's been removed and code has been cleaned up.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
