### PR TITLE
Remove use of deprecated GTK methods

### DIFF
--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -94,4 +94,4 @@ class ActivityItemPage(PropertyPageBase):
         )
 
     def on_parameters_info_clicked(self, image, event):
-        self.info.show()
+        self.info.set_visible(True)

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -63,7 +63,7 @@ class AssociationPropertyPage(PropertyPageBase):
             stereotype_list.set_model(stereotypes_model)
         else:
             stereotype_frame = builder.get_object(f"{end_name}-stereotype-frame")
-            stereotype_frame.hide()
+            stereotype_frame.set_visible(False)
 
     def update_end_name(self, builder, end_name, subject):
         name = builder.get_object(f"{end_name}-name")

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -176,4 +176,4 @@ class AssociationPropertyPage(PropertyPageBase):
 
     def _on_association_info_clicked(self, widget, event):
         self.info.set_relative_to(widget)
-        self.info.show()
+        self.info.set_visible(True)

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -344,7 +344,7 @@ class AttributesPage(PropertyPageBase):
         self.item.request_update()
 
     def on_attributes_info_clicked(self, image, event):
-        self.info.show()
+        self.info.set_visible(True)
 
 
 @PropertyPages.register(DataTypeItem)
@@ -428,7 +428,7 @@ class OperationsPage(PropertyPageBase):
         self.item.request_update()
 
     def on_operations_info_clicked(self, image, event):
-        self.info.show()
+        self.info.set_visible(True)
 
 
 @PropertyPages.register(UML.Component)

--- a/gaphor/UML/classes/enumerationpropertypages.py
+++ b/gaphor/UML/classes/enumerationpropertypages.py
@@ -81,7 +81,7 @@ class EnumerationPage(PropertyPageBase):
         self.item.request_update()
 
     def on_enumerations_info_clicked(self, image, event):
-        self.info.show()
+        self.info.set_visible(True)
 
 
 PropertyPages.register(EnumerationItem)(AttributesPage)

--- a/gaphor/diagram/instanteditors.py
+++ b/gaphor/diagram/instanteditors.py
@@ -55,7 +55,6 @@ def popup_entry(text, update_text=None, done=None):
     buffer = Gtk.EntryBuffer()
     buffer.set_text(text, -1)
     entry = Gtk.Entry.new_with_buffer(buffer)
-    entry.show()
     return entry
 
 

--- a/gaphor/diagram/instanteditors.py
+++ b/gaphor/diagram/instanteditors.py
@@ -54,8 +54,7 @@ def named_item_editor(item, view, event_manager, pos=None) -> bool:
 def popup_entry(text, update_text=None, done=None):
     buffer = Gtk.EntryBuffer()
     buffer.set_text(text, -1)
-    entry = Gtk.Entry.new_with_buffer(buffer)
-    return entry
+    return Gtk.Entry.new_with_buffer(buffer)
 
 
 def show_popover(widget, view, box, commit):

--- a/gaphor/diagram/instanteditors.py
+++ b/gaphor/diagram/instanteditors.py
@@ -99,6 +99,6 @@ def show_popover(widget, view, box, commit):
 
     if popover.get_root():
         # Test for root window to avoid segfaults in unit test
-        popover.show()
+        popover.set_visible(True)
 
     return popover

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -256,7 +256,7 @@ def help_link(builder, help_widget, popover):
     """Show the help popover for a `Help` link in the property page."""
 
     def on_activate(*_args):
-        builder.get_object(popover).show()
+        builder.get_object(popover).set_visible(True)
 
     help = builder.get_object(help_widget)
     help.set_accessible_role(Gtk.AccessibleRole.BUTTON)

--- a/gaphor/diagram/tools/tests/test_txtool.py
+++ b/gaphor/diagram/tools/tests/test_txtool.py
@@ -9,7 +9,7 @@ from gaphor.transaction import TransactionBegin
 def window(view):
     window = Gtk.Window.new()
     window.set_child(view)
-    window.show()
+    window.set_visible(True)
     yield window
     window.destroy()
 

--- a/gaphor/plugins/console/console.py
+++ b/gaphor/plugins/console/console.py
@@ -350,7 +350,7 @@ def main(main_loop=True):
     console.text_controller.connect("key-pressed", key_event)
 
     window.set_child(console)
-    window.show()
+    window.set_visible(True)
 
     if main_loop:
 

--- a/gaphor/plugins/console/consolewindow.py
+++ b/gaphor/plugins/console/consolewindow.py
@@ -74,7 +74,7 @@ class ConsoleWindow(UIComponent, ActionProvider):
         box.append(console)
         window.set_content(box)
         window.connect("close-request", self.close)
-        window.show()
+        window.set_visible(True)
         self.window = window
 
         def key_event(widget, keyval, keycode, state):

--- a/gaphor/plugins/errorreports/errorreports.py
+++ b/gaphor/plugins/errorreports/errorreports.py
@@ -70,7 +70,7 @@ class ErrorReports(UIComponent, ActionProvider):
         self.buffer = builder.get_object("buffer")
 
         self.window.connect("destroy", self.close)
-        self.window.show()
+        self.window.set_visible(True)
 
         self.update_text()
 

--- a/gaphor/ui/appfilemanager.py
+++ b/gaphor/ui/appfilemanager.py
@@ -63,7 +63,7 @@ class AppFileManager(Service, ActionProvider):
                         )
 
                     dialog.connect("response", response)
-                    dialog.show()
+                    dialog.set_visible(True)
                 else:
                     self.application.new_session(filename=filename)
 

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -253,7 +253,7 @@ class EditorStack:
 
         def on_show_tips_changed(checkbox, gparam):
             active = checkbox.get_active()
-            tips.show() if active else tips.hide()
+            tips.set_visible(active)
             self.properties.set("show-tips", active)
 
         show_tips = builder.get_object("show-tips")

--- a/gaphor/ui/errorhandler.py
+++ b/gaphor/ui/errorhandler.py
@@ -42,4 +42,4 @@ def error_handler(message, secondary_message="", window=None, close=None):
             close()
 
     dialog.connect("response", response)
-    dialog.show()
+    dialog.set_visible(True)

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -56,7 +56,7 @@ def open_file_dialog(title, handler, parent=None, dirname=None, filters=None) ->
     dialog.set_modal(True)
     if dirname:
         dialog.set_current_folder(Gio.File.parse_name(dirname))
-    dialog.show()
+    dialog.set_visible(True)
 
 
 def save_file_dialog(
@@ -93,7 +93,7 @@ def save_file_dialog(
                 dialog.destroy()
                 handler(filename)
             else:
-                dialog.show()
+                dialog.set_visible(True)
         else:
             dialog.destroy()
 
@@ -102,5 +102,5 @@ def save_file_dialog(
         set_filename(filename)
         dialog.set_current_folder(Gio.File.parse_name(str(filename.parent)))
     dialog.set_modal(True)
-    dialog.show()
+    dialog.set_visible(True)
     return dialog

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -433,7 +433,7 @@ def resolve_merge_conflict_dialog(window: Gtk.Window, filename: Path, handler) -
         handler(answer)
 
     dialog.connect("response", response)
-    dialog.show()
+    dialog.set_visible(True)
 
 
 def save_changes_before_closing_dialog(window: Gtk.Window, handler) -> None:
@@ -462,4 +462,4 @@ def save_changes_before_closing_dialog(window: Gtk.Window, handler) -> None:
         handler(answer)
 
     dialog.connect("response", response)
-    dialog.show()
+    dialog.set_visible(True)

--- a/gaphor/ui/greeter.py
+++ b/gaphor/ui/greeter.py
@@ -105,7 +105,7 @@ class Greeter(Service, ActionProvider):
             for widget in self.create_recent_files():
                 listbox.add(widget)
         else:
-            builder.get_object("recent-files").hide()
+            builder.get_object("recent-files").set_visible(False)
 
         for widget in self.create_templates():
             templates.add(widget)

--- a/gaphor/ui/greeter.py
+++ b/gaphor/ui/greeter.py
@@ -111,7 +111,7 @@ class Greeter(Service, ActionProvider):
             templates.add(widget)
 
         self.greeter.connect("close-request", self._on_window_close_request)
-        self.greeter.show()
+        self.greeter.set_visible(True)
 
     def close(self):
         if self.greeter:

--- a/gaphor/ui/help/__init__.py
+++ b/gaphor/ui/help/__init__.py
@@ -39,7 +39,7 @@ class HelpService(Service, ActionProvider):
         about.set_transient_for(self.window)
 
         about.set_modal(True)
-        about.show()
+        about.set_visible(True)
 
     @action(name="app.shortcuts")
     def shortcuts(self):
@@ -54,5 +54,5 @@ class HelpService(Service, ActionProvider):
         shortcuts.set_modal(True)
         shortcuts.set_transient_for(self.window)
 
-        shortcuts.show()
+        shortcuts.set_visible(True)
         return shortcuts

--- a/gaphor/ui/layout.py
+++ b/gaphor/ui/layout.py
@@ -99,7 +99,6 @@ def paned(parent, index, properties, name, orientation, position=None):
     add(paned, index, parent)
     paned.set_position(properties.get(name, int(position)))
     paned.connect("notify::position", _position_changed, properties)
-    paned.show()
     return paned
 
 
@@ -112,5 +111,4 @@ def box(parent, index, properties, orientation, resize="false"):
         0,
     )
     add(box, index, parent, resize == "true")
-    box.show()
     return box

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -204,7 +204,7 @@ class MainWindow(Service, ActionProvider):
         window.connect("close-request", self._on_window_close_request)
         window.connect("notify::default-height", self._on_window_size_changed)
         window.connect("notify::default-width", self._on_window_size_changed)
-        window.show()
+        window.set_visible(True)
 
         window.connect("notify::is-active", self._on_window_active)
 

--- a/gaphor/ui/statuswindow.py
+++ b/gaphor/ui/statuswindow.py
@@ -58,7 +58,7 @@ class StatusWindow:
 
         assert self.window
 
-        self.window.show()
+        self.window.set_visible(True)
 
     def progress(self, percentage: int):
         """Update progress percentage (0..100)."""

--- a/gaphor/ui/statuswindow.py
+++ b/gaphor/ui/statuswindow.py
@@ -44,7 +44,7 @@ class StatusWindow:
         vbox.append(self.progress_bar)
 
         self.window.set_title(self.title)
-        self.window.get_style_context().add_class("status-window")
+        self.window.add_css_class("status-window")
         if self.parent:
             self.window.set_transient_for(self.parent)
         self.window.set_modal(True)

--- a/gaphor/ui/tests/test_filedialog.py
+++ b/gaphor/ui/tests/test_filedialog.py
@@ -46,7 +46,7 @@ class FileChooserStub:
     def set_modal(self, modal):
         pass
 
-    def show(self):
+    def set_visible(self, visible):
         pass
 
     def destroy(self):

--- a/gaphor/ui/tests/test_handletool.py
+++ b/gaphor/ui/tests/test_handletool.py
@@ -28,7 +28,7 @@ def diagrams(event_manager, element_factory, modeling_language, properties):
     box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
     window.set_child(box)
     box.append(diagrams.open())
-    window.show()
+    window.set_visible(True)
     yield diagrams
     diagrams.close()
 

--- a/gaphor/ui/uipreview.py
+++ b/gaphor/ui/uipreview.py
@@ -45,7 +45,7 @@ def in_window(app, name, component):
     window.set_child(component)
     window.set_title(name)
     window.set_default_size(226, -1)
-    window.show()
+    window.set_visible(True)
     app.add_window(window)
     return window
 

--- a/tests/test_placement_tools.py
+++ b/tests/test_placement_tools.py
@@ -42,7 +42,7 @@ def tab(event_manager, element_factory):
     window = Gtk.Window.new()
     window.set_child(tab.construct())
 
-    window.show()
+    window.set_visible(True)
     yield tab
     window.destroy()
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

`Gtk.Widget.show()`, `Gtk.Widget.hide()`, and `Gtk.StyleContext.add_class()` are deprecated since GTK 4.10.

Issue Number: #2231 

### What is the new behavior?

Replace uses of mentioned methods with newer versions.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
