### PR TITLE
Replace deprecated Gtk.FileChooser by FileDialog

### DIFF
--- a/gaphor/diagram/general/generalpropertypages.py
+++ b/gaphor/diagram/general/generalpropertypages.py
@@ -125,7 +125,7 @@ class PicturePropertyPage(PropertyPageBase):
         open_file_dialog(
             gettext("Select a picture..."),
             self.open_files,
-            pixbuf_formats=True,
+            image_filter=True,
             parent=button.get_root(),
         )
 

--- a/gaphor/ui/appfilemanager.py
+++ b/gaphor/ui/appfilemanager.py
@@ -6,14 +6,9 @@ from gi.repository import Adw
 
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import action, gettext
-from gaphor.ui.filedialog import open_file_dialog
+from gaphor.ui.filedialog import GAPHOR_FILTER, open_file_dialog
 
 log = logging.getLogger(__name__)
-
-
-FILTERS = [
-    (gettext("All Gaphor Models"), "*.gaphor", "application/x-gaphor"),
-]
 
 
 class AppFileManager(Service, ActionProvider):
@@ -77,5 +72,5 @@ class AppFileManager(Service, ActionProvider):
             open_files,
             parent=self.window,
             dirname=self.last_dir,
-            filters=FILTERS,
+            filters=GAPHOR_FILTER,
         )

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -46,7 +46,7 @@ def open_file_dialog(
     parent=None,
     dirname=None,
     filters=None,
-    image_filter = False,
+    image_filter=False,
 ) -> None:
     dialog = Gtk.FileDialog.new()
     dialog.set_title(title)

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -30,22 +30,14 @@ def new_image_filter() -> Gtk.FileFilter:
     return f
 
 
-def _file_dialog_with_filters(
-    title, parent, action, filters, pixbuf_formats: bool
-) -> Gtk.FileChooserNative:
-    dialog = Gtk.FileChooserNative.new(title, parent, action, None, None)
-
-    if parent:
-        dialog.set_transient_for(parent)
-
-    if sys.platform != "darwin":
-        if pixbuf_formats:
-            dialog.add_filter(new_image_filter())
-        else:
-            for name, patterns, mime_type in filters:
-                dialog.add_filter(new_filter(name, patterns, mime_type))
-        dialog.add_filter(new_filter(gettext("All Files"), "*"))
-    return dialog
+def new_filters(filters, images=False):
+    store = Gio.ListStore.new(Gtk.FileFilter)
+    if images:
+        store.append(new_image_filter())
+    for name, pattern, mime_type in filters:
+        store.append(new_filter(name, pattern, mime_type))
+    store.append(new_filter(gettext("All Files"), "*"))
+    return store
 
 
 def open_file_dialog(
@@ -54,31 +46,16 @@ def open_file_dialog(
     parent=None,
     dirname=None,
     filters=None,
-    pixbuf_formats: bool = False,
+    image_filter = False,
 ) -> None:
-    # if filters is None:
-    #     filters = []
-    # dialog = _file_dialog_with_filters(
-    #     title, parent, Gtk.FileChooserAction.OPEN, filters, pixbuf_formats
-    # )
-    # dialog.set_select_multiple(True)
     dialog = Gtk.FileDialog.new()
     dialog.set_title(title)
 
     if dirname:
         dialog.set_initial_folder(Gio.File.parse_name(dirname))
 
-    if filters or pixbuf_formats:
-        store = Gio.ListStore.new(Gtk.FileFilter)
-        if pixbuf_formats:
-            store.append(new_image_filter())
-        for name, pattern, mime_type in filters:
-            filter = Gtk.FileFilter.new()
-            filter.set_name(name)
-            filter.add_pattern(pattern)
-            filter.add_mime_type(mime_type)
-            store.append(filter)
-        dialog.set_filters(store)
+    if filters:
+        dialog.set_filters(new_filters(filters, image_filter))
 
     def response(dialog, result):
         files = dialog.open_multiple_finish(result)
@@ -95,42 +72,26 @@ def save_file_dialog(
     extension=None,
     filters=None,
 ) -> Gtk.FileChooser:
-    if filters is None:
-        filters = []
-    dialog = _file_dialog_with_filters(
-        title, parent, Gtk.FileChooserAction.SAVE, filters, False
-    )
+    dialog = Gtk.FileDialog.new()
+    dialog.set_title(title)
+    
+    if filename:
+        dialog.set_initial_file(Gio.File.parse_name(str(filename)))
 
-    def get_filename() -> Path:
-        return Path(dialog.get_file().get_path())
+    if filters:
+        dialog.set_filters(new_filters(filters))
 
-    def set_filename(filename: Path):
-        dialog.set_current_name(str(filename.name))
-
-    def overwrite_check() -> Path | None:
-        filename = get_filename()
+    def response(dialog, result):
+        filename = Path(dialog.save_finish(result).get_path())
         if extension and filename.suffix != extension:
             filename = filename.with_suffix(extension)
-            set_filename(filename)
-            return None if filename.exists() else filename
-        return filename
+            if filename.exists():
+                dialog.set_initial_file(Gio.File.parse_name(str(filename)))
+                dialog.save(parent=parent, cancellable=None, callback=response)
+                return
+        handler(filename)
 
-    def response(_dialog, answer):
-        if answer == Gtk.ResponseType.ACCEPT:
-            if filename := overwrite_check():
-                dialog.destroy()
-                handler(filename)
-            else:
-                dialog.show()
-        else:
-            dialog.destroy()
-
-    dialog.connect("response", response)
-    if filename:
-        set_filename(filename)
-        dialog.set_current_folder(Gio.File.parse_name(str(filename.parent)))
-    dialog.set_modal(True)
-    dialog.show()
+    dialog.save(parent=parent, cancellable=None, callback=response)
     return dialog
 
 

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -11,7 +11,7 @@ from gi.repository import Gio, Gtk
 
 from gaphor.i18n import gettext
 
-GAPHOR_FILTER = [(gettext("All Gaphor Models"), "*.gaphor", "application/x-gaphor")]
+GAPHOR_FILTER = [(gettext("Gaphor Models"), "*.gaphor", "application/x-gaphor")]
 
 
 def new_filter(name: str, pattern: str, mime_type: str | None = None) -> Gtk.FileFilter:
@@ -74,7 +74,7 @@ def save_file_dialog(
 ) -> Gtk.FileChooser:
     dialog = Gtk.FileDialog.new()
     dialog.set_title(title)
-    
+
     if filename:
         dialog.set_initial_file(Gio.File.parse_name(str(filename)))
 

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -58,6 +58,10 @@ def open_file_dialog(
         dialog.set_filters(new_filters(filters, image_filter))
 
     def response(dialog, result):
+        if result.had_error():
+            # File dialog was cancelled
+            return
+
         files = dialog.open_multiple_finish(result)
         handler([Path(f.get_path()) for f in files])
 
@@ -82,6 +86,10 @@ def save_file_dialog(
         dialog.set_filters(new_filters(filters))
 
     def response(dialog, result):
+        if result.had_error():
+            # File dialog was cancelled
+            return
+
         filename = Path(dialog.save_finish(result).get_path())
         if extension and filename.suffix != extension:
             filename = filename.with_suffix(extension)

--- a/gaphor/ui/tests/test_filedialog.py
+++ b/gaphor/ui/tests/test_filedialog.py
@@ -7,6 +7,11 @@ from gi.repository import Gio, Gtk
 from gaphor.ui.filedialog import pretty_path, save_file_dialog
 
 
+class TaskMock:
+    def had_error(self):
+        return False
+
+
 class FileDialogMock(Gtk.FileDialog):
     def __init__(self):
         super().__init__()
@@ -14,7 +19,7 @@ class FileDialogMock(Gtk.FileDialog):
 
     def save(self, parent, cancellable, callback):
         self.save_callback = callback
-        callback(self, "mock result")
+        callback(self, TaskMock())
 
     def save_finish(self, result):
         return self._save_response

--- a/gaphor/ui/tests/test_filedialog.py
+++ b/gaphor/ui/tests/test_filedialog.py
@@ -7,64 +7,35 @@ from gi.repository import Gio, Gtk
 from gaphor.ui.filedialog import pretty_path, save_file_dialog
 
 
-class FileChooserStub:
-    def __init__(self) -> None:
-        self._response_callback = None
-        self._current_name = None
-        self._current_folder = None
+class FileDialogMock(Gtk.FileDialog):
+    def __init__(self):
+        super().__init__()
+        self._save_response = Gio.File.parse_name("/unset")
 
-    @property
-    def stub_current_name(self):
-        return self._current_name
+    def save(self, parent, cancellable, callback):
+        self.save_callback = callback
+        callback(self, "mock result")
 
-    @property
-    def stub_current_folder(self):
-        return self._current_folder
+    def save_finish(self, result):
+        return self._save_response
 
-    def stub_select_file(self, folder, name):
-        self._current_folder = folder
-        self._current_name = name
-        assert self._response_callback
-        self._response_callback(self, Gtk.ResponseType.ACCEPT)
-
-    def connect(self, signal, callback):
-        assert signal == "response"
-        self._response_callback = callback
-
-    def get_file(self):
-        return Gio.File.new_for_path(self._current_folder).get_child(self._current_name)
-
-    def set_current_name(self, name: str):
-        self._current_name = name
-
-    def set_current_folder(self, name: Gio.File):
-        self._current_folder = name.get_parse_name()
-
-    def add_filter(self, filter):
-        pass
-
-    def set_modal(self, modal):
-        pass
-
-    def show(self):
-        pass
-
-    def destroy(self):
-        pass
+    def define_response(self, response):
+        self._save_response = Gio.File.parse_name(response)
 
 
 @pytest.fixture
-def file_chooser(monkeypatch):
-    stub = FileChooserStub()
+def file_dialog(monkeypatch):
+    stub = FileDialogMock()
 
-    def new_file_chooser(title, parent, action, accept_label, cancel_label):
+    def new_file_dialog():
         return stub
 
-    monkeypatch.setattr("gi.repository.Gtk.FileChooserNative.new", new_file_chooser)
+    monkeypatch.setattr("gi.repository.Gtk.FileDialog.new", new_file_dialog)
     return stub
 
 
-def test_save_dialog(file_chooser):
+def test_save_dialog(file_dialog):
+    file_dialog.define_response("/test/path/model.gaphor")
     selected_file = None
 
     def save_handler(f):
@@ -79,12 +50,10 @@ def test_save_dialog(file_chooser):
         filters=[],
     )
 
-    file_chooser.stub_select_file("/test/path", "model.gaphor")
-
     assert selected_file.parts == (os.path.sep, "test", "path", "model.gaphor")
 
 
-def test_save_dialog_with_full_file_name(file_chooser):
+def test_save_dialog_with_full_file_name(file_dialog):
     selected_file = None
 
     def save_handler(f):
@@ -100,35 +69,11 @@ def test_save_dialog_with_full_file_name(file_chooser):
         filters=[],
     )
 
-    assert file_chooser.stub_current_folder == str(filename.parent)
-    assert file_chooser.stub_current_name == filename.name
+    assert file_dialog.get_initial_name() == filename.name
 
 
-def test_save_dialog_with_only_file_name(file_chooser):
-    selected_file = None
-
-    def save_handler(f):
-        nonlocal selected_file
-        selected_file = f
-
-    filename = Path("model.gaphor")
-    save_file_dialog(
-        "title",
-        save_handler,
-        filename=filename,
-        extension=".gaphor",
-        filters=[],
-    )
-
-    # On GitHub CI, the path is returning the absolute path, both are fine
-    assert file_chooser.stub_current_folder in (
-        str(filename.parent),
-        str(filename.parent.absolute()),
-    )
-    assert file_chooser.stub_current_name == filename.name
-
-
-def test_save_dialog_filename_without_extension(file_chooser):
+def test_save_dialog_filename_without_extension(file_dialog):
+    file_dialog.define_response("/test/path/model")
     selected_file = None
 
     def save_handler(f):
@@ -142,8 +87,6 @@ def test_save_dialog_filename_without_extension(file_chooser):
         extension=".gaphor",
         filters=[],
     )
-
-    file_chooser.stub_select_file("/test/path", "model")
 
     assert selected_file.parts == (os.path.sep, "test", "path", "model.gaphor")
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -2124,7 +2124,7 @@ msgstr "Estat"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
 #, fuzzy
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Anomena i desa el model de Gaphor"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/cs.po
+++ b/po/cs.po
@@ -2099,7 +2099,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Všechny modely Gaphor"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/de.po
+++ b/po/de.po
@@ -2096,7 +2096,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Alle Gaphor-Modelle"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/es.po
+++ b/po/es.po
@@ -2087,7 +2087,7 @@ msgid "Date"
 msgstr "Fecha"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Todos los modelos Gaphor"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/fi.po
+++ b/po/fi.po
@@ -2067,7 +2067,7 @@ msgid "Date"
 msgstr "Päiväys"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Kaikki Gaphor-mallit"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/fr.po
+++ b/po/fr.po
@@ -2107,7 +2107,7 @@ msgstr "État"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
 #, fuzzy
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Modèles Gaphor"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/gaphor.pot
+++ b/po/gaphor.pot
@@ -1999,7 +1999,7 @@ msgid "Date"
 msgstr ""
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr ""
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/gl.po
+++ b/po/gl.po
@@ -2081,7 +2081,7 @@ msgid "Date"
 msgstr "dataType"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Todos os modelos Gaphor"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/hr.po
+++ b/po/hr.po
@@ -2081,7 +2081,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Svi Gaphor modeli"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/hu.po
+++ b/po/hu.po
@@ -2097,7 +2097,7 @@ msgid "Date"
 msgstr "Dátum"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Minden Gaphor-modell"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/it.po
+++ b/po/it.po
@@ -2151,7 +2151,7 @@ msgstr "Stato"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
 #, fuzzy
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Modelli Gaphor"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/ja.po
+++ b/po/ja.po
@@ -2100,7 +2100,7 @@ msgid "Date"
 msgstr "状態"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "全Gaphorモデル"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/ko.po
+++ b/po/ko.po
@@ -2138,7 +2138,7 @@ msgid "Date"
 msgstr "데이터형식"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "모든 가포 모델"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/nl.po
+++ b/po/nl.po
@@ -2084,7 +2084,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Alle Gaphor-modellen"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/pl.po
+++ b/po/pl.po
@@ -2062,7 +2062,7 @@ msgid "Date"
 msgstr "Data"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Wszystkie modele Gaphora"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2102,7 +2102,7 @@ msgid "Date"
 msgstr "Tipo de dado"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Todos os modelos Gaphor"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/ru.po
+++ b/po/ru.po
@@ -2083,7 +2083,7 @@ msgid "Date"
 msgstr "Дата"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Все Модели Gaphor"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/sl.po
+++ b/po/sl.po
@@ -2012,7 +2012,7 @@ msgid "Date"
 msgstr ""
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr ""
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/sv.po
+++ b/po/sv.po
@@ -2095,7 +2095,7 @@ msgstr "Datum"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
 #, fuzzy
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Alla Gaphormodeller"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/ta.po
+++ b/po/ta.po
@@ -2002,7 +2002,7 @@ msgid "Date"
 msgstr ""
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr ""
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/tr.po
+++ b/po/tr.po
@@ -2087,7 +2087,7 @@ msgid "Date"
 msgstr "Tarih"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
+msgid "Gaphor Models"
 msgstr "Tüm Gaphor Modelleri"
 
 #: gaphor/ui/appfilemanager.py:42

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -2061,8 +2061,8 @@ msgid "Date"
 msgstr "日期"
 
 #: gaphor/ui/appfilemanager.py:16 gaphor/ui/filedialog.py:13
-msgid "All Gaphor Models"
-msgstr "所有 Gaphor 模型"
+msgid "Gaphor Models"
+msgstr "Gaphor 模型"
 
 #: gaphor/ui/appfilemanager.py:42
 msgid "Switch to {name}?"


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?


Issue Number: #2231 

### What is the new behavior?

Use the modern `FileDialog` API.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Not sure if it's still using the native dialogs on Windows and macOS.

`Gtk.FileDialog` is introduced in GTK 4.10. ~We're still building on 4.6 (Ubuntu 22.04). 
I think we can wait until we have GTK 4.10+ available on our build machines.~
