### PR TITLE
Use consistent naming for element_factory in storage module

### DIFF
--- a/gaphor/conftest.py
+++ b/gaphor/conftest.py
@@ -92,7 +92,9 @@ def loader(element_factory, modeling_language):
         assert not list(element_factory.select())
 
         f = StringIO(data)
-        storage.load(f, factory=element_factory, modeling_language=modeling_language)
+        storage.load(
+            f, element_factory=element_factory, modeling_language=modeling_language
+        )
         f.close()
 
     return load

--- a/gaphor/storage/tests/test_storage.py
+++ b/gaphor/storage/tests/test_storage.py
@@ -49,7 +49,7 @@ def test_save_uml(element_factory):
     element_factory.create(UML.Class)
 
     out = PseudoFile()
-    storage.save(out, factory=element_factory)
+    storage.save(out, element_factory=element_factory)
     out.close()
 
     assert "<Package " in out.data
@@ -64,7 +64,7 @@ def test_save_item(diagram, element_factory):
     diagram.create(CommentItem, subject=element_factory.create(Comment))
 
     out = PseudoFile()
-    storage.save(out, factory=element_factory)
+    storage.save(out, element_factory=element_factory)
     out.close()
 
     assert "<Diagram " in out.data
@@ -198,7 +198,7 @@ def test_save_and_load_of_association_with_two_connected_classes(
     assert a.subject
 
     fd = StringIO()
-    storage.save(fd, factory=element_factory)
+    storage.save(fd, element_factory=element_factory)
     data = fd.getvalue()
     fd.close()
 
@@ -207,7 +207,9 @@ def test_save_and_load_of_association_with_two_connected_classes(
     element_factory.flush()
     assert not list(element_factory.select())
     fd = StringIO(data)
-    storage.load(fd, factory=element_factory, modeling_language=modeling_language)
+    storage.load(
+        fd, element_factory=element_factory, modeling_language=modeling_language
+    )
     fd.close()
 
     diagrams = element_factory.lselect(Diagram)
@@ -229,13 +231,13 @@ def test_load_and_save_of_a_model(element_factory, modeling_language, test_model
     with open(path, encoding="utf-8") as ifile:
         storage.load(
             ifile,
-            factory=element_factory,
+            element_factory=element_factory,
             modeling_language=modeling_language,
         )
 
     pf = PseudoFile()
 
-    storage.save(pf, factory=element_factory)
+    storage.save(pf, element_factory=element_factory)
 
     orig = path.read_text(encoding="utf-8")
     copy = pf.data
@@ -256,7 +258,7 @@ def test_can_not_load_models_older_that_0_17_0(
         with open(path, encoding="utf-8") as ifile:
             storage.load(
                 ifile,
-                factory=element_factory,
+                element_factory=element_factory,
                 modeling_language=modeling_language,
             )
 

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -290,7 +290,7 @@ class ModelConsistency(RuleBasedStateMachine):
                 buffer.seek(0)
                 storage.load(
                     buffer,
-                    factory=new_model,
+                    element_factory=new_model,
                     modeling_language=self.session.get_service("modeling_language"),
                 )
 


### PR DESCRIPTION
Rename all `factory` arguments to `element_factory`, so the naming is in line with the rest of the app.

<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [ ] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
