### PR TITLE
Restore CSS completion

### DIFF
--- a/gaphor/ui/csscompletion.py
+++ b/gaphor/ui/csscompletion.py
@@ -42,7 +42,6 @@ class CssNamedColorsCompletionProvider(GObject.GObject, GtkSource.CompletionProv
         return "Colors"
 
     def do_populate_async(self, context, cancellable, callback, user_data=None) -> None:
-        task = Gio.Task.new(self, cancellable, callback)
         store = Gio.ListStore.new(CssNamedColorProposal)
         self._filter_data.word = context.get_word()
 
@@ -54,12 +53,8 @@ class CssNamedColorsCompletionProvider(GObject.GObject, GtkSource.CompletionProv
             return proposal.text.startswith(data.word)
 
         store_filter = Gtk.CustomFilter.new(filter_fn, self._filter_data)
-        task.proposals = Gtk.FilterListModel.new(store, store_filter)
-        task.return_boolean(True)
-
-    def do_populate_finish(self, result: Gio.AsyncResult) -> Gio.ListModel:
-        if result.propagate_boolean():
-            return result.proposals
+        proposals = Gtk.FilterListModel.new(store, store_filter)
+        context.set_proposals_for_provider(self, proposals)
 
     def do_refilter(
         self, context: GtkSource.CompletionContext, model: Gio.ListModel
@@ -127,7 +122,6 @@ class CssFunctionCompletionProvider(GObject.GObject, GtkSource.CompletionProvide
         return "Functions"
 
     def do_populate_async(self, context, cancellable, callback, user_data=None) -> None:
-        task = Gio.Task.new(self, cancellable, callback)
         store = Gio.ListStore.new(CssFunctionProposal)
         self._filter_data.word = context.get_word()
 
@@ -139,12 +133,8 @@ class CssFunctionCompletionProvider(GObject.GObject, GtkSource.CompletionProvide
             return proposal.text.startswith(data.word)
 
         store_filter = Gtk.CustomFilter.new(filter_fn, self._filter_data)
-        task.proposals = Gtk.FilterListModel.new(store, store_filter)
-        task.return_boolean(True)
-
-    def do_populate_finish(self, result: Gio.AsyncResult) -> Gio.ListModel:
-        if result.propagate_boolean():
-            return result.proposals
+        proposals = Gtk.FilterListModel.new(store, store_filter)
+        context.set_proposals_for_provider(self, proposals)
 
     def do_refilter(
         self, context: GtkSource.CompletionContext, model: Gio.ListModel
@@ -205,7 +195,6 @@ class CssPropertyCompletionProvider(GObject.GObject, GtkSource.CompletionProvide
         return "Properties"
 
     def do_populate_async(self, context, cancellable, callback, user_data=None) -> None:
-        task = Gio.Task.new(self, cancellable, callback)
         store = Gio.ListStore.new(CssPropertyProposal)
         self._filter_data.word = context.get_word()
 
@@ -217,12 +206,8 @@ class CssPropertyCompletionProvider(GObject.GObject, GtkSource.CompletionProvide
             return proposal.text.startswith(data.word)
 
         store_filter = Gtk.CustomFilter.new(filter_fn, self._filter_data)
-        task.proposals = Gtk.FilterListModel.new(store, store_filter)
-        task.return_boolean(True)
-
-    def do_populate_finish(self, result: Gio.AsyncResult) -> Gio.ListModel:
-        if result.propagate_boolean():
-            return result.proposals
+        proposals = Gtk.FilterListModel.new(store, store_filter)
+        context.set_proposals_for_provider(self, proposals)
 
     def do_refilter(
         self, context: GtkSource.CompletionContext, model: Gio.ListModel

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -20,6 +20,11 @@ from gaphor.core.modeling.event import (
 from gaphor.diagram.propertypages import PropertyPages, new_resource_builder
 from gaphor.i18n import localedir
 from gaphor.ui.abc import UIComponent
+from gaphor.ui.csscompletion import (
+    CssFunctionCompletionProvider,
+    CssNamedColorsCompletionProvider,
+    CssPropertyCompletionProvider,
+)
 from gaphor.ui.event import DiagramSelectionChanged
 from gaphor.ui.modelmerge import ModelMerge
 from gaphor.event import ModelLoaded
@@ -314,10 +319,10 @@ class PreferencesStack:
             self.lang_manager.get_language("gaphorcss")
         )
 
-        # view_completion = self.style_sheet_view.get_completion()
-        # view_completion.add_provider(CssFunctionCompletionProvider())
-        # view_completion.add_provider(CssNamedColorsCompletionProvider())
-        # view_completion.add_provider(CssPropertyCompletionProvider())
+        view_completion = self.style_sheet_view.get_completion()
+        view_completion.add_provider(CssFunctionCompletionProvider())
+        view_completion.add_provider(CssNamedColorsCompletionProvider())
+        view_completion.add_provider(CssPropertyCompletionProvider())
         assert self.style_manager
         self._notify_dark_id = self.style_manager.connect(
             "notify::dark", self._on_notify_dark

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -21,9 +21,10 @@ from gaphor.diagram.propertypages import PropertyPages, new_resource_builder
 from gaphor.i18n import localedir
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.csscompletion import (
-    CssFunctionCompletionProvider,
-    CssNamedColorsCompletionProvider,
-    CssPropertyCompletionProvider,
+    CssFunctionProposals,
+    CssNamedColorProposals,
+    CssPropertyProposals,
+    CompletionProviderWrapper,
 )
 from gaphor.ui.event import DiagramSelectionChanged
 from gaphor.ui.modelmerge import ModelMerge
@@ -320,9 +321,15 @@ class PreferencesStack:
         )
 
         view_completion = self.style_sheet_view.get_completion()
-        view_completion.add_provider(CssFunctionCompletionProvider())
-        view_completion.add_provider(CssNamedColorsCompletionProvider())
-        view_completion.add_provider(CssPropertyCompletionProvider())
+        view_completion.add_provider(
+            CompletionProviderWrapper(priority=3, proposals=CssFunctionProposals())
+        )
+        view_completion.add_provider(
+            CompletionProviderWrapper(priority=-4, proposals=CssNamedColorProposals())
+        )
+        view_completion.add_provider(
+            CompletionProviderWrapper(priority=1, proposals=CssPropertyProposals())
+        )
         assert self.style_manager
         self._notify_dark_id = self.style_manager.connect(
             "notify::dark", self._on_notify_dark


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

CSS Completion has been removed due to #2242.

### What is the new behavior?

This PR restores the CSS Completion feature. Since I had to apply the changes on 3 places, I decided to separate the GtkSource `CompletionProvider` code and callbacks and the code that provides the proposals.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
