### PR TITLE
UI: Mark translatable strings yes

### DIFF
--- a/gaphor/UML/states/propertypages.ui
+++ b/gaphor/UML/states/propertypages.ui
@@ -87,7 +87,7 @@
     <property name="margin-top">12</property>
     <child type="label">
       <object class="GtkLabel" id="titlelabel">
-        <property name="label" translatable="1">Regions</property>
+        <property name="label" translatable="yes">Regions</property>
         <attributes>
           <attribute name="weight" value="bold"></attribute>
         </attributes>
@@ -100,7 +100,7 @@
           <object class="GtkBox">
             <child>
               <object class="GtkLabel">
-                <property name="label" translatable="1">Show Regions</property>
+                <property name="label" translatable="yes">Show Regions</property>
                 <property name="halign">start</property>
                 <property name="hexpand">1</property>
               </object>
@@ -116,7 +116,7 @@
           <object class="GtkBox">
             <child>
               <object class="GtkLabel">
-                <property name="label" translatable="1">Regions</property>
+                <property name="label" translatable="yes">Regions</property>
                 <property name="halign">start</property>
                 <property name="hexpand">1</property>
               </object>

--- a/gaphor/plugins/errorreports/errorreports.ui
+++ b/gaphor/plugins/errorreports/errorreports.ui
@@ -3,7 +3,7 @@
   <requires lib="gtk" version="4.0"/>
   <object class="GtkTextBuffer" id="buffer"/>
   <object class="GtkWindow" id="error-reports">
-    <property name="title" translatable="1">Error Reports</property>
+    <property name="title" translatable="yes">Error Reports</property>
     <property name="default-width">600</property>
     <property name="default-height">400</property>
     <property name="child">
@@ -15,7 +15,7 @@
             <property name="margin-end">6</property>
             <property name="margin-top">6</property>
             <property name="margin-bottom">6</property>
-            <property name="label" translatable="1">Any unhandled errors are shown here. You can use these to provide extra information when you create an issue on GitHub.</property>
+            <property name="label" translatable="yes">Any unhandled errors are shown here. You can use these to provide extra information when you create an issue on GitHub.</property>
             <property name="wrap">1</property>
             <property name="xalign">0</property>
           </object>

--- a/gaphor/ui/mainwindow.ui
+++ b/gaphor/ui/mainwindow.ui
@@ -60,7 +60,7 @@
           <object class="GtkMenuButton">
             <property name="icon_name">list-add-symbolic</property>
             <property name="popover">diagram-types</property>
-            <property name="tooltip-text" translatable="true">New diagram menu</property>
+            <property name="tooltip-text" translatable="yes">New diagram menu</property>
             <property name="always-show-arrow">1</property>
           </object>
         </child>
@@ -68,14 +68,14 @@
           <object class="GtkMenuButton">
             <property name="popover">hamburger</property>
             <property name="icon_name">open-menu-symbolic</property>
-            <property name="tooltip-text" translatable="true">Open application menu</property>
+            <property name="tooltip-text" translatable="yes">Open application menu</property>
             <property name="primary">1</property>
           </object>
         </child>
         <child type="end">
           <object class="GtkToggleButton">
             <property name="action_name">win.show-editors</property>
-            <property name="tooltip-text" translatable="true">Toggle property editor</property>
+            <property name="tooltip-text" translatable="yes">Toggle property editor</property>
             <child>
               <object class="GtkImage">
                 <property name="icon_name">sidebar-show-right-symbolic</property>


### PR DESCRIPTION
It appeares that using "yes" is a common practice for translatable strings in GNOME apps.

### PR Checklist
- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

- [x] Chore (refactoring, formatting, local variables, other cleanup)

### Does this PR introduce a breaking change?
- [x] No

