### PR TITLE
Do no longer package TkInter

### DIFF
--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -89,7 +89,7 @@ a = Analysis(  # type: ignore
         "fix_path.py",
         "pydot_patch.py",
     ],
-    excludes=[],
+    excludes=["FixTk", "tcl", "tk", "_tkinter", "tkinter", "Tkinter"],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,
     cipher=block_cipher,

--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -66,8 +66,7 @@ a = Analysis(  # type: ignore
     ]
     + ui_files
     + mo_files
-    + copy_metadata("gaphor")
-    + copy_metadata("gaphas"),
+    + copy_metadata("gaphor"),
     hiddenimports=collect_entry_points(
         "gaphor.argparsers",
         "gaphor.services",


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

I noticed Tk(Inter) is bundled with our app. That makes no sense.

### What is the new behavior?

Nothing changed. TkInter has been excluded.

See https://github.com/pyinstaller/pyinstaller/wiki/Recipe-remove-tkinter-tcl

Also, there's no need for Gaphas dist-info, so that's also removed.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
