### PR TITLE
Fix order when undoing deletion from association

### DIFF
--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -98,7 +98,7 @@ class AssociationAdded(AssociationUpdated):
 class AssociationDeleted(AssociationUpdated):
     """An association element has been deleted."""
 
-    def __init__(self, element, association, old_value):
+    def __init__(self, element, association, old_value, index):
         """Constructor.
 
         The element parameter is the element the association has been
@@ -108,6 +108,7 @@ class AssociationDeleted(AssociationUpdated):
 
         super().__init__(element, association)
         self.old_value = old_value
+        self.index = index
 
 
 class DerivedUpdated(AssociationUpdated):
@@ -153,7 +154,7 @@ class DerivedDeleted(AssociationDeleted, DerivedUpdated):
         of the derived property.
         """
 
-        super().__init__(element, association, old_value)
+        super().__init__(element, association, old_value, index=-1)
 
 
 class RedefinedSet(AssociationSet):
@@ -187,7 +188,7 @@ class RedefinedAdded(AssociationAdded):
 class RedefinedDeleted(AssociationDeleted):
     """A redefined property has been deleted."""
 
-    def __init__(self, element, association, old_value):
+    def __init__(self, element, association, old_value, index):
         """Constructor.
 
         The element parameter is the element to which the property
@@ -195,7 +196,7 @@ class RedefinedDeleted(AssociationDeleted):
         property.
         """
 
-        super().__init__(element, association, old_value)
+        super().__init__(element, association, old_value, index)
 
 
 class ElementCreated(ServiceEvent):

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -434,11 +434,12 @@ class UndoManager(Service, ActionProvider):
             return
         element_id = event.element.id
         value_id = event.old_value.id
+        index = event.index
 
         def undo_association_delete_event():
             element = self.lookup(element_id)
             value = self.lookup(value_id)
-            association.set(element, value, from_opposite=True)
+            association.set(element, value, index=index, from_opposite=True)
 
         undo_association_delete_event.__doc__ = (
             f"{event.element}.{association.name} add {event.old_value}."


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Issue Number: #2366

### What is the new behavior?

The index of an element deleted from an association is recorded, so it can be placed
back on the same index when it was deleted.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
