### PR TITLE
Fix ports on properties

### DIFF
--- a/gaphor/SysML/blocks/tests/test_connectors.py
+++ b/gaphor/SysML/blocks/tests/test_connectors.py
@@ -7,12 +7,21 @@ from gaphor.SysML import sysml
 from gaphor.SysML.blocks.block import BlockItem
 from gaphor.SysML.blocks.connectors import BlockProperyProxyPortConnector
 from gaphor.SysML.blocks.proxyport import ProxyPortItem
+from gaphor.SysML.blocks.property import PropertyItem
 from gaphor.UML.deployments import ConnectorItem
 
 
 @pytest.fixture
 def block_item(diagram, element_factory):
     return diagram.create(BlockItem, subject=element_factory.create(sysml.Block))
+
+
+@pytest.fixture
+def property_item(diagram, element_factory):
+    type = element_factory.create(sysml.Block)
+    prop = diagram.create(PropertyItem, subject=element_factory.create(sysml.Property))
+    prop.subject.type = type
+    return prop
 
 
 @pytest.fixture
@@ -76,6 +85,19 @@ def test_disconnect_proxy_port_to_block(block_item, proxy_port_item):
 
     assert proxy_port_item.subject is None
     assert proxy_port_item.diagram
+
+
+def test_connect_proxy_port_to_property(property_item, proxy_port_item):
+    connector = Connector(property_item, proxy_port_item)
+
+    connected = connector.connect(
+        proxy_port_item.handles()[0], property_item.ports()[0]
+    )
+
+    assert connected
+    assert proxy_port_item.subject
+    assert proxy_port_item.subject.encapsulatedClassifier is property_item.subject.type
+    assert proxy_port_item.subject in property_item.subject.type.ownedPort
 
 
 def test_allow_connector_to_proxy_port(

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -182,6 +182,20 @@
         <signal name="notify::selected" handler="aggregation-changed" swapped="no" />
       </object>
     </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Type</property>
+        <property name="xalign">0</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="property-type">
+        <property name="enable-search">1</property>
+        <property name="expression">
+          <lookup type="LabelValue" name="label" />
+        </property>
+      </object>
+    </child>
     <style>
       <class name="propertypage"/>
     </style>

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -97,6 +97,23 @@ def test_property_property_page(element_factory):
     assert subject.aggregation == "composite"
 
 
+def test_property_type(element_factory):
+    subject = element_factory.create(SysML.sysml.Property)
+    type = element_factory.create(UML.Class)
+    type.name = "Bar"
+    property_page = PropertyPropertyPage(subject)
+
+    widget = property_page.construct()
+    dropdown = find(widget, "property-type")
+    bar_index = next(
+        n for n, lv in enumerate(dropdown.get_model()) if lv.value == type.id
+    )
+    dropdown.set_selected(bar_index)
+
+    assert dropdown.get_selected_item().label == "Bar"
+    assert subject.type is type
+
+
 def test_association_item_flow(association):
     property_page = ItemFlowPropertyPage(association)
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Ports can be attached to properies but end up at toplevel in the model browser.

Issue Number: #2368 

### What is the new behavior?

* Properties can be assigned a proper type, like we do for `ItemFlow` and `Partition`.
* Ports can be attached to properties with a type assigned.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
