### PR TITLE
Information Flow for Associations

### DIFF
--- a/docs/coffee_machine_concept.md
+++ b/docs/coffee_machine_concept.md
@@ -135,12 +135,6 @@ grinder, and the water source.
 :alt: Block definition diagram showing context of the coffee shop with external entities
 ```
 
-```{attention}
-The interactions between the Espresso Machine and the external entities should
-be shown as ItemFlows on the associations. We don't currently support adding flows
-like this, but we hopefully will soon!
-```
-
 The ants need more of your help to rename the Feature Context diagram and update it
 so that it matches the one above.
 

--- a/examples/coffee-machine.gaphor
+++ b/examples/coffee-machine.gaphor
@@ -172,6 +172,7 @@
 <ref refid="17dc1de9-bacb-11ed-92fd-f47b099bf663"/>
 <ref refid="1cce24c4-bacb-11ed-9b62-f47b099bf663"/>
 <ref refid="7d824774-bacc-11ed-8288-f47b099bf663"/>
+<ref refid="18d051f8-f565-11ed-b488-0456e5e540ed"/>
 </reflist>
 </ownedType>
 <package>
@@ -1146,12 +1147,6 @@
 <ref refid="63bf2d0f-bb8e-11ed-a7b9-f47b099bf663"/>
 </reflist>
 </end>
-<informationFlow>
-<reflist>
-<ref refid="68558e8e-7170-11ec-999a-f47b099bf663"/>
-<ref refid="748e4872-bb94-11ed-b75c-f47b099bf663"/>
-</reflist>
-</informationFlow>
 <name>
 <val>waterPump</val>
 </name>
@@ -1539,12 +1534,6 @@
 <ref refid="6b2cf073-be19-11ed-a550-f47b099bf663"/>
 </reflist>
 </end>
-<informationFlow>
-<reflist>
-<ref refid="766698ce-7170-11ec-999a-f47b099bf663"/>
-<ref refid="69ab795d-bb94-11ed-85b6-f47b099bf663"/>
-</reflist>
-</informationFlow>
 <name>
 <val>waterHeater</val>
 </name>
@@ -4184,16 +4173,11 @@
 <ref refid="cb6b2d4d-baca-11ed-9f24-f47b099bf663"/>
 <ref refid="d3aef462-baca-11ed-bf5b-f47b099bf663"/>
 <ref refid="f7313989-baca-11ed-bfbf-f47b099bf663"/>
-<ref refid="2299ec38-bacc-11ed-8f6b-f47b099bf663"/>
-<ref refid="48d25b68-bacc-11ed-9b91-f47b099bf663"/>
 <ref refid="73f4c6be-bacc-11ed-ade6-f47b099bf663"/>
-<ref refid="7fafe317-bacc-11ed-8735-f47b099bf663"/>
 <ref refid="170feb24-bacb-11ed-bf1e-f47b099bf663"/>
 <ref refid="1b8da006-bacb-11ed-a7fb-f47b099bf663"/>
-<ref refid="2a0f2076-bacc-11ed-ac03-f47b099bf663"/>
-<ref refid="51fb8c8e-bacc-11ed-932a-f47b099bf663"/>
 <ref refid="7c8d5457-bacc-11ed-a6e4-f47b099bf663"/>
-<ref refid="85d8ba5e-bacc-11ed-8cbd-f47b099bf663"/>
+<ref refid="17d1de16-f565-11ed-b488-0456e5e540ed"/>
 </reflist>
 </ownedPresentation>
 <presentation>
@@ -4224,7 +4208,7 @@
 </BlockItem>
 <BlockItem id="d3aef462-baca-11ed-bf5b-f47b099bf663">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 93.50388717651367, 72.390625)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 57.4023551940918, 77.48658131551741)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -4244,7 +4228,7 @@
 </BlockItem>
 <BlockItem id="f7313989-baca-11ed-bfbf-f47b099bf663">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 97.90232467651367, 313.6796875)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 226.90233039855957, 381.26171875)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -4285,7 +4269,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 190.04685974121094, 132.45314025878906)</val>
 </matrix>
 <points>
-<val>[(0.0, -0.0625152587890625), (99.16798400878906, 62.101531982421875)]</val>
+<val>[(-32.64450454711914, -24.96655894327165), (149.16798400878906, 55.976531982421875)]</val>
 </points>
 <head-connection>
 <ref refid="d3aef462-baca-11ed-bf5b-f47b099bf663"/>
@@ -4295,11 +4279,11 @@
 </tail-connection>
 </AssociationItem>
 <Association id="17dc1de9-bacb-11ed-92fd-f47b099bf663">
-<comment>
+<abstraction>
 <reflist>
-<ref refid="2299e338-bacc-11ed-9c51-f47b099bf663"/>
+<ref refid="0cdb751c-f565-11ed-b488-0456e5e540ed"/>
 </reflist>
-</comment>
+</abstraction>
 <memberEnd>
 <reflist>
 <ref refid="17dc40e4-bacb-11ed-95b5-f47b099bf663"/>
@@ -4366,7 +4350,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 198.71482849121094, 290.8125)</val>
 </matrix>
 <points>
-<val>[(3.1874961853027344, 23.63671875), (90.50001525878906, -24.382827758789062)]</val>
+<val>[(80.18750190734863, 90.44921875), (140.50001525878906, -24.382827758789062)]</val>
 </points>
 <head-connection>
 <ref refid="f7313989-baca-11ed-bfbf-f47b099bf663"/>
@@ -4376,11 +4360,11 @@
 </tail-connection>
 </AssociationItem>
 <Association id="1cce24c4-bacb-11ed-9b62-f47b099bf663">
-<comment>
+<abstraction>
 <reflist>
-<ref refid="48d25277-bacc-11ed-832a-f47b099bf663"/>
+<ref refid="fef0ca4c-f564-11ed-b488-0456e5e540ed"/>
 </reflist>
-</comment>
+</abstraction>
 <memberEnd>
 <reflist>
 <ref refid="1cce7975-bacb-11ed-b1f3-f47b099bf663"/>
@@ -4424,125 +4408,9 @@
 <ref refid="96c0ac02-70f5-11ec-aabc-f47b099bf663"/>
 </type>
 </Property>
-<Comment id="2299e338-bacc-11ed-9c51-f47b099bf663">
-<annotatedElement>
-<reflist>
-<ref refid="17dc1de9-bacb-11ed-92fd-f47b099bf663"/>
-</reflist>
-</annotatedElement>
-<body>
-<val>ItemFlows for Turn On/Off and Temp / Pressure feedback</val>
-</body>
-<presentation>
-<reflist>
-<ref refid="2299ec38-bacc-11ed-8f6b-f47b099bf663"/>
-</reflist>
-</presentation>
-</Comment>
-<CommentItem id="2299ec38-bacc-11ed-8f6b-f47b099bf663">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 289.21484375, 40.07786854696273)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>177.55078125</val>
-</width>
-<height>
-<val>67.4087127685547</val>
-</height>
-<diagram>
-<ref refid="c018a4d2-baca-11ed-a610-f47b099bf663"/>
-</diagram>
-<subject>
-<ref refid="2299e338-bacc-11ed-9c51-f47b099bf663"/>
-</subject>
-</CommentItem>
-<CommentLineItem id="2a0f2076-bacc-11ed-ac03-f47b099bf663">
-<diagram>
-<ref refid="c018a4d2-baca-11ed-a610-f47b099bf663"/>
-</diagram>
-<horizontal>
-<val>0</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 274.5390625, 120.1796875)</val>
-</matrix>
-<points>
-<val>[(14.67578125, -15.673835202217106), (-40.18820665142855, 39.98316393497817)]</val>
-</points>
-<head-connection>
-<ref refid="2299ec38-bacc-11ed-8f6b-f47b099bf663"/>
-</head-connection>
-<tail-connection>
-<ref refid="170feb24-bacb-11ed-bf1e-f47b099bf663"/>
-</tail-connection>
-</CommentLineItem>
-<Comment id="48d25277-bacc-11ed-832a-f47b099bf663">
-<annotatedElement>
-<reflist>
-<ref refid="1cce24c4-bacb-11ed-9b62-f47b099bf663"/>
-</reflist>
-</annotatedElement>
-<body>
-<val>ItemFlow for Ground Coffee</val>
-</body>
-<presentation>
-<reflist>
-<ref refid="48d25b68-bacc-11ed-9b91-f47b099bf663"/>
-</reflist>
-</presentation>
-</Comment>
-<CommentItem id="48d25b68-bacc-11ed-9b91-f47b099bf663">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 294.6953125, 330.95703125)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>100.0</val>
-</width>
-<height>
-<val>64.0</val>
-</height>
-<diagram>
-<ref refid="c018a4d2-baca-11ed-a610-f47b099bf663"/>
-</diagram>
-<subject>
-<ref refid="48d25277-bacc-11ed-832a-f47b099bf663"/>
-</subject>
-</CommentItem>
-<CommentLineItem id="51fb8c8e-bacc-11ed-932a-f47b099bf663">
-<diagram>
-<ref refid="c018a4d2-baca-11ed-a610-f47b099bf663"/>
-</diagram>
-<horizontal>
-<val>0</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 244.96873474121094, 284.7109375)</val>
-</matrix>
-<points>
-<val>[(2.5558643655750615, 4.647252470984331), (49.72657775878906, 50.94921875)]</val>
-</points>
-<head-connection>
-<ref refid="1b8da006-bacb-11ed-a7fb-f47b099bf663"/>
-</head-connection>
-<tail-connection>
-<ref refid="48d25b68-bacc-11ed-9b91-f47b099bf663"/>
-</tail-connection>
-</CommentLineItem>
 <BlockItem id="73f4c6be-bacc-11ed-ade6-f47b099bf663">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 578.7213472237867, 227.42967224121094)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 530.2212861886304, 236.42967224121094)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -4583,7 +4451,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 388.29550493863013, 238.33708836847165)</val>
 </matrix>
 <points>
-<val>[(0.9193388113698688, 0.0), (190.42584228515653, 23.269546508789062)]</val>
+<val>[(0.9193388113698688, -10.907416127260717), (141.92578125000028, 28.092583872739283)]</val>
 </points>
 <head-connection>
 <ref refid="cb6b2d4d-baca-11ed-9f24-f47b099bf663"/>
@@ -4593,11 +4461,11 @@
 </tail-connection>
 </AssociationItem>
 <Association id="7d824774-bacc-11ed-8288-f47b099bf663">
-<comment>
+<abstraction>
 <reflist>
-<ref refid="7fafda08-bacc-11ed-af27-f47b099bf663"/>
+<ref refid="3032c06a-f565-11ed-b488-0456e5e540ed"/>
 </reflist>
-</comment>
+</abstraction>
 <memberEnd>
 <reflist>
 <ref refid="7d829fc4-bacc-11ed-8b84-f47b099bf663"/>
@@ -4641,64 +4509,6 @@
 <ref refid="e16f964c-bac8-11ed-be70-f47b099bf663"/>
 </type>
 </Property>
-<Comment id="7fafda08-bacc-11ed-af27-f47b099bf663">
-<annotatedElement>
-<reflist>
-<ref refid="7d824774-bacc-11ed-8288-f47b099bf663"/>
-</reflist>
-</annotatedElement>
-<body>
-<val>ItemFlow for Water</val>
-</body>
-<presentation>
-<reflist>
-<ref refid="7fafe317-bacc-11ed-8735-f47b099bf663"/>
-</reflist>
-</presentation>
-</Comment>
-<CommentItem id="7fafe317-bacc-11ed-8735-f47b099bf663">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 479.25253618863013, 144.89571263604978)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>100.0</val>
-</width>
-<height>
-<val>50.0</val>
-</height>
-<diagram>
-<ref refid="c018a4d2-baca-11ed-a610-f47b099bf663"/>
-</diagram>
-<subject>
-<ref refid="7fafda08-bacc-11ed-af27-f47b099bf663"/>
-</subject>
-</CommentItem>
-<CommentLineItem id="85d8ba5e-bacc-11ed-8cbd-f47b099bf663">
-<diagram>
-<ref refid="c018a4d2-baca-11ed-a610-f47b099bf663"/>
-</diagram>
-<horizontal>
-<val>0</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 477.79159868863013, 195.88005711847165)</val>
-</matrix>
-<points>
-<val>[(1.4609375, -0.984344482421875), (-26.16929907576312, 50.120056898600275)]</val>
-</points>
-<head-connection>
-<ref refid="7fafe317-bacc-11ed-8735-f47b099bf663"/>
-</head-connection>
-<tail-connection>
-<ref refid="7c8d5457-bacc-11ed-a6e4-f47b099bf663"/>
-</tail-connection>
-</CommentLineItem>
 <Requirement id="a779c5c9-bacf-11ed-8c6a-f47b099bf663">
 <name>
 <val>Heatup Time</val>
@@ -4921,11 +4731,6 @@
 <ref refid="6df5849f-bb93-11ed-81ef-f47b099bf663"/>
 </reflist>
 </end>
-<informationFlow>
-<reflist>
-<ref refid="01bfed5e-bb95-11ed-9ca6-f47b099bf663"/>
-</reflist>
-</informationFlow>
 <name>
 <val>portafilter</val>
 </name>
@@ -5020,12 +4825,6 @@
 <ref refid="6b2cea22-be19-11ed-970c-f47b099bf663"/>
 </reflist>
 </end>
-<informationFlow>
-<reflist>
-<ref refid="a6981f05-bb94-11ed-9483-f47b099bf663"/>
-<ref refid="71db6a9c-be19-11ed-80a2-f47b099bf663"/>
-</reflist>
-</informationFlow>
 <name>
 <val>controller</val>
 </name>
@@ -5191,11 +4990,6 @@
 <ref refid="71753316-bb93-11ed-822d-f47b099bf663"/>
 </reflist>
 </end>
-<informationFlow>
-<reflist>
-<ref refid="37d4b816-bb94-11ed-99e1-f47b099bf663"/>
-</reflist>
-</informationFlow>
 <name>
 <val>grouphead</val>
 </name>
@@ -6620,7 +6414,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 97.6839534441502, 56.03830487800482)</val>
 </matrix>
 <point>
-<val>(-2.514021550426463, 1.626792298559053)</val>
+<val>(-2.514021550426463, -0.5377125422132849)</val>
 </point>
 <connection>
 <ref refid="dde21dec-7171-11ec-999a-f47b099bf663"/>
@@ -9262,4 +9056,181 @@
 </reflist>
 </presentation>
 </Comment>
+<ItemFlow id="fef0ca4c-f564-11ed-b488-0456e5e540ed">
+<informationSource>
+<ref refid="1cce7975-bacb-11ed-b1f3-f47b099bf663"/>
+</informationSource>
+<informationTarget>
+<ref refid="1ccec87b-bacb-11ed-8b4e-f47b099bf663"/>
+</informationTarget>
+<itemProperty>
+<ref refid="fef160f6-f564-11ed-b488-0456e5e540ed"/>
+</itemProperty>
+<realization>
+<reflist>
+<ref refid="1cce24c4-bacb-11ed-9b62-f47b099bf663"/>
+</reflist>
+</realization>
+</ItemFlow>
+<Property id="fef160f6-f564-11ed-b488-0456e5e540ed">
+<itemFlow>
+<ref refid="fef0ca4c-f564-11ed-b488-0456e5e540ed"/>
+</itemFlow>
+<name>
+<val>Ground Coffee</val>
+</name>
+</Property>
+<ItemFlow id="0cdb751c-f565-11ed-b488-0456e5e540ed">
+<informationSource>
+<ref refid="17dc40e4-bacb-11ed-95b5-f47b099bf663"/>
+</informationSource>
+<informationTarget>
+<ref refid="17dc59e7-bacb-11ed-b019-f47b099bf663"/>
+</informationTarget>
+<itemProperty>
+<ref refid="0cdc4cc6-f565-11ed-b488-0456e5e540ed"/>
+</itemProperty>
+<realization>
+<reflist>
+<ref refid="17dc1de9-bacb-11ed-92fd-f47b099bf663"/>
+</reflist>
+</realization>
+</ItemFlow>
+<Property id="0cdc4cc6-f565-11ed-b488-0456e5e540ed">
+<itemFlow>
+<ref refid="0cdb751c-f565-11ed-b488-0456e5e540ed"/>
+</itemFlow>
+<name>
+<val>On/Off</val>
+</name>
+</Property>
+<AssociationItem id="17d1de16-f565-11ed-b488-0456e5e540ed">
+<diagram>
+<ref refid="c018a4d2-baca-11ed-a610-f47b099bf663"/>
+</diagram>
+<head_subject>
+<ref refid="18d0b454-f565-11ed-b488-0456e5e540ed"/>
+</head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="18d051f8-f565-11ed-b488-0456e5e540ed"/>
+</subject>
+<tail_subject>
+<ref refid="18d0fcfc-f565-11ed-b488-0456e5e540ed"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 301.0, 218.49998474121094)</val>
+</matrix>
+<points>
+<val>[(-11.78515625, 8.9296875), (-193.5976448059082, -81.01340342569353)]</val>
+</points>
+<head-connection>
+<ref refid="cb6b2d4d-baca-11ed-9f24-f47b099bf663"/>
+</head-connection>
+<tail-connection>
+<ref refid="d3aef462-baca-11ed-bf5b-f47b099bf663"/>
+</tail-connection>
+</AssociationItem>
+<Association id="18d051f8-f565-11ed-b488-0456e5e540ed">
+<abstraction>
+<reflist>
+<ref refid="1d9d032a-f565-11ed-b488-0456e5e540ed"/>
+</reflist>
+</abstraction>
+<memberEnd>
+<reflist>
+<ref refid="18d0b454-f565-11ed-b488-0456e5e540ed"/>
+<ref refid="18d0fcfc-f565-11ed-b488-0456e5e540ed"/>
+</reflist>
+</memberEnd>
+<ownedEnd>
+<reflist>
+<ref refid="18d0b454-f565-11ed-b488-0456e5e540ed"/>
+<ref refid="18d0fcfc-f565-11ed-b488-0456e5e540ed"/>
+</reflist>
+</ownedEnd>
+<package>
+<ref refid="07bbcb9a-70f5-11ec-aabc-f47b099bf663"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="17d1de16-f565-11ed-b488-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="18d0b454-f565-11ed-b488-0456e5e540ed">
+<association>
+<ref refid="18d051f8-f565-11ed-b488-0456e5e540ed"/>
+</association>
+<owningAssociation>
+<ref refid="18d051f8-f565-11ed-b488-0456e5e540ed"/>
+</owningAssociation>
+<type>
+<ref refid="96c0ac02-70f5-11ec-aabc-f47b099bf663"/>
+</type>
+</Property>
+<Property id="18d0fcfc-f565-11ed-b488-0456e5e540ed">
+<association>
+<ref refid="18d051f8-f565-11ed-b488-0456e5e540ed"/>
+</association>
+<owningAssociation>
+<ref refid="18d051f8-f565-11ed-b488-0456e5e540ed"/>
+</owningAssociation>
+<type>
+<ref refid="91bb8eb6-70f5-11ec-aabc-f47b099bf663"/>
+</type>
+</Property>
+<ItemFlow id="1d9d032a-f565-11ed-b488-0456e5e540ed">
+<informationSource>
+<ref refid="18d0b454-f565-11ed-b488-0456e5e540ed"/>
+</informationSource>
+<informationTarget>
+<ref refid="18d0fcfc-f565-11ed-b488-0456e5e540ed"/>
+</informationTarget>
+<itemProperty>
+<ref refid="1d9d62de-f565-11ed-b488-0456e5e540ed"/>
+</itemProperty>
+<realization>
+<reflist>
+<ref refid="18d051f8-f565-11ed-b488-0456e5e540ed"/>
+</reflist>
+</realization>
+</ItemFlow>
+<Property id="1d9d62de-f565-11ed-b488-0456e5e540ed">
+<itemFlow>
+<ref refid="1d9d032a-f565-11ed-b488-0456e5e540ed"/>
+</itemFlow>
+<name>
+<val>Temp./Preassure</val>
+</name>
+</Property>
+<ItemFlow id="3032c06a-f565-11ed-b488-0456e5e540ed">
+<informationSource>
+<ref refid="7d82f645-bacc-11ed-84f7-f47b099bf663"/>
+</informationSource>
+<informationTarget>
+<ref refid="7d829fc4-bacc-11ed-8b84-f47b099bf663"/>
+</informationTarget>
+<itemProperty>
+<ref refid="3033b27c-f565-11ed-b488-0456e5e540ed"/>
+</itemProperty>
+<realization>
+<reflist>
+<ref refid="7d824774-bacc-11ed-8288-f47b099bf663"/>
+</reflist>
+</realization>
+</ItemFlow>
+<Property id="3033b27c-f565-11ed-b488-0456e5e540ed">
+<itemFlow>
+<ref refid="3032c06a-f565-11ed-b488-0456e5e540ed"/>
+</itemFlow>
+<name>
+<val>Water</val>
+</name>
+</Property>
 </gaphor>

--- a/gaphor/SysML/blocks/tests/conftest.py
+++ b/gaphor/SysML/blocks/tests/conftest.py
@@ -1,1 +1,0 @@
-from gaphor.SysML.tests.fixtures import modeling_language

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -2,68 +2,81 @@
 <interface>
   <requires lib="gtk" version="4.0" />
 
-  <object class="GtkBox" id="item-flow-editor">
-    <property name="orientation">vertical</property>
-    <child>
-      <object class="GtkBox">
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Item Flow</property>
-            <property name="halign">start</property>
-            <property name="hexpand">yes</property>
-            <attributes>
-              <attribute name="weight" value="bold" />
-            </attributes>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSwitch" id="use-item-flow">
-            <signal name="notify::active" handler="item-flow-active" swapped="no" />
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
+  <object class="GtkExpander" id="item-flow-editor">
+    <property name="expanded">1</property>
+    <child type="label">
       <object class="GtkLabel">
-        <property name="label" translatable="yes">Item Property</property>
-        <property name="xalign">0</property>
+        <property name="label" translatable="yes">Item Flow</property>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
       <object class="GtkBox">
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkEntry" id="item-flow-name">
-            <signal name="changed" handler="item-flow-name-changed" swapped="no" />
-            <property name="halign">start</property>
-            <property name="hexpand">yes</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkButton" id="item-flow-invert">
-            <property name="tooltip-text" translatable="yes">Invert direction</property>
-            <signal name="clicked" handler="invert-direction-changed" swapped="no" />
+          <object class="GtkBox">
             <child>
-              <object class="GtkImage">
-                <property name="icon-name">object-flip-horizontal-symbolic</property>
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Enable Item Flow</property>
+                <property name="halign">start</property>
+                <property name="hexpand">yes</property>
               </object>
             </child>
-            <style>
-              <class name="flat" />
-            </style>
+            <child>
+              <object class="GtkSwitch" id="use-item-flow">
+                <signal name="notify::active" handler="item-flow-active" swapped="no" />
+              </object>
+            </child>
           </object>
         </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Allocated Type</property>
-        <property name="xalign">0</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkComboBoxText" id="item-flow-type">
-        <property name="has-entry">1</property>
-        <signal name="changed" handler="item-flow-type-changed" swapped="no" />
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Item Property</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <child>
+              <object class="GtkEntry" id="item-flow-name">
+                <signal name="changed" handler="item-flow-name-changed" swapped="no" />
+                <property name="halign">start</property>
+                <property name="hexpand">yes</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="item-flow-invert">
+                <property name="tooltip-text" translatable="yes">Invert direction</property>
+                <signal name="clicked" handler="invert-direction-changed" swapped="no" />
+                <child>
+                  <object class="GtkImage">
+                    <property name="icon-name">object-flip-horizontal-symbolic</property>
+                  </object>
+                </child>
+                <style>
+                  <class name="flat" />
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Allocated Type</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="item-flow-type">
+            <property name="has-entry">1</property>
+            <signal name="changed" handler="item-flow-type-changed" swapped="no" />
+          </object>
+        </child>
+        <style>
+          <class name="propertypage"/>
+        </style>
       </object>
     </child>
     <style>

--- a/gaphor/SysML/requirements/tests/conftest.py
+++ b/gaphor/SysML/requirements/tests/conftest.py
@@ -1,1 +1,0 @@
-from gaphor.SysML.tests.fixtures import modeling_language

--- a/gaphor/SysML/tests/conftest.py
+++ b/gaphor/SysML/tests/conftest.py
@@ -1,1 +1,0 @@
-from gaphor.SysML.tests.fixtures import modeling_language

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -13,14 +13,9 @@ from gaphor.SysML.propertypages import (
 
 @pytest.fixture
 def connector(element_factory):
-    subject = element_factory.create(UML.Connector)
-    head_end = element_factory.create(UML.ConnectorEnd)
-    head_end.role = element_factory.create(UML.Property)
-    tail_end = element_factory.create(UML.ConnectorEnd)
-    tail_end.role = element_factory.create(UML.Property)
-    subject.end = head_end
-    subject.end = tail_end
-    return subject
+    prop_a = element_factory.create(UML.Property)
+    prop_b = element_factory.create(UML.Property)
+    return UML.recipes.create_connector(prop_a, prop_b)
 
 
 def test_requirement_property_page_id(element_factory):

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -12,6 +12,13 @@ from gaphor.SysML.propertypages import (
 
 
 @pytest.fixture
+def association(element_factory):
+    class_a = element_factory.create(UML.Class)
+    class_b = element_factory.create(UML.Class)
+    return UML.recipes.create_association(class_a, class_b)
+
+
+@pytest.fixture
 def connector(element_factory):
     prop_a = element_factory.create(UML.Property)
     prop_b = element_factory.create(UML.Property)
@@ -90,12 +97,26 @@ def test_property_property_page(element_factory):
     assert subject.aggregation == "composite"
 
 
-def test_item_flow(connector):
+def test_association_item_flow(association):
+    property_page = ItemFlowPropertyPage(association)
+
+    widget = property_page.construct()
+    use = find(widget, "use-item-flow")
+    use.set_active(True)
+
+    assert association.abstraction
+    assert association.abstraction[0].itemProperty
+    assert association.abstraction[0].informationSource is association.memberEnd[0]
+    assert association.abstraction[0].informationTarget is association.memberEnd[1]
+
+
+def test_connector_item_flow(connector):
     property_page = ItemFlowPropertyPage(connector)
 
     widget = property_page.construct()
     use = find(widget, "use-item-flow")
     use.set_active(True)
+
     assert connector.informationFlow
     assert connector.informationFlow[0].itemProperty
 
@@ -166,16 +187,8 @@ def test_item_flow_source_and_target(element_factory):
     assert subject.informationFlow[0].informationTarget is tail_end.role
 
 
-def test_item_flow_invert_direction(element_factory):
-    subject = element_factory.create(UML.Connector)
-    head_end = element_factory.create(UML.ConnectorEnd)
-    head_end.role = element_factory.create(UML.Property)
-    tail_end = element_factory.create(UML.ConnectorEnd)
-    tail_end.role = element_factory.create(UML.Property)
-    subject.end = head_end
-    subject.end = tail_end
-
-    property_page = ItemFlowPropertyPage(subject)
+def test_connector_item_flow_invert_direction(connector):
+    property_page = ItemFlowPropertyPage(connector)
 
     widget = property_page.construct()
     use = find(widget, "use-item-flow")
@@ -183,5 +196,20 @@ def test_item_flow_invert_direction(element_factory):
 
     property_page._invert_direction_changed(None)
 
-    assert subject.informationFlow[0].informationSource is tail_end.role
-    assert subject.informationFlow[0].informationTarget is head_end.role
+    information_flow = connector.informationFlow[0]
+    assert information_flow.informationSource is connector.end[1].role
+    assert information_flow.informationTarget is connector.end[0].role
+
+
+def test_association_item_flow_invert_direction(association):
+    property_page = ItemFlowPropertyPage(association)
+
+    widget = property_page.construct()
+    use = find(widget, "use-item-flow")
+    use.set_active(True)
+
+    property_page._invert_direction_changed(None)
+
+    information_flow = association.abstraction[0]
+    assert information_flow.informationSource is association.memberEnd[1]
+    assert information_flow.informationTarget is association.memberEnd[0]

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -29,6 +29,12 @@ from gaphor.diagram.support import represents
 from gaphor.diagram.text import Layout
 from gaphor.UML.recipes import stereotypes_str
 from gaphor.UML.umlfmt import format_association_end
+from gaphor.UML.informationflow import (
+    shape_information_flow,
+    watch_information_flow,
+    draw_information_flow,
+)
+
 
 half_pi = pi / 2
 
@@ -51,6 +57,7 @@ class AssociationItem(Named, LinePresentation[UML.Association]):
                     text=lambda: stereotypes_str(self.subject),
                 ),
                 Text(text=lambda: self.subject.name or ""),
+                *shape_information_flow(self, "abstraction"),
             ),
         )
 
@@ -97,6 +104,7 @@ class AssociationItem(Named, LinePresentation[UML.Association]):
         ).watch(
             "preferred_aggregation", self.on_association_end_value
         )
+        watch_information_flow(self, "Association", "abstraction")
 
     show_direction: attribute[int] = attribute("show_direction", int, default=False)
     preferred_aggregation = enumeration(
@@ -191,6 +199,14 @@ class AssociationItem(Named, LinePresentation[UML.Association]):
 
     def draw(self, context):
         super().draw(context)
+
+        if self.subject and self.subject.abstraction:
+            draw_information_flow(
+                self,
+                context,
+                self.subject.memberEnd[0]
+                in self.subject.abstraction[:].informationTarget,
+            )
 
         handles = self.handles()
 

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -7,7 +7,7 @@ Plan:
    for line ends.
 """
 
-from math import atan2, pi
+from math import pi
 from typing import Optional
 
 from gaphas.connector import Handle
@@ -16,7 +16,7 @@ from gaphas.geometry import Rectangle, distance_rectangle_point
 from gaphor import UML
 from gaphor.core.modeling.properties import association, attribute, enumeration
 from gaphor.core.styling import Style, merge_styles
-from gaphor.diagram.presentation import LinePresentation, Named
+from gaphor.diagram.presentation import LinePresentation, Named, get_center_pos
 from gaphor.diagram.shapes import (
     Box,
     Text,
@@ -26,7 +26,7 @@ from gaphor.diagram.shapes import (
     stroke,
 )
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import Layout, middle_segment
+from gaphor.diagram.text import Layout
 from gaphor.UML.recipes import stereotypes_str
 from gaphor.UML.umlfmt import format_association_end
 
@@ -221,17 +221,6 @@ class AssociationItem(Named, LinePresentation[UML.Association]):
                 cr.line_to(6 * inv, 7)
                 cr.line_to(0, 12)
                 cr.fill()
-
-
-def get_center_pos(points):
-    """Return position in the centre of middle segment of a line.
-
-    Angle of the middle segment is also returned.
-    """
-    h0, h1 = middle_segment(points)
-    pos = (h0.pos.x + h1.pos.x) / 2, (h0.pos.y + h1.pos.y) / 2
-    angle = atan2(h1.pos.y - h0.pos.y, h1.pos.x - h0.pos.x)
-    return pos, angle
 
 
 def draw_head_none(context):

--- a/gaphor/UML/deletable.py
+++ b/gaphor/UML/deletable.py
@@ -12,7 +12,6 @@ def property_deletable(element: Property) -> bool:
     return not (
         element.association
         or element.end
-        or element.informationFlow
         or element.itemFlow  # type: ignore[attr-defined]
     )
 

--- a/gaphor/UML/deployments/connector.py
+++ b/gaphor/UML/deployments/connector.py
@@ -135,20 +135,23 @@ class ConnectorItem(Named, LinePresentation[UML.Connector]):
                     text=lambda: stereotypes_str(self.subject),
                 ),
                 Text(text=lambda: self.subject.name or ""),
-                *shape_information_flow(self),
+                *shape_information_flow(self, "informationFlow"),
             ),
         )
 
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
-        watch_information_flow(self)
+        watch_information_flow(self, "Connector", "informationFlow")
 
     def draw(self, context):
         super().draw(context)
-        draw_information_flow(
-            self,
-            context,
-        )
+        subject = self.subject
+        if subject and subject.informationFlow:
+            draw_information_flow(
+                self,
+                context,
+                subject.end[0].role in subject.informationFlow[:].informationTarget,
+            )
 
     def draw_tail(self, context):
         cr = context.cairo

--- a/gaphor/UML/deployments/tests/test_connect.py
+++ b/gaphor/UML/deployments/tests/test_connect.py
@@ -1,28 +1,14 @@
 """Test connector item connectors."""
 
-import pytest
 
 from gaphor import UML
-from gaphor.core.modeling.modelinglanguage import (
-    CoreModelingLanguage,
-    MockModelingLanguage,
-)
 from gaphor.diagram.tests.fixtures import allow, connect, disconnect
-from gaphor.SysML.modelinglanguage import SysMLModelingLanguage
 from gaphor.UML.classes.component import ComponentItem
 from gaphor.UML.classes.dependency import DependencyItem
 from gaphor.UML.classes.interface import Folded, InterfaceItem, Side
 from gaphor.UML.classes.interfacerealization import InterfaceRealizationItem
 from gaphor.UML.deployments import ConnectorItem
 from gaphor.UML.deployments.connectorconnect import LegacyConnectorConnectBase
-from gaphor.UML.modelinglanguage import UMLModelingLanguage
-
-
-@pytest.fixture
-def modeling_language():
-    return MockModelingLanguage(
-        CoreModelingLanguage(), UMLModelingLanguage(), SysMLModelingLanguage()
-    )
 
 
 def provide(component, interface):

--- a/gaphor/UML/deployments/tests/test_connector.py
+++ b/gaphor/UML/deployments/tests/test_connector.py
@@ -1,21 +1,6 @@
-import pytest
-
 from gaphor import UML
 from gaphor.core.modeling import Diagram
-from gaphor.core.modeling.modelinglanguage import (
-    CoreModelingLanguage,
-    MockModelingLanguage,
-)
-from gaphor.SysML.modelinglanguage import SysMLModelingLanguage
 from gaphor.UML.deployments.connector import ConnectorItem
-from gaphor.UML.modelinglanguage import UMLModelingLanguage
-
-
-@pytest.fixture
-def modeling_language():
-    return MockModelingLanguage(
-        CoreModelingLanguage(), UMLModelingLanguage(), SysMLModelingLanguage()
-    )
 
 
 def test_create(create):

--- a/gaphor/UML/deployments/tests/test_copypaste.py
+++ b/gaphor/UML/deployments/tests/test_copypaste.py
@@ -1,22 +1,7 @@
-import pytest
-
 from gaphor import UML
-from gaphor.core.modeling.modelinglanguage import (
-    CoreModelingLanguage,
-    MockModelingLanguage,
-)
 from gaphor.diagram.tests.fixtures import connect, copy_clear_and_paste_link
-from gaphor.SysML.modelinglanguage import SysMLModelingLanguage
 from gaphor.UML.classes import ComponentItem, InterfaceItem
 from gaphor.UML.deployments import ConnectorItem
-from gaphor.UML.modelinglanguage import UMLModelingLanguage
-
-
-@pytest.fixture
-def modeling_language():
-    return MockModelingLanguage(
-        CoreModelingLanguage(), UMLModelingLanguage(), SysMLModelingLanguage()
-    )
 
 
 def test_connector(diagram, element_factory):

--- a/gaphor/UML/informationflow.py
+++ b/gaphor/UML/informationflow.py
@@ -1,0 +1,83 @@
+"""Support functions for information flow
+
+And by extension SysML item flow.
+"""
+
+from gaphor.core.format import format
+from gaphor.diagram.presentation import Presentation
+from gaphor.diagram.shapes import Text, cairo_state
+from gaphor.UML.classes.association import get_center_pos
+from gaphor.UML.recipes import stereotypes_str
+
+
+def shape_information_flow(presentation: Presentation) -> list[Text]:
+    return [
+        Text(
+            text=lambda: ", ".join(
+                presentation.subject.informationFlow[:].conveyed[:].name
+            )
+        ),
+        # Also support SysML ItemFlow:
+        Text(
+            text=lambda: stereotypes_str(
+                presentation.subject.informationFlow[0].itemProperty.type,
+                raaml_stereotype_workaround(
+                    presentation.subject.informationFlow[0].itemProperty.type
+                ),
+            )
+            if presentation.subject.informationFlow
+            else ""
+        ),
+        Text(
+            text=lambda: format(
+                presentation.subject.informationFlow[0].itemProperty, type=True
+            )
+            if presentation.subject.informationFlow
+            else ""
+        ),
+    ]
+
+
+def watch_information_flow(presentation: Presentation) -> None:
+    presentation.watch("subject[Connector].informationFlow.informationSource")
+    presentation.watch("subject[Connector].informationFlow.conveyed.name")
+    presentation.watch("subject[Connector].informationFlow[ItemFlow].itemProperty.name")
+    presentation.watch(
+        "subject[Connector].informationFlow[ItemFlow].itemProperty.type.name"
+    )
+    presentation.watch(
+        "subject[Connector].informationFlow[ItemFlow].itemProperty.type.appliedStereotype.classifier.name"
+    )
+
+
+def draw_information_flow(presentation: Presentation, context) -> None:
+    subject = presentation.subject
+    if not subject or not subject.informationFlow:
+        return
+
+    handles = presentation.handles()
+    pos, angle = get_center_pos(handles)
+    inv = (
+        1
+        if (subject.end[0].role in subject.informationFlow[:].informationTarget)
+        else -1
+    )
+    with cairo_state(context.cairo) as cr:
+        cr.translate(*pos)
+        cr.rotate(angle)
+        cr.move_to(0, 0)
+        cr.line_to(12 * inv, 8)
+        cr.line_to(12 * inv, -8)
+        cr.fill()
+
+
+def raaml_stereotype_workaround(element):
+    """This is a temporary fix to ensure ItemFlow is showing proper stereotypes
+    for Controller, Feedback and ControlAction from RAAML."""
+    if not element:
+        return ()
+
+    name: str = type(element).__name__
+    if name in {"Controller", "Feedback", "ControlAction"}:
+        return (name[0].lower() + name[1:],)
+    return ()

--- a/gaphor/UML/interactions/message.py
+++ b/gaphor/UML/interactions/message.py
@@ -45,16 +45,15 @@ operation information in message's name.
 See also ``lifeline`` module documentation.
 """
 
-from math import atan2, pi
+from math import pi
 
 from gaphas.connector import Handle
 from gaphas.constraint import constraint
 
 from gaphor import UML
-from gaphor.diagram.presentation import LinePresentation, Named
+from gaphor.diagram.presentation import LinePresentation, Named, get_center_pos
 from gaphor.diagram.shapes import Box, Text, cairo_state, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import middle_segment
 from gaphor.UML.interactions.lifeline import LifelineItem
 from gaphor.UML.recipes import stereotypes_str
 
@@ -119,16 +118,6 @@ class MessageItem(Named, LinePresentation[UML.Message]):
         super().remove_handle(handle)
         if len(self.handles()) == 2:
             self.diagram.connections.add_constraint(self, self._horizontal_line)
-
-    def _get_center_pos(self):
-        """Return position in the centre of middle segment of a line.
-
-        Angle of the middle segment is also returned.
-        """
-        p0, p1 = middle_segment([h.pos for h in self.handles()])
-        pos = (p0.x + p1.x) / 2, (p0.y + p1.y) / 2
-        angle = atan2(p1.y - p0.y, p1.x - p0.x)
-        return pos, angle
 
     def _draw_circle(self, cr):
         """Draw circle for lost/found messages."""
@@ -239,7 +228,7 @@ class MessageItem(Named, LinePresentation[UML.Message]):
         # inverted messages
         self._is_communication = self.is_communication()
         if self._is_communication:
-            pos, angle = self._get_center_pos()
+            pos, angle = get_center_pos(self.handles())
             self._arrow_pos = pos
             self._arrow_angle = angle
             cr = context.cairo

--- a/gaphor/conftest.py
+++ b/gaphor/conftest.py
@@ -24,6 +24,7 @@ from gaphor.core.modeling.modelinglanguage import (
     MockModelingLanguage,
 )
 from gaphor.storage import storage
+from gaphor.SysML.modelinglanguage import SysMLModelingLanguage
 from gaphor.UML.modelinglanguage import UMLModelingLanguage
 
 
@@ -43,7 +44,9 @@ def element_factory(event_manager, modeling_language):
 
 @pytest.fixture
 def modeling_language():
-    return MockModelingLanguage(CoreModelingLanguage(), UMLModelingLanguage())
+    return MockModelingLanguage(
+        CoreModelingLanguage(), UMLModelingLanguage(), SysMLModelingLanguage()
+    )
 
 
 @pytest.fixture

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -17,7 +17,7 @@ from gaphor.core.modeling.presentation import Presentation, S, literal_eval
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import Style, merge_styles
 from gaphor.diagram.shapes import stroke
-from gaphor.diagram.text import TextAlign, text_point_at_line
+from gaphor.diagram.text import TextAlign, text_point_at_line, middle_segment
 
 
 class Named:
@@ -356,6 +356,17 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
         ):
             self.update_orthogonal_constraints()
         super().handle(event)
+
+
+def get_center_pos(points):
+    """Return position in the centre of middle segment of a line.
+
+    Angle of the middle segment is also returned.
+    """
+    h0, h1 = middle_segment(points)
+    pos = (h0.pos.x + h1.pos.x) / 2, (h0.pos.y + h1.pos.y) / 2
+    angle = atan2(h1.pos.y - h0.pos.y, h1.pos.x - h0.pos.x)
+    return pos, angle
 
 
 def draw_line_end(context, end_handle, second_handle, draw):

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -179,6 +179,8 @@ def _load_elements_and_canvasitems(
             elem = upgrade_generalization_arrow_direction(elem)
         if version_lower_than(gaphor_version, (2, 9, 0)):
             elem = upgrade_flow_item_to_control_flow_item(elem, elements)
+        if version_lower_than(gaphor_version, (2, 19, 0)):
+            elem = upgrade_delete_property_information_flow(elem)
 
         if not (cls := modeling_language.lookup_element(elem.type)):
             raise UnknownModelElementError(
@@ -399,4 +401,11 @@ def upgrade_flow_item_to_control_flow_item(elem, elements):
             subject_type = "ControlFlow"
 
         elem.type = f"{subject_type}Item"
+    return elem
+
+
+# since 2.18.2
+def upgrade_delete_property_information_flow(elem):
+    if elem.type == "Property" and "informationFlow" in elem.references:
+        del elem.references["informationFlow"]
     return elem

--- a/gaphor/ui/modelmerge/tests/conftest.py
+++ b/gaphor/ui/modelmerge/tests/conftest.py
@@ -1,1 +1,0 @@
-from gaphor.SysML.tests.fixtures import modeling_language

--- a/gaphor/ui/modelmerge/tests/test_organize_uml.py
+++ b/gaphor/ui/modelmerge/tests/test_organize_uml.py
@@ -143,7 +143,7 @@ def test_connector_with_item_flow(element_factory, modeling_language, create):
     all(compare(current, current, element_factory))
     tree = list(organize_changes(current, modeling_language))
 
-    assert len(tree) == 1
+    assert len(tree) == 3
     assert {e.id for e in current.select(PendingChange)} == set(all_change_ids(tree))
 
 

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.17.0">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.18.1">
 <Association id="DCE:12A2B620-4B3C-11D7-B391-02BBFE4396CE">
 <memberEnd>
 <reflist>
@@ -38,9 +38,6 @@
 <association>
 <ref refid="DCE:4A112B20-83E1-11D7-ADE2-4B1972AF3391"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -55,9 +52,6 @@
 <association>
 <ref refid="DCE:C90400F8-83E1-11D7-ADE2-4B1972AF3391"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -108,9 +102,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:068AFED0-6692-11D7-A84E-6C8643AD0CA4">
 <appliedStereotype>
@@ -136,9 +127,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:C9A0DCAA-509E-11D7-9F0D-F80F4B06507D">
 <generalization>
@@ -212,9 +200,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:A3BC67B6-4A88-11D7-B08C-133D836EF880">
 <appliedStereotype>
@@ -249,9 +234,6 @@
 <association>
 <ref refid="DCE:0BCB2D7E-8403-11D8-82A2-7B88E55A3BEC"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <owningAssociation>
 <ref refid="DCE:0BCB2D7E-8403-11D8-82A2-7B88E55A3BEC"/>
 </owningAssociation>
@@ -278,9 +260,6 @@
 <association>
 <ref refid="DCE:7876B574-4A87-11D7-B089-133D836EF880"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -319,9 +298,6 @@
 <association>
 <ref refid="DCE:FE75FBA6-6690-11D7-A84E-6C8643AD0CA4"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -464,9 +440,6 @@
 <diagram>
 <ref refid="DCE:DD80D3EC-4A86-11D7-B086-133D836EF880"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -519,9 +492,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:6A5E8372-4A87-11D7-B089-133D836EF880"/>
 </subject>
@@ -554,9 +524,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:7876B574-4A87-11D7-B089-133D836EF880"/>
 </subject>
@@ -618,9 +585,6 @@
 <diagram>
 <ref refid="DCE:DD80D3EC-4A86-11D7-B086-133D836EF880"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -670,9 +634,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:72656E80-83D9-11D7-ADE2-4B1972AF3391"/>
 </subject>
@@ -708,9 +669,6 @@
 <diagram>
 <ref refid="DCE:DD80D3EC-4A86-11D7-B086-133D836EF880"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -847,9 +805,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:52EE3722-863A-11D7-8239-5A25B8C2F569"/>
 </subject>
@@ -942,9 +897,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:C392E5BC-6690-11D7-A84E-6C8643AD0CA4">
 <generalization>
@@ -1021,9 +973,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:68CAA7BA-4B32-11D7-B391-02BBFE4396CE">
 <general>
@@ -1062,9 +1011,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:A9937B0A-4A88-11D7-B08C-133D836EF880">
 <appliedStereotype>
@@ -1172,9 +1118,6 @@
 <association>
 <ref refid="DCE:F3B245D6-4B3C-11D7-B391-02BBFE4396CE"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -1212,9 +1155,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:E96CD03E-509E-11D7-9F0D-F80F4B06507D">
 <aggregation>
@@ -1243,9 +1183,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:3C66A162-8405-11D8-82A2-7B88E55A3BEC">
 <generalization>
@@ -1350,9 +1287,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:BEBC1974-8402-11D8-82A2-7B88E55A3BEC">
 <memberEnd>
@@ -1498,9 +1432,6 @@
 <diagram>
 <ref refid="DCE:4A9E3AF4-A419-11D8-B4C8-00061BC22919"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -1579,9 +1510,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:8625B9D8-A419-11D8-B4C8-00061BC22919"/>
 </subject>
@@ -1614,9 +1542,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:87E5AA0C-A419-11D8-B4C8-00061BC22919"/>
 </subject>
@@ -1678,9 +1603,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:E944B2A8-A419-11D8-A88E-00061BC22919"/>
 </subject>
@@ -1742,9 +1664,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:40E9D2EC-A41A-11D8-A88E-00061BC22919"/>
 </subject>
@@ -1806,9 +1725,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:9F911116-A41A-11D8-A88E-00061BC22919"/>
 </subject>
@@ -1858,6 +1774,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="daef062f-6527-11eb-9492-9757bcbe474b"/>
 </subject>
@@ -1901,6 +1820,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 837.0, 205.0)</val>
 </matrix>
@@ -1921,6 +1843,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 1051.0, 291.0)</val>
 </matrix>
@@ -1992,9 +1917,6 @@
 <diagram>
 <ref refid="DCE:1FD159C8-A41B-11D8-BCB9-00061BC22919"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -2099,9 +2021,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:62E17BB8-A41B-11D8-BCB9-00061BC22919"/>
 </subject>
@@ -2241,9 +2160,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="44d8bdea-ec84-11ea-96dc-bf74f1f80424"/>
 </subject>
@@ -2331,6 +2247,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="13d6094a-62d2-11eb-9492-9757bcbe474b"/>
 </subject>
@@ -2360,6 +2279,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="285663e2-62d2-11eb-9492-9757bcbe474b"/>
 </subject>
@@ -2562,9 +2484,6 @@
 <diagram>
 <ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -2617,9 +2536,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:70B41C2A-8404-11D8-82A2-7B88E55A3BEC"/>
 </subject>
@@ -2681,9 +2597,6 @@
 <diagram>
 <ref refid="DCE:47C3C202-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -2895,9 +2808,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:24A4777A-8324-11D8-8D1E-00C00C03A405"/>
 </subject>
@@ -2932,6 +2842,7 @@
 <ownedAttribute>
 <reflist>
 <ref refid="DCE:5375CF56-45CF-11D7-B5CA-613352B2821F"/>
+<ref refid="3ae046f2-ebeb-11eb-8d68-2d4b211d5079"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -2976,9 +2887,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:411FF874-4A87-11D7-B087-133D836EF880">
 <appliedStereotype>
@@ -3038,9 +2946,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:8F7D73F4-464D-11D7-AA08-1B85D5275D8A">
 <appliedStereotype>
@@ -3069,9 +2974,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:BFC74BCC-4B37-11D7-B391-02BBFE4396CE">
 <memberEnd>
@@ -3112,9 +3014,6 @@
 <association>
 <ref refid="DCE:53D40BEC-4B34-11D7-B391-02BBFE4396CE"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -3158,9 +3057,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:BDC038A2-4A88-11D7-B08D-133D836EF880">
 <comment>
@@ -3267,9 +3163,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:81F3AEEE-4B32-11D7-B391-02BBFE4396CE">
 <memberEnd>
@@ -3421,9 +3314,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:CAD8A604-4B33-11D7-B391-02BBFE4396CE">
 <generalization>
@@ -3499,9 +3389,6 @@
 <association>
 <ref refid="DCE:9D2930DC-8405-11D8-82A2-7B88E55A3BEC"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <owningAssociation>
 <ref refid="DCE:9D2930DC-8405-11D8-82A2-7B88E55A3BEC"/>
 </owningAssociation>
@@ -3519,9 +3406,6 @@
 <association>
 <ref refid="DCE:2013DDFC-8402-11D8-82A2-7B88E55A3BEC"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <owningAssociation>
 <ref refid="DCE:2013DDFC-8402-11D8-82A2-7B88E55A3BEC"/>
 </owningAssociation>
@@ -3686,9 +3570,6 @@
 <diagram>
 <ref refid="DCE:5198F474-4B3D-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -3715,9 +3596,6 @@
 <diagram>
 <ref refid="DCE:5198F474-4B3D-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -3741,9 +3619,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:3A8414B0-4B53-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -3831,9 +3706,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:C0FEEEF2-4B53-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -3866,9 +3738,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:F5531DA2-4B53-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -3930,9 +3799,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:0E00B206-4B56-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -4075,9 +3941,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:C90400F8-83E1-11D7-ADE2-4B1972AF3391"/>
 </subject>
@@ -4110,9 +3973,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:8CB1D104-4B56-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -4174,9 +4034,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:C314E05A-4B57-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -4209,9 +4066,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:E085CF12-4B57-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -4273,9 +4127,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="b872a8c2-b76d-11de-a410-000d93868322"/>
 </subject>
@@ -4334,9 +4185,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:A69C2782-A417-11D8-B4C8-00061BC22919"/>
 </subject>
@@ -4369,9 +4217,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:0E1B4648-509C-11D7-811E-AF5893A6470D"/>
 </subject>
@@ -4573,9 +4418,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:C9046C78-83E1-11D7-ADE2-4B1972AF3391">
 <appliedStereotype>
@@ -4610,9 +4452,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:4A9BD768-A35C-11D8-9D85-00C00C03A405">
 <general>
@@ -4639,9 +4478,6 @@
 <class_>
 <ref refid="DCE:512052B8-97BA-11D8-9E36-00C00C03A405"/>
 </class_>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val>appliedProfile</val>
 </name>
@@ -4654,9 +4490,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:B2B2706C-8324-11D8-8D1E-00C00C03A405">
 <memberEnd>
@@ -4809,9 +4642,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:64DA6552-50A3-11D7-807A-302CB4EF44FD">
 <appliedStereotype>
@@ -4837,9 +4667,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:3AEC26CA-8405-11D8-82A2-7B88E55A3BEC">
 <generalization>
@@ -4937,9 +4764,6 @@
 <association>
 <ref refid="DCE:C314E05A-4B57-11D7-A5E6-6257AF3C5118"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -4977,9 +4801,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:1249CDF0-8324-11D8-8D1E-00C00C03A405">
 <general>
@@ -5053,9 +4874,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:D339DC26-4694-11D7-B567-379CA7034986">
 <memberEnd>
@@ -5160,9 +4978,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:1C11E592-83DA-11D7-ADE2-4B1972AF3391">
 <general>
@@ -5276,9 +5091,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:B8B3E96A-8321-11D8-BEC8-00C00C03A405">
 <appliedStereotype>
@@ -5376,9 +5188,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:B2B7FDC2-8324-11D8-8D1E-00C00C03A405">
 <appliedStereotype>
@@ -5467,9 +5276,6 @@
 <association>
 <ref refid="DCE:8C2A3672-8323-11D8-8D1E-00C00C03A405"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <owningAssociation>
 <ref refid="DCE:8C2A3672-8323-11D8-8D1E-00C00C03A405"/>
 </owningAssociation>
@@ -5579,9 +5385,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:9D2F4206-8405-11D8-82A2-7B88E55A3BEC">
 <association>
@@ -5613,9 +5416,6 @@
 <association>
 <ref refid="DCE:BA58D856-6692-11D7-A84E-6C8643AD0CA4"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -5861,9 +5661,6 @@
 <diagram>
 <ref refid="DCE:30B2FAF8-6679-11D7-A84E-6C8643AD0CA4"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -5913,9 +5710,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:D37E67DC-8320-11D8-BEC8-00C00C03A405"/>
 </subject>
@@ -5948,9 +5742,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:4276693C-8321-11D8-BEC8-00C00C03A405"/>
 </subject>
@@ -6012,9 +5803,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:F0533B36-8FD1-11D8-9422-00C00C03A405"/>
 </subject>
@@ -6084,17 +5872,11 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:2A2C3E12-4B3A-11D7-B391-02BBFE4396CE">
 <association>
 <ref refid="DCE:2A2C053C-4B3A-11D7-B391-02BBFE4396CE"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -6157,9 +5939,6 @@
 <class_>
 <ref refid="DCE:3DB14614-97BA-11D8-9E36-00C00C03A405"/>
 </class_>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val>metamodelReference</val>
 </name>
@@ -6172,9 +5951,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:329DEAB0-A41B-11D8-BCB9-00061BC22919">
 <appliedStereotype>
@@ -6194,9 +5970,6 @@
 <typeValue>
 <val>String</val>
 </typeValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:4CC2F2A4-4B3C-11D7-B391-02BBFE4396CE">
 <appliedStereotype>
@@ -6228,9 +6001,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:12A3CA4C-4B3C-11D7-B391-02BBFE4396CE">
 <aggregation>
@@ -6259,9 +6029,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:F91A720A-4B37-11D7-B391-02BBFE4396CE">
 <generalization>
@@ -6321,9 +6088,6 @@
 <class_>
 <ref refid="DCE:7DDD179A-4B3D-11D7-B391-02BBFE4396CE"/>
 </class_>
-<isDerived>
-<val>0</val>
-</isDerived>
 <lowerValue>
 <val>0</val>
 </lowerValue>
@@ -6364,7 +6128,6 @@
 <ref refid="DCE:B7B7E77C-4694-11D7-B567-379CA7034986"/>
 <ref refid="98bdb712-b9b1-11eb-93ad-535118859f0b"/>
 <ref refid="aa8a8fb0-e185-11ea-b7ab-f5b4c130f24e"/>
-<ref refid="feb2bcea-ebeb-11eb-8d68-2d4b211d5079"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -6436,9 +6199,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:E7330EBA-4B32-11D7-B391-02BBFE4396CE">
 <general>
@@ -6519,9 +6279,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:90BAFB94-4B55-11D7-A5E6-6257AF3C5118">
 <memberEnd>
@@ -6697,9 +6454,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:E96C654A-509E-11D7-9F0D-F80F4B06507D">
 <memberEnd>
@@ -6747,9 +6501,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:AFE3193E-8323-11D8-8D1E-00C00C03A405">
 <generalization>
@@ -6780,15 +6531,9 @@
 </specialization>
 </Class>
 <Property id="DCE:F5535620-4B53-11D7-A5E6-6257AF3C5118">
-<aggregation>
-<val>none</val>
-</aggregation>
 <association>
 <ref refid="DCE:F5531DA2-4B53-11D7-A5E6-6257AF3C5118"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -6861,9 +6606,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:86263504-A419-11D8-B4C8-00061BC22919">
 <association>
@@ -7123,9 +6865,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:881EEA92-65CF-11D7-89A9-9C62884CFFDE">
 <association>
@@ -7202,9 +6941,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:8C2A3672-8323-11D8-8D1E-00C00C03A405">
 <memberEnd>
@@ -7365,9 +7101,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:D06FA292-8323-11D8-8D1E-00C00C03A405">
 <general>
@@ -7502,9 +7235,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:16034FB0-97BB-11D8-9E38-00C00C03A405">
 <memberEnd>
@@ -7540,9 +7270,6 @@
 <association>
 <ref refid="DCE:79C3FCAA-4695-11D7-B567-379CA7034986"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -7580,9 +7307,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:D18A8FCE-6692-11D7-A84E-6C8643AD0CA4">
 <appliedStereotype>
@@ -7608,9 +7332,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Diagram id="DCE:539997D4-4B37-11D7-B391-02BBFE4396CE">
 <element>
@@ -7736,9 +7457,6 @@
 <diagram>
 <ref refid="DCE:539997D4-4B37-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -7762,9 +7480,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:BFC74BCC-4B37-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -7826,9 +7541,6 @@
 <diagram>
 <ref refid="DCE:539997D4-4B37-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -7936,9 +7648,6 @@
 <diagram>
 <ref refid="DCE:539997D4-4B37-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -8046,9 +7755,6 @@
 <diagram>
 <ref refid="DCE:539997D4-4B37-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -8075,9 +7781,6 @@
 <diagram>
 <ref refid="DCE:539997D4-4B37-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -8182,9 +7885,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:30858F26-4B39-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -8217,9 +7917,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:CFB3139A-83E0-11D7-ADE2-4B1972AF3391"/>
 </subject>
@@ -8281,9 +7978,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:2A2C053C-4B3A-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -8472,9 +8166,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="15079adc-909f-11ea-85c4-7f4489bdcce3"/>
 </subject>
@@ -8533,9 +8224,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="4b2049f2-909f-11ea-85c4-7f4489bdcce3"/>
 </subject>
@@ -8568,9 +8256,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="81d0d822-909f-11ea-85c4-7f4489bdcce3"/>
 </subject>
@@ -8861,9 +8546,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:E90FFE38-6690-11D7-A84E-6C8643AD0CA4">
 <generalization>
@@ -8921,9 +8603,6 @@
 <typeValue>
 <val>Boolean</val>
 </typeValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:4F5A57FE-97BB-11D8-9E39-00C00C03A405">
 <general>
@@ -9115,9 +8794,6 @@
 <diagram>
 <ref refid="DCE:F4CAA7BA-97B9-11D8-9E36-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -9170,9 +8846,6 @@
 <diagram>
 <ref refid="DCE:F4CAA7BA-97B9-11D8-9E36-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -9196,9 +8869,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:67493E60-97BA-11D8-9E36-00C00C03A405"/>
 </subject>
@@ -9231,9 +8901,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:94E2ED46-97BA-11D8-9E37-00C00C03A405"/>
 </subject>
@@ -9269,9 +8936,6 @@
 <diagram>
 <ref refid="DCE:F4CAA7BA-97B9-11D8-9E36-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -9353,9 +9017,6 @@
 <diagram>
 <ref refid="DCE:F4CAA7BA-97B9-11D8-9E36-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -9379,9 +9040,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:16034FB0-97BB-11D8-9E38-00C00C03A405"/>
 </subject>
@@ -9443,9 +9101,6 @@
 <diagram>
 <ref refid="DCE:F4CAA7BA-97B9-11D8-9E36-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -9524,9 +9179,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:74410A38-97BB-11D8-9E39-00C00C03A405"/>
 </subject>
@@ -9559,9 +9211,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:9C1CFD00-97BB-11D8-9E3A-00C00C03A405"/>
 </subject>
@@ -9594,9 +9243,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:DAE7507E-97BB-11D8-9E3B-00C00C03A405"/>
 </subject>
@@ -9658,9 +9304,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:1DCA3E30-97BC-11D8-9E3C-00C00C03A405"/>
 </subject>
@@ -9693,9 +9336,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:215BFFFA-97BC-11D8-9E3D-00C00C03A405"/>
 </subject>
@@ -9875,9 +9515,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="04298c44-e968-11ea-96dc-bf74f1f80424"/>
 </subject>
@@ -10030,17 +9667,11 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:2889A756-6693-11D7-A84E-6C8643AD0CA4">
 <association>
 <ref refid="DCE:28896E64-6693-11D7-A84E-6C8643AD0CA4"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -10143,9 +9774,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:CC9DE0D0-6690-11D7-A84E-6C8643AD0CA4">
 <generalization>
@@ -10200,9 +9828,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:CF605C46-8406-11D8-82A2-7B88E55A3BEC">
 <association>
@@ -10334,9 +9959,6 @@
 <diagram>
 <ref refid="DCE:33061A3A-4A88-11D7-B08B-133D836EF880"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -10389,9 +10011,6 @@
 <diagram>
 <ref refid="DCE:33061A3A-4A88-11D7-B08B-133D836EF880"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -10441,9 +10060,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="33123440-e20e-11ea-b7ab-f5b4c130f24e"/>
 </subject>
@@ -10602,9 +10218,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:64D9FAAE-50A3-11D7-807A-302CB4EF44FD">
 <memberEnd>
@@ -10666,9 +10279,6 @@
 <association>
 <ref refid="DCE:C0FEEEF2-4B53-11D7-A5E6-6257AF3C5118"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -10709,9 +10319,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:94E2A5A2-97BA-11D8-9E38-00C00C03A405">
 <association>
@@ -10771,9 +10378,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:DECC6864-4A87-11D7-B08A-133D836EF880">
 <generalization>
@@ -10885,9 +10489,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:9C1F856E-97BB-11D8-9E3B-00C00C03A405">
 <appliedStereotype>
@@ -10938,9 +10539,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:6D987F90-464D-11D7-AA08-1B85D5275D8A">
 <generalization>
@@ -11182,9 +10780,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:B71C4ADE-65C6-11D7-89A9-9C62884CFFDE">
 <appliedStereotype>
@@ -11210,9 +10805,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:522B0894-45D1-11D7-B5CA-613352B2821F">
 <memberEnd>
@@ -11273,9 +10865,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:8CB23AE8-4B56-11D7-A5E6-6257AF3C5118">
 <appliedStereotype>
@@ -11307,9 +10896,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:9B2CD32A-8404-11D8-82A2-7B88E55A3BEC">
 <appliedStereotype>
@@ -11351,9 +10937,6 @@
 <association>
 <ref refid="DCE:215BFFFA-97BC-11D8-9E3D-00C00C03A405"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <owningAssociation>
 <ref refid="DCE:215BFFFA-97BC-11D8-9E3D-00C00C03A405"/>
 </owningAssociation>
@@ -11365,9 +10948,6 @@
 <association>
 <ref refid="DCE:C021A320-4695-11D7-B567-379CA7034986"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -11463,9 +11043,6 @@
 <diagram>
 <ref refid="DCE:34764E0C-4A89-11D7-B08E-133D836EF880"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -11602,9 +11179,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:07DBA3DA-4A8A-11D7-B090-133D836EF880"/>
 </subject>
@@ -11637,9 +11211,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:1E0D0BDC-4A8A-11D7-B090-133D836EF880"/>
 </subject>
@@ -11672,9 +11243,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="5d8d968c-e96c-11ea-96dc-bf74f1f80424"/>
 </subject>
@@ -11722,9 +11290,6 @@
 <typeValue>
 <val>VisibilityKind</val>
 </typeValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:22B3AA56-4B32-11D7-B391-02BBFE4396CE">
 <generalization>
@@ -11788,9 +11353,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:8CB2097E-4B56-11D7-A5E6-6257AF3C5118">
 <aggregation>
@@ -11819,9 +11381,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:657F77E8-4B3C-11D7-B391-02BBFE4396CE">
 <appliedStereotype>
@@ -11853,9 +11412,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:1F2D9A6A-4B53-11D7-A5E6-6257AF3C5118">
 <appliedStereotype>
@@ -11899,9 +11455,6 @@
 <association>
 <ref refid="DCE:315E9378-83E1-11D7-ADE2-4B1972AF3391"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -11957,9 +11510,6 @@
 <association>
 <ref refid="DCE:E136E842-4B34-11D7-B391-02BBFE4396CE"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -12000,9 +11550,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:526679C6-97BB-11D8-9E39-00C00C03A405">
 <generalization>
@@ -12057,9 +11604,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:B0388110-4B34-11D7-B391-02BBFE4396CE">
 <appliedStereotype>
@@ -12085,9 +11629,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:7A536F14-8324-11D8-8D1E-00C00C03A405">
 <general>
@@ -12194,17 +11735,11 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:7265A7FE-83D9-11D7-ADE2-4B1972AF3391">
 <association>
 <ref refid="DCE:72656E80-83D9-11D7-ADE2-4B1972AF3391"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -12252,9 +11787,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:5C68DFBE-45D1-11D7-B5CA-613352B2821F">
 <comment>
@@ -12340,9 +11872,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:309D5284-4B32-11D7-B391-02BBFE4396CE">
 <generalization>
@@ -12453,9 +11982,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:B71D5D18-83E2-11D7-ADE2-4B1972AF3391">
 <aggregation>
@@ -12484,9 +12010,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:E08C83BE-8323-11D8-8D1E-00C00C03A405">
 <generalization>
@@ -12559,9 +12082,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:0E00B206-4B56-11D7-A5E6-6257AF3C5118">
 <memberEnd>
@@ -12595,9 +12115,6 @@
 <association>
 <ref refid="DCE:1DCA3E30-97BC-11D8-9E3C-00C00C03A405"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <owningAssociation>
 <ref refid="DCE:1DCA3E30-97BC-11D8-9E3C-00C00C03A405"/>
 </owningAssociation>
@@ -12668,9 +12185,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:BEC6FD8A-8402-11D8-82A2-7B88E55A3BEC">
 <appliedStereotype>
@@ -12730,9 +12244,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:8A1AEF86-50A2-11D7-807A-302CB4EF44FD">
 <appliedStereotype>
@@ -12790,9 +12301,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:39886AB6-8405-11D8-82A2-7B88E55A3BEC">
 <generalization>
@@ -12915,9 +12423,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Diagram id="DCE:54022A8C-8325-11D8-8D1E-00C00C03A405">
 <element>
@@ -12996,9 +12501,6 @@
 <diagram>
 <ref refid="DCE:54022A8C-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -13025,9 +12527,6 @@
 <diagram>
 <ref refid="DCE:54022A8C-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -13054,9 +12553,6 @@
 <diagram>
 <ref refid="DCE:54022A8C-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -13083,9 +12579,6 @@
 <diagram>
 <ref refid="DCE:54022A8C-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -13112,9 +12605,6 @@
 <diagram>
 <ref refid="DCE:54022A8C-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -13193,9 +12683,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:9D2930DC-8405-11D8-82A2-7B88E55A3BEC"/>
 </subject>
@@ -13335,9 +12822,6 @@
 <diagram>
 <ref refid="DCE:54022A8C-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -13390,9 +12874,6 @@
 <diagram>
 <ref refid="DCE:54022A8C-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -13445,9 +12926,6 @@
 <diagram>
 <ref refid="DCE:54022A8C-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -13526,9 +13004,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:AC3D4242-44B2-11DA-B054-000D936B094A"/>
 </subject>
@@ -13581,6 +13056,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="DCE:D80530B0-8323-11D8-8D1E-00C00C03A405"/>
 </subject>
@@ -13829,9 +13307,6 @@
 <association>
 <ref refid="DCE:64D9FAAE-50A3-11D7-807A-302CB4EF44FD"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -13914,9 +13389,6 @@
 <diagram>
 <ref refid="DCE:9661A9EE-509B-11D7-811E-AF5893A6470D"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -13943,9 +13415,6 @@
 <diagram>
 <ref refid="DCE:9661A9EE-509B-11D7-811E-AF5893A6470D"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -13998,9 +13467,6 @@
 <diagram>
 <ref refid="DCE:9661A9EE-509B-11D7-811E-AF5893A6470D"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -14079,9 +13545,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:0E1B4648-509C-11D7-811E-AF5893A6470D"/>
 </subject>
@@ -14143,9 +13606,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:941D2040-509C-11D7-811E-AF5893A6470D"/>
 </subject>
@@ -14236,9 +13696,6 @@
 <diagram>
 <ref refid="DCE:9661A9EE-509B-11D7-811E-AF5893A6470D"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -14288,9 +13745,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:E96C654A-509E-11D7-9F0D-F80F4B06507D"/>
 </subject>
@@ -14454,9 +13908,6 @@
 <association>
 <ref refid="DCE:24A4777A-8324-11D8-8D1E-00C00C03A405"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <owningAssociation>
 <ref refid="DCE:24A4777A-8324-11D8-8D1E-00C00C03A405"/>
 </owningAssociation>
@@ -14491,9 +13942,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:AA7609CE-4B38-11D7-B391-02BBFE4396CE">
 <appliedStereotype>
@@ -14606,9 +14054,6 @@
 <association>
 <ref refid="DCE:4276693C-8321-11D8-BEC8-00C00C03A405"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <owningAssociation>
 <ref refid="DCE:4276693C-8321-11D8-BEC8-00C00C03A405"/>
 </owningAssociation>
@@ -14664,9 +14109,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:70B41C2A-8404-11D8-82A2-7B88E55A3BEC">
 <memberEnd>
@@ -14713,9 +14155,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:2C688CEE-50A3-11D7-807A-302CB4EF44FD">
 <aggregation>
@@ -14744,9 +14183,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:4537764E-4B3B-11D7-B391-02BBFE4396CE">
 <appliedStereotype>
@@ -14778,9 +14214,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:16049AF8-97BB-11D8-9E38-00C00C03A405">
 <association>
@@ -14804,9 +14237,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:28989FC4-A41B-11D8-BCB9-00061BC22919">
 <generalization>
@@ -14986,9 +14416,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:8EA3E7DC-8405-11D8-82A2-7B88E55A3BEC">
 <general>
@@ -15036,9 +14463,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:B7B77E54-4694-11D7-B567-379CA7034986">
 <memberEnd>
@@ -15073,9 +14497,6 @@
 <association>
 <ref refid="DCE:814B31E0-4B34-11D7-B391-02BBFE4396CE"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -15113,9 +14534,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:5E50732C-8403-11D8-82A2-7B88E55A3BEC">
 <general>
@@ -15229,9 +14647,6 @@
 <diagram>
 <ref refid="DCE:94ED9700-4B3A-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -15310,9 +14725,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:45370AFE-4B3B-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -15374,9 +14786,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:12A2B620-4B3C-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -15409,9 +14818,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:4CC2BA3C-4B3C-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -15444,9 +14850,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:657F3EEA-4B3C-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -15479,9 +14882,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:315E9378-83E1-11D7-ADE2-4B1972AF3391"/>
 </subject>
@@ -15514,9 +14914,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:F3B245D6-4B3C-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -15578,9 +14975,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:4A112B20-83E1-11D7-ADE2-4B1972AF3391"/>
 </subject>
@@ -15642,9 +15036,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:90BAFB94-4B55-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -15706,9 +15097,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:CB4709B0-A417-11D8-B4C8-00061BC22919"/>
 </subject>
@@ -15741,9 +15129,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:941D2040-509C-11D7-811E-AF5893A6470D"/>
 </subject>
@@ -15962,9 +15347,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Diagram id="DCE:3A957AF4-8325-11D8-8D1E-00C00C03A405">
 <element>
@@ -16070,9 +15452,6 @@
 <diagram>
 <ref refid="DCE:3A957AF4-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -16096,9 +15475,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:2013DDFC-8402-11D8-82A2-7B88E55A3BEC"/>
 </subject>
@@ -16131,9 +15507,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:416F3ADC-8402-11D8-82A2-7B88E55A3BEC"/>
 </subject>
@@ -16166,9 +15539,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:4AAA922A-8402-11D8-82A2-7B88E55A3BEC"/>
 </subject>
@@ -16282,9 +15652,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:BEBC1974-8402-11D8-82A2-7B88E55A3BEC"/>
 </subject>
@@ -16317,9 +15684,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:0BCB2D7E-8403-11D8-82A2-7B88E55A3BEC"/>
 </subject>
@@ -16355,9 +15719,6 @@
 <diagram>
 <ref refid="DCE:3A957AF4-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -16384,9 +15745,6 @@
 <diagram>
 <ref refid="DCE:3A957AF4-8325-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -16517,9 +15875,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="f2eab176-e96f-11ea-96dc-bf74f1f80424"/>
 </subject>
@@ -16552,9 +15907,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:8C2A3672-8323-11D8-8D1E-00C00C03A405"/>
 </subject>
@@ -16746,9 +16098,6 @@
 <diagram>
 <ref refid="DCE:DA3B1A4E-8405-11D8-82A2-7B88E55A3BEC"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -16827,9 +16176,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:4080B156-8406-11D8-82A2-7B88E55A3BEC"/>
 </subject>
@@ -16862,9 +16208,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:7F971C42-8406-11D8-82A2-7B88E55A3BEC"/>
 </subject>
@@ -16955,9 +16298,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:CF5B429C-8406-11D8-82A2-7B88E55A3BEC"/>
 </subject>
@@ -16990,9 +16330,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:E0CC5228-8406-11D8-82A2-7B88E55A3BEC"/>
 </subject>
@@ -17025,9 +16362,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="366c194e-b592-11de-8278-000d93868322"/>
 </subject>
@@ -17063,9 +16397,6 @@
 <diagram>
 <ref refid="DCE:DA3B1A4E-8405-11D8-82A2-7B88E55A3BEC"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -17118,9 +16449,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="92deccd0-b592-11de-8278-000d93868322"/>
 </subject>
@@ -17182,9 +16510,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="35dad4a6-b593-11de-8278-000d93868322"/>
 </subject>
@@ -17283,9 +16608,6 @@
 <association>
 <ref refid="DCE:B038166C-4B34-11D7-B391-02BBFE4396CE"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -17415,9 +16737,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:53756494-45CF-11D7-B5CA-613352B2821F"/>
 </subject>
@@ -17502,9 +16821,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:522B0894-45D1-11D7-B5CA-613352B2821F"/>
 </subject>
@@ -17537,9 +16853,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:5C68DFBE-45D1-11D7-B5CA-613352B2821F"/>
 </subject>
@@ -17665,9 +16978,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:59C1E950-97BD-11D8-9E0D-00C00C03A405">
 <general>
@@ -17775,9 +17085,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:DB2CD0EE-509B-11D7-811E-AF5893A6470D">
 <generalization>
@@ -17874,9 +17181,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:DF5202C0-4B32-11D7-B391-02BBFE4396CE">
 <memberEnd>
@@ -17941,17 +17245,11 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:54B4A61C-4B33-11D7-B391-02BBFE4396CE">
 <association>
 <ref refid="DCE:54B46D78-4B33-11D7-B391-02BBFE4396CE"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -18176,9 +17474,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:4CC2BA3C-4B3C-11D7-B391-02BBFE4396CE">
 <memberEnd>
@@ -18226,9 +17521,6 @@
 <association>
 <ref refid="DCE:6A5E8372-4A87-11D7-B089-133D836EF880"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -18331,9 +17623,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:0BC178A2-4B53-11D7-A5E6-6257AF3C5118">
 <appliedStereotype>
@@ -18539,9 +17828,6 @@
 <diagram>
 <ref refid="DCE:954E534C-A41C-11D8-BCB9-00061BC22919"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -18594,9 +17880,6 @@
 <diagram>
 <ref refid="DCE:954E534C-A41C-11D8-BCB9-00061BC22919"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -18649,9 +17932,6 @@
 <diagram>
 <ref refid="DCE:954E534C-A41C-11D8-BCB9-00061BC22919"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -18733,9 +18013,6 @@
 <diagram>
 <ref refid="DCE:954E534C-A41C-11D8-BCB9-00061BC22919"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -18828,9 +18105,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="e242b900-b0ae-11de-8491-000d93868322"/>
 </subject>
@@ -19088,9 +18362,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:A1BA2C46-83D9-11D7-ADE2-4B1972AF3391">
 <general>
@@ -19132,9 +18403,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:C2293130-A418-11D8-B4C8-00061BC22919">
 <appliedStereotype>
@@ -19236,17 +18504,11 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:00ED273C-4B35-11D7-B391-02BBFE4396CE">
 <association>
 <ref refid="DCE:00ECEF06-4B35-11D7-B391-02BBFE4396CE"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -19324,9 +18586,6 @@
 <class_>
 <ref refid="DCE:B445FB00-4695-11D7-B567-379CA7034986"/>
 </class_>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val>appliedProfile</val>
 </name>
@@ -19339,9 +18598,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:B71C181E-65C6-11D7-89A9-9C62884CFFDE">
 <appliedStereotype>
@@ -19472,9 +18728,6 @@
 <diagram>
 <ref refid="DCE:2D47DA48-50A5-11D7-807A-302CB4EF44FD"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -19585,9 +18838,6 @@
 <diagram>
 <ref refid="DCE:2D47DA48-50A5-11D7-807A-302CB4EF44FD"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -19669,9 +18919,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:A69C2782-A417-11D8-B4C8-00061BC22919"/>
 </subject>
@@ -19704,9 +18951,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:CB4709B0-A417-11D8-B4C8-00061BC22919"/>
 </subject>
@@ -19739,9 +18983,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:EE13C07A-A417-11D8-B4C8-00061BC22919"/>
 </subject>
@@ -19774,9 +19015,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:459B0E02-A418-11D8-B4C8-00061BC22919"/>
 </subject>
@@ -19809,9 +19047,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:6A6F434A-A418-11D8-B4C8-00061BC22919"/>
 </subject>
@@ -19870,9 +19105,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:C229073A-A418-11D8-B4C8-00061BC22919"/>
 </subject>
@@ -20014,6 +19246,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 292.0, 460.0)</val>
 </matrix>
@@ -20252,9 +19487,6 @@
 <diagram>
 <ref refid="DCE:2817DA5A-50A1-11D7-9F0D-F80F4B06507D"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -20330,9 +19562,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:8A1AB6E0-50A2-11D7-807A-302CB4EF44FD"/>
 </subject>
@@ -20365,9 +19594,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:B71CF2AE-83E2-11D7-ADE2-4B1972AF3391"/>
 </subject>
@@ -20432,9 +19658,6 @@
 <diagram>
 <ref refid="DCE:2817DA5A-50A1-11D7-9F0D-F80F4B06507D"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -20484,9 +19707,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:2C6820C6-50A3-11D7-807A-302CB4EF44FD"/>
 </subject>
@@ -20519,9 +19739,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:64D9FAAE-50A3-11D7-807A-302CB4EF44FD"/>
 </subject>
@@ -20554,9 +19771,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:7E6CF516-50A3-11D7-807A-302CB4EF44FD"/>
 </subject>
@@ -20652,6 +19866,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 235.0, 504.0)</val>
 </matrix>
@@ -20818,9 +20035,6 @@
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:62E1A808-A41B-11D8-BCB9-00061BC22919">
 <appliedStereotype>
@@ -20851,9 +20065,6 @@
 <association>
 <ref refid="DCE:67493E60-97BA-11D8-9E36-00C00C03A405"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <owningAssociation>
 <ref refid="DCE:67493E60-97BA-11D8-9E36-00C00C03A405"/>
 </owningAssociation>
@@ -20936,9 +20147,6 @@
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:AA0772B2-83E0-11D7-ADE2-4B1972AF3391">
 <general>
@@ -21289,9 +20497,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:80637926-4B38-11D7-B391-02BBFE4396CE">
 <appliedStereotype>
@@ -21390,9 +20595,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Diagram id="DCE:039A7C82-4B32-11D7-B391-02BBFE4396CE">
 <element>
@@ -21473,9 +20675,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:039A7C82-4B32-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -21502,9 +20701,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:039A7C82-4B32-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -21528,9 +20724,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:DF5202C0-4B32-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -21618,9 +20811,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:81F3AEEE-4B32-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -21682,9 +20872,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:BCEB5704-4B32-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -21772,9 +20959,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:3A818386-4B3E-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -21807,9 +20991,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:54B46D78-4B33-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -22330,9 +21511,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -22414,9 +21592,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:B71BDF0C-65C6-11D7-89A9-9C62884CFFDE"/>
 </subject>
@@ -22449,9 +21624,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:BAEA7364-65C6-11D7-89A9-9C62884CFFDE"/>
 </subject>
@@ -22539,9 +21711,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -22568,9 +21737,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -22597,9 +21763,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -22649,9 +21812,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:881E7D46-65CF-11D7-89A9-9C62884CFFDE"/>
 </subject>
@@ -22779,9 +21939,6 @@ specially for Gaphor</val>
 <association>
 <ref refid="DCE:70B41C2A-8404-11D8-82A2-7B88E55A3BEC"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <owningAssociation>
 <ref refid="DCE:70B41C2A-8404-11D8-82A2-7B88E55A3BEC"/>
 </owningAssociation>
@@ -22813,9 +21970,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:D18A2462-6692-11D7-A84E-6C8643AD0CA4">
 <memberEnd>
@@ -22850,9 +22004,6 @@ specially for Gaphor</val>
 <association>
 <ref refid="DCE:81F3AEEE-4B32-11D7-B391-02BBFE4396CE"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -23071,9 +22222,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:879315F4-A41B-11D8-BCB9-00061BC22919">
 <general>
@@ -23115,9 +22263,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:8A67FB14-8404-11D8-82A2-7B88E55A3BEC">
 <general>
@@ -23348,9 +22493,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -23403,9 +22545,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -23432,9 +22571,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -23487,9 +22623,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -23539,9 +22672,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:8F7C5ED8-464D-11D7-AA08-1B85D5275D8A"/>
 </subject>
@@ -23574,9 +22704,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:B7B77E54-4694-11D7-B567-379CA7034986"/>
 </subject>
@@ -23609,9 +22736,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:D339DC26-4694-11D7-B567-379CA7034986"/>
 </subject>
@@ -23676,9 +22800,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -23728,9 +22849,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:79C3FCAA-4695-11D7-B567-379CA7034986"/>
 </subject>
@@ -23766,9 +22884,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -23847,9 +22962,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:C021A320-4695-11D7-B567-379CA7034986"/>
 </subject>
@@ -23882,9 +22994,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:18E7456A-4697-11D7-B567-379CA7034986"/>
 </subject>
@@ -23917,9 +23026,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:7D11DA3A-4697-11D7-B567-379CA7034986"/>
 </subject>
@@ -23981,9 +23087,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="5d8d968c-e96c-11ea-96dc-bf74f1f80424"/>
 </subject>
@@ -24164,9 +23267,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:8C2E9172-8323-11D8-8D1E-00C00C03A405">
 <appliedStereotype>
@@ -24263,9 +23363,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:FB6167F2-8405-11D8-82A2-7B88E55A3BEC">
 <generalization>
@@ -24311,9 +23408,6 @@ specially for Gaphor</val>
 <class_>
 <ref refid="DCE:AB14F544-4B3A-11D7-B391-02BBFE4396CE"/>
 </class_>
-<isDerived>
-<val>0</val>
-</isDerived>
 <lowerValue>
 <val>0</val>
 </lowerValue>
@@ -24363,9 +23457,6 @@ specially for Gaphor</val>
 <association>
 <ref refid="DCE:E085CF12-4B57-11D7-A5E6-6257AF3C5118"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -24383,9 +23474,6 @@ specially for Gaphor</val>
 <class_>
 <ref refid="DCE:37B70572-8323-11D8-8D1E-00C00C03A405"/>
 </class_>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val>incoming</val>
 </name>
@@ -24403,9 +23491,6 @@ specially for Gaphor</val>
 <association>
 <ref refid="DCE:54F91F8E-6692-11D7-A84E-6C8643AD0CA4"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -24417,9 +23502,6 @@ specially for Gaphor</val>
 </type>
 </Property>
 <Property id="DCE:3A81EE0C-4B3E-11D7-B391-02BBFE4396CE">
-<aggregation>
-<val>none</val>
-</aggregation>
 <appliedStereotype>
 <reflist>
 <ref refid="175e176c-fa90-11de-bd51-00224128e79d"/>
@@ -24448,9 +23530,6 @@ specially for Gaphor</val>
 <association>
 <ref refid="DCE:CFB3139A-83E0-11D7-ADE2-4B1972AF3391"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -24526,9 +23605,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Generalization id="DCE:4AAA9EE4-6693-11D7-A84E-6C8643AD0CA4">
 <general>
@@ -24617,9 +23693,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:FE75FBA6-6690-11D7-A84E-6C8643AD0CA4">
 <memberEnd>
@@ -24842,9 +23915,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:71EC6E5E-6690-11D7-A84E-6C8643AD0CA4"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -24871,9 +23941,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:71EC6E5E-6690-11D7-A84E-6C8643AD0CA4"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -24900,9 +23967,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:71EC6E5E-6690-11D7-A84E-6C8643AD0CA4"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -24929,9 +23993,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:71EC6E5E-6690-11D7-A84E-6C8643AD0CA4"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -24958,9 +24019,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:71EC6E5E-6690-11D7-A84E-6C8643AD0CA4"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -24984,9 +24042,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:FE75FBA6-6690-11D7-A84E-6C8643AD0CA4"/>
 </subject>
@@ -25071,9 +24126,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:B751CA7E-6691-11D7-A84E-6C8643AD0CA4"/>
 </subject>
@@ -25106,9 +24158,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:D0A2B6FA-6691-11D7-A84E-6C8643AD0CA4"/>
 </subject>
@@ -25141,9 +24190,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:068A66A0-6692-11D7-A84E-6C8643AD0CA4"/>
 </subject>
@@ -25176,9 +24222,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:54F91F8E-6692-11D7-A84E-6C8643AD0CA4"/>
 </subject>
@@ -25211,9 +24254,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:BA58D856-6692-11D7-A84E-6C8643AD0CA4"/>
 </subject>
@@ -25246,9 +24286,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:D18A2462-6692-11D7-A84E-6C8643AD0CA4"/>
 </subject>
@@ -25307,9 +24344,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:28896E64-6693-11D7-A84E-6C8643AD0CA4"/>
 </subject>
@@ -25368,9 +24402,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:3EEB934C-6698-11D7-A84E-6C8643AD0CA4"/>
 </subject>
@@ -25524,9 +24555,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Diagram id="DCE:052880F2-8323-11D8-8D1E-00C00C03A405">
 <element>
@@ -25599,9 +24627,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:052880F2-8323-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -25709,9 +24734,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:052880F2-8323-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -25790,9 +24812,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:B2B2706C-8324-11D8-8D1E-00C00C03A405"/>
 </subject>
@@ -25828,9 +24847,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:052880F2-8323-11D8-8D1E-00C00C03A405"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -25883,9 +24899,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:3A7BD5C8-425B-11DA-B3D0-000D936B094A"/>
 </subject>
@@ -25947,9 +24960,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:E4328032-425B-11DA-B3D0-000D936B094A"/>
 </subject>
@@ -26018,9 +25028,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Class id="DCE:6B38D020-83D9-11D7-ADE2-4B1972AF3391">
 <generalization>
@@ -26060,9 +25067,6 @@ specially for Gaphor</val>
 </specialization>
 </Class>
 <Property id="DCE:5C694A28-45D1-11D7-B5CA-613352B2821F">
-<aggregation>
-<val>none</val>
-</aggregation>
 <appliedStereotype>
 <reflist>
 <ref refid="17613dc0-fa90-11de-bd51-00224128e79d"/>
@@ -26095,9 +25099,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:5375CF56-45CF-11D7-B5CA-613352B2821F">
 <appliedStereotype>
@@ -26132,9 +25133,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>*</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Property id="DCE:7265D99A-83D9-11D7-ADE2-4B1972AF3391">
 <appliedStereotype>
@@ -26166,9 +25164,6 @@ specially for Gaphor</val>
 <upperValue>
 <val>1</val>
 </upperValue>
-<visibility>
-<val>public</val>
-</visibility>
 </Property>
 <Association id="DCE:94E2ED46-97BA-11D8-9E37-00C00C03A405">
 <memberEnd>
@@ -26312,9 +25307,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:90F60210-4B33-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -26367,9 +25359,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:90F60210-4B33-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -26500,9 +25489,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:53D40BEC-4B34-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -26535,9 +25521,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:814B31E0-4B34-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -26570,9 +25553,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:B038166C-4B34-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -26605,9 +25585,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:E136E842-4B34-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -26640,9 +25617,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:00ECEF06-4B35-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -26678,9 +25652,6 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:90F60210-4B33-11D7-B391-02BBFE4396CE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -26704,9 +25675,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:99FB3CE8-4B35-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -26739,9 +25707,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:B0D2CA8A-4B35-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -26858,9 +25823,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:BFC74BCC-4B37-11D7-B391-02BBFE4396CE"/>
 </subject>
@@ -26922,9 +25884,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:38A944DE-4B54-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -26986,9 +25945,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:28896E64-6693-11D7-A84E-6C8643AD0CA4"/>
 </subject>
@@ -27050,9 +26006,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:3EEB934C-6698-11D7-A84E-6C8643AD0CA4"/>
 </subject>
@@ -27115,9 +26068,6 @@ specially for Gaphor</val>
 <association>
 <ref refid="DCE:8A3CEA88-4B53-11D7-A5E6-6257AF3C5118"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -27273,9 +26223,6 @@ specially for Gaphor</val>
 <association>
 <ref refid="DCE:52EE3722-863A-11D7-8239-5A25B8C2F569"/>
 </association>
-<isDerived>
-<val>0</val>
-</isDerived>
 <name>
 <val></val>
 </name>
@@ -27517,9 +26464,6 @@ specially for Gaphor</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:535FC86C-E81E-11DD-BD54-000D936B094A"/>
 </subject>
@@ -28184,9 +27128,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:8E6B58CC-3B13-11D9-83CE-A0BAF22E8A12"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -28213,9 +27154,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:8E6B58CC-3B13-11D9-83CE-A0BAF22E8A12"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -28317,9 +27255,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:2CB46C1A-3B14-11D9-83CE-A0BAF22E8A12"/>
 </subject>
@@ -28381,9 +27316,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:8E6B58CC-3B13-11D9-83CE-A0BAF22E8A12"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -28436,9 +27368,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:AE644012-3B14-11D9-83CE-A0BAF22E8A12"/>
 </subject>
@@ -28500,9 +27429,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:8E6B58CC-3B13-11D9-83CE-A0BAF22E8A12"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -28578,9 +27504,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="5f66f3a8-5561-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -28984,12 +27907,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:EA8890EA-3B14-11D9-83CE-A0BAF22E8A12"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
-<show_operations>
-<val>1</val>
-</show_operations>
 <show_stereotypes>
 <val>0</val>
 </show_stereotypes>
@@ -29039,9 +27956,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:61E0B340-3B15-11D9-83CE-A0BAF22E8A12"/>
 </subject>
@@ -29074,9 +27988,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:7A13E372-3B15-11D9-83CE-A0BAF22E8A12"/>
 </subject>
@@ -29311,9 +28222,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="88c1d78e-5563-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -29346,9 +28254,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="8bf5c29e-5563-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -29639,9 +28544,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:14C6D1BC-3B17-11D9-83CE-A0BAF22E8A12"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -29720,9 +28622,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:8389D414-3B17-11D9-83CE-A0BAF22E8A12"/>
 </subject>
@@ -29758,9 +28657,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:14C6D1BC-3B17-11D9-83CE-A0BAF22E8A12"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -29787,9 +28683,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:14C6D1BC-3B17-11D9-83CE-A0BAF22E8A12"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -29813,9 +28706,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:83BDEDFE-3B8B-11D9-96AF-B1C16A765BD4"/>
 </subject>
@@ -29851,9 +28741,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:14C6D1BC-3B17-11D9-83CE-A0BAF22E8A12"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -29877,9 +28764,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:FD680EAC-3B8A-11D9-96AF-B1C16A765BD4"/>
 </subject>
@@ -29912,9 +28796,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:06181922-3B8B-11D9-96AF-B1C16A765BD4"/>
 </subject>
@@ -30152,9 +29033,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="62e91738-55b4-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -30184,6 +29062,9 @@ directly in a model.</val>
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="4f377b36-63c7-11eb-9492-9757bcbe474b"/>
 </subject>
@@ -31006,9 +29887,6 @@ directly in a model.</val>
 <show_attributes>
 <val>0</val>
 </show_attributes>
-<show_operations>
-<val>1</val>
-</show_operations>
 <show_stereotypes>
 <val>0</val>
 </show_stereotypes>
@@ -31061,9 +29939,6 @@ directly in a model.</val>
 <show_attributes>
 <val>0</val>
 </show_attributes>
-<show_operations>
-<val>1</val>
-</show_operations>
 <show_stereotypes>
 <val>0</val>
 </show_stereotypes>
@@ -31110,9 +29985,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:D5656242-5FD6-11D9-89DE-0050040A5923"/>
 </subject>
@@ -31145,9 +30017,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:0CA3AB76-3509-11DA-8668-000D936B094A"/>
 </subject>
@@ -31180,9 +30049,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:10D0457E-3509-11DA-8668-000D936B094A"/>
 </subject>
@@ -31215,9 +30081,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:03A7EBCA-5FD7-11D9-89DE-0050040A5923"/>
 </subject>
@@ -31250,9 +30113,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:E2202BAA-5FDF-11D9-BE08-000D936B094A"/>
 </subject>
@@ -31369,9 +30229,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:3B1AB012-61DF-11D9-A154-0050040A5923"/>
 </subject>
@@ -31410,9 +30267,6 @@ directly in a model.</val>
 <show_attributes>
 <val>0</val>
 </show_attributes>
-<show_operations>
-<val>1</val>
-</show_operations>
 <show_stereotypes>
 <val>0</val>
 </show_stereotypes>
@@ -31436,9 +30290,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:3B936BE0-5FD2-11D9-89DE-0050040A5923"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -31517,9 +30368,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:203459A0-34CE-11DA-B939-00306EB655C9"/>
 </subject>
@@ -31552,9 +30400,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:0BAE4600-5FE6-11D9-A512-000D936B094A"/>
 </subject>
@@ -31645,9 +30490,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:72AC4FE6-1FCF-11DA-A6C3-000D936B094A"/>
 </subject>
@@ -31712,9 +30554,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:3B936BE0-5FD2-11D9-89DE-0050040A5923"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -31764,9 +30603,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:DB97402A-3507-11DA-842A-000D936B094A"/>
 </subject>
@@ -32924,9 +31760,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -32953,9 +31786,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -32982,9 +31812,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -33037,9 +31864,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -33063,9 +31887,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:4BE7DD96-4587-11DA-A04F-00123FE76EBE"/>
 </subject>
@@ -33156,9 +31977,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -33208,9 +32026,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:F2E55830-4587-11DA-A04F-00123FE76EBE"/>
 </subject>
@@ -33246,9 +32061,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -33301,9 +32113,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:75D388A2-4588-11DA-A04F-00123FE76EBE"/>
 </subject>
@@ -33362,9 +32171,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:C331DD24-4588-11DA-A04F-00123FE76EBE"/>
 </subject>
@@ -33397,9 +32203,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:05B861C2-4589-11DA-A04F-00123FE76EBE"/>
 </subject>
@@ -33464,9 +32267,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -33493,12 +32293,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
-<show_operations>
-<val>1</val>
-</show_operations>
 <show_stereotypes>
 <val>0</val>
 </show_stereotypes>
@@ -33571,9 +32365,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:A1B65190-4589-11DA-A04F-00123FE76EBE"/>
 </subject>
@@ -33606,9 +32397,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:B0FA97A8-4589-11DA-A04F-00123FE76EBE"/>
 </subject>
@@ -33641,9 +32429,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:F3C58994-4589-11DA-A04F-00123FE76EBE"/>
 </subject>
@@ -33679,12 +32464,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
-<show_operations>
-<val>1</val>
-</show_operations>
 <show_stereotypes>
 <val>0</val>
 </show_stereotypes>
@@ -33757,9 +32536,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:1B2210D8-458B-11DA-A04F-00123FE76EBE"/>
 </subject>
@@ -33792,9 +32568,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:5BA8FCC0-458B-11DA-A04F-00123FE76EBE"/>
 </subject>
@@ -33827,9 +32600,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:C3102AE6-458B-11DA-A04F-00123FE76EBE"/>
 </subject>
@@ -33865,9 +32635,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:AEC6FCA4-4586-11DA-A04F-00123FE76EBE"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -33946,9 +32713,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:F81D06C8-4662-11DA-A766-00123FE76EBE"/>
 </subject>
@@ -33981,9 +32745,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:12943D78-4663-11DA-A766-00123FE76EBE"/>
 </subject>
@@ -34016,9 +32777,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:28F7D0B6-4663-11DA-A766-00123FE76EBE"/>
 </subject>
@@ -34051,9 +32809,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:6DDC2678-4663-11DA-A766-00123FE76EBE"/>
 </subject>
@@ -34115,9 +32870,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:F0F43F28-4663-11DA-A766-00123FE76EBE"/>
 </subject>
@@ -34150,9 +32902,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:1A671AEC-4664-11DA-A766-00123FE76EBE"/>
 </subject>
@@ -34185,9 +32934,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:BD30CE66-46F4-11DA-91FC-00123FE76EBE"/>
 </subject>
@@ -36262,9 +35008,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:F8852E08-8352-11DD-8EDA-000D936B094A"/>
 </subject>
@@ -36329,9 +35072,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="DCE:647E10B2-8352-11DD-8EDA-000D936B094A"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -36381,9 +35121,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:89DBA954-8353-11DD-8EDA-000D936B094A"/>
 </subject>
@@ -36786,9 +35523,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="9ab5c2dc-3fe1-11de-8375-00224128e79d"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -36841,9 +35575,6 @@ directly in a model.</val>
 <diagram>
 <ref refid="9ab5c2dc-3fe1-11de-8375-00224128e79d"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -37194,9 +35925,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:8A3CEA88-4B53-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -37255,9 +35983,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="e9505452-e962-11ea-87d1-cbf2d1fcaed0"/>
 </subject>
@@ -37290,9 +36015,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:3A8414B0-4B53-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -37354,9 +36076,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:90BAFB94-4B55-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -37418,9 +36137,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:16034FB0-97BB-11D8-9E38-00C00C03A405"/>
 </subject>
@@ -37502,6 +36218,9 @@ directly in a model.</val>
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="ee7c075e-63cf-11eb-9492-9757bcbe474b"/>
 </subject>
@@ -37872,9 +36591,6 @@ directly in a model.</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="ba0f29a6-b13e-11de-9fae-000d93868322"/>
 </subject>
@@ -37907,9 +36623,6 @@ directly in a model.</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="bdf9da20-b13e-11de-9fae-000d93868322"/>
 </subject>
@@ -45977,9 +44690,6 @@ to accommodate simpleAttribute</val>
 <diagram>
 <ref refid="bb8daa5a-3801-11e0-87bf-0021e9e5a3cd"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -46165,9 +44875,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="15371e5a-3803-11e0-87bf-0021e9e5a3cd"/>
 </subject>
@@ -46200,9 +44907,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="845eb1da-3803-11e0-87bf-0021e9e5a3cd"/>
 </subject>
@@ -46235,9 +44939,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="9f9a57f6-3803-11e0-87bf-0021e9e5a3cd"/>
 </subject>
@@ -46299,9 +45000,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="c32a9b9a-3803-11e0-87bf-0021e9e5a3cd"/>
 </subject>
@@ -46415,9 +45113,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="fd7ec1e0-3803-11e0-87bf-0021e9e5a3cd"/>
 </subject>
@@ -46450,9 +45145,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="12ac0294-3804-11e0-87bf-0021e9e5a3cd"/>
 </subject>
@@ -46485,9 +45177,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="2bb61806-3804-11e0-87bf-0021e9e5a3cd"/>
 </subject>
@@ -47479,9 +46168,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="b278c790-38fd-11e0-98cd-0021e9e5a3cd"/>
 </subject>
@@ -47856,9 +46542,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="842e7b62-4066-11e0-b382-0019d2b28af0"/>
 </subject>
@@ -48239,9 +46922,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="f36de124-40f3-11e0-9acb-0019d2b28af0"/>
 </subject>
@@ -48349,9 +47029,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="a55f35d6-909a-11ea-9685-03ae027faeeb"/>
 </subject>
@@ -48413,9 +47090,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="3fc6e372-e96e-11ea-96dc-bf74f1f80424"/>
 </subject>
@@ -49408,9 +48082,6 @@ to accommodate simpleAttribute</val>
 <diagram>
 <ref refid="6cd26680-55b6-11ea-8c7d-fd01dce16f0a"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -49434,9 +48105,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="d12cdc47-55b6-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -49469,9 +48137,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="f1f71267-55b6-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -49585,9 +48250,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="1c0ce23c-55b8-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -49695,9 +48357,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="c5ad5c36-55b8-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -49730,9 +48389,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="c96521d8-55b8-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -49765,9 +48421,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="cd2c18bc-55b8-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -49950,9 +48603,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="8a6fabc8-55b9-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -49985,9 +48635,6 @@ to accommodate simpleAttribute</val>
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="8ed4600a-55b9-11ea-8c7d-fd01dce16f0a"/>
 </subject>
@@ -51706,9 +50353,6 @@ association:not([memberEnd.navigability*=true]) {
 <diagram>
 <ref refid="3bf6ebec-e20d-11ea-b7ab-f5b4c130f24e"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -51761,9 +50405,6 @@ association:not([memberEnd.navigability*=true]) {
 <diagram>
 <ref refid="3bf6ebec-e20d-11ea-b7ab-f5b4c130f24e"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -51790,9 +50431,6 @@ association:not([memberEnd.navigability*=true]) {
 <diagram>
 <ref refid="3bf6ebec-e20d-11ea-b7ab-f5b4c130f24e"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -51845,9 +50483,6 @@ association:not([memberEnd.navigability*=true]) {
 <diagram>
 <ref refid="3bf6ebec-e20d-11ea-b7ab-f5b4c130f24e"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -51900,9 +50535,6 @@ association:not([memberEnd.navigability*=true]) {
 <diagram>
 <ref refid="3bf6ebec-e20d-11ea-b7ab-f5b4c130f24e"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -51955,9 +50587,6 @@ association:not([memberEnd.navigability*=true]) {
 <diagram>
 <ref refid="3bf6ebec-e20d-11ea-b7ab-f5b4c130f24e"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -52065,9 +50694,6 @@ association:not([memberEnd.navigability*=true]) {
 <diagram>
 <ref refid="3bf6ebec-e20d-11ea-b7ab-f5b4c130f24e"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -53035,9 +51661,6 @@ association:not([memberEnd.navigability*=true]) {
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:C90400F8-83E1-11D7-ADE2-4B1972AF3391"/>
 </subject>
@@ -53099,9 +51722,6 @@ association:not([memberEnd.navigability*=true]) {
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:0E00B206-4B56-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -53163,9 +51783,6 @@ association:not([memberEnd.navigability*=true]) {
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="b872a8c2-b76d-11de-a410-000d93868322"/>
 </subject>
@@ -53198,9 +51815,6 @@ association:not([memberEnd.navigability*=true]) {
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="DCE:8CB1D104-4B56-11D7-A5E6-6257AF3C5118"/>
 </subject>
@@ -53921,9 +52535,6 @@ association:not([memberEnd.navigability*=true]) {
 <diagram>
 <ref refid="c6e0fa86-ea00-11ea-96dc-bf74f1f80424"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -55405,6 +54016,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="8026cb74-ebea-11eb-8d68-2d4b211d5079"/>
 </subject>
@@ -55444,6 +54058,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="848c5cb0-ebea-11eb-8d68-2d4b211d5079"/>
 </subject>
@@ -55536,13 +54153,13 @@ have an opposite end.
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="3ae03180-ebeb-11eb-8d68-2d4b211d5079"/>
-<ref refid="bf3ff4de-ebea-11eb-8d68-2d4b211d5079"/>
 <ref refid="c931bda0-ebeb-11eb-8d68-2d4b211d5079"/>
 <ref refid="b489823e-ebeb-11eb-8d68-2d4b211d5079"/>
-<ref refid="e4b55078-ebeb-11eb-8d68-2d4b211d5079"/>
 <ref refid="02379ee4-ebec-11eb-8d68-2d4b211d5079"/>
+<ref refid="e4b55078-ebeb-11eb-8d68-2d4b211d5079"/>
 <ref refid="feb2e59e-ebeb-11eb-8d68-2d4b211d5079"/>
+<ref refid="bf3ff4de-ebea-11eb-8d68-2d4b211d5079"/>
+<ref refid="3ae03180-ebeb-11eb-8d68-2d4b211d5079"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -55706,6 +54323,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="fef3fddc-ebea-11eb-8d68-2d4b211d5079"/>
 </subject>
@@ -55768,6 +54388,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="19904844-ebeb-11eb-8d68-2d4b211d5079"/>
 </subject>
@@ -55833,6 +54456,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="3ae01204-ebeb-11eb-8d68-2d4b211d5079"/>
 </subject>
@@ -55859,11 +54485,6 @@ have an opposite end.
 <ref refid="3ae046f2-ebeb-11eb-8d68-2d4b211d5079"/>
 </reflist>
 </memberEnd>
-<ownedEnd>
-<reflist>
-<ref refid="3ae046f2-ebeb-11eb-8d68-2d4b211d5079"/>
-</reflist>
-</ownedEnd>
 <package>
 <ref refid="34985146-ebea-11eb-8d68-2d4b211d5079"/>
 </package>
@@ -55894,15 +54515,18 @@ have an opposite end.
 </upperValue>
 </Property>
 <Property id="3ae046f2-ebeb-11eb-8d68-2d4b211d5079">
+<aggregation>
+<val>composite</val>
+</aggregation>
 <association>
 <ref refid="3ae01204-ebeb-11eb-8d68-2d4b211d5079"/>
 </association>
+<class_>
+<ref refid="DCE:38CB97A8-45CF-11D7-B5CA-613352B2821F"/>
+</class_>
 <name>
 <val>abstraction</val>
 </name>
-<owningAssociation>
-<ref refid="3ae01204-ebeb-11eb-8d68-2d4b211d5079"/>
-</owningAssociation>
 <type>
 <ref refid="aa6793be-ebea-11eb-8d68-2d4b211d5079"/>
 </type>
@@ -56027,6 +54651,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="b4893388-ebeb-11eb-8d68-2d4b211d5079"/>
 </subject>
@@ -56117,6 +54744,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="c9318e8e-ebeb-11eb-8d68-2d4b211d5079"/>
 </subject>
@@ -56207,6 +54837,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="e4b512d4-ebeb-11eb-8d68-2d4b211d5079"/>
 </subject>
@@ -56340,6 +54973,11 @@ have an opposite end.
 <ref refid="feb2e59e-ebeb-11eb-8d68-2d4b211d5079"/>
 </reflist>
 </memberEnd>
+<ownedEnd>
+<reflist>
+<ref refid="feb2bcea-ebeb-11eb-8d68-2d4b211d5079"/>
+</reflist>
+</ownedEnd>
 <package>
 <ref refid="34985146-ebea-11eb-8d68-2d4b211d5079"/>
 </package>
@@ -56358,12 +54996,12 @@ have an opposite end.
 <association>
 <ref refid="feb27faa-ebeb-11eb-8d68-2d4b211d5079"/>
 </association>
-<class_>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</class_>
 <name>
 <val>informationFlow</val>
 </name>
+<owningAssociation>
+<ref refid="feb27faa-ebeb-11eb-8d68-2d4b211d5079"/>
+</owningAssociation>
 <type>
 <ref refid="aa6793be-ebea-11eb-8d68-2d4b211d5079"/>
 </type>
@@ -56796,6 +55434,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 389.2109375, 235.44926264044943)</val>
 </matrix>
@@ -56983,6 +55624,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="de901442-bb63-11ec-a9db-0456e5e540ed"/>
 </subject>
@@ -57371,6 +56015,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 248.0, 507.0)</val>
 </matrix>
@@ -57391,6 +56038,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 308.0, 515.0)</val>
 </matrix>
@@ -57569,6 +56219,9 @@ have an opposite end.
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 179.56248474121094, 521.53125)</val>
 </matrix>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

`ItemFlow` can be applied to Connectors, but not Associations.

Issue Number: #2125

### What is the new behavior?

Support for `ItemFlow` on Associations.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

The Coffee Machine tutorial has been updated as well: https://gaphor--2312.org.readthedocs.build/en/2312/coffee_machine_concept.html#context-diagram.

The editor for item flow now shows as an expander.

![image](https://github.com/gaphor/gaphor/assets/96249/a20586ac-cbbb-4d7b-b6fc-26a7b0677d38)
