### PR TITLE
Load plugins installed in plugin folder

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: 05f6288b94a87daa172d3e96a33ec331a4374be7d01eb9a42b3b21c4c550a8ff
         with:
-          coverageCommand: poetry run coverage xml
+          coverageCommand: poetry run coverage xml --omit="/tmp/*"
       - name: Create Source Dist and Wheel
         if: ${{ matrix.python_version == env.python_version }}
         run: poetry build

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ html
 *~
 \#*\#
 .eggs/
-gaphor.egg-info/
+*.egg-info/
 gaphor.prof
 .gpg
 pip-wheel-metadata

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ Did you know Gaphor has excellent integration with :doc:`Sphinx <sphinx>` and :d
    scripting
    stereotypes
    merge_conflicts
+   plugins
 
 .. toctree::
    :caption: Installation

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,47 @@
+# Plugins
+
+```{important}
+Plugins is an experimental feature! The API may change.
+
+We welcome you to try and provide your feedback.
+```
+
+Plugins allow you to extend the functionality of Gaphor beyond the features provided in the standard distributions.
+In particular, plugins can be helpful if you install the binary distributions available on the [download page](https://gaphor.org/download/).
+
+Gaphor can be extended via entry points in several ways:
+
+1. Application (global) services (`gaphor.appservices`)
+2. Session specific services (`gaphor.services`)
+3. [Modeling languages](modeling_language) (`gaphor.modelinglanguages`)
+4. (Sub)command line parsers (`gaphor.argparsers`)
+5. Indirectly loaded modules (`gaphor.modules`), mainly for UI components
+
+
+The default location for plugins is `$HOME/.local/gaphor/plugins-2` (`$USER/.local/gaphor/plugins-2` on Windows).
+This location can be changed by setting the environment variable `GAPHOR_PLUGIN_PATH` and point to a directory.
+
+
+## Install a plugin
+
+At this moment Gaphor does not have functionality bundled to install and maintain plugins.
+To install a plugin, use `pip` from a Python installation on your computer. On macOS and Linux, that should be easy,
+on Windows you may need to install Python separately from [python.org](https://python.org) or the Windows Store.
+
+```{important}
+Since plugins are installed with your system Python version, it's important that
+plugins are pure python - e.i. do not contain compiled C code.
+```
+
+For example: to install the [Hello World plugin](https://github.com/gaphor/gaphor_plugin_helloworld) on Linux and macOS, enter:
+
+```bash
+pip install --target $HOME/.local/gaphor/plugins-2 git+https://github.com/gaphor/gaphor_plugin_helloworld.git
+```
+
+Then start Gaphor as you normally would.
+A new Hello World entry has been added to the tools menu (![open menu](images/open-menu-symbolic.svg) → Tools → Hello World).
+
+If you want to write a plugin yourself, you can familiarize yourself with Gaphor's
+[design principles](design_principles), [service oriented architecture](service_oriented), and [event driven framework](framework).
+Next you can have a look at the [Hello World plugin](https://github.com/gaphor/gaphor_plugin_helloworld) available on GitHub.

--- a/docs/style_sheets.md
+++ b/docs/style_sheets.md
@@ -317,8 +317,7 @@ Here are some ideas that go just beyond changing a color or a font. With the
 following examples we dig in to Gaphor's model structure to reveal more
 information to the users.
 
-To create your own expression you may want to use the Console (Tools ->
-Console, in the Hamburger menu). Drop us a line on
+To create your own expression you may want to use the Console (![open menu](images/open-menu-symbolic.svg) → Tools → Console). Drop us a line on
 [Gitter](https://gitter.im/gaphor/Lobby) and we would be happy to help you.
 
 ### The drafts package

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -5,6 +5,7 @@ import sys
 
 from gaphor.application import distribution
 from gaphor.entrypoint import initialize
+from gaphor.plugins import enable_plugins, default_plugin_path
 
 LOG_FORMAT = "%(name)s %(levelname)s %(message)s"
 
@@ -14,22 +15,23 @@ def main(argv=sys.argv) -> int:
 
     logging_config()
 
-    commands: dict[str, argparse.ArgumentParser] = initialize("gaphor.argparsers")
+    with enable_plugins(default_plugin_path()):
+        commands: dict[str, argparse.ArgumentParser] = initialize("gaphor.argparsers")
 
-    args = parse_args(argv[1:], commands)
+        args = parse_args(argv[1:], commands)
 
-    if args.profiler:
-        import cProfile
-        import pstats
+        if args.profiler:
+            import cProfile
+            import pstats
 
-        with cProfile.Profile() as profile:
-            exit_code: int = profile.runcall(args.command, args)
+            with cProfile.Profile() as profile:
+                exit_code: int = profile.runcall(args.command, args)
 
-        profile_stats = pstats.Stats(profile)
-        profile_stats.strip_dirs().sort_stats("time").print_stats(50)
-        return exit_code
+            profile_stats = pstats.Stats(profile)
+            profile_stats.strip_dirs().sort_stats("time").print_stats(50)
+            return exit_code
 
-    return args.command(args)  # type: ignore[no-any-return]
+        return args.command(args)  # type: ignore[no-any-return]
 
 
 def parse_args(args: list[str], commands: dict[str, argparse.ArgumentParser]):

--- a/gaphor/plugins/__init__.py
+++ b/gaphor/plugins/__init__.py
@@ -15,3 +15,47 @@ Plugins can be registered in Gaphor by declaring them as service entry point::
 There is a thin line between a service and a plugin. A service typically performs some basic need for the applications (such as the element factory or the undo mechanism). A plugin is more of an add-on. For example a plugin can depend on external libraries or provide a cross-over function between two applications.
 
 """
+import contextlib
+import importlib.abc
+import importlib.machinery
+import importlib.metadata
+import pathlib
+import os
+import sys
+
+from gaphor import entrypoint
+
+PLUGIN_VERSION = 2
+
+
+def default_plugin_path() -> pathlib.Path:
+    if plugin_path_envvar := os.getenv("GAPHOR_PLUGIN_PATH"):
+        return pathlib.Path(plugin_path_envvar)
+    else:
+        return pathlib.Path.home() / ".local" / "gaphor" / f"plugins-{PLUGIN_VERSION}"
+
+
+@contextlib.contextmanager
+def enable_plugins(plugin_path: pathlib.Path):
+    entrypoint.list_entry_points.cache_clear()
+    path_finder = PluginMetaPathFinder(plugin_path)
+    sys.meta_path.append(path_finder)
+    yield
+    sys.meta_path.remove(path_finder)
+
+
+class PluginMetaPathFinder(importlib.abc.MetaPathFinder):
+    def __init__(self, plugin_path: pathlib.Path):
+        self.plugin_path = str(plugin_path)
+
+    def find_spec(self, fullname, path=None, target=None):
+        return importlib.machinery.PathFinder.find_spec(
+            fullname, path=[self.plugin_path], target=target
+        )
+
+    def find_distributions(self, *args, **kwargs):
+        return importlib.metadata.MetadataPathFinder.find_distributions(
+            context=importlib.metadata.DistributionFinder.Context(
+                path=[self.plugin_path]
+            )
+        )

--- a/test-plugin/gaphor_test_plugin.py
+++ b/test-plugin/gaphor_test_plugin.py
@@ -1,0 +1,13 @@
+import logging
+
+from gaphor.abc import Service
+
+log = logging.getLogger(__name__)
+
+
+class TestService(Service):
+    def __init__(self):
+        log.info("Initializing test service")
+
+    def shutdown(self):
+        log.info("Shutting down test service")

--- a/test-plugin/pyproject.toml
+++ b/test-plugin/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gaphor-test-plugin"
+description = "Just for plugin integration testing"
+version = "1.0"
+
+[project.entry-points."gaphor.services"]
+test_plugin = "gaphor_test_plugin:TestService"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,30 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from gaphor.plugins import (
+    enable_plugins,
+    default_plugin_path,
+)
+from gaphor.entrypoint import load_entry_points
+
+
+def test_loading_plugins(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAPHOR_PLUGIN_PATH", str(tmp_path))
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--target",
+            str(tmp_path),
+            Path(__file__).parent.parent / "test-plugin",
+        ]
+    )
+
+    with enable_plugins(default_plugin_path()):
+        entry_points = load_entry_points("gaphor.services")
+
+    assert "test_plugin" in entry_points


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When Gaphor is packaged as Window exe or in a macOS app, there's no way to add extra functionality to the app.

Issue Number: #389

### What is the new behavior?

Gaphor can load and initialize services defined in a separate plugins folder (`$HOME/.local/gaphor/plugins-2` by default). This location can be overridden by an environment variable `GAPHOR_PLUGIN_PATH`.

### Other information

This PR contains the working parts -- loading of plugins -- from #2353.

Plugin installation and maintenance is a lot harder can cannot be done from within Gaphor at the moment. This should be fixed in a future PR.
