### PR TITLE
Execute scripts from the command line

### DIFF
--- a/gaphor/__main__.py
+++ b/gaphor/__main__.py
@@ -1,6 +1,7 @@
 import sys
 
-from gaphor.ui import main
+from gaphor.main import main
+
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -7,7 +7,7 @@ from gaphor.application import distribution
 LOG_FORMAT = "%(name)s %(levelname)s %(message)s"
 
 
-def main(argv) -> int:
+def main(argv=sys.argv) -> int:
     """Start Gaphor from the command line."""
     args = parse_args(argv)
 
@@ -98,4 +98,4 @@ def parse_args(argv):
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    sys.exit(main())

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -66,28 +66,28 @@ def ui(prog, models, self_test, profiler, gapplication_service) -> int:
 def parse_args(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-v", "--version", help="Print version and exit", action="store_true"
+        "-v", "--version", help="print version and exit", action="store_true"
     )
     parser.add_argument(
-        "-d", "--debug", help="Enable debug logging", action="store_true"
+        "-d", "--debug", help="enable debug logging", action="store_true"
     )
     parser.add_argument(
-        "-q", "--quiet", help="Only show warning and error logging", action="store_true"
+        "-q", "--quiet", help="only show warning and error logging", action="store_true"
     )
 
-    exec_group = parser.add_argument_group("Scripting options")
+    exec_group = parser.add_argument_group("scripting options")
     exec_group.add_argument(
-        "--exec", help="Execute a script file and exit", dest="script"
+        "--exec", help="execute a script file and exit", dest="script", metavar="script"
     )
 
-    ui_group = parser.add_argument_group("Interactive (GUI) options")
+    ui_group = parser.add_argument_group("interactive (GUI) options")
     ui_group.add_argument(
-        "-p", "--profiler", help="Run in profiler (cProfile)", action="store_true"
+        "-p", "--profiler", help="run in profiler (cProfile)", action="store_true"
     )
     ui_group.add_argument(
-        "--self-test", help="Run self test and exit", action="store_true"
+        "--self-test", help="run self test and exit", action="store_true"
     )
-    ui_group.add_argument("model", nargs="*", help="Model file(s) to load")
+    ui_group.add_argument("model", nargs="*", help="model file(s) to load")
 
     gapplication_group = parser.add_argument_group(
         "GApplication settings (use from D-Bus service files)"

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -64,7 +64,7 @@ def ui(prog, models, self_test, profiler, gapplication_service) -> int:
 
 
 def parse_args(argv):
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="Gaphor is the simple modeling tool.")
     parser.add_argument(
         "-v", "--version", help="print version and exit", action="store_true"
     )

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -1,0 +1,84 @@
+import argparse
+import logging
+import sys
+
+from gaphor.application import distribution
+
+LOG_FORMAT = "%(name)s %(levelname)s %(message)s"
+
+
+def main(argv) -> int:
+    """Start Gaphor from the command line.  This function creates an option
+    parser for retrieving arguments and options from the command line.  This
+    includes a Gaphor model to load.
+
+    The application is then initialized, passing along the option
+    parser.  This provides plugins and services with access to the
+    command line options and may add their own.
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v", "--version", help="Print version and exit", action="store_true"
+    )
+    parser.add_argument("-d", "--debug", help="Debug output", action="store_true")
+    parser.add_argument("-q", "--quiet", help="Quiet output", action="store_true")
+    parser.add_argument(
+        "-p", "--profiler", help="Run in profiler (cProfile)", action="store_true"
+    )
+    parser.add_argument(
+        "--self-test", help="Run self test and exit", action="store_true"
+    )
+    parser.add_argument(
+        "--gapplication-service",
+        help="Enter GApplication service mode (use from D-Bus service files)",
+        action="store_true",
+    )
+    parser.add_argument("filename", nargs="*", help="Model(s) to load")
+
+    args = parser.parse_args(args=argv[1:])
+
+    if args.version:
+        print(f"Gaphor {distribution().version}")
+        return 0
+
+    if args.debug:
+        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+        logging.getLogger("gaphor").setLevel(logging.DEBUG)
+    elif args.quiet:
+        logging.basicConfig(level=logging.WARNING, format=LOG_FORMAT)
+    else:
+        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+
+    return ui(
+        argv[0], args.filename, args.self_test, args.profiler, args.gapplication_service
+    )
+
+
+def ui(prog, filenames, self_test, profiler, gapplication_service) -> int:
+    # Only now import the UI module
+    from gaphor.ui import run
+
+    run_argv = [prog]
+    if self_test:
+        run_argv += ["--self-test"]
+    if gapplication_service:
+        run_argv += ["--gapplication-service"]
+    run_argv.extend(filenames)
+
+    if profiler:
+        import cProfile
+        import pstats
+
+        with cProfile.Profile() as profile:
+            exit_code = profile.runcall(run, run_argv)
+
+        profile_stats = pstats.Stats(profile)
+        profile_stats.strip_dirs().sort_stats("time").print_stats(50)
+        return exit_code
+
+    return run(run_argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -26,6 +26,7 @@ def main(argv) -> int:
     parser.add_argument(
         "-p", "--profiler", help="Run in profiler (cProfile)", action="store_true"
     )
+    parser.add_argument("--exec", help="Execute a script file and exit", dest="script")
     parser.add_argument(
         "--self-test", help="Run self test and exit", action="store_true"
     )
@@ -50,9 +51,19 @@ def main(argv) -> int:
     else:
         logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 
+    if args.script:
+        return execute_script(args.script)
+
     return ui(
         argv[0], args.filename, args.self_test, args.profiler, args.gapplication_service
     )
+
+
+def execute_script(script: str) -> int:
+    import runpy
+
+    runpy.run_path(script, run_name="__main__")
+    return 0
 
 
 def ui(prog, filenames, self_test, profiler, gapplication_service) -> int:

--- a/gaphor/tests/run_script.py
+++ b/gaphor/tests/run_script.py
@@ -1,0 +1,4 @@
+from gaphor.application import distribution
+
+if __name__ == "__main__":
+    print("Running a test script for Gaphor", distribution().version)

--- a/gaphor/tests/test_main.py
+++ b/gaphor/tests/test_main.py
@@ -1,0 +1,56 @@
+import logging
+
+import pytest
+
+import gaphor.ui
+from gaphor.main import main
+
+APP_NAME = "/path/to/gaphor"
+
+
+@pytest.fixture(autouse=True)
+def mock_gaphor_ui_run(monkeypatch):
+    _argv = []
+
+    def run(argv):
+        _argv[:] = argv
+        return 0
+
+    monkeypatch.setattr(gaphor.ui, "run", run)
+    return _argv
+
+
+def test_run_main():
+    exit_code = main([APP_NAME])
+
+    assert exit_code == 0
+
+
+def test_version(capsys):
+    main([APP_NAME, "-v"])
+
+    assert "Gaphor" in capsys.readouterr().out
+
+
+def test_debug_logging():
+    main([APP_NAME, "-d"])
+
+    assert logging.getLogger("gaphor").getEffectiveLevel() == logging.DEBUG
+
+
+def test_quiet_logging():
+    main([APP_NAME, "-q"])
+
+    assert logging.getLogger("root").getEffectiveLevel() == logging.WARNING
+
+
+def test_self_test(mock_gaphor_ui_run):
+    main([APP_NAME, "--self-test"])
+
+    assert mock_gaphor_ui_run == [APP_NAME, "--self-test"]
+
+
+def test_gapplication_service(mock_gaphor_ui_run):
+    main([APP_NAME, "--gapplication-service"])
+
+    assert mock_gaphor_ui_run == [APP_NAME, "--gapplication-service"]

--- a/gaphor/tests/test_main.py
+++ b/gaphor/tests/test_main.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 import pytest
 
@@ -54,3 +55,11 @@ def test_gapplication_service(mock_gaphor_ui_run):
     main([APP_NAME, "--gapplication-service"])
 
     assert mock_gaphor_ui_run == [APP_NAME, "--gapplication-service"]
+
+
+def test_run_script(capsys):
+    run_script = Path(__file__).parent / "run_script.py"
+
+    main([APP_NAME, "--exec", str(run_script)])
+
+    assert "Running a test script for Gaphor" in capsys.readouterr().out

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -1,9 +1,7 @@
 """This module contains user interface related code, such as the main screen
 and diagram windows."""
 
-import logging
-import sys
-from typing import Optional
+from __future__ import annotations
 
 import gi
 
@@ -14,58 +12,18 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Adw, Gio, GLib, Gtk, GtkSource
 
-from gaphor.application import Application, Session, distribution
+from gaphor.application import Application, Session
 from gaphor.core import event_handler
 from gaphor.event import ActiveSessionChanged, ApplicationShutdown, SessionCreated
 from gaphor.ui.actiongroup import apply_application_actions
 
 APPLICATION_ID = "org.gaphor.Gaphor"
-LOG_FORMAT = "%(name)s %(levelname)s %(message)s"
 
 GtkSource.init()
 
 
-def main(argv=sys.argv) -> int:
-    """Start Gaphor from the command line.  This function creates an option
-    parser for retrieving arguments and options from the command line.  This
-    includes a Gaphor model to load.
-
-    The application is then initialized, passing along the option
-    parser.  This provides plugins and services with access to the
-    command line options and may add their own.
-    """
-
-    def has_option(*options):
-        return any(o in argv for o in options)
-
-    if has_option("-v", "--version"):
-        print(f"Gaphor {distribution().version}")
-        return 0
-
-    if has_option("-d", "--debug"):
-        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
-        logging.getLogger("gaphor").setLevel(logging.DEBUG)
-    elif has_option("-q", "--quiet"):
-        logging.basicConfig(level=logging.WARNING, format=LOG_FORMAT)
-    else:
-        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
-
-    if has_option("-p", "--profiler"):
-        import cProfile
-        import pstats
-
-        with cProfile.Profile() as profile:
-            exit_code = profile.runcall(run, argv)
-
-        profile_stats = pstats.Stats(profile)
-        profile_stats.strip_dirs().sort_stats("time").print_stats(50)
-        return exit_code
-
-    return run(argv)
-
-
 def run(argv: list[str]) -> int:
-    application: Optional[Application] = None
+    application: Application | None = None
 
     def app_startup(gtk_app):
         nonlocal application
@@ -129,42 +87,7 @@ def run(argv: list[str]) -> int:
 
 
 def add_main_options(gtk_app):
-    """These parameters are handled in `gaphor.ui.main()`.
-
-    Define them here, so they show up on `gaphor --help`.
-    """
-    gtk_app.add_main_option(
-        "version",
-        ord("v"),
-        GLib.OptionFlags.NONE,
-        GLib.OptionArg.NONE,
-        "Print version and exit",
-        None,
-    )
-    gtk_app.add_main_option(
-        "debug",
-        ord("d"),
-        GLib.OptionFlags.NONE,
-        GLib.OptionArg.NONE,
-        "Debug output",
-        None,
-    )
-    gtk_app.add_main_option(
-        "quiet",
-        ord("q"),
-        GLib.OptionFlags.NONE,
-        GLib.OptionArg.NONE,
-        "Quiet output",
-        None,
-    )
-    gtk_app.add_main_option(
-        "profiler",
-        ord("p"),
-        GLib.OptionFlags.NONE,
-        GLib.OptionArg.NONE,
-        "Run in profiler",
-        None,
-    )
+    """These parameters are handled in `gaphor.ui.run()`."""
     gtk_app.add_main_option(
         "self-test",
         0,

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -189,7 +189,7 @@ def display_type():
 
 def windows_console_output_workaround():
     if sys.platform == "win32":
-        from gaphor.ui import LOG_FORMAT
+        from gaphor.main import LOG_FORMAT
 
         logging.basicConfig(
             level=logging.INFO,

--- a/gaphor/ui/tests/test_main.py
+++ b/gaphor/ui/tests/test_main.py
@@ -1,7 +1,7 @@
 import pytest
 from gi.repository import GLib, Gtk
 
-import gaphor.ui
+import gaphor.main
 
 
 @pytest.fixture(autouse=True)
@@ -31,7 +31,7 @@ def fake_run(monkeypatch):
 def test_application_startup(monkeypatch):
     run = fake_run(monkeypatch)
 
-    gaphor.ui.main(["gaphor"])
+    gaphor.main.main(["gaphor"])
 
     assert run == ["gaphor"]
 
@@ -39,6 +39,6 @@ def test_application_startup(monkeypatch):
 def test_application_startup_with_model(monkeypatch):
     run = fake_run(monkeypatch)
 
-    gaphor.ui.main(["gaphor", "test-models/all-elements.gaphor"])
+    gaphor.main.main(["gaphor", "test-models/all-elements.gaphor"])
 
     assert run == ["gaphor", "test-models/all-elements.gaphor"]

--- a/gaphor/ui/tests/test_selftest.py
+++ b/gaphor/ui/tests/test_selftest.py
@@ -1,10 +1,10 @@
 import logging
 
-from gaphor.ui import main
+from gaphor.ui import run
 
 
 def test_self_test(caplog):
     caplog.set_level(logging.INFO)
-    exit_code = main(["--self-test"])
+    exit_code = run(["--self-test"])
 
     assert exit_code == 0, caplog.text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ tomli = { version = ">=1.2,<3.0", python = "<3.11" }
 docs = [ "sphinx", "sphinx-copybutton", "sphinx-intl", "myst-nb", "furo" ]
 
 [tool.poetry.scripts]
-gaphor = "gaphor.ui:main"
+gaphor = "gaphor.main:main"
 gaphorconvert = "gaphor.plugins.diagramexport.gaphorconvert:main"
 
 [tool.poetry.plugins."gaphor.appservices"]


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Currently command line parsing is done in the UI module. This limits the extensibility (and usability of Gaphor in non-UI environments).

Issue Number: #389

### What is the new behavior?

Command line arguments are parsed in `gaphor.main`. The arguments are nicely grouped.

It was also pretty easy to add script execution (I recall it being discussed somewhere). It also opens the door for plugin support: we can provide options to install plugins and list plugins.

```
usage: gaphor [-h] [-v] [-d] [-q] [--exec script] [-p] [--self-test] [--gapplication-service] [model ...]

Gaphor is the simple modeling tool.

options:
  -h, --help            show this help message and exit
  -v, --version         print version and exit
  -d, --debug           enable debug logging
  -q, --quiet           only show warning and error logging

scripting options:
  --exec script         execute a script file and exit

interactive (GUI) options:
  -p, --profiler        run in profiler (cProfile)
  --self-test           run self test and exit
  model                 model file(s) to load

GApplication settings (use from D-Bus service files):
  --gapplication-service
```
### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

### Other information
