### PR TITLE
Add a simple pip-based plugin installer

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: 05f6288b94a87daa172d3e96a33ec331a4374be7d01eb9a42b3b21c4c550a8ff
         with:
-          coverageCommand: poetry run coverage xml
+          coverageCommand: poetry run coverage xml --omit="/tmp/*"
       - name: Create Source Dist and Wheel
         if: ${{ matrix.python_version == env.python_version }}
         run: poetry build

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ html
 *~
 \#*\#
 .eggs/
-gaphor.egg-info/
+*.egg-info/
 gaphor.prof
 .gpg
 pip-wheel-metadata

--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -74,7 +74,15 @@ a = Analysis(  # type: ignore
         "gaphor.modelinglanguages",
         "gaphor.modules",
     )
-    + ["_cffi_backend", "babel.numbers"],
+    + [
+        "_cffi_backend",
+        "babel.numbers",
+        "pip.__main__",
+        "pip._internal.commands.check",
+        "pip._internal.commands.install",
+        "pip._internal.commands.list",
+        "pip._internal.commands.uninstall",
+    ],
     hooksconfig={
         "gi": {
             "module-versions": {

--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -40,6 +40,27 @@ def collect_entry_points(*names):
     return hidden_imports
 
 
+import glob
+import pip
+from pip._internal.commands import commands_dict as pip_commands_dict
+
+pip_hiddenimports: list[str] = [
+    "pip.__main__",
+    "pip.__pip-runner__",
+    "pip._vendor.pyproject_hooks._in_process._in_process",
+    *(c.module_path for c in pip_commands_dict.values()),
+    "setuptools.build_meta",
+    "wheel.__main__",
+]
+
+pip_datas: list[tuple[str, str]] = [
+    (
+        str(Path(pip.__file__).parent / "_vendor" / "certifi" / "cacert.pem"),
+        "pip/_vendor/certifi",
+    )
+]
+
+
 a = Analysis(  # type: ignore
     ["../gaphor/__main__.py"],
     pathex=["../"],
@@ -63,6 +84,7 @@ a = Analysis(  # type: ignore
         ("../gaphor/ui/language-specs/*.lang", "gaphor/ui/language-specs"),
         ("../LICENSE.txt", "gaphor"),
         ("../gaphor/templates/*.gaphor", "gaphor/templates"),
+        *pip_datas,
     ]
     + ui_files
     + mo_files
@@ -77,12 +99,8 @@ a = Analysis(  # type: ignore
     + [
         "_cffi_backend",
         "babel.numbers",
-        "pip.__main__",
-        "pip._internal.commands.check",
-        "pip._internal.commands.install",
-        "pip._internal.commands.list",
-        "pip._internal.commands.uninstall",
-    ],
+    ]
+    + pip_hiddenimports,
     hooksconfig={
         "gi": {
             "module-versions": {

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -13,6 +13,15 @@ LOG_FORMAT = "%(name)s %(levelname)s %(message)s"
 def main(argv=sys.argv) -> int:
     """Start Gaphor from the command line."""
 
+    # This is a workaround for plugin installs: pip launches
+    # subprocesses and we need to catch those, since we only
+    # have one main process when the app is packaged with
+    # PyInstaller.
+    if os.getenv("_GAPHOR_PIP_RUNNING_IN_SUBPROCESS") == "1":
+        from gaphor.plugins.manager import run_pip_subprocess
+
+        return run_pip_subprocess(sys.argv)
+
     logging_config()
 
     with enable_plugins(default_plugin_path()):

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -5,6 +5,7 @@ import sys
 
 from gaphor.application import distribution
 from gaphor.entrypoint import initialize
+from gaphor.plugins import enable_plugins, default_plugin_path
 
 LOG_FORMAT = "%(name)s %(levelname)s %(message)s"
 
@@ -14,22 +15,23 @@ def main(argv=sys.argv) -> int:
 
     logging_config()
 
-    commands: dict[str, argparse.ArgumentParser] = initialize("gaphor.argparsers")
+    with enable_plugins(default_plugin_path()):
+        commands: dict[str, argparse.ArgumentParser] = initialize("gaphor.argparsers")
 
-    args = parse_args(argv[1:], commands)
+        args = parse_args(argv[1:], commands)
 
-    if args.profiler:
-        import cProfile
-        import pstats
+        if args.profiler:
+            import cProfile
+            import pstats
 
-        with cProfile.Profile() as profile:
-            exit_code: int = profile.runcall(args.command, args)
+            with cProfile.Profile() as profile:
+                exit_code: int = profile.runcall(args.command, args)
 
-        profile_stats = pstats.Stats(profile)
-        profile_stats.strip_dirs().sort_stats("time").print_stats(50)
-        return exit_code
+            profile_stats = pstats.Stats(profile)
+            profile_stats.strip_dirs().sort_stats("time").print_stats(50)
+            return exit_code
 
-    return args.command(args)  # type: ignore[no-any-return]
+        return args.command(args)  # type: ignore[no-any-return]
 
 
 def parse_args(args: list[str], commands: dict[str, argparse.ArgumentParser]):

--- a/gaphor/plugins/__init__.py
+++ b/gaphor/plugins/__init__.py
@@ -25,12 +25,14 @@ import sys
 
 from gaphor import entrypoint
 
+PLUGIN_VERSION = 2
+
 
 def default_plugin_path() -> pathlib.Path:
     if plugin_path_envvar := os.getenv("GAPHOR_PLUGIN_PATH"):
         return pathlib.Path(plugin_path_envvar)
     else:
-        return pathlib.Path.home() / ".local" / "gaphor" / "plugins-2"
+        return pathlib.Path.home() / ".local" / "gaphor" / f"plugins-{PLUGIN_VERSION}"
 
 
 @contextlib.contextmanager

--- a/gaphor/plugins/__init__.py
+++ b/gaphor/plugins/__init__.py
@@ -15,3 +15,45 @@ Plugins can be registered in Gaphor by declaring them as service entry point::
 There is a thin line between a service and a plugin. A service typically performs some basic need for the applications (such as the element factory or the undo mechanism). A plugin is more of an add-on. For example a plugin can depend on external libraries or provide a cross-over function between two applications.
 
 """
+import contextlib
+import importlib.abc
+import importlib.machinery
+import importlib.metadata
+import pathlib
+import os
+import sys
+
+from gaphor import entrypoint
+
+
+def default_plugin_path() -> pathlib.Path:
+    if plugin_path_envvar := os.getenv("GAPHOR_PLUGIN_PATH"):
+        return pathlib.Path(plugin_path_envvar)
+    else:
+        return pathlib.Path.home() / ".local" / "gaphor" / "plugins-2"
+
+
+@contextlib.contextmanager
+def enable_plugins(plugin_path: pathlib.Path):
+    entrypoint.list_entry_points.cache_clear()
+    path_finder = PluginMetaPathFinder(plugin_path)
+    sys.meta_path.append(path_finder)
+    yield
+    sys.meta_path.remove(path_finder)
+
+
+class PluginMetaPathFinder(importlib.abc.MetaPathFinder):
+    def __init__(self, plugin_path: pathlib.Path):
+        self.plugin_path = str(plugin_path)
+
+    def find_spec(self, fullname, path=None, target=None):
+        return importlib.machinery.PathFinder.find_spec(
+            fullname, path=[self.plugin_path], target=target
+        )
+
+    def find_distributions(self, *args, **kwargs):
+        return importlib.metadata.MetadataPathFinder.find_distributions(
+            context=importlib.metadata.DistributionFinder.Context(
+                path=[self.plugin_path]
+            )
+        )

--- a/gaphor/plugins/manager.py
+++ b/gaphor/plugins/manager.py
@@ -6,32 +6,44 @@ import sys
 
 
 from gaphor.plugins import default_plugin_path
+from gaphor.main import prog
 
 
 def parser():
-    parser = argparse.ArgumentParser(description="Export diagrams from a Gaphor model.")
+    parser = argparse.ArgumentParser(description="Plugin related subcommands.")
 
-    subparser = parser.add_subparsers(title="plugin subcommands")
+    subparser = parser.add_subparsers(
+        title="plugin subcommands",
+        description=f"Get help for plugin commands with {prog()} plugin COMMAND --help.",
+    )
 
     list_parser = subparser.add_parser(
-        "list", description="list all installed plugin modules"
+        "list",
+        description="List all installed plugin packages.",
+        help="list all installed plugin packages",
     )
     list_parser.set_defaults(command=list_plugins)
 
     install_parser = subparser.add_parser(
-        "install", description="install plugin modules"
+        "install",
+        description="Install plugin packages from pypi.",
+        help="install plugin packages",
     )
     install_parser.add_argument("name")
     install_parser.set_defaults(command=install_plugin)
 
     uninstall_parser = subparser.add_parser(
-        "uninstall", description="uninstalled plugin modules"
+        "uninstall",
+        description="Uninstall packages from the plugin folder.",
+        help="uninstalled plugin modules",
     )
     uninstall_parser.add_argument("name")
     uninstall_parser.set_defaults(command=uninstall_plugin)
 
     check_parser = subparser.add_parser(
-        "check", description="check plugin module dependencies"
+        "check",
+        description="Check plugin package dependencies.",
+        help="check plugin package dependencies",
     )
     check_parser.set_defaults(command=check_plugins)
 

--- a/gaphor/plugins/manager.py
+++ b/gaphor/plugins/manager.py
@@ -3,12 +3,9 @@
 import argparse
 import subprocess
 import sys
-import pathlib
 
-from gi.repository import GLib
 
-PLUGIN_PATH = pathlib.Path(GLib.get_user_state_dir(), "gaphor-plugins-2")
-PLUGIN_PATH.mkdir(parents=True, exist_ok=True)
+from gaphor.plugins import default_plugin_path
 
 
 def parser():
@@ -44,12 +41,26 @@ def parser():
 
 
 def list_plugins(args):
-    subprocess.run([sys.executable, "-m", "pip", "list", "--path", PLUGIN_PATH])
+    subprocess.run(
+        [sys.executable, "-m", "pip", "list", "--path", default_plugin_path()]
+    )
 
 
 def install_plugin(args):
+    path = default_plugin_path()
+    path.mkdir(parents=True, exist_ok=True)
+
     subprocess.run(
-        [sys.executable, "-m", "pip", "install", "--target", PLUGIN_PATH, args.name]
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--force-reinstall",
+            "--target",
+            path,
+            args.name,
+        ]
     )
 
 
@@ -57,7 +68,7 @@ def uninstall_plugin(args):
     subprocess.run(
         [sys.executable, "-m", "pip", "uninstall", args.name],
         env={
-            "PYTHONPATH": PLUGIN_PATH,
+            "PYTHONPATH": default_plugin_path(),
         },
     )
 
@@ -66,6 +77,6 @@ def check_plugins(args):
     subprocess.run(
         [sys.executable, "-m", "pip", "check"],
         env={
-            "PYTHONPATH": PLUGIN_PATH,
+            "PYTHONPATH": default_plugin_path(),
         },
     )

--- a/gaphor/plugins/manager.py
+++ b/gaphor/plugins/manager.py
@@ -1,0 +1,71 @@
+"""A plugins manager."""
+
+import argparse
+import subprocess
+import sys
+import pathlib
+
+from gi.repository import GLib
+
+PLUGIN_PATH = pathlib.Path(GLib.get_user_state_dir(), "gaphor-plugins-2")
+PLUGIN_PATH.mkdir(parents=True, exist_ok=True)
+
+
+def parser():
+    parser = argparse.ArgumentParser(description="Export diagrams from a Gaphor model.")
+
+    subparser = parser.add_subparsers(title="plugin subcommands")
+
+    list_parser = subparser.add_parser(
+        "list", description="list all installed plugin modules"
+    )
+    list_parser.set_defaults(command=list_plugins)
+
+    install_parser = subparser.add_parser(
+        "install", description="install plugin modules"
+    )
+    install_parser.add_argument("name")
+    install_parser.set_defaults(command=install_plugin)
+
+    uninstall_parser = subparser.add_parser(
+        "uninstall", description="uninstalled plugin modules"
+    )
+    uninstall_parser.add_argument("name")
+    uninstall_parser.set_defaults(command=uninstall_plugin)
+
+    check_parser = subparser.add_parser(
+        "check", description="check plugin module dependencies"
+    )
+    check_parser.set_defaults(command=check_plugins)
+
+    parser.set_defaults(command=lambda _: parser.print_usage())
+
+    return parser
+
+
+def list_plugins(args):
+    subprocess.run([sys.executable, "-m", "pip", "list", "--path", PLUGIN_PATH])
+
+
+def install_plugin(args):
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--target", PLUGIN_PATH, args.name]
+    )
+
+
+def uninstall_plugin(args):
+    subprocess.run(
+        [sys.executable, "-m", "pip", "uninstall", args.name],
+        env={
+            "PYTHONPATH": PLUGIN_PATH,
+        },
+    )
+
+
+def check_plugins(args):
+    subprocess.run(
+        [sys.executable, "-m", "pip", "check"],
+        env={
+            "PYTHONPATH": PLUGIN_PATH,
+        },
+    )

--- a/gaphor/plugins/manager.py
+++ b/gaphor/plugins/manager.py
@@ -54,7 +54,7 @@ def parser():
 
 def list_plugins(args):
     completed = subprocess.run(
-        [sys.executable, "-m", "pip", "list", "--path", default_plugin_path()],
+        [sys.executable, "-m", "pip", "list", "--path", str(default_plugin_path())],
         capture_output=True,
     )
     print(completed.stdout)
@@ -76,7 +76,7 @@ def install_plugin(args):
             "install",
             "--force-reinstall",
             "--target",
-            path,
+            str(path),
             args.name,
         ]
     )
@@ -87,7 +87,7 @@ def uninstall_plugin(args):
     completed = subprocess.run(
         [sys.executable, "-m", "pip", "uninstall", args.name],
         env={
-            "PYTHONPATH": default_plugin_path(),
+            "PYTHONPATH": str(default_plugin_path()),
         },
     )
     return completed.returncode
@@ -97,7 +97,7 @@ def check_plugins(args):
     completed = subprocess.run(
         [sys.executable, "-m", "pip", "check"],
         env={
-            "PYTHONPATH": default_plugin_path(),
+            "PYTHONPATH": str(default_plugin_path()),
         },
     )
     return completed.returncode

--- a/gaphor/plugins/manager.py
+++ b/gaphor/plugins/manager.py
@@ -41,16 +41,22 @@ def parser():
 
 
 def list_plugins(args):
-    subprocess.run(
-        [sys.executable, "-m", "pip", "list", "--path", default_plugin_path()]
+    completed = subprocess.run(
+        [sys.executable, "-m", "pip", "list", "--path", default_plugin_path()],
+        capture_output=True,
     )
+    print(completed.stdout)
+    if completed.stderr:
+        print("--- stderr ---", file=sys.stderr)
+        print(completed.stderr, file=sys.stderr)
+    return completed.returncode
 
 
 def install_plugin(args):
     path = default_plugin_path()
     path.mkdir(parents=True, exist_ok=True)
 
-    subprocess.run(
+    completed = subprocess.run(
         [
             sys.executable,
             "-m",
@@ -62,21 +68,24 @@ def install_plugin(args):
             args.name,
         ]
     )
+    return completed.returncode
 
 
 def uninstall_plugin(args):
-    subprocess.run(
+    completed = subprocess.run(
         [sys.executable, "-m", "pip", "uninstall", args.name],
         env={
             "PYTHONPATH": default_plugin_path(),
         },
     )
+    return completed.returncode
 
 
 def check_plugins(args):
-    subprocess.run(
+    completed = subprocess.run(
         [sys.executable, "-m", "pip", "check"],
         env={
             "PYTHONPATH": default_plugin_path(),
         },
     )
+    return completed.returncode

--- a/gaphor/tests/test_main.py
+++ b/gaphor/tests/test_main.py
@@ -7,7 +7,10 @@ import pytest
 import gaphor.ui
 from gaphor.main import main
 
-APP_NAME = sys.argv[0]
+
+@pytest.fixture
+def app_name():
+    return sys.argv[0]
 
 
 @pytest.fixture(autouse=True)
@@ -22,46 +25,46 @@ def mock_gaphor_ui_run(monkeypatch):
     return _argv
 
 
-def test_run_main():
-    exit_code = main([APP_NAME])
+def test_run_main(app_name):
+    exit_code = main([app_name])
 
     assert exit_code == 0
 
 
-def test_version(capsys):
+def test_version(capsys, app_name):
     with pytest.raises(SystemExit):
-        main([APP_NAME, "-V"])
+        main([app_name, "-V"])
 
     assert "Gaphor" in capsys.readouterr().out
 
 
-def test_debug_logging():
-    main([APP_NAME, "-v"])
+def test_debug_logging(app_name):
+    main([app_name, "-v"])
 
     assert logging.getLogger("gaphor").getEffectiveLevel() == logging.DEBUG
 
 
-def test_quiet_logging():
-    main([APP_NAME, "-q"])
+def test_quiet_logging(app_name):
+    main([app_name, "-q"])
 
     assert logging.getLogger("root").getEffectiveLevel() == logging.WARNING
 
 
-def test_self_test(mock_gaphor_ui_run):
-    main([APP_NAME, "--self-test"])
+def test_self_test(mock_gaphor_ui_run, app_name):
+    main([app_name, "--self-test"])
 
-    assert mock_gaphor_ui_run == [APP_NAME, "--self-test"]
-
-
-def test_gapplication_service(mock_gaphor_ui_run):
-    main([APP_NAME, "--gapplication-service"])
-
-    assert mock_gaphor_ui_run == [APP_NAME, "--gapplication-service"]
+    assert mock_gaphor_ui_run == [app_name, "--self-test"]
 
 
-def test_run_script(capsys):
+def test_gapplication_service(mock_gaphor_ui_run, app_name):
+    main([app_name, "--gapplication-service"])
+
+    assert mock_gaphor_ui_run == [app_name, "--gapplication-service"]
+
+
+def test_run_script(capsys, app_name):
     run_script = Path(__file__).parent / "run_script.py"
 
-    main([APP_NAME, "exec", str(run_script)])
+    main([app_name, "exec", str(run_script)])
 
     assert "Running a test script for Gaphor" in capsys.readouterr().out

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -162,7 +162,7 @@ class SelfTest(Service):
     @test
     def test_plugin_support(self, status):
         parser = manager.parser()
-        args = parser.parse_args(["check"])
+        args = parser.parse_args(["list"])
         if args.command(args) == 0:
             status.complete()
 

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -15,6 +15,7 @@ from gaphor.abc import Service
 from gaphor.application import Application, distribution
 from gaphor.core import Transaction
 from gaphor.core.modeling import Diagram
+from gaphor.plugins import manager
 
 log = logging.getLogger(__name__)
 
@@ -70,6 +71,7 @@ class SelfTest(Service):
         self.test_new_session()
         self.test_auto_layout()
         self.test_git_support()
+        self.test_plugin_support()
 
     def init_timer(self, gtk_app, timeout):
         start = time.time()
@@ -156,6 +158,13 @@ class SelfTest(Service):
         with tempfile.TemporaryDirectory() as temp_dir:
             pygit2.init_repository(temp_dir)
         status.complete()
+
+    @test
+    def test_plugin_support(self, status):
+        parser = manager.parser()
+        args = parser.parse_args(["check"])
+        if args.command(args) == 0:
+            status.complete()
 
 
 def system_information():

--- a/gaphor/ui/tests/test_main.py
+++ b/gaphor/ui/tests/test_main.py
@@ -6,7 +6,9 @@ from gi.repository import GLib, Gtk
 import gaphor.main
 
 
-APP_NAME = sys.argv[0]
+@pytest.fixture
+def app_name():
+    return sys.argv[0]
 
 
 @pytest.fixture(autouse=True)
@@ -33,17 +35,17 @@ def fake_run(monkeypatch):
     return run
 
 
-def test_application_startup(monkeypatch):
+def test_application_startup(monkeypatch, app_name):
     run = fake_run(monkeypatch)
 
-    gaphor.main.main([APP_NAME])
+    gaphor.main.main([app_name])
 
-    assert run == [APP_NAME]
+    assert run == [app_name]
 
 
-def test_application_startup_with_model(monkeypatch):
+def test_application_startup_with_model(monkeypatch, app_name):
     run = fake_run(monkeypatch)
 
-    gaphor.main.main([APP_NAME, "test-models/all-elements.gaphor"])
+    gaphor.main.main([app_name, "test-models/all-elements.gaphor"])
 
-    assert run == [APP_NAME, "test-models/all-elements.gaphor"]
+    assert run == [app_name, "test-models/all-elements.gaphor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ gaphor = "gaphor.main:main"
 gui = "gaphor.main:gui_parser"
 exec = "gaphor.main:exec_parser"
 export = "gaphor.plugins.diagramexport.exportcli:export_parser"
+plugins = "gaphor.plugins.manager:parser"
 
 [tool.poetry.plugins."babel.extractors"]
 "gaphor" = "gaphor.babel:extract_gaphor"

--- a/test-plugin/gaphor_test_plugin.py
+++ b/test-plugin/gaphor_test_plugin.py
@@ -1,0 +1,13 @@
+import logging
+
+from gaphor.abc import Service
+
+log = logging.getLogger(__name__)
+
+
+class TestService(Service):
+    def __init__(self):
+        log.info("Initializing test service")
+
+    def shutdown(self):
+        log.info("Shutting down test service")

--- a/test-plugin/pyproject.toml
+++ b/test-plugin/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gaphor-test-plugin"
+description = "Just for plugin integration testing"
+version = "1.0"
+
+[project.entry-points."gaphor.services"]
+test_plugin = "gaphor_test_plugin:TestService"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,19 @@
+from gaphor.plugins import (
+    manager,
+    enable_plugins,
+    default_plugin_path,
+)
+from gaphor.entrypoint import load_entry_points
+
+
+def test_plugin_installation(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAPHOR_PLUGIN_PATH", str(tmp_path))
+
+    parser = manager.parser()
+    args = parser.parse_args(["install", "test-plugin/"])
+    args.command(args)
+
+    with enable_plugins(default_plugin_path()):
+        entry_points = load_entry_points("gaphor.services")
+
+    assert "test_plugin" in entry_points

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from gaphor.plugins import (
@@ -14,7 +16,9 @@ def install_test_plugin(tmp_path, monkeypatch):
 
     parser = manager.parser()
     args = parser.parse_args(["install", "test-plugin/"])
-    args.command(args)
+    exit_code = args.command(args)
+
+    assert exit_code == 0
 
 
 def test_plugin_installed(tmp_path):
@@ -22,6 +26,16 @@ def test_plugin_installed(tmp_path):
         entry_points = load_entry_points("gaphor.services")
 
     assert "test_plugin" in entry_points
+
+
+def test_sys_argv_is_not_changed():
+    orig_argv = list(sys.argv)
+
+    parser = manager.parser()
+    args = parser.parse_args(["list"])
+    args.command(args)
+
+    assert sys.argv == orig_argv
 
 
 def test_plugin_list(capsys):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Gaphor is only extensible if installed manually via pip (e.i. set up a dev environment).

Issue Number: N/A

### What is the new behavior?

Allow to install extra packages from pypi and make them available when running a packaged version of Gaphor.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

- [x] Add plugin path before any entrypoints are loaded
- [ ] Add documentation on how to use the plugin commands
- [x] Add a self-check (ensure pip is bundled)
- [ ] Once packaged, the `sys.executable` is no longer `python`, but `gaphor-exe`. I suppose pip should be run from inside our Gaphor instance, instead of spawning a subprocess, although that's discouraged.

https://pip.pypa.io/en/stable/user_guide/#using-pip-from-your-program
