### PR TITLE
Make style sheet and merge editor panel wider

### DIFF
--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -88,6 +88,7 @@
             <style>
               <class name="toolbar"/>
             </style>
+            <property name="halign">end</property>
             <child>
               <object class="GtkBox">
                 <child>
@@ -197,6 +198,7 @@
         <child>
           <object class="GtkStack" id="editor-stack">
             <property name="transition_type">slide-left-right</property>
+            <property name="hhomogeneous">0</property>
             <child>
               <object class="GtkStackPage">
                 <property name="name">editors</property>
@@ -228,6 +230,9 @@
                 <property name="title" translatable="yes">Preferences</property>
                 <property name="child">
                   <object class="GtkBox">
+                    <style>
+                      <class name="editor-wide" />
+                    </style>
                     <property name="margin_start">6</property>
                     <property name="margin_end">6</property>
                     <property name="margin_top">12</property>
@@ -349,6 +354,9 @@
                 <property name="title" translatable="yes">Merge Models</property>
                 <property name="child">
                   <object class="GtkBox">
+                    <style>
+                      <class name="editor-wide" />
+                    </style>
                     <property name="margin_start">6</property>
                     <property name="margin_end">6</property>
                     <property name="margin_top">6</property>

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -146,6 +146,10 @@ listview .row {
   border-left: 1px solid @unfocused_borders;
 }
 
+.editor-wide {
+  min-width: 350px;
+}
+
 #toolbox > viewport > box {
   margin: 6px;
 }


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2359 

### What is the new behavior?

The editor panes for settings and the merge editor are wider now.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


### Other information

I could not make it work with a `GtkPaned`, so I just changed the width a little. The settings part is also changed, so it's easier to edit style sheets.

Before:

![image](https://github.com/gaphor/gaphor/assets/96249/4e5c0b00-69fb-4ed1-85dd-4272881336e7)

After:

![image](https://github.com/gaphor/gaphor/assets/96249/371c7caa-cd9f-4a89-97a8-31efd6c16e7a)
