### PR TITLE
Enable PyPI trusted publisher

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -335,6 +335,8 @@ jobs:
     name: Publish to PyPI (release only)
     needs: [ linux-wheel, linux-flatpak-devel, check-macos-app, check-windows-installer ]
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
     if: github.event_name == 'release'
     outputs:
       version: ${{ needs.linux-wheel.outputs.version }}
@@ -348,8 +350,6 @@ jobs:
           name: ${{ needs.linux-wheel.outputs.wheel }}
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
 
   trigger-website-version-update:
     name: Trigger version update on gaphor/gaphor.github.io

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -10,21 +10,8 @@ env:
   mainline_build: ${{ github.ref == 'refs/heads/main' || github.event.label.name == 'translation' || github.event_name == 'release' }}
 
 jobs:
-  skip-check:
-    name: Skip Run if Duplicate
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5.3.0
-        with:
-          concurrent_skipping: 'same_content'
-          do_not_skip: '["release", "workflow_dispatch", "schedule"]'
-
   lint:
     name: Lint
-    needs: skip-check
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: "!contains(github.event.head_commit.message, 'skip ci')"
@@ -195,7 +182,6 @@ jobs:
 
   windows-build-gtk:
     name: Windows (Build GTK)
-    needs: skip-check
     runs-on: windows-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
This PR replaces using a PyPI token with the new trusted publisher feature. I also removed the skip check action since I haven't seen it actually skipping any runs.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
