### PR TITLE
chore: clean up deprecated properties from UIComponent

### DIFF
--- a/gaphor/plugins/console/consolewindow.py
+++ b/gaphor/plugins/console/consolewindow.py
@@ -16,9 +16,6 @@ log = logging.getLogger(__name__)
 
 
 class ConsoleWindow(UIComponent, ActionProvider):
-    title = gettext("Gaphor Console")
-    size = (400, 400)
-
     def __init__(self, component_registry, main_window, tools_menu):
         self.component_registry = component_registry
         self.main_window = main_window
@@ -58,7 +55,7 @@ class ConsoleWindow(UIComponent, ActionProvider):
     def construct(self):
         window = Adw.Window.new()
         window.set_transient_for(self.main_window.window)
-        window.set_title(self.title)
+        window.set_title(gettext("Gaphor Console"))
         window.set_default_size(700, 480)
 
         element_factory = self.component_registry.get_service("element_factory")

--- a/gaphor/ui/abc.py
+++ b/gaphor/ui/abc.py
@@ -1,15 +1,10 @@
 import abc
-from typing import Tuple
 
 from gaphor.abc import Service
 
 
 class UIComponent(Service):
     """A user interface component."""
-
-    ui_name: str  # "The UIComponent name, provided by the loader"
-
-    size: Tuple[int, int]  # "Size used for floating the component"
 
     @abc.abstractmethod
     def open(self):

--- a/tests/test_action_issue.py
+++ b/tests/test_action_issue.py
@@ -6,85 +6,72 @@ from gaphor.storage import storage
 from gaphor.UML.actions import ActionItem, ControlFlowItem
 
 
-class TestActionIssue:
-    def test_it(self, element_factory, modeling_language, test_models):
-        """Test an issue when loading a freshly created action diagram."""
-        with (test_models / "action-issue.gaphor").open(encoding="utf-8") as f:
-            storage.load(f, element_factory, modeling_language)
+def test_action_issue(element_factory, modeling_language, test_models):
+    """Test an issue when loading a freshly created action diagram."""
+    with (test_models / "action-issue.gaphor").open(encoding="utf-8") as f:
+        storage.load(f, element_factory, modeling_language)
 
-        actions = element_factory.lselect(UML.Action)
-        flows = element_factory.lselect(UML.ControlFlow)
-        assert 3 == len(actions)
-        assert 3 == len(flows)
+    actions = element_factory.lselect(UML.Action)
+    flows = element_factory.lselect(UML.ControlFlow)
+    assert 3 == len(actions)
+    assert 3 == len(flows)
 
-        # Actions live in partitions:
-        partitions = element_factory.lselect(UML.ActivityPartition)
-        assert 2 == len(partitions)
+    # Actions live in partitions:
+    partitions = element_factory.lselect(UML.ActivityPartition)
+    assert 2 == len(partitions)
 
-        # Okay, so far the data model is saved correctly. Now, how do the
-        # handles behave?
-        diagrams = element_factory.lselect(Diagram)
-        assert 1 == len(diagrams)
+    # Okay, so far the data model is saved correctly. Now, how do the
+    # handles behave?
+    diagrams = element_factory.lselect(Diagram)
+    assert 1 == len(diagrams)
 
-        diagram = diagrams[0]
-        assert 7 == len(list(diagram.get_all_items()))
-        # Part, Act, Act, Act, Flow, Flow, Flow
+    diagram = diagrams[0]
+    assert 7 == len(list(diagram.get_all_items()))
+    # Part, Act, Act, Act, Flow, Flow, Flow
 
-        for e in actions + flows:
-            assert 1 == len(e.presentation), e
-        for i in diagram.select(lambda e: isinstance(e, (ControlFlowItem, ActionItem))):
-            assert i.subject, i
+    for e in actions + flows:
+        assert 1 == len(e.presentation), e
+    for i in diagram.select(lambda e: isinstance(e, (ControlFlowItem, ActionItem))):
+        assert i.subject, i
 
-        # Loaded as:
-        #
-        # actions[0] --> flows[0, 1]
-        # flows[0, 2] --> actions[1]
-        # flows[1] --> actions[2] --> flows[2]
+    # Loaded as:
+    #
+    # actions[0] --> flows[0, 1]
+    # flows[0, 2] --> actions[1]
+    # flows[1] --> actions[2] --> flows[2]
 
-        # start element:
-        assert actions[0].outgoing[0] is flows[0]
-        assert actions[0].outgoing[1] is flows[1]
-        assert actions[2].outgoing[0] is flows[2]
-        assert not actions[0].incoming
+    # start element:
+    assert actions[0].outgoing[0] is flows[0]
+    assert actions[0].outgoing[1] is flows[1]
+    assert actions[2].outgoing[0] is flows[2]
+    assert not actions[0].incoming
 
-        (cinfo,) = diagram.connections.get_connections(
-            handle=flows[0].presentation[0].head
-        )
-        assert cinfo.connected is actions[0].presentation[0]
-        (cinfo,) = diagram.connections.get_connections(
-            handle=flows[1].presentation[0].head
-        )
-        assert cinfo.connected is actions[0].presentation[0]
+    (cinfo,) = diagram.connections.get_connections(handle=flows[0].presentation[0].head)
+    assert cinfo.connected is actions[0].presentation[0]
+    (cinfo,) = diagram.connections.get_connections(handle=flows[1].presentation[0].head)
+    assert cinfo.connected is actions[0].presentation[0]
 
-        # Intermediate element:
-        assert actions[2].incoming[0] is flows[1]
-        assert actions[2].outgoing[0] is flows[2]
+    # Intermediate element:
+    assert actions[2].incoming[0] is flows[1]
+    assert actions[2].outgoing[0] is flows[2]
 
-        (cinfo,) = diagram.connections.get_connections(
-            handle=flows[1].presentation[0].tail
-        )
-        assert cinfo.connected is actions[2].presentation[0]
-        (cinfo,) = diagram.connections.get_connections(
-            handle=flows[2].presentation[0].head
-        )
-        assert cinfo.connected is actions[2].presentation[0]
+    (cinfo,) = diagram.connections.get_connections(handle=flows[1].presentation[0].tail)
+    assert cinfo.connected is actions[2].presentation[0]
+    (cinfo,) = diagram.connections.get_connections(handle=flows[2].presentation[0].head)
+    assert cinfo.connected is actions[2].presentation[0]
 
-        # Final element:
-        assert actions[1].incoming[0] is flows[0]
-        assert actions[1].incoming[1] is flows[2]
+    # Final element:
+    assert actions[1].incoming[0] is flows[0]
+    assert actions[1].incoming[1] is flows[2]
 
-        (cinfo,) = diagram.connections.get_connections(
-            handle=flows[0].presentation[0].tail
-        )
-        assert cinfo.connected is actions[1].presentation[0]
-        (cinfo,) = diagram.connections.get_connections(
-            handle=flows[2].presentation[0].tail
-        )
-        assert cinfo.connected is actions[1].presentation[0]
+    (cinfo,) = diagram.connections.get_connections(handle=flows[0].presentation[0].tail)
+    assert cinfo.connected is actions[1].presentation[0]
+    (cinfo,) = diagram.connections.get_connections(handle=flows[2].presentation[0].tail)
+    assert cinfo.connected is actions[1].presentation[0]
 
-        # Test the parent-child connectivity
-        for a in actions:
-            (p,) = a.inPartition
-            assert p
-            assert a.presentation[0].parent
-            assert a.presentation[0].parent is p.presentation[0]
+    # Test the parent-child connectivity
+    for a in actions:
+        (p,) = a.inPartition
+        assert p
+        assert a.presentation[0].parent
+        assert a.presentation[0].parent is p.presentation[0]


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The UIComponent interface still advertizes a `ui_name` and `size` property. Both are not in use anymore.

### What is the new behavior?

Cleaned interface.

Updated the last tests that use test classes to functions.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
