### PR TITLE
Allow grouping of property with current owner element

### DIFF
--- a/gaphor/SysML/blocks/group.py
+++ b/gaphor/SysML/blocks/group.py
@@ -7,7 +7,7 @@ def block_property_group(parent, element):
     """Add Property to a Block."""
 
     if element.association:
-        return False
+        return element.owner is parent
 
     parent.ownedAttribute = element
     return True


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

I was not able to let the properties of "Espresso Machine" (in the coffee machine example) be grouped in an espresso machine. Problem seemed to be that there was an association related to those properties.

Issue Number: N/A

### What is the new behavior?

Return `True` from the `group()` dispatch function when the property is already owned by the requested parent. This allows the properties to be grouped on their existing owner.
 
### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
