### PR TITLE
Allow Object Flows to Connect to Join/Fork Nodes

### DIFF
--- a/gaphor/UML/actions/flowconnect.py
+++ b/gaphor/UML/actions/flowconnect.py
@@ -114,7 +114,7 @@ Connector.register(InputPinItem, ObjectFlowItem)(FlowConnect)
 Connector.register(OutputPinItem, ObjectFlowItem)(FlowConnect)
 
 
-class FlowForkDecisionNodeControlFlowConnect(FlowConnect):
+class FlowForkDecisionNodeFlowConnect(FlowConnect):
     """Abstract class with common behaviour for Fork/Join node and
     Decision/Merge node."""
 
@@ -224,7 +224,7 @@ class FlowForkDecisionNodeControlFlowConnect(FlowConnect):
 
 @Connector.register(ForkNodeItem, ControlFlowItem)
 @Connector.register(ForkNodeItem, ObjectFlowItem)
-class FlowForkNodeControlFlowConnect(FlowForkDecisionNodeControlFlowConnect):
+class FlowForkNodeFlowConnect(FlowForkDecisionNodeFlowConnect):
     """Connect Flow to a ForkNode."""
 
     fork_node_cls = UML.ForkNode
@@ -232,7 +232,8 @@ class FlowForkNodeControlFlowConnect(FlowForkDecisionNodeControlFlowConnect):
 
 
 @Connector.register(DecisionNodeItem, ControlFlowItem)
-class FlowDecisionNodeControlFlowConnect(FlowForkDecisionNodeControlFlowConnect):
+@Connector.register(DecisionNodeItem, ObjectFlowItem)
+class FlowDecisionNodeFlowConnect(FlowForkDecisionNodeFlowConnect):
     """Connect Flow to a DecisionNode."""
 
     fork_node_cls = UML.DecisionNode

--- a/gaphor/UML/actions/flowconnect.py
+++ b/gaphor/UML/actions/flowconnect.py
@@ -223,6 +223,7 @@ class FlowForkDecisionNodeControlFlowConnect(FlowConnect):
 
 
 @Connector.register(ForkNodeItem, ControlFlowItem)
+@Connector.register(ForkNodeItem, ObjectFlowItem)
 class FlowForkNodeControlFlowConnect(FlowForkDecisionNodeControlFlowConnect):
     """Connect Flow to a ForkNode."""
 

--- a/gaphor/UML/actions/flowconnect.py
+++ b/gaphor/UML/actions/flowconnect.py
@@ -80,7 +80,7 @@ class FlowConnect(RelationshipConnect):
         otc = self.get_connected(opposite)
         if (
             opposite
-            and (isinstance(line, ControlFlowItem) or isinstance(line, ObjectFlowItem))
+            and (isinstance(line, (ControlFlowItem, ObjectFlowItem)))
             and isinstance(otc, (ForkNodeItem, DecisionNodeItem))
         ):
             adapter = Connector(otc, line)
@@ -93,7 +93,7 @@ class FlowConnect(RelationshipConnect):
         otc = self.get_connected(opposite)
         if (
             opposite
-            and (isinstance(line, ControlFlowItem) or isinstance(line, ObjectFlowItem))
+            and (isinstance(line, (ControlFlowItem, ObjectFlowItem)))
             and isinstance(otc, (ForkNodeItem, DecisionNodeItem))
         ):
             adapter = Connector(otc, line)

--- a/gaphor/UML/actions/flowconnect.py
+++ b/gaphor/UML/actions/flowconnect.py
@@ -80,7 +80,7 @@ class FlowConnect(RelationshipConnect):
         otc = self.get_connected(opposite)
         if (
             opposite
-            and isinstance(line, ControlFlowItem)
+            and (isinstance(line, ControlFlowItem) or isinstance(line, ObjectFlowItem))
             and isinstance(otc, (ForkNodeItem, DecisionNodeItem))
         ):
             adapter = Connector(otc, line)
@@ -93,7 +93,7 @@ class FlowConnect(RelationshipConnect):
         otc = self.get_connected(opposite)
         if (
             opposite
-            and isinstance(line, ControlFlowItem)
+            and (isinstance(line, ControlFlowItem) or isinstance(line, ObjectFlowItem))
             and isinstance(otc, (ForkNodeItem, DecisionNodeItem))
         ):
             adapter = Connector(otc, line)
@@ -107,8 +107,9 @@ Connector.register(AcceptEventActionItem, ControlFlowItem)(FlowConnect)
 
 Connector.register(ActionItem, ObjectFlowItem)(FlowConnect)
 Connector.register(ActivityNodeItem, ObjectFlowItem)(FlowConnect)
-Connector.register(ObjectNodeItem, ObjectFlowItem)(FlowConnect)
 Connector.register(SendSignalActionItem, ObjectFlowItem)(FlowConnect)
+
+Connector.register(ObjectNodeItem, ObjectFlowItem)(FlowConnect)
 Connector.register(ActivityParameterNodeItem, ObjectFlowItem)(FlowConnect)
 Connector.register(InputPinItem, ObjectFlowItem)(FlowConnect)
 Connector.register(OutputPinItem, ObjectFlowItem)(FlowConnect)
@@ -180,7 +181,9 @@ class FlowForkDecisionNodeFlowConnect(FlowConnect):
     def decombine_nodes(self):
         """Decombine join/fork or decision/merge nodes."""
         element = self.element
+        print('here1')
         if element.combined:
+            print('here2')
             join_node = element.subject
             cflow = join_node.outgoing[0]  # combining flow
             fork_node = cflow.target
@@ -191,17 +194,20 @@ class FlowForkDecisionNodeFlowConnect(FlowConnect):
             assert isinstance(fork_node, fork_node_cls)
 
             if len(join_node.incoming) < 2 or len(fork_node.outgoing) < 2:
+                print('here3')
                 # Move all outgoing edges to the first node (the join node):
                 for f in list(fork_node.outgoing):
                     f.source = join_node
                 cflow.unlink()
                 fork_node.unlink()
-
                 # swap subject to fork node if outgoing > 1
                 if len(join_node.outgoing) > 1:
+                    print('here4')
                     assert len(join_node.incoming) < 2
                     UML.recipes.swap_element(join_node, fork_node_cls)
                 del element.combined
+                print(f"--element:-{element.combined}---")
+
 
     def connect_subject(self, handle):
         """In addition to a subject connect, the subject of the element may be

--- a/gaphor/UML/actions/flowconnect.py
+++ b/gaphor/UML/actions/flowconnect.py
@@ -181,9 +181,7 @@ class FlowForkDecisionNodeFlowConnect(FlowConnect):
     def decombine_nodes(self):
         """Decombine join/fork or decision/merge nodes."""
         element = self.element
-        print('here1')
         if element.combined:
-            print('here2')
             join_node = element.subject
             cflow = join_node.outgoing[0]  # combining flow
             fork_node = cflow.target
@@ -194,7 +192,6 @@ class FlowForkDecisionNodeFlowConnect(FlowConnect):
             assert isinstance(fork_node, fork_node_cls)
 
             if len(join_node.incoming) < 2 or len(fork_node.outgoing) < 2:
-                print('here3')
                 # Move all outgoing edges to the first node (the join node):
                 for f in list(fork_node.outgoing):
                     f.source = join_node
@@ -202,11 +199,9 @@ class FlowForkDecisionNodeFlowConnect(FlowConnect):
                 fork_node.unlink()
                 # swap subject to fork node if outgoing > 1
                 if len(join_node.outgoing) > 1:
-                    print('here4')
                     assert len(join_node.incoming) < 2
                     UML.recipes.swap_element(join_node, fork_node_cls)
                 del element.combined
-                print(f"--element:-{element.combined}---")
 
 
     def connect_subject(self, handle):

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -555,18 +555,15 @@ class FlowItemDecisionAndForkNodes:
         # needed for tests below
         flow = jn.subject.outgoing[0]
         node = jn.combined
-        print(flow4)
-        print(f"++{node}++")
+
         assert flow in element_factory.lselect(uml_flow)
         assert node in element_factory.lselect(self.fork_node_cls)
 
         # test disconnection
-        print(f"\n\n===={jn.combined}====")
         disconnect(flow4, flow4.head)        
         assert get_connected(flow4, flow4.head) is None
 
-        #!!!!MRFK !!!!
-        print(f"* jn:*{jn.combined}*********")
+
         assert jn.combined is None
 
         flows = element_factory.lselect(uml_flow)

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -1,6 +1,8 @@
 """Flow item connection adapters tests."""
 
-from typing import Type
+from typing import Type, Union
+
+import pytest as pytest
 
 from gaphor import UML
 from gaphor.core.modeling import Presentation
@@ -368,7 +370,7 @@ def test_object_flow_reconnection(create):
 class FlowItemDecisionAndForkNodes:
     """Base class for flow connecting to decision and fork nodes.
 
-    See `TestFlowItemDecisionNode` and `Test FlowItemForkNode` test cases.
+    See `TestFlowItemDecisionNode` and `TestFlowItemForkNode` test cases.
 
     Not tested yet
 
@@ -379,12 +381,13 @@ class FlowItemDecisionAndForkNodes:
     """
 
     item_cls: Type[Presentation]
-    fork_node_cls: Type[UML.ControlNode]
-    join_node_cls: Type[UML.ControlNode]
+    fork_node_cls: Union[UML.ControlNode, UML.ObjectNode]
+    join_node_cls: Union[UML.ControlNode, UML.ObjectNode]
 
-    def test_glue(self, create):
+    @pytest.mark.parametrize("flow_item", [ControlFlowItem, ObjectFlowItem])
+    def test_glue(self, create, flow_item):
         """Test decision/fork nodes glue."""
-        flow = create(ControlFlowItem)
+        flow = create(flow_item)
         action = create(ActionItem, UML.Action)
         node = create(self.item_cls, self.join_node_cls)
 
@@ -396,7 +399,8 @@ class FlowItemDecisionAndForkNodes:
         glued = allow(flow, flow.tail, node)
         assert glued
 
-    def test_node_class_change(self, create):
+    @pytest.mark.parametrize("flow_item", [ControlFlowItem, ObjectFlowItem])
+    def test_node_class_change(self, create, flow_item):
         """Test node incoming edges.
 
         Connection scheme is presented below::
@@ -408,9 +412,9 @@ class FlowItemDecisionAndForkNodes:
 
         Node class changes due to two incoming edges and one outgoing edge.
         """
-        flow1 = create(ControlFlowItem)
-        flow2 = create(ControlFlowItem)
-        flow3 = create(ControlFlowItem)
+        flow1 = create(flow_item)
+        flow2 = create(flow_item)
+        flow3 = create(flow_item)
         a1 = create(ActionItem, UML.Action)
         a2 = create(ActionItem, UML.Action)
         jn = create(self.item_cls, self.fork_node_cls)
@@ -430,7 +434,8 @@ class FlowItemDecisionAndForkNodes:
         # node class changes
         assert isinstance(jn.subject, self.join_node_cls)
 
-    def test_outgoing_edges(self, create):
+    @pytest.mark.parametrize("flow_item", [ControlFlowItem, ObjectFlowItem])
+    def test_outgoing_edges(self, create, flow_item):
         """Test outgoing edges.
 
         Connection scheme is presented below::
@@ -439,9 +444,9 @@ class FlowItemDecisionAndForkNodes:
             [ a1 ] --flow1--> [ jn ]
                                  | --flow3-->[ a3 ]
         """
-        flow1 = create(ControlFlowItem)
-        flow2 = create(ControlFlowItem)
-        flow3 = create(ControlFlowItem)
+        flow1 = create(flow_item)
+        flow2 = create(flow_item)
+        flow3 = create(flow_item)
         a1 = create(ActionItem, UML.Action)
         a2 = create(ActionItem, UML.Action)
         jn = create(self.item_cls, self.join_node_cls)
@@ -468,7 +473,8 @@ class FlowItemDecisionAndForkNodes:
 
         assert isinstance(jn.subject, self.fork_node_cls), f"{jn.subject}"
 
-    def test_combined_nodes_connection(self, create):
+    @pytest.mark.parametrize("flow_item", [ControlFlowItem, ObjectFlowItem])
+    def test_combined_nodes_connection(self, create, flow_item):
         """Test combined nodes connection.
 
         Connection scheme is presented below::
@@ -479,10 +485,10 @@ class FlowItemDecisionAndForkNodes:
 
         Flow `flow4` will force the node to become a combined node.
         """
-        flow1 = create(ControlFlowItem)
-        flow2 = create(ControlFlowItem)
-        flow3 = create(ControlFlowItem)
-        flow4 = create(ControlFlowItem)
+        flow1 = create(flow_item)
+        flow2 = create(flow_item)
+        flow3 = create(flow_item)
+        flow4 = create(flow_item)
         a1 = create(ActionItem, UML.Action)
         a2 = create(ActionItem, UML.Action)
         a4 = create(ActionItem, UML.Action)
@@ -508,7 +514,14 @@ class FlowItemDecisionAndForkNodes:
         assert len(jn.combined.incoming) == 1
         assert jn.subject.outgoing[0] is jn.combined.incoming[0]
 
-    def test_combined_node_disconnection(self, create, element_factory):
+    @pytest.mark.xfail
+    @pytest.mark.parametrize(
+        "flow_item,uml_flow",
+        [(ControlFlowItem, UML.ControlFlow), (ObjectFlowItem, UML.ObjectFlow)],
+    )
+    def test_combined_node_disconnection(
+        self, create, element_factory, flow_item, uml_flow
+    ):
         """Test combined nodes disconnection.
 
         Connection scheme is presented below::
@@ -519,10 +532,10 @@ class FlowItemDecisionAndForkNodes:
 
         Flow `flow4` will force the node to become a combined node.
         """
-        flow1 = create(ControlFlowItem)
-        flow2 = create(ControlFlowItem)
-        flow3 = create(ControlFlowItem)
-        flow4 = create(ControlFlowItem)
+        flow1 = create(flow_item)
+        flow2 = create(flow_item)
+        flow3 = create(flow_item)
+        flow4 = create(flow_item)
         a1 = create(ActionItem, UML.Action)
         a2 = create(ActionItem, UML.Action)
         a4 = create(ActionItem, UML.Action)
@@ -541,20 +554,20 @@ class FlowItemDecisionAndForkNodes:
         connect(flow4, flow4.tail, jn)
 
         # needed for tests below
-        cflow = jn.subject.outgoing[0]
-        cnode = jn.combined
-        assert cflow in element_factory.lselect(UML.ControlFlow)
-        assert cnode in element_factory.lselect(self.fork_node_cls)
+        flow = jn.subject.outgoing[0]
+        node = jn.combined
+        assert flow in element_factory.lselect(uml_flow)
+        assert node in element_factory.lselect(self.fork_node_cls)
 
         # test disconnection
         disconnect(flow4, flow4.head)
         assert get_connected(flow4, flow4.head) is None
         assert jn.combined is None
 
-        flows = element_factory.lselect(UML.ControlFlow)
+        flows = element_factory.lselect(uml_flow)
         nodes = element_factory.lselect(self.fork_node_cls)
-        assert cnode not in nodes, f"{cnode} in {nodes}"
-        assert cflow not in flows, f"{cflow} in {flows}"
+        assert node not in nodes, f"{node} in {nodes}"
+        assert flow not in flows, f"{flow} in {flows}"
 
 
 class TestFlowItemForkNode(FlowItemDecisionAndForkNodes):
@@ -567,17 +580,3 @@ class TestFlowItemDecisionNode(FlowItemDecisionAndForkNodes):
     item_cls = DecisionNodeItem
     fork_node_cls = UML.DecisionNode
     join_node_cls = UML.MergeNode
-
-
-class TestObjectFlowItemForkNode(FlowItemDecisionAndForkNodes):
-    item_cls = ForkNodeItem
-    fork_node_cls = UML.ForkNode
-    join_node_cls = UML.JoinNode
-    flow_cls = ObjectFlowItem
-
-
-class TestObjectFlowItemDecisionNode(FlowItemDecisionAndForkNodes):
-    item_cls = DecisionNodeItem
-    fork_node_cls = UML.DecisionNode
-    join_node_cls = UML.MergeNode
-    flow_cls = ObjectFlowItem

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -568,11 +568,13 @@ class TestFlowItemDecisionNode(FlowItemDecisionAndForkNodes):
     fork_node_cls = UML.DecisionNode
     join_node_cls = UML.MergeNode
 
+
 class TestObjectFlowItemForkNode(FlowItemDecisionAndForkNodes):
     item_cls = ForkNodeItem
     fork_node_cls = UML.ForkNode
     join_node_cls = UML.JoinNode
     flow_cls = ObjectFlowItem
+
 
 class TestObjectFlowItemDecisionNode(FlowItemDecisionAndForkNodes):
     item_cls = DecisionNodeItem

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -565,7 +565,6 @@ class FlowItemDecisionAndForkNodes:
 
         assert jn.combined is None
 
-
         flows = element_factory.lselect(uml_flow)
         nodes = element_factory.lselect(self.fork_node_cls)
         assert node not in nodes, f"{node} in {nodes}"

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -514,7 +514,6 @@ class FlowItemDecisionAndForkNodes:
         assert len(jn.combined.incoming) == 1
         assert jn.subject.outgoing[0] is jn.combined.incoming[0]
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize(
         "flow_item,uml_flow",
         [(ControlFlowItem, UML.ControlFlow), (ObjectFlowItem, UML.ObjectFlow)],

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -568,8 +568,8 @@ class FlowItemDecisionAndForkNodes:
 
         flows = element_factory.lselect(uml_flow)
         nodes = element_factory.lselect(self.fork_node_cls)
-        #assert node not in nodes, f"{node} in {nodes}"
-        #assert flow not in flows, f"{flow} in {flows}"
+        assert node not in nodes, f"{node} in {nodes}"
+        assert flow not in flows, f"{flow} in {flows}"
 
 
 class TestFlowItemForkNode(FlowItemDecisionAndForkNodes):

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -555,18 +555,24 @@ class FlowItemDecisionAndForkNodes:
         # needed for tests below
         flow = jn.subject.outgoing[0]
         node = jn.combined
+        print(flow4)
+        print(f"++{node}++")
         assert flow in element_factory.lselect(uml_flow)
         assert node in element_factory.lselect(self.fork_node_cls)
 
         # test disconnection
-        disconnect(flow4, flow4.head)
+        print(f"\n\n===={jn.combined}====")
+        disconnect(flow4, flow4.head)        
         assert get_connected(flow4, flow4.head) is None
+
+        #!!!!MRFK !!!!
+        print(f"* jn:*{jn.combined}*********")
         assert jn.combined is None
 
         flows = element_factory.lselect(uml_flow)
         nodes = element_factory.lselect(self.fork_node_cls)
-        assert node not in nodes, f"{node} in {nodes}"
-        assert flow not in flows, f"{flow} in {flows}"
+        #assert node not in nodes, f"{node} in {nodes}"
+        #assert flow not in flows, f"{flow} in {flows}"
 
 
 class TestFlowItemForkNode(FlowItemDecisionAndForkNodes):

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -567,3 +567,15 @@ class TestFlowItemDecisionNode(FlowItemDecisionAndForkNodes):
     item_cls = DecisionNodeItem
     fork_node_cls = UML.DecisionNode
     join_node_cls = UML.MergeNode
+
+class TestObjectFlowItemForkNode(FlowItemDecisionAndForkNodes):
+    item_cls = ForkNodeItem
+    fork_node_cls = UML.ForkNode
+    join_node_cls = UML.JoinNode
+    flow_cls = ObjectFlowItem
+
+class TestObjectFlowItemDecisionNode(FlowItemDecisionAndForkNodes):
+    item_cls = DecisionNodeItem
+    fork_node_cls = UML.DecisionNode
+    join_node_cls = UML.MergeNode
+    flow_cls = ObjectFlowItem


### PR DESCRIPTION
Resolve issue #2278 - object flow cannot connect to fork node.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2278

### What is the new behavior?
Flow nodes can now connect to fork nodes.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
