### PR TITLE
Diagram export as gaphor CLI subcommand

### DIFF
--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -69,6 +69,7 @@ a = Analysis(  # type: ignore
     + copy_metadata("gaphor")
     + copy_metadata("gaphas"),
     hiddenimports=collect_entry_points(
+        "gaphor.argparsers",
         "gaphor.services",
         "gaphor.appservices",
         "gaphor.modelinglanguages",

--- a/gaphor/entrypoint.py
+++ b/gaphor/entrypoint.py
@@ -28,7 +28,7 @@ def load_entry_points(scope, services=None) -> Dict[str, type]:
     for ep in list_entry_points(scope):
         cls = ep.load()
         if not services or ep.name in services:
-            logger.debug(f'found service entry point "{ep.name}"')
+            logger.debug(f'found entry point "{scope}.{ep.name}"')
             uninitialized_services[ep.name] = cls
     return uninitialized_services
 

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from gaphor.application import distribution
-from gaphor.plugins.diagramexport.exportcli import export_parser
+from gaphor.entrypoint import initialize
 
 LOG_FORMAT = "%(name)s %(levelname)s %(message)s"
 
@@ -14,10 +14,7 @@ def main(argv=sys.argv) -> int:
 
     logging_config()
 
-    commands = {
-        "exec": exec_parser(),
-        "export": export_parser(),
-    }
+    commands: dict[str, argparse.ArgumentParser] = initialize("gaphor.argparsers")
 
     args = parse_args(argv[1:], commands)
 

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -3,6 +3,7 @@ import logging
 import sys
 
 from gaphor.application import distribution
+from gaphor.plugins.diagramexport.exportcli import export_parser
 
 LOG_FORMAT = "%(name)s %(levelname)s %(message)s"
 
@@ -122,21 +123,11 @@ def exec_parser():
         runpy.run_path(script, run_name="__main__")
         return 0
 
-    parser = argparse.ArgumentParser()
-    parser.description = "Execute a python script from within Gaphor."
+    parser = argparse.ArgumentParser(
+        description="Execute a python script from within Gaphor."
+    )
     parser.add_argument("script", help="execute a script file and exit")
     parser.set_defaults(command=execute_script)
-    return parser
-
-
-def export_parser():
-    def export_script(args) -> int:
-        print("Placeholder for diagram export")
-        return 0
-
-    parser = argparse.ArgumentParser()
-    parser.description = "Export diagrams from a Gaphor model."
-    parser.set_defaults(command=export_script)
     return parser
 
 

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -12,23 +12,28 @@ def main(argv=sys.argv) -> int:
 
     logging_config()
 
-    args = parse_args(argv)
+    commands = {
+        "exec": exec_parser,
+        "export": export_parser,
+    }
+
+    args = parse_args(argv, commands)
 
     if args.profiler:
         import cProfile
         import pstats
 
         with cProfile.Profile() as profile:
-            exit_code: int = profile.runcall(args.func, args)
+            exit_code: int = profile.runcall(args.command, args)
 
         profile_stats = pstats.Stats(profile)
         profile_stats.strip_dirs().sort_stats("time").print_stats(50)
         return exit_code
 
-    return args.func(args)  # type: ignore[no-any-return]
+    return args.command(args)  # type: ignore[no-any-return]
 
 
-def parse_args(argv):
+def parse_args(argv, commands):
     parser = argparse.ArgumentParser(add_help=False)
 
     parser.add_argument(
@@ -56,11 +61,6 @@ def parse_args(argv):
     parser.add_argument(
         "-p", "--profiler", help="run in profiler (cProfile)", action="store_true"
     )
-
-    commands = {
-        "exec": exec_parser,
-        "export": export_parser,
-    }
 
     args, extra_args = parser.parse_known_args(args=argv[1:])
 
@@ -110,7 +110,7 @@ def gui_parser():
     )
     group.add_argument("--gapplication-service", action="store_true")
     group.add_argument("model", nargs="*", help="model file(s) to load")
-    parser.set_defaults(func=run)
+    parser.set_defaults(command=run)
     return parser
 
 
@@ -125,7 +125,7 @@ def exec_parser():
     parser = argparse.ArgumentParser()
     parser.description = "Execute a python script from within Gaphor."
     parser.add_argument("script", help="execute a script file and exit")
-    parser.set_defaults(func=execute_script)
+    parser.set_defaults(command=execute_script)
     return parser
 
 
@@ -136,7 +136,7 @@ def export_parser():
 
     parser = argparse.ArgumentParser()
     parser.description = "Export diagrams from a Gaphor model."
-    parser.set_defaults(func=export_script)
+    parser.set_defaults(command=export_script)
     return parser
 
 

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -37,9 +37,12 @@ def parse_args(args: list[str], commands: dict[str, argparse.ArgumentParser]):
     parser = argparse.ArgumentParser(
         description="Gaphor is the simple modeling tool.",
         epilog="Thank you for using Gaphor <https://gaphor.org>.",
-        parents=[defaults],
+        parents=[version_parser()],
     )
-    subparsers = parser.add_subparsers(title="subcommands")
+    subparsers = parser.add_subparsers(
+        title="subcommands (default: gui)",
+        description=f"Get help for commands with {prog()} COMMAND --help.",
+    )
 
     for name, cmd_parser in commands.items():
         sp = subparsers.add_parser(
@@ -59,19 +62,22 @@ def parse_args(args: list[str], commands: dict[str, argparse.ArgumentParser]):
     return parser.parse_args(args)
 
 
-def default_parser():
-    parser = argparse.ArgumentParser(
-        description="Gaphor is the simple modeling tool.", add_help=False
-    )
+def version_parser():
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument(
         "-V", "--version", help="print version and exit", nargs=0, action=VersionAction
     )
+    return parser
+
+
+def default_parser():
+    parser = argparse.ArgumentParser(add_help=False)
 
     loglevel = parser.add_mutually_exclusive_group()
     loglevel.add_argument(
         "-v",
         "--verbose",
-        help="enable debug logging",
+        help="enable verbose logging",
         nargs=0,
         action=LogLevelAction,
         const=logging.DEBUG,
@@ -85,7 +91,7 @@ def default_parser():
         const=logging.WARNING,
     )
     parser.add_argument(
-        "-p", "--profiler", help="run in profiler (cProfile)", action="store_true"
+        "--profiler", help="run in profiler (cProfile)", action="store_true"
     )
     return parser
 
@@ -95,6 +101,7 @@ def gui_parser():
         # Only now import the UI module
         import gaphor.ui
 
+        # Recreate a command line for our GTK gui
         run_argv = [sys.argv[0]]
         if args.self_test:
             run_argv += ["--self-test"]
@@ -105,7 +112,7 @@ def gui_parser():
         return gaphor.ui.run(run_argv)
 
     parser = argparse.ArgumentParser(
-        description="Start the GUI (default if no subcommand is provided)."
+        description="Launch the GUI.", parents=[version_parser()]
     )
 
     group = parser.add_argument_group("options (no command provided)")

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -66,19 +66,28 @@ def parse_args(argv):
 
     if extra_args and (command := commands.get(extra_args[0])):
         cmd, *extra_args = extra_args
-        cmd_parser = command(
-            argparse.ArgumentParser(prog=f"{parser.prog} {cmd}", parents=[parser])
+        p = command()
+        cmd_parser = argparse.ArgumentParser(
+            description=p.description,
+            prog=f"{parser.prog} {cmd}",
+            parents=[parser, p],
+            add_help=False,
         )
+
     else:
-        cmd_parser = gui_parser(
-            argparse.ArgumentParser(prog=f"{parser.prog} [command]", parents=[parser])
+        p = gui_parser()
+        cmd_parser = argparse.ArgumentParser(
+            description=p.description,
+            prog=f"{parser.prog} [command]",
+            parents=[parser, p],
+            add_help=False,
         )
         cmd_parser.epilog = f"commands: {', '.join(commands)}"
 
     return cmd_parser.parse_args(extra_args, namespace=args)
 
 
-def gui_parser(parser):
+def gui_parser():
     def run(args) -> int:
         # Only now import the UI module
         import gaphor.ui
@@ -92,6 +101,7 @@ def gui_parser(parser):
 
         return gaphor.ui.run(run_argv)
 
+    parser = argparse.ArgumentParser()
     parser.description = "Gaphor is the simple modeling tool."
     parser.add_argument(
         "--self-test", help="run self test and exit", action="store_true"
@@ -102,7 +112,7 @@ def gui_parser(parser):
     return parser
 
 
-def exec_parser(parser):
+def exec_parser():
     def execute_script(args) -> int:
         import runpy
 
@@ -110,17 +120,19 @@ def exec_parser(parser):
         runpy.run_path(script, run_name="__main__")
         return 0
 
+    parser = argparse.ArgumentParser()
     parser.description = "Execute a python script from within Gaphor."
     parser.add_argument("script", help="execute a script file and exit")
     parser.set_defaults(func=execute_script)
     return parser
 
 
-def export_parser(parser):
+def export_parser():
     def export_script(args) -> int:
         print("Placeholder for diagram export")
         return 0
 
+    parser = argparse.ArgumentParser()
     parser.description = "Export diagrams from a Gaphor model."
     parser.set_defaults(func=export_script)
     return parser

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -103,11 +103,13 @@ def gui_parser():
 
     parser = argparse.ArgumentParser()
     parser.description = "Gaphor is the simple modeling tool."
-    parser.add_argument(
+
+    group = parser.add_argument_group("options (no command provided)")
+    group.add_argument(
         "--self-test", help="run self test and exit", action="store_true"
     )
-    parser.add_argument("--gapplication-service", action="store_true")
-    parser.add_argument("model", nargs="*", help="model file(s) to load")
+    group.add_argument("--gapplication-service", action="store_true")
+    group.add_argument("model", nargs="*", help="model file(s) to load")
     parser.set_defaults(func=run)
     return parser
 

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -56,13 +56,13 @@ def parse_args(args, commands):
 def default_parser():
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument(
-        "-v", "--version", help="print version and exit", nargs=0, action=VersionAction
+        "-V", "--version", help="print version and exit", nargs=0, action=VersionAction
     )
 
     loglevel = parser.add_mutually_exclusive_group()
     loglevel.add_argument(
-        "-d",
-        "--debug",
+        "-v",
+        "--verbose",
         help="enable debug logging",
         nargs=0,
         action=LogLevelAction,

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -9,120 +9,139 @@ LOG_FORMAT = "%(name)s %(levelname)s %(message)s"
 
 def main(argv=sys.argv) -> int:
     """Start Gaphor from the command line."""
+
+    logging_config()
+
     args = parse_args(argv)
 
-    logging_config(args)
-
-    if hasattr(args, "func"):
-        return args.func(args)  # type: ignore[no-any-return]
-
-    return ui(
-        argv[0], args.model, args.self_test, args.profiler, args.gapplication_service
-    )
-
-
-def logging_config(args):
-    if args.debug:
-        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
-        logging.getLogger("gaphor").setLevel(logging.DEBUG)
-    elif args.quiet:
-        logging.basicConfig(level=logging.WARNING, format=LOG_FORMAT)
-    else:
-        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
-
-
-def execute_script(args) -> int:
-    import runpy
-
-    logging_config(args)
-    script = args.script
-    runpy.run_path(script, run_name="__main__")
-    return 0
-
-
-def export_script(args):
-    print("Placeholder for diagram export")
-    return 0
-
-
-def ui(prog, models, self_test, profiler, gapplication_service) -> int:
-    # Only now import the UI module
-    from gaphor.ui import run
-
-    run_argv = [prog]
-    if self_test:
-        run_argv += ["--self-test"]
-    if gapplication_service:
-        run_argv += ["--gapplication-service"]
-    run_argv.extend(models)
-
-    if profiler:
+    if args.profiler:
         import cProfile
         import pstats
 
         with cProfile.Profile() as profile:
-            exit_code = profile.runcall(run, run_argv)
+            exit_code: int = profile.runcall(args.func, args)
 
         profile_stats = pstats.Stats(profile)
         profile_stats.strip_dirs().sort_stats("time").print_stats(50)
         return exit_code
 
-    return run(run_argv)
+    return args.func(args)  # type: ignore[no-any-return]
 
 
 def parse_args(argv):
-    parser = argparse.ArgumentParser(
-        description="Gaphor is the simple modeling tool.",
-        add_help=False,
-    )
+    parser = argparse.ArgumentParser(add_help=False)
 
     parser.add_argument(
         "-v", "--version", help="print version and exit", nargs=0, action=VersionAction
     )
 
-    parser.add_argument(
-        "-d", "--debug", help="enable debug logging", action="store_true"
+    loglevel = parser.add_mutually_exclusive_group()
+    loglevel.add_argument(
+        "-d",
+        "--debug",
+        help="enable debug logging",
+        nargs=0,
+        action=LogLevelAction,
+        const=logging.DEBUG,
     )
-    parser.add_argument(
-        "-q", "--quiet", help="only show warning and error logging", action="store_true"
+    loglevel.add_argument(
+        "-q",
+        "--quiet",
+        help="only show warning and error logging",
+        nargs=0,
+        action=LogLevelAction,
+        const=logging.WARNING,
     )
 
-    gui_parser = argparse.ArgumentParser(parents=[parser])
-    gui_parser.add_argument(
+    parser.add_argument(
         "-p", "--profiler", help="run in profiler (cProfile)", action="store_true"
     )
-    gui_parser.add_argument(
-        "--self-test", help="run self test and exit", action="store_true"
-    )
-    gui_parser.add_argument("--gapplication-service", action="store_true")
-    gui_parser.add_argument("model", nargs="*", help="model file(s) to load")
-
-    exec_parser = argparse.ArgumentParser(parents=[parser])
-    exec_parser.add_argument("script", help="execute a script file and exit")
-    exec_parser.set_defaults(func=execute_script)
-
-    export_parser = argparse.ArgumentParser(parents=[parser])
-    export_parser.set_defaults(func=export_script)
 
     commands = {
-        "gui": gui_parser,
         "exec": exec_parser,
         "export": export_parser,
     }
 
-    gui_parser.epilog = "extra commands: exec, export"
-
     args, extra_args = parser.parse_known_args(args=argv[1:])
 
-    if extra_args and (cmd_parser := commands.get(extra_args[0])):
-        cmd_parser.parse_args(extra_args[1:], namespace=args)
+    if extra_args and (command := commands.get(extra_args[0])):
+        cmd, *extra_args = extra_args
+        cmd_parser = command(
+            argparse.ArgumentParser(prog=f"{parser.prog} {cmd}", parents=[parser])
+        )
     else:
-        gui_parser.parse_args(extra_args, namespace=args)
+        cmd_parser = gui_parser(
+            argparse.ArgumentParser(prog=f"{parser.prog} [command]", parents=[parser])
+        )
+        cmd_parser.epilog = f"commands: {', '.join(commands)}"
 
-    return args
+    return cmd_parser.parse_args(extra_args, namespace=args)
+
+
+def gui_parser(parser):
+    def run(args) -> int:
+        # Only now import the UI module
+        import gaphor.ui
+
+        run_argv = [sys.argv[0]]
+        if args.self_test:
+            run_argv += ["--self-test"]
+        if args.gapplication_service:
+            run_argv += ["--gapplication-service"]
+        run_argv.extend(args.model)
+
+        return gaphor.ui.run(run_argv)
+
+    parser.description = "Gaphor is the simple modeling tool."
+    parser.add_argument(
+        "--self-test", help="run self test and exit", action="store_true"
+    )
+    parser.add_argument("--gapplication-service", action="store_true")
+    parser.add_argument("model", nargs="*", help="model file(s) to load")
+    parser.set_defaults(func=run)
+    return parser
+
+
+def exec_parser(parser):
+    def execute_script(args) -> int:
+        import runpy
+
+        script = args.script
+        runpy.run_path(script, run_name="__main__")
+        return 0
+
+    parser.description = "Execute a python script from within Gaphor."
+    parser.add_argument("script", help="execute a script file and exit")
+    parser.set_defaults(func=execute_script)
+    return parser
+
+
+def export_parser(parser):
+    def export_script(args) -> int:
+        print("Placeholder for diagram export")
+        return 0
+
+    parser.description = "Export diagrams from a Gaphor model."
+    parser.set_defaults(func=export_script)
+    return parser
+
+
+def logging_config(level=logging.INFO):
+    if level <= logging.DEBUG:
+        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, force=True)
+        logging.getLogger("gaphor").setLevel(logging.DEBUG)
+    elif level >= logging.WARNING:
+        logging.basicConfig(level=logging.WARNING, format=LOG_FORMAT, force=True)
+    else:
+        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, force=True)
 
 
 class VersionAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         print(f"Gaphor {distribution().version}")
         parser.exit()
+
+
+class LogLevelAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        logging_config(self.const)

--- a/gaphor/plugins/diagramexport/exportcli.py
+++ b/gaphor/plugins/diagramexport/exportcli.py
@@ -4,7 +4,6 @@ import argparse
 import logging
 import os
 import re
-import sys
 from typing import List
 
 from gaphor.application import Session
@@ -26,7 +25,7 @@ def pkg2dir(package):
 
 
 def export_parser():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="Export diagrams from a Gaphor model.")
 
     parser.add_argument(
         "-u",
@@ -36,7 +35,7 @@ def export_parser():
         help="use underscores instead of spaces for output filenames",
     )
     parser.add_argument(
-        "-d", "--dir", metavar="directory", help="output to directory", default="."
+        "-o", "--dir", metavar="directory", help="output to directory", default="."
     )
     parser.add_argument(
         "-f",
@@ -119,11 +118,3 @@ def export_command(args):
                 save_png(outfilename, diagram)
             else:
                 raise RuntimeError(f"Unknown file format: {args.format}")
-
-
-def main(argv=sys.argv[1:]):
-    parser = export_parser()
-
-    args = parser.parse_args(argv)
-
-    return export_command(args)

--- a/gaphor/tests/test_main.py
+++ b/gaphor/tests/test_main.py
@@ -30,13 +30,13 @@ def test_run_main():
 
 def test_version(capsys):
     with pytest.raises(SystemExit):
-        main([APP_NAME, "-v"])
+        main([APP_NAME, "-V"])
 
     assert "Gaphor" in capsys.readouterr().out
 
 
 def test_debug_logging():
-    main([APP_NAME, "-d"])
+    main([APP_NAME, "-v"])
 
     assert logging.getLogger("gaphor").getEffectiveLevel() == logging.DEBUG
 

--- a/gaphor/tests/test_main.py
+++ b/gaphor/tests/test_main.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from pathlib import Path
 
 import pytest
@@ -6,7 +7,7 @@ import pytest
 import gaphor.ui
 from gaphor.main import main
 
-APP_NAME = "/path/to/gaphor"
+APP_NAME = sys.argv[0]
 
 
 @pytest.fixture(autouse=True)
@@ -61,6 +62,6 @@ def test_gapplication_service(mock_gaphor_ui_run):
 def test_run_script(capsys):
     run_script = Path(__file__).parent / "run_script.py"
 
-    main([APP_NAME, "--exec", str(run_script)])
+    main([APP_NAME, "exec", str(run_script)])
 
     assert "Running a test script for Gaphor" in capsys.readouterr().out

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -2,6 +2,7 @@
 and diagram windows."""
 
 from __future__ import annotations
+import sys
 
 import gi
 
@@ -96,3 +97,7 @@ def add_main_options(gtk_app):
         "Run self test and exit",
         None,
     )
+
+
+if __name__ == "__main__":
+    run(sys.argv)

--- a/gaphor/ui/tests/test_main.py
+++ b/gaphor/ui/tests/test_main.py
@@ -1,7 +1,12 @@
+import sys
+
 import pytest
 from gi.repository import GLib, Gtk
 
 import gaphor.main
+
+
+APP_NAME = sys.argv[0]
 
 
 @pytest.fixture(autouse=True)
@@ -31,14 +36,14 @@ def fake_run(monkeypatch):
 def test_application_startup(monkeypatch):
     run = fake_run(monkeypatch)
 
-    gaphor.main.main(["gaphor"])
+    gaphor.main.main([APP_NAME])
 
-    assert run == ["gaphor"]
+    assert run == [APP_NAME]
 
 
 def test_application_startup_with_model(monkeypatch):
     run = fake_run(monkeypatch)
 
-    gaphor.main.main(["gaphor", "test-models/all-elements.gaphor"])
+    gaphor.main.main([APP_NAME, "test-models/all-elements.gaphor"])
 
-    assert run == ["gaphor", "test-models/all-elements.gaphor"]
+    assert run == [APP_NAME, "test-models/all-elements.gaphor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,10 @@ gaphor = "gaphor.main:main"
 "C4Model" = "gaphor.C4Model.modelinglanguage:C4ModelLanguage"
 "RAAML" = "gaphor.RAAML.modelinglanguage:RAAMLModelingLanguage"
 
+[tool.poetry.plugins."gaphor.argparsers"]
+exec = "gaphor.main:exec_parser"
+export = "gaphor.plugins.diagramexport.exportcli:export_parser"
+
 [tool.poetry.plugins."babel.extractors"]
 "gaphor" = "gaphor.babel:extract_gaphor"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ docs = [ "sphinx", "sphinx-copybutton", "sphinx-intl", "myst-nb", "furo" ]
 
 [tool.poetry.scripts]
 gaphor = "gaphor.main:main"
-gaphorconvert = "gaphor.plugins.diagramexport.gaphorconvert:main"
 
 [tool.poetry.plugins."gaphor.appservices"]
 "event_manager" = "gaphor.core.eventmanager:EventManager"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ gaphor = "gaphor.main:main"
 "RAAML" = "gaphor.RAAML.modelinglanguage:RAAMLModelingLanguage"
 
 [tool.poetry.plugins."gaphor.argparsers"]
+gui = "gaphor.main:gui_parser"
 exec = "gaphor.main:exec_parser"
 export = "gaphor.plugins.diagramexport.exportcli:export_parser"
 

--- a/tests/test_diagramexport.py
+++ b/tests/test_diagramexport.py
@@ -2,20 +2,20 @@ import importlib
 
 import pytest
 
-from gaphor.plugins.diagramexport import gaphorconvert
+from gaphor.main import main
 
 
 def test_help_output(capsys):
     with pytest.raises(SystemExit, match="0"):
-        gaphorconvert.main(["--help"])
+        main(["gaphor", "export", "--help"])
 
     captured = capsys.readouterr()
     assert "--help" in captured.out
-    assert "--verbose" in captured.out
+    assert "--debug" in captured.out
     assert "--use-underscores" in captured.out
-    assert "--dir=directory" in captured.out
-    assert "--format=format" in captured.out
-    assert "--regex=regex" in captured.out
+    assert "--dir directory" in captured.out
+    assert "--format format" in captured.out
+    assert "--regex regex" in captured.out
 
 
 @pytest.fixture
@@ -24,7 +24,7 @@ def model():
 
 
 def test_export_pdf(tmp_path, model):
-    gaphorconvert.main(["-v", "-d", str(tmp_path), str(model)])
+    main(["gaphor", "export", "-d", "-o", str(tmp_path), str(model)])
 
     model_path = tmp_path / "New model"
 
@@ -33,7 +33,7 @@ def test_export_pdf(tmp_path, model):
 
 
 def test_export_png(tmp_path, model):
-    gaphorconvert.main(["-v", "-f", "png", "-d", str(tmp_path), str(model)])
+    main(["gaphor", "export", "-d", "-f", "png", "-o", str(tmp_path), str(model)])
 
     model_path = tmp_path / "New model"
 
@@ -42,7 +42,7 @@ def test_export_png(tmp_path, model):
 
 
 def test_export_svg(tmp_path, model):
-    gaphorconvert.main(["-v", "-f", "svg", "-d", str(tmp_path), str(model)])
+    main(["gaphor", "export", "-d", "-f", "svg", "-o", str(tmp_path), str(model)])
 
     model_path = tmp_path / "New model"
 

--- a/tests/test_diagramexport.py
+++ b/tests/test_diagramexport.py
@@ -11,7 +11,7 @@ def test_help_output(capsys):
 
     captured = capsys.readouterr()
     assert "--help" in captured.out
-    assert "--debug" in captured.out
+    assert "--verbose" in captured.out
     assert "--use-underscores" in captured.out
     assert "--dir directory" in captured.out
     assert "--format format" in captured.out
@@ -24,7 +24,7 @@ def model():
 
 
 def test_export_pdf(tmp_path, model):
-    main(["gaphor", "export", "-d", "-o", str(tmp_path), str(model)])
+    main(["gaphor", "export", "-v", "-o", str(tmp_path), str(model)])
 
     model_path = tmp_path / "New model"
 
@@ -33,7 +33,7 @@ def test_export_pdf(tmp_path, model):
 
 
 def test_export_png(tmp_path, model):
-    main(["gaphor", "export", "-d", "-f", "png", "-o", str(tmp_path), str(model)])
+    main(["gaphor", "export", "-v", "-f", "png", "-o", str(tmp_path), str(model)])
 
     model_path = tmp_path / "New model"
 
@@ -42,7 +42,7 @@ def test_export_png(tmp_path, model):
 
 
 def test_export_svg(tmp_path, model):
-    main(["gaphor", "export", "-d", "-f", "svg", "-o", str(tmp_path), str(model)])
+    main(["gaphor", "export", "-v", "-f", "svg", "-o", str(tmp_path), str(model)])
 
     model_path = tmp_path / "New model"
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

in #2301 I added an option to execute a script from the command line. However, this approach does not scale.
What I wanted is to say something like `gaphor exec script.py`. This is different from an option, since now we have more control over what arguments are supported.

Issue Number: N/A

### What is the new behavior?

In the new behavior you can execute `gaphor exec script.py`. This can be extended by `gaphor export` for exporting diagrams, replacing `gaphorconvert`.

```
$ gaphor --help
usage: gaphor [-h] [-V] {exec,export,gui} ...

Gaphor is the simple modeling tool.

options:
  -h, --help         show this help message and exit
  -V, --version      print version and exit

subcommands (default: gui):
  Get help for commands with gaphor COMMAND --help.

  {exec,export,gui}
    exec             execute a python script from within gaphor
    export           export diagrams from a gaphor model
    gui              launch the gui

Thank you for using Gaphor <https://gaphor.org>.
```
```
$ gaphor export --help
usage: gaphor export [-v | -q] [--profiler] [-h] [-u] [-o directory] [-f format]
                     [-r regex]
                     model [model ...]

Export diagrams from a Gaphor model.

positional arguments:
  model

options:
  -v, --verbose         enable verbose logging
  -q, --quiet           only show warning and error logging
  --profiler            run in profiler (cProfile)
  -h, --help            show this help message and exit
  -u, --use-underscores
                        use underscores instead of spaces for output filenames
  -o directory, --dir directory
                        output to directory
  -f format, --format format
                        output file format, default pdf
  -r regex, --regex regex
                        process diagrams which name matches given regular expression;
                        name includes package name; regular expressions are case
                        insensitive
```

There is a bit of smartness involved: a subcommand should be provided as first argument. Default options (`-v/-q/-p/-V`) are supported for all (sub)commands. If no known subcommand is provided, the default (gui) parser is used.

A new entry point has been introduced: `gaphor.argparsers`. Here we can define parsers for commands we want to support via the CLI.

### Other information

I tried to make it work with Click first, but it did not work with default options (including multiple model arguments) and subcommands. Therefore I went back to argparse.