### PR TITLE
Replace deprecated Gtk.TreeView with ListView: Activity Parameter Nodes

### DIFF
--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -19,9 +19,10 @@ new_builder = new_resource_builder("gaphor.UML.actions")
 
 
 class ActivityParameterNodeView(GObject.Object):
-    def __init__(self, node: UML.ActivityParameterNode | None):
+    def __init__(self, node: UML.ActivityParameterNode | None, activity: UML.Activity):
         super().__init__()
         self.node = node
+        self.activity = activity
 
     @GObject.Property(type=str)
     def parameter(self) -> str:
@@ -30,6 +31,12 @@ class ActivityParameterNodeView(GObject.Object):
     @parameter.setter  # type: ignore[no-redef]
     @transactional
     def parameter(self, value):
+        if not self.node:
+            model = self.activity.model
+            node = model.create(UML.ActivityParameterNode)
+            node.parameter = model.create(UML.Parameter)
+            self.node = node
+            self.activity.node = node
         parse(self.node.parameter, value)
 
 
@@ -38,8 +45,8 @@ def activity_parameter_node_model(activity: UML.Activity) -> Gio.ListModel:
 
     for node in activity.node:
         if isinstance(node, UML.ActivityParameterNode) and node.parameter:
-            store.append(ActivityParameterNodeView(node))
-    store.append(ActivityParameterNodeView(None))
+            store.append(ActivityParameterNodeView(node, activity))
+    store.append(ActivityParameterNodeView(None, activity))
 
     return store
 

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -165,6 +165,14 @@ def list_item_factory_setup(_factory, list_item):
     key_ctrl.connect("key-pressed", text_key_pressed)
     text.add_controller(key_ctrl)
 
+    def double_click(ctrl, n_press, x, y):
+        if n_press == 2:
+            stack.activate_action("parameter.rename")
+
+    click_ctrl = Gtk.GestureClick.new()
+    click_ctrl.connect("pressed", double_click)
+    builder.get_object("label").add_controller(click_ctrl)
+
     def start_editing(stack, pspec):
         if stack.get_visible_child_name() == "editing":
             text.grab_focus()

--- a/gaphor/UML/actions/parameter.ui
+++ b/gaphor/UML/actions/parameter.ui
@@ -5,7 +5,7 @@
     <property name="child">
       <object class="GtkStack" id="stack">
         <binding name="visible-child-name">
-          <lookup name="mode" type="gaphor+UML+actions+activitypropertypage+ActivityParameterNodeView">
+          <lookup name="mode" type="ActivityParameterNodeView">
             <lookup name="item">GtkListItem</lookup>
           </lookup>
         </binding>
@@ -16,7 +16,7 @@
               <object class="GtkLabel">
                 <property name="xalign">0</property>
                 <binding name="label">
-                  <lookup name="parameter" type="gaphor+UML+actions+activitypropertypage+ActivityParameterNodeView">
+                  <lookup name="parameter" type="ActivityParameterNodeView">
                     <lookup name="item">GtkListItem</lookup>
                   </lookup>
                 </binding>
@@ -43,7 +43,7 @@
   </template>
   <object class="GtkEntryBuffer" id="buffer">
     <binding name="text">
-      <lookup name="parameter" type="gaphor+UML+actions+activitypropertypage+ActivityParameterNodeView">
+      <lookup name="parameter" type="ActivityParameterNodeView">
         <lookup name="item">GtkListItem</lookup>
       </lookup>
     </binding>

--- a/gaphor/UML/actions/parameter.ui
+++ b/gaphor/UML/actions/parameter.ui
@@ -16,7 +16,7 @@
           <object class="GtkStackPage">
             <property name="name">readonly</property>
             <property name="child">
-              <object class="GtkLabel">
+              <object class="GtkLabel" id="label">
                 <property name="xalign">0</property>
                 <binding name="label">
                   <lookup name="parameter" type="ActivityParameterNodeView">

--- a/gaphor/UML/actions/parameter.ui
+++ b/gaphor/UML/actions/parameter.ui
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<interface>
+  <requires lib="gtk" version="4.6"/>
+  <template class="GtkListItem">
+    <property name="child">
+      <object class="GtkLabel">
+        <property name="xalign">0</property>
+        <binding name="label">
+          <lookup name="parameter" type="gaphor+UML+actions+activitypropertypage+ActivityParameterNodeView">
+            <lookup name="item">GtkListItem</lookup>
+          </lookup>
+        </binding>
+      </object>
+    </property>
+  </template>
+</interface>

--- a/gaphor/UML/actions/parameter.ui
+++ b/gaphor/UML/actions/parameter.ui
@@ -4,6 +4,9 @@
   <template class="GtkListItem">
     <property name="child">
       <object class="GtkStack" id="stack">
+        <style>
+          <class name="row"/>
+        </style>
         <binding name="visible-child-name">
           <lookup name="mode" type="ActivityParameterNodeView">
             <lookup name="item">GtkListItem</lookup>

--- a/gaphor/UML/actions/parameter.ui
+++ b/gaphor/UML/actions/parameter.ui
@@ -3,14 +3,49 @@
   <requires lib="gtk" version="4.6"/>
   <template class="GtkListItem">
     <property name="child">
-      <object class="GtkLabel">
-        <property name="xalign">0</property>
-        <binding name="label">
-          <lookup name="parameter" type="gaphor+UML+actions+activitypropertypage+ActivityParameterNodeView">
+      <object class="GtkStack" id="stack">
+        <binding name="visible-child-name">
+          <lookup name="mode" type="gaphor+UML+actions+activitypropertypage+ActivityParameterNodeView">
             <lookup name="item">GtkListItem</lookup>
           </lookup>
         </binding>
+        <child>
+          <object class="GtkStackPage">
+            <property name="name">readonly</property>
+            <property name="child">
+              <object class="GtkLabel">
+                <property name="xalign">0</property>
+                <binding name="label">
+                  <lookup name="parameter" type="gaphor+UML+actions+activitypropertypage+ActivityParameterNodeView">
+                    <lookup name="item">GtkListItem</lookup>
+                  </lookup>
+                </binding>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStackPage">
+            <property name="name">editing</property>
+            <property name="child">
+              <object class="GtkText" id="text">
+                <property name="propagate-text-width">yes</property>
+                <property name="buffer">buffer</property>
+                <style>
+                  <class name="editing"/>
+                </style>
+              </object>
+            </property>
+          </object>
+        </child>
       </object>
     </property>
   </template>
+  <object class="GtkEntryBuffer" id="buffer">
+    <binding name="text">
+      <lookup name="parameter" type="gaphor+UML+actions+activitypropertypage+ActivityParameterNodeView">
+        <lookup name="item">GtkListItem</lookup>
+      </lookup>
+    </binding>
+  </object>
 </interface>

--- a/gaphor/UML/actions/parameter.ui
+++ b/gaphor/UML/actions/parameter.ui
@@ -3,52 +3,16 @@
   <requires lib="gtk" version="4.6"/>
   <template class="GtkListItem">
     <property name="child">
-      <object class="GtkStack" id="stack">
+      <object class="GtkEditableLabel" id="text">
         <style>
           <class name="row"/>
         </style>
-        <binding name="visible-child-name">
-          <lookup name="mode" type="ActivityParameterNodeView">
+        <binding name="text">
+          <lookup name="parameter" type="ActivityParameterNodeView">
             <lookup name="item">GtkListItem</lookup>
           </lookup>
         </binding>
-        <child>
-          <object class="GtkStackPage">
-            <property name="name">readonly</property>
-            <property name="child">
-              <object class="GtkLabel" id="label">
-                <property name="xalign">0</property>
-                <binding name="label">
-                  <lookup name="parameter" type="ActivityParameterNodeView">
-                    <lookup name="item">GtkListItem</lookup>
-                  </lookup>
-                </binding>
-              </object>
-            </property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkStackPage">
-            <property name="name">editing</property>
-            <property name="child">
-              <object class="GtkText" id="text">
-                <property name="propagate-text-width">yes</property>
-                <property name="buffer">buffer</property>
-                <style>
-                  <class name="editing"/>
-                </style>
-              </object>
-            </property>
-          </object>
-        </child>
       </object>
     </property>
   </template>
-  <object class="GtkEntryBuffer" id="buffer">
-    <binding name="text">
-      <lookup name="parameter" type="ActivityParameterNodeView">
-        <lookup name="item">GtkListItem</lookup>
-      </lookup>
-    </binding>
-  </object>
 </interface>

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -259,35 +259,9 @@
         <child>
           <object class="GtkFrame">
             <property name="child">
-              <object class="GtkTreeView" id="parameter-list">
+              <object class="GtkListView" id="parameter-list">
                 <property name="height-request">112</property>
                 <property name="focusable">1</property>
-                <property name="headers-clickable">0</property>
-                <property name="enable-search">0</property>
-                <property name="show-expanders">0</property>
-                <property name="enable-grid-lines">horizontal</property>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection"/>
-                </child>
-                <child>
-                  <object class="GtkTreeViewColumn">
-                    <property name="resizable">1</property>
-                    <property name="title" translatable="yes">Parameters</property>
-                    <property name="expand">1</property>
-                    <child>
-                      <object class="GtkCellRendererText">
-                        <property name="xpad">2</property>
-                        <property name="ypad">2</property>
-                        <property name="xalign">0</property>
-                        <property name="editable">1</property>
-                        <signal name="edited" handler="parameter-edited" swapped="no"/>
-                      </object>
-                      <attributes>
-                        <attribute name="text">0</attribute>
-                      </attributes>
-                    </child>
-                  </object>
-                </child>
               </object>
             </property>
           </object>

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -1,3 +1,4 @@
+import pytest
 from gi.repository import Gtk
 
 from gaphor import UML
@@ -40,13 +41,15 @@ def test_activity_parameter_node_reorder(create, element_factory):
     assert activity_item.subject.node[2] is node2
 
 
+@pytest.mark.skip
 def test_activity_page_add_attribute(create):
     activity_item = create(ActivityItem, UML.Activity)
     property_page = ActivityItemPage(activity_item)
 
     property_page.construct()
-    iter = property_page.model.get_iter((0,))
-    property_page.model.update(iter, 0, "in attr: str")
+    view = property_page.model.get_item(0)
+
+    view.parameter = "in attr: str"
 
     assert activity_item.subject.node[0].parameter.direction == "in"
     assert activity_item.subject.node[0].parameter.name == "attr"

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -64,6 +64,62 @@ def test_activity_parameter_node_add_new_parameter(element_factory):
     assert parameter.typeValue == "str"
 
 
+def test_update_model_when_new_parameter_added(create, element_factory):
+    activity_item = create(ActivityItem, UML.Activity)
+
+    property_page = ActivityItemPage(activity_item)
+    property_page.construct()
+
+    activity_item.subject.node = activity_parameter_node(element_factory, "one")
+
+    assert property_page.model.get_n_items() == 2  # one + empty row
+
+
+def test_update_model_when_new_parameter_added_via_list_model(create, element_factory):
+    activity_item = create(ActivityItem, UML.Activity)
+
+    property_page = ActivityItemPage(activity_item)
+    property_page.construct()
+
+    new_view = property_page.model.get_item(0)
+    new_view.parameter = "new"
+
+    assert property_page.model.get_n_items() == 2  # one + empty row
+    assert property_page.model.get_item(0).node is new_view.node
+    assert property_page.model.get_item(1).node is None
+
+
+def test_update_model_with_single_node_when_parameter_deleted(create, element_factory):
+    activity_item = create(ActivityItem, UML.Activity)
+    activity_item.subject.node = node = activity_parameter_node(element_factory, "one")
+
+    property_page = ActivityItemPage(activity_item)
+    property_page.construct()
+
+    del activity_item.subject.node[node]
+
+    assert not activity_item.subject.node
+    assert property_page.model.get_n_items() == 1
+    assert property_page.model.get_item(0).node is None
+
+
+def test_update_model_with_multiple_nodes_when_parameter_deleted(
+    create, element_factory
+):
+    activity_item = create(ActivityItem, UML.Activity)
+    activity_item.subject.node = node = activity_parameter_node(element_factory, "one")
+    activity_item.subject.node = activity_parameter_node(element_factory, "two")
+
+    property_page = ActivityItemPage(activity_item)
+    property_page.construct()
+
+    del activity_item.subject.node[node]
+
+    assert property_page.model.get_n_items() == 2
+    assert property_page.model.get_item(0).node in activity_item.subject.node
+    assert property_page.model.get_item(1).node is None
+
+
 @pytest.mark.skip
 def test_activity_parameter_node_reorder(create, element_factory):
     ...

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -1,7 +1,9 @@
 import pytest
 
 from gaphor import UML
+from gaphor.UML.actions.activity import ActivityItem
 from gaphor.UML.actions.activitypropertypage import (
+    ActivityItemPage,
     activity_parameter_node_model,
 )
 
@@ -65,3 +67,12 @@ def test_activity_parameter_node_add_new_parameter(element_factory):
 @pytest.mark.skip
 def test_activity_parameter_node_reorder(create, element_factory):
     ...
+
+
+def test_construct_activity_itemproperty_page(create):
+    activity_item = create(ActivityItem, UML.Activity)
+
+    property_page = ActivityItemPage(activity_item)
+    widget = property_page.construct()
+
+    assert widget

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -1,11 +1,12 @@
-import pytest
-
+from gi.repository import Gdk
 from gaphor import UML
 from gaphor.UML.actions.activity import ActivityItem
 from gaphor.UML.actions.activitypropertypage import (
     ActivityItemPage,
     activity_parameter_node_model,
+    list_view_handler,
 )
+from gaphor.diagram.tests.fixtures import find
 
 
 def activity_parameter_node(element_factory, name=None):
@@ -120,9 +121,59 @@ def test_update_model_with_multiple_nodes_when_parameter_deleted(
     assert property_page.model.get_item(1).node is None
 
 
-@pytest.mark.skip
-def test_activity_parameter_node_reorder(create, element_factory):
-    ...
+def test_activity_parameter_node_reorder_down(create, element_factory):
+    activity_item = create(ActivityItem, UML.Activity)
+    activity_item.subject.node = activity_parameter_node(element_factory, "one")
+    activity_item.subject.node = activity_parameter_node(element_factory, "two")
+    node_one, node_two = activity_item.subject.node
+
+    property_page = ActivityItemPage(activity_item)
+    widget = property_page.construct()
+
+    list_view = find(widget, "parameter-list")
+    selection = list_view.get_model()
+
+    list_view_handler(None, Gdk.KEY_plus, None, 0, selection)
+
+    assert activity_item.subject.node[0] is node_two
+    assert activity_item.subject.node[1] is node_one
+
+
+def test_activity_parameter_node_reorder_up(create, element_factory):
+    activity_item = create(ActivityItem, UML.Activity)
+    activity_item.subject.node = activity_parameter_node(element_factory, "one")
+    activity_item.subject.node = activity_parameter_node(element_factory, "two")
+    node_one, node_two = activity_item.subject.node
+
+    property_page = ActivityItemPage(activity_item)
+    widget = property_page.construct()
+
+    list_view = find(widget, "parameter-list")
+    selection = list_view.get_model()
+    selection.set_selected(1)
+
+    list_view_handler(None, Gdk.KEY_minus, None, 0, selection)
+
+    assert activity_item.subject.node[0] is node_two
+    assert activity_item.subject.node[1] is node_one
+
+
+def test_activity_parameter_node_reorder_first_node_up(create, element_factory):
+    activity_item = create(ActivityItem, UML.Activity)
+    activity_item.subject.node = activity_parameter_node(element_factory, "one")
+    activity_item.subject.node = activity_parameter_node(element_factory, "two")
+    node_one, node_two = activity_item.subject.node
+
+    property_page = ActivityItemPage(activity_item)
+    widget = property_page.construct()
+
+    list_view = find(widget, "parameter-list")
+    selection = list_view.get_model()
+
+    list_view_handler(None, Gdk.KEY_minus, None, 0, selection)
+
+    assert activity_item.subject.node[0] is node_one
+    assert activity_item.subject.node[1] is node_two
 
 
 def test_construct_activity_itemproperty_page(create):

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -104,6 +104,15 @@ frame > textview {
   padding: 6px;
 }
 
+.editing {
+  background-color: @theme_bg_color;
+  color: @theme_fg_color;
+}
+
+.editing selection {
+  background-color: alpha(@theme_selected_bg_color, 0.3);
+}
+
 .info:hover {
   background-color: @shade_color;
 }
@@ -114,15 +123,6 @@ frame > textview {
 
 #model_browser treeexpander {
   margin: 0 6px;
-}
-
-#model_browser .editing {
-  background-color: @theme_bg_color;
-  color: @theme_fg_color;
-}
-
-#model_browser .editing selection {
-  background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
 #model_browser .row {

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -104,6 +104,10 @@ frame > textview {
   padding: 6px;
 }
 
+listview .row {
+  padding: 2px 0;
+}
+
 .editing {
   background-color: @theme_bg_color;
   color: @theme_fg_color;
@@ -126,7 +130,6 @@ frame > textview {
 }
 
 #model_browser .row {
-  padding: 2px 0;
   border-top: 0 solid @shade_color;
   transition: border 200ms;
 }

--- a/gaphor/ui/treeitem.ui
+++ b/gaphor/ui/treeitem.ui
@@ -10,7 +10,9 @@
         </binding>
         <property name="child">
           <object class="GtkBox" id="row">
-            <style><class name="row"/></style>
+            <style>
+              <class name="row"/>
+            </style>
             <property name="spacing">6</property>
             <child>
               <object class="GtkImage">


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

`Gtk.TreeView` is deprecated. GTK 4 has a much nicer tree widget: `Gtk.ListVIew`. It's already used for the model browser. We should also use it in the property editor, for both consistency and ease of use.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

`Gtk.ListView` has no header. This will be [introduced in GTK 4.12](https://docs.gtk.org/gtk4/property.ListView.header-factory.html). So we may want to postpone changing to `ListView`s.