### PR TITLE
Reapply #2329 - Gtk.ListView for Activity Parameters

### DIFF
--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -1,62 +1,81 @@
-from gi.repository import Gtk
+from __future__ import annotations
+
+from gi.repository import Gdk, Gio, GObject, Gtk
 
 from gaphor import UML
-from gaphor.core import transactional
+from gaphor.core import event_handler, transactional
 from gaphor.core.format import format, parse
+from gaphor.core.modeling import AssociationUpdated
 from gaphor.diagram.propertypages import (
-    EditableTreeModel,
     PropertyPageBase,
     PropertyPages,
     handler_blocking,
     help_link,
     new_resource_builder,
-    on_text_cell_edited,
     unsubscribe_all_on_destroy,
 )
 from gaphor.diagram.propertypages import (
     new_builder as diagram_new_builder,
 )
+from gaphor.i18n import translated_ui_string
 from gaphor.UML.actions.activity import ActivityItem
-from gaphor.UML.classes.classespropertypages import on_keypress_event
 
 new_builder = new_resource_builder("gaphor.UML.actions")
 
 
-class ActivityParameters(EditableTreeModel):
-    """GTK tree model to edit class attributes."""
+class ActivityParameterNodeView(GObject.Object):
+    __gtype_name__ = "ActivityParameterNodeView"
 
-    def __init__(self, item):
-        super().__init__(item, cols=(str, object))
+    def __init__(self, node: UML.ActivityParameterNode | None, activity: UML.Activity):
+        super().__init__()
+        self.node = node
+        self.activity = activity
 
-    def get_rows(self):
-        for node in self._item.subject.node:
-            if isinstance(node, UML.ActivityParameterNode):
-                yield [format(node.parameter), node]
+    @GObject.Property(type=str)
+    def parameter(self) -> str:
+        return format(self.node.parameter) if self.node else ""
 
-    def create_object(self):
-        model = self._item.model
-        node = model.create(UML.ActivityParameterNode)
-        node.parameter = model.create(UML.Parameter)
-        self._item.subject.node = node
-        return node
-
+    @parameter.setter  # type: ignore[no-redef]
     @transactional
-    def set_object_value(self, row, col, value):
-        node = row[-1]
-        if col == 0:
-            parse(node.parameter, value)
-            row[0] = format(node.parameter)
-        elif col == 1:
-            # Value in attribute object changed:
-            row[0] = format(node.parameter)
+    def parameter(self, value):
+        if not self.node:
+            model = self.activity.model
+            node = model.create(UML.ActivityParameterNode)
+            node.parameter = model.create(UML.Parameter)
+            self.node = node
+            self.activity.node = node
+        parse(self.node.parameter, value)
 
-    def swap_objects(self, o1, o2):
-        return self._item.subject.node.swap(o1, o2)
 
-    def sync_model(self, new_order):
-        self._item.subject.node.order(
-            lambda key: new_order.index(key) if key in new_order else -1
-        )
+def activity_parameter_node_model(activity: UML.Activity) -> Gio.ListModel:
+    store = Gio.ListStore.new(ActivityParameterNodeView)
+
+    for node in activity.node:
+        if isinstance(node, UML.ActivityParameterNode) and node.parameter:
+            store.append(ActivityParameterNodeView(node, activity))
+    store.append(ActivityParameterNodeView(None, activity))
+
+    return store
+
+
+def update_activity_parameter_node_model(
+    store: Gio.ListStore, activity: UML.Activity
+) -> None:
+    n = 0
+    for node in activity.node:
+        if node is not store.get_item(n).node:
+            store.remove(n)
+            store.insert(n, ActivityParameterNodeView(node, activity))
+        n += 1
+
+    while store.get_n_items() > n:
+        store.remove(store.get_n_items() - 1)
+
+    if (
+        not store.get_n_items()
+        or store.get_item(store.get_n_items() - 1).node is not None
+    ):
+        store.append(ActivityParameterNodeView(None, activity))
 
 
 @PropertyPages.register(ActivityItem)
@@ -73,13 +92,10 @@ class ActivityItemPage(PropertyPageBase):
         if not subject:
             return
 
-        self.model = ActivityParameters(self.item)
-
         builder = new_builder(
             "activity-editor",
             "parameters-info",
             signals={
-                "parameter-edited": (on_text_cell_edited, self.model, 0),
                 "parameters-info-clicked": (self.on_parameters_info_clicked),
             },
         )
@@ -87,18 +103,86 @@ class ActivityItemPage(PropertyPageBase):
         self.info = builder.get_object("parameters-info")
         help_link(builder, "parameters-info-icon", "parameters-info")
 
-        tree_view: Gtk.TreeView = builder.get_object("parameter-list")
-        tree_view.set_model(self.model)
-        controller = Gtk.EventControllerKey.new()
-        tree_view.add_controller(controller)
-        controller.connect("key-pressed", on_keypress_event, tree_view)
+        list_view: Gtk.ListView = builder.get_object("parameter-list")
+
+        self.model = activity_parameter_node_model(subject)
+        selection = Gtk.SingleSelection.new(self.model)
+        list_view.set_model(selection)
+        list_view.add_controller(keyboard_shortcuts(selection))
+
+        factory = Gtk.SignalListItemFactory.new()
+        factory.connect(
+            "setup",
+            list_item_factory_setup,
+        )
+
+        list_view.set_factory(factory)
+
+        if self.watcher:
+            self.watcher.watch("node", self.on_nodes_changed)
 
         return unsubscribe_all_on_destroy(
             builder.get_object("activity-editor"), self.watcher
         )
 
+    @event_handler(AssociationUpdated)
+    def on_nodes_changed(self, event):
+        update_activity_parameter_node_model(self.model, self.item.subject)
+
     def on_parameters_info_clicked(self, image, event):
         self.info.set_visible(True)
+
+
+def list_item_factory_setup(_factory, list_item):
+    builder = Gtk.Builder()
+    builder.set_current_object(list_item)
+    builder.extend_with_template(
+        list_item,
+        type(list_item).__gtype__,
+        translated_ui_string("gaphor.UML.actions", "parameter.ui"),
+        -1,
+    )
+
+    def end_editing(text, pspec):
+        if not text.props.editing:
+            list_item.get_item().parameter = text.get_text()
+
+    text = builder.get_object("text")
+    text.connect("notify::editing", end_editing)
+
+
+def keyboard_shortcuts(selection):
+    ctrl = Gtk.EventControllerKey.new()
+    ctrl.connect("key-pressed", list_view_handler, selection)
+    return ctrl
+
+
+@transactional
+def list_view_handler(_list_view, keyval, _keycode, state, selection):
+    item = selection.get_selected_item()
+    if not (item and item.node):
+        return False
+
+    if keyval in (Gdk.KEY_Delete, Gdk.KEY_BackSpace) and not state & (
+        Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK
+    ):
+        item.node.unlink()
+        return True
+
+    elif keyval in (Gdk.KEY_equal, Gdk.KEY_plus, Gdk.KEY_minus, Gdk.KEY_underscore):
+        pos = selection.get_selected()
+        swap_pos = pos + 1 if keyval in (Gdk.KEY_equal, Gdk.KEY_plus) else pos - 1
+        if not 0 <= swap_pos < selection.get_n_items():
+            return False
+
+        other = selection.get_item(swap_pos)
+        if not (other and other.node):
+            return False
+
+        if item.activity.node.swap(item.node, other.node):
+            selection.set_selected(swap_pos)
+        return True
+    return False
 
 
 @PropertyPages.register(UML.ActivityParameterNode)

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -41,6 +41,9 @@ class ActivityParameterNodeView(GObject.Object):
     @transactional
     def parameter(self, value):
         if not self.node:
+            if not value:
+                return
+
             model = self.activity.model
             node = model.create(UML.ActivityParameterNode)
             node.parameter = model.create(UML.Parameter)

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -31,6 +31,8 @@ class ActivityParameterNodeView(GObject.Object):
         self.node = node
         self.activity = activity
 
+    editing = GObject.Property(type=bool, default=False)
+
     @GObject.Property(type=str)
     def parameter(self) -> str:
         return format(self.node.parameter) if self.node else ""
@@ -45,6 +47,9 @@ class ActivityParameterNodeView(GObject.Object):
             self.node = node
             self.activity.node = node
         parse(self.node.parameter, value)
+
+    def start_editing(self):
+        self.editing = True
 
 
 def activity_parameter_node_model(activity: UML.Activity) -> Gio.ListModel:
@@ -161,6 +166,11 @@ def keyboard_shortcuts(selection):
 @transactional
 def list_view_handler(_list_view, keyval, _keycode, state, selection):
     item = selection.get_selected_item()
+
+    if keyval in (Gdk.KEY_F2,):
+        item.start_editing()
+        return True
+
     if not (item and item.node):
         return False
 

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -143,12 +143,32 @@ def list_item_factory_setup(_factory, list_item):
         -1,
     )
 
+    text = builder.get_object("text")
+
+    def on_double_click(ctrl, n_press, x, y):
+        if n_press == 2:
+            text.start_editing()
+
+    ctrl = Gtk.GestureClick.new()
+    ctrl.set_button(Gdk.BUTTON_PRIMARY)
+    ctrl.connect("pressed", on_double_click)
+    text.add_controller(ctrl)
+
+    def start_editing(_ctrl, keyval, _keycode, _state):
+        if keyval in (Gdk.KEY_F2,):
+            text.start_editing()
+            return True
+        return False
+
+    key_ctrl = Gtk.EventControllerKey.new()
+    key_ctrl.connect("key-pressed", start_editing)
+    text.add_controller(key_ctrl)
+
     def end_editing(text, pspec):
         if not text.props.editing:
-            list_item.get_item().parameter = text.get_text()
+            list_item.get_item().parameter = text.editable_text
 
-    text = builder.get_object("text")
-    text.connect("notify::editing", end_editing)
+    text.connect("done-editing", end_editing)
 
 
 def keyboard_shortcuts(selection):

--- a/gaphor/UML/actions/parameter.ui
+++ b/gaphor/UML/actions/parameter.ui
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<interface>
+  <requires lib="gtk" version="4.6"/>
+  <template class="GtkListItem">
+    <property name="child">
+      <object class="GtkEditableLabel" id="text">
+        <style>
+          <class name="row"/>
+        </style>
+        <binding name="text">
+          <lookup name="parameter" type="ActivityParameterNodeView">
+            <lookup name="item">GtkListItem</lookup>
+          </lookup>
+        </binding>
+      </object>
+    </property>
+  </template>
+</interface>

--- a/gaphor/UML/actions/parameter.ui
+++ b/gaphor/UML/actions/parameter.ui
@@ -3,15 +3,20 @@
   <requires lib="gtk" version="4.6"/>
   <template class="GtkListItem">
     <property name="child">
-      <object class="GtkEditableLabel" id="text">
-        <style>
-          <class name="row"/>
-        </style>
-        <binding name="text">
+      <object class="TextField" id="text">
+        <binding name="editable-text">
           <lookup name="parameter" type="ActivityParameterNodeView">
             <lookup name="item">GtkListItem</lookup>
           </lookup>
         </binding>
+        <binding name="readonly-text">
+          <lookup name="parameter" type="ActivityParameterNodeView">
+            <lookup name="item">GtkListItem</lookup>
+          </lookup>
+        </binding>
+        <style>
+          <class name="row"/>
+        </style>
       </object>
     </property>
   </template>

--- a/gaphor/UML/actions/parameter.ui
+++ b/gaphor/UML/actions/parameter.ui
@@ -4,6 +4,7 @@
   <template class="GtkListItem">
     <property name="child">
       <object class="TextField" id="text">
+        <property name="placeholder-text" translatable="yes">Add a Parameter</property>
         <binding name="editable-text">
           <lookup name="parameter" type="ActivityParameterNodeView">
             <lookup name="item">GtkListItem</lookup>

--- a/gaphor/UML/actions/parameter.ui
+++ b/gaphor/UML/actions/parameter.ui
@@ -14,6 +14,11 @@
             <lookup name="item">GtkListItem</lookup>
           </lookup>
         </binding>
+        <binding name="editing">
+          <lookup name="editing" type="ActivityParameterNodeView">
+            <lookup name="item">GtkListItem</lookup>
+          </lookup>
+        </binding>
         <child>
           <object class="GtkGestureClick">
             <property name="button">1</property>

--- a/gaphor/UML/actions/parameter.ui
+++ b/gaphor/UML/actions/parameter.ui
@@ -14,6 +14,13 @@
             <lookup name="item">GtkListItem</lookup>
           </lookup>
         </binding>
+        <child>
+          <object class="GtkGestureClick">
+            <property name="button">1</property>
+            <signal name="pressed" handler="on_double_click" />
+          </object>
+        </child>
+        <signal name="done-editing" handler="end_editing" object="GtkListItem" swapped="no" />
         <style>
           <class name="row"/>
         </style>

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -304,35 +304,9 @@
         <child>
           <object class="GtkFrame">
             <property name="child">
-              <object class="GtkTreeView" id="parameter-list">
+              <object class="GtkListView" id="parameter-list">
                 <property name="height-request">112</property>
                 <property name="focusable">1</property>
-                <property name="headers-clickable">0</property>
-                <property name="enable-search">0</property>
-                <property name="show-expanders">0</property>
-                <property name="enable-grid-lines">horizontal</property>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection" />
-                </child>
-                <child>
-                  <object class="GtkTreeViewColumn">
-                    <property name="resizable">1</property>
-                    <property name="title" translatable="yes">Parameters</property>
-                    <property name="expand">1</property>
-                    <child>
-                      <object class="GtkCellRendererText">
-                        <property name="xpad">2</property>
-                        <property name="ypad">2</property>
-                        <property name="xalign">0</property>
-                        <property name="editable">1</property>
-                        <signal name="edited" handler="parameter-edited" swapped="no" />
-                      </object>
-                      <attributes>
-                        <attribute name="text">0</attribute>
-                      </attributes>
-                    </child>
-                  </object>
-                </child>
               </object>
             </property>
           </object>

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -1,4 +1,4 @@
-from gi.repository import Gtk
+from gi.repository import Gdk
 
 from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
@@ -6,56 +6,76 @@ from gaphor.UML.actions.activity import ActivityItem
 from gaphor.UML.actions.activitypropertypage import (
     ActivityItemPage,
     ActivityParameterNodeNamePropertyPage,
-    ActivityParameters,
+    activity_parameter_node_model,
+    list_view_handler,
 )
 
 
-def test_activity_parameter_node_editing(create):
+def activity_parameter_node(element_factory, name=None):
+    node = element_factory.create(UML.ActivityParameterNode)
+    node.parameter = element_factory.create(UML.Parameter)
+    node.name = name
+    return node
+
+
+def test_activity_parameter_node_empty(element_factory):
+    activity = element_factory.create(UML.Activity)
+    model = activity_parameter_node_model(activity)
+
+    empty = model.get_item(0)
+
+    assert not empty.node
+
+
+def test_activity_parameter_node_in_model(element_factory):
+    activity = element_factory.create(UML.Activity)
+    activity.node = activity_parameter_node(element_factory, "name")
+    model = activity_parameter_node_model(activity)
+
+    param = model.get_item(0)
+    empty = model.get_item(1)
+
+    assert param.node is activity.node[0]
+    assert not empty.node
+
+
+def test_activity_parameter_node_edit_existing_parameter(element_factory):
+    activity = element_factory.create(UML.Activity)
+    activity.node = activity_parameter_node(element_factory)
+    parameter = activity.node[0].parameter
+    model = activity_parameter_node_model(activity)
+
+    view = model.get_item(0)
+    view.parameter = "in attr: str"
+
+    assert parameter.direction == "in"
+    assert parameter.name == "attr"
+    assert parameter.typeValue == "str"
+
+
+def test_activity_parameter_node_add_new_parameter(element_factory):
+    activity = element_factory.create(UML.Activity)
+    model = activity_parameter_node_model(activity)
+
+    view = model.get_item(0)
+    view.parameter = "in attr: str"
+    parameter = activity.node[0].parameter
+
+    assert view.node in activity.node
+    assert parameter.direction == "in"
+    assert parameter.name == "attr"
+    assert parameter.typeValue == "str"
+
+
+def test_update_model_when_new_parameter_added(create, element_factory):
     activity_item = create(ActivityItem, UML.Activity)
-    model = ActivityParameters(activity_item)
-    model.append([None, None])
-    path = Gtk.TreePath.new_first()
-    iter = model.get_iter(path)
-    model.update(iter, col=0, value="param")
 
-    assert model[iter][-1] is activity_item.subject.node[0]
-
-
-def test_activity_parameter_node_reorder(create, element_factory):
-    activity_item = create(ActivityItem, UML.Activity)
-
-    def activity_parameter_node(name):
-        node = element_factory.create(UML.ActivityParameterNode)
-        node.parameter = element_factory.create(UML.Parameter)
-        node.name = name
-        activity_item.subject.node = node
-        return node
-
-    node1 = activity_parameter_node("param1")
-    node2 = activity_parameter_node("param2")
-    node3 = activity_parameter_node("param3")
-
-    list_store = ActivityParameters(activity_item)
-
-    new_order = [node3, node1, node2]
-    list_store.sync_model(new_order)
-
-    assert activity_item.subject.node[0] is node3
-    assert activity_item.subject.node[1] is node1
-    assert activity_item.subject.node[2] is node2
-
-
-def test_activity_page_add_attribute(create):
-    activity_item = create(ActivityItem, UML.Activity)
     property_page = ActivityItemPage(activity_item)
-
     property_page.construct()
-    iter = property_page.model.get_iter((0,))
-    property_page.model.update(iter, 0, "in attr: str")
 
-    assert activity_item.subject.node[0].parameter.direction == "in"
-    assert activity_item.subject.node[0].parameter.name == "attr"
-    assert activity_item.subject.node[0].parameter.typeValue == "str"
+    activity_item.subject.node = activity_parameter_node(element_factory, "one")
+
+    assert property_page.model.get_n_items() == 2  # one + empty row
 
 
 def test_activity_parameter_node_name_editing(create, element_factory):
@@ -68,3 +88,112 @@ def test_activity_parameter_node_name_editing(create, element_factory):
     name.set_text("A new name")
 
     assert subject.parameter.name == "A new name"
+
+
+def test_update_model_when_new_parameter_added_via_list_model(create, element_factory):
+    activity_item = create(ActivityItem, UML.Activity)
+
+    property_page = ActivityItemPage(activity_item)
+    property_page.construct()
+
+    new_view = property_page.model.get_item(0)
+    new_view.parameter = "new"
+
+    assert property_page.model.get_n_items() == 2  # one + empty row
+    assert property_page.model.get_item(0).node is new_view.node
+    assert property_page.model.get_item(1).node is None
+
+
+def test_update_model_with_single_node_when_parameter_deleted(create, element_factory):
+    activity_item = create(ActivityItem, UML.Activity)
+    activity_item.subject.node = node = activity_parameter_node(element_factory, "one")
+
+    property_page = ActivityItemPage(activity_item)
+    property_page.construct()
+
+    del activity_item.subject.node[node]
+
+    assert not activity_item.subject.node
+    assert property_page.model.get_n_items() == 1
+    assert property_page.model.get_item(0).node is None
+
+
+def test_update_model_with_multiple_nodes_when_parameter_deleted(
+    create, element_factory
+):
+    activity_item = create(ActivityItem, UML.Activity)
+    activity_item.subject.node = node = activity_parameter_node(element_factory, "one")
+    activity_item.subject.node = activity_parameter_node(element_factory, "two")
+
+    property_page = ActivityItemPage(activity_item)
+    property_page.construct()
+
+    del activity_item.subject.node[node]
+
+    assert property_page.model.get_n_items() == 2
+    assert property_page.model.get_item(0).node in activity_item.subject.node
+    assert property_page.model.get_item(1).node is None
+
+
+def test_activity_parameter_node_reorder_down(create, element_factory):
+    activity_item = create(ActivityItem, UML.Activity)
+    activity_item.subject.node = activity_parameter_node(element_factory, "one")
+    activity_item.subject.node = activity_parameter_node(element_factory, "two")
+    node_one, node_two = activity_item.subject.node
+
+    property_page = ActivityItemPage(activity_item)
+    widget = property_page.construct()
+
+    list_view = find(widget, "parameter-list")
+    selection = list_view.get_model()
+
+    list_view_handler(None, Gdk.KEY_plus, None, 0, selection)
+
+    assert activity_item.subject.node[0] is node_two
+    assert activity_item.subject.node[1] is node_one
+
+
+def test_activity_parameter_node_reorder_up(create, element_factory):
+    activity_item = create(ActivityItem, UML.Activity)
+    activity_item.subject.node = activity_parameter_node(element_factory, "one")
+    activity_item.subject.node = activity_parameter_node(element_factory, "two")
+    node_one, node_two = activity_item.subject.node
+
+    property_page = ActivityItemPage(activity_item)
+    widget = property_page.construct()
+
+    list_view = find(widget, "parameter-list")
+    selection = list_view.get_model()
+    selection.set_selected(1)
+
+    list_view_handler(None, Gdk.KEY_minus, None, 0, selection)
+
+    assert activity_item.subject.node[0] is node_two
+    assert activity_item.subject.node[1] is node_one
+
+
+def test_activity_parameter_node_reorder_first_node_up(create, element_factory):
+    activity_item = create(ActivityItem, UML.Activity)
+    activity_item.subject.node = activity_parameter_node(element_factory, "one")
+    activity_item.subject.node = activity_parameter_node(element_factory, "two")
+    node_one, node_two = activity_item.subject.node
+
+    property_page = ActivityItemPage(activity_item)
+    widget = property_page.construct()
+
+    list_view = find(widget, "parameter-list")
+    selection = list_view.get_model()
+
+    list_view_handler(None, Gdk.KEY_minus, None, 0, selection)
+
+    assert activity_item.subject.node[0] is node_one
+    assert activity_item.subject.node[1] is node_two
+
+
+def test_construct_activity_itemproperty_page(create):
+    activity_item = create(ActivityItem, UML.Activity)
+
+    property_page = ActivityItemPage(activity_item)
+    widget = property_page.construct()
+
+    assert widget

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -15,6 +15,7 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Adw, Gio, GLib, GtkSource
 
+import gaphor.ui.textfield
 from gaphor.application import Application, Session
 from gaphor.core import event_handler
 from gaphor.event import ActiveSessionChanged, ApplicationShutdown, SessionCreated

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -462,49 +462,13 @@ def list_item_factory_setup(
     drop_target.connect("drop", list_item_drop_drop, list_item, event_manager)
     row.add_controller(drop_target)
 
-    text = builder.get_object("text")
-
-    should_commit = True
-
-    def end_editing():
-        list_item.get_item().get_item().visible_child_name = "default"
-        row.get_parent().grab_focus()
-
-    def text_focus_out(ctrl):
+    def done_editing(text_field, should_commit):
         if should_commit:
-            edit_text = text.get_buffer().get_text()
             tree_item = list_item.get_item().get_item()
             with Transaction(event_manager):
-                tree_item.edit_text = edit_text
-        end_editing()
+                tree_item.editable_text = text_field.editable_text
 
-    def text_key_pressed(ctrl, keyval, keycode, state):
-        if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
-            end_editing()
-            return True
-        elif keyval == Gdk.KEY_Escape:
-            nonlocal should_commit
-            should_commit = False
-            list_item.get_item().get_item().sync()
-            end_editing()
-            return True
-        return False
-
-    focus_ctrl = Gtk.EventControllerFocus.new()
-    focus_ctrl.connect("leave", text_focus_out)
-    text.add_controller(focus_ctrl)
-
-    key_ctrl = Gtk.EventControllerKey.new()
-    key_ctrl.connect("key-pressed", text_key_pressed)
-    text.add_controller(key_ctrl)
-
-    def start_editing(stack, pspec):
-        nonlocal should_commit
-        if stack.get_visible_child_name() == "editing":
-            should_commit = True
-            text.grab_focus()
-
-    builder.get_object("stack").connect("notify::visible-child-name", start_editing)
+    builder.get_object("text").connect("done-editing", done_editing)
 
 
 def list_item_drag_prepare(

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -103,6 +103,19 @@ frame > textview {
   padding: 6px;
 }
 
+listview .row {
+  padding: 2px 0;
+}
+
+.editing {
+  background-color: @theme_bg_color;
+  color: @theme_fg_color;
+}
+
+.editing selection {
+  background-color: alpha(@theme_selected_bg_color, 0.3);
+}
+
 .info:hover {
   background-color: @shade_color;
 }
@@ -115,17 +128,7 @@ frame > textview {
   margin: 0 6px;
 }
 
-#model_browser .editing {
-  background-color: @theme_bg_color;
-  color: @theme_fg_color;
-}
-
-#model_browser .editing selection {
-  background-color: alpha(@theme_selected_bg_color, 0.3);
-}
-
 #model_browser .row {
-  padding: 2px 0;
   border-top: 0 solid @shade_color;
   transition: border 200ms;
 }

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -110,6 +110,7 @@ listview .row {
 textfield text {
   background-color: @theme_bg_color;
   color: @theme_fg_color;
+  border: 1px solid @theme_bg_color;
 }
 
 textfield text selection {

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -107,12 +107,12 @@ listview .row {
   padding: 2px 0;
 }
 
-.editing {
+textfield text {
   background-color: @theme_bg_color;
   color: @theme_fg_color;
 }
 
-.editing selection {
+textfield text selection {
   background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 

--- a/gaphor/ui/tests/test_modelbrowser.py
+++ b/gaphor/ui/tests/test_modelbrowser.py
@@ -129,7 +129,7 @@ def test_element_name_changed(model_browser, element_factory):
 
     weight, style = tree_item.attributes.get_attributes()
 
-    assert tree_item.text == "foo"
+    assert tree_item.readonly_text == "foo"
     assert weight.as_int().value == 400
     assert style.as_int().value == 0
 
@@ -264,7 +264,7 @@ def test_generalization_text(model_browser, element_factory):
     branch = model.branches[tree_item]
     assert tree_item
     assert branch.relationships[0].element is generalization
-    assert branch.relationships[0].text == "general: General"
+    assert branch.relationships[0].readonly_text == "general: General"
 
 
 def test_drop_multiple_elements(model_browser, element_factory, event_manager):

--- a/gaphor/ui/tests/test_treemodel.py
+++ b/gaphor/ui/tests/test_treemodel.py
@@ -197,7 +197,7 @@ def test_tree_model_relationship_subtree(element_factory):
 
     assert package_model
     assert isinstance(relationship_item, RelationshipItem)
-    assert relationship_item.text == gettext("<Relationships>")
+    assert relationship_item.readonly_text == gettext("<Relationships>")
     assert association_item is relationship_model.get_item(0)
 
 
@@ -245,9 +245,9 @@ def test_tree_model_remove_relationship(element_factory):
 
 def test_tree_model_sort_relationship_item_first(element_factory):
     a = TreeItem(UML.Package())
-    a.text = "a"
+    a.readonly_text = "a"
     b = TreeItem(UML.Package())
-    b.text = "b"
+    b.readonly_text = "b"
     r = RelationshipItem(None)
 
     assert tree_item_sort(r, b) == -1

--- a/gaphor/ui/textfield.py
+++ b/gaphor/ui/textfield.py
@@ -37,6 +37,16 @@ _XML = """\
                 </binding>
               </object>
             </property>
+            <child>
+              <object class="GtkEventControllerFocus">
+                <signal name="leave" handler="on_text_focus_out" />
+              </object>
+            </child>
+            <child>
+              <object class="GtkEventControllerKey">
+                <signal name="key-pressed" handler="on_text_key_pressed" />
+              </object>
+            </child>
           </object>
         </property>
       </object>
@@ -61,7 +71,6 @@ class TextField(Gtk.Stack):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        _text_field_edit_controls(self)
 
     readonly_text = GObject.Property(type=str, default="")
     editable_text = GObject.Property(type=str, default="")
@@ -108,28 +117,20 @@ class TextField(Gtk.Stack):
         else:
             self._text.get_buffer().set_text(self.editable_text, -1)
 
+    @Gtk.Template.Callback()
+    def on_text_focus_out(self, _ctrl):
+        if self.editing:
+            self.done_editing(True)
 
-TextField.set_css_name("textfield")
-
-
-def _text_field_edit_controls(text_field: TextField):
-    def text_focus_out(_ctrl):
-        if text_field.editing:
-            text_field.done_editing(True)
-
-    def text_key_pressed(_ctrl, keyval, _keycode, _state):
+    @Gtk.Template.Callback()
+    def on_text_key_pressed(self, _ctrl, keyval, _keycode, _state):
         if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
-            text_field.done_editing(True)
+            self.done_editing(True)
             return True
         elif keyval == Gdk.KEY_Escape:
-            text_field.done_editing(False)
+            self.done_editing(False)
             return True
         return False
 
-    focus_ctrl = Gtk.EventControllerFocus.new()
-    focus_ctrl.connect("leave", text_focus_out)
-    text_field._text.add_controller(focus_ctrl)
 
-    key_ctrl = Gtk.EventControllerKey.new()
-    key_ctrl.connect("key-pressed", text_key_pressed)
-    text_field._text.add_controller(key_ctrl)
+TextField.set_css_name("textfield")

--- a/gaphor/ui/textfield.py
+++ b/gaphor/ui/textfield.py
@@ -1,0 +1,134 @@
+from gi.repository import GLib, Gdk, GObject, Gtk, Pango
+
+_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <template class="TextField" parent="GtkStack">
+    <child>
+      <object class="GtkStackPage">
+        <property name="name">default</property>
+        <property name="child">
+          <object class="GtkLabel">
+            <property name="xalign">0</property>
+            <property name="hexpand">yes</property>
+            <binding name="attributes">
+              <lookup name="attributes">TextField</lookup>
+            </binding>
+            <binding name="label">
+              <lookup name="readonly-text">TextField</lookup>
+            </binding>
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkStackPage">
+        <property name="name">editing</property>
+        <property name="child">
+          <object class="GtkText" id="_text">
+            <property name="propagate-text-width">yes</property>
+            <property name="buffer">
+              <object class="GtkEntryBuffer">
+                <binding name="text">
+                  <lookup name="editable-text">TextField</lookup>
+                </binding>
+              </object>
+            </property>
+          </object>
+        </property>
+      </object>
+    </child>
+  </template>
+</interface>
+"""
+
+
+@Gtk.Template(string=_XML)
+class TextField(Gtk.Stack):
+    """A text input field for use in ``ListView``s.
+
+    The Text Field contains two layers of text. One for displaying
+    (a `Gtk.Label`), and one for editing (`Gtk.Text`).
+    This allows us to easily define a separate text for editing.
+    For example: a class attribute is represented as `+ attr: int = 0`,
+    but if we edit it, we should only be able to edit it's name (`attr`).
+    """
+
+    __gtype_name__ = "TextField"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        _text_field_edit_controls(self)
+        self.connect("notify::readonly-text", print)
+
+    readonly_text = GObject.Property(type=str, default="")
+    editable_text = GObject.Property(type=str, default="")
+    attributes = GObject.Property(type=Pango.AttrList)
+    """Pango style attributes for the readonly text."""
+
+    can_edit = GObject.Property(type=bool, default=True)
+
+    @GObject.Property(type=bool, default=False)
+    def editing(self):
+        return self.get_visible_child_name() == "editing"
+
+    @editing.setter  # type: ignore[no-redef]
+    def editing(self, value):
+        if value:
+            GLib.timeout_add(
+                START_EDIT_DELAY, lambda: self.set_visible_child_name("editing")
+            )
+        else:
+            self.set_visible_child_name("default")
+
+    _text = Gtk.Template.Child()
+
+    def start_editing(self):
+        self.editing = True  # type: ignore[method-assign]
+
+    def done_editing(self, should_commit):
+        if self.editing:
+            self.emit("done-editing", should_commit)
+
+    @GObject.Signal(name="done-editing", arg_types=(bool,))
+    def _done_editing(self, should_commit: bool) -> None:
+        self.editing = False  # type: ignore[method-assign]
+        if parent := self.get_parent():
+            parent.grab_focus()
+        if should_commit:
+            self.editable_text = self._text.get_buffer().get_text()
+        else:
+            self._text.get_buffer().set_text(self.editable_text, -1)
+
+
+TextField.set_css_name("textfield")
+
+
+def _text_field_edit_controls(text_field: TextField):
+    def text_focus_out(_ctrl):
+        if text_field.editing:
+            text_field.done_editing(True)
+
+    def text_key_pressed(_ctrl, keyval, _keycode, _state):
+        if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
+            text_field.done_editing(True)
+            return True
+        elif keyval == Gdk.KEY_Escape:
+            text_field.done_editing(False)
+            return True
+        return False
+
+    focus_ctrl = Gtk.EventControllerFocus.new()
+    focus_ctrl.connect("leave", text_focus_out)
+    text_field._text.add_controller(focus_ctrl)
+
+    key_ctrl = Gtk.EventControllerKey.new()
+    key_ctrl.connect("key-pressed", text_key_pressed)
+    text_field._text.add_controller(key_ctrl)
+
+    def start_editing(text_field, _pspec):
+        if text_field.get_visible_child_name() == "editing":
+            text_field._text.grab_focus()
+
+    text_field.connect("notify::visible-child-name", start_editing)

--- a/gaphor/ui/textfield.py
+++ b/gaphor/ui/textfield.py
@@ -76,10 +76,16 @@ class TextField(Gtk.Stack):
 
     @editing.setter  # type: ignore[no-redef]
     def editing(self, value):
+        if not self.can_edit:
+            return
+
         if value:
-            GLib.timeout_add(
-                START_EDIT_DELAY, lambda: self.set_visible_child_name("editing")
-            )
+
+            def _start_editing():
+                self.set_visible_child_name("editing")
+                self._text.grab_focus()
+
+            GLib.timeout_add(START_EDIT_DELAY, _start_editing)
         else:
             self.set_visible_child_name("default")
 
@@ -127,9 +133,3 @@ def _text_field_edit_controls(text_field: TextField):
     key_ctrl = Gtk.EventControllerKey.new()
     key_ctrl.connect("key-pressed", text_key_pressed)
     text_field._text.add_controller(key_ctrl)
-
-    def start_editing(text_field, _pspec):
-        if text_field.get_visible_child_name() == "editing":
-            text_field._text.grab_focus()
-
-    text_field.connect("notify::visible-child-name", start_editing)

--- a/gaphor/ui/textfield.py
+++ b/gaphor/ui/textfield.py
@@ -51,6 +51,23 @@ _XML = """\
         </property>
       </object>
     </child>
+    <child>
+      <object class="GtkStackPage">
+        <property name="name">placeholder</property>
+        <property name="child">
+          <object class="GtkLabel">
+            <property name="xalign">0</property>
+            <property name="hexpand">yes</property>
+            <binding name="label">
+              <lookup name="placeholder-text">TextField</lookup>
+            </binding>
+            <style>
+              <class name="dim-label" />
+            </style>
+          </object>
+        </property>
+      </object>
+    </child>
   </template>
 </interface>
 """
@@ -71,13 +88,23 @@ class TextField(Gtk.Stack):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self._readonly_text = ""
 
-    readonly_text = GObject.Property(type=str, default="")
     editable_text = GObject.Property(type=str, default="")
+    placeholder_text = GObject.Property(type=str, default="")
     attributes = GObject.Property(type=Pango.AttrList)
     """Pango style attributes for the readonly text."""
 
     can_edit = GObject.Property(type=bool, default=True)
+
+    @GObject.Property(type=str, default="")
+    def readonly_text(self):
+        return self._readonly_text
+
+    @readonly_text.setter  # type: ignore[no-redef]
+    def readonly_text(self, value):
+        self._readonly_text = value or ""
+        self.set_visible_child_name("default" if value else "placeholder")
 
     @GObject.Property(type=bool, default=False)
     def editing(self):
@@ -96,7 +123,9 @@ class TextField(Gtk.Stack):
 
             GLib.timeout_add(START_EDIT_DELAY, _start_editing)
         else:
-            self.set_visible_child_name("default")
+            self.set_visible_child_name(
+                "default" if self.readonly_text else "placeholder"
+            )
 
     _text = Gtk.Template.Child()
 

--- a/gaphor/ui/textfield.py
+++ b/gaphor/ui/textfield.py
@@ -1,4 +1,6 @@
-from gi.repository import GLib, Gdk, GObject, Gtk, Pango
+from gi.repository import Gdk, GLib, GObject, Gtk, Pango
+
+START_EDIT_DELAY = 100  # ms
 
 _XML = """\
 <?xml version="1.0" encoding="UTF-8"?>
@@ -60,7 +62,6 @@ class TextField(Gtk.Stack):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         _text_field_edit_controls(self)
-        self.connect("notify::readonly-text", print)
 
     readonly_text = GObject.Property(type=str, default="")
     editable_text = GObject.Property(type=str, default="")

--- a/gaphor/ui/treeitem.ui
+++ b/gaphor/ui/treeitem.ui
@@ -10,7 +10,9 @@
         </binding>
         <property name="child">
           <object class="GtkBox" id="row">
-            <style><class name="row"/></style>
+            <style>
+              <class name="row"/>
+            </style>
             <property name="spacing">6</property>
             <child>
               <object class="GtkImage">

--- a/gaphor/ui/treeitem.ui
+++ b/gaphor/ui/treeitem.ui
@@ -29,47 +29,32 @@
               </object>
             </child>
             <child>
-              <object class="GtkStack" id="stack">
-                <binding name="visible-child-name">
-                  <lookup name="visible_child_name" type="gaphor+ui+treemodel+TreeItem">
+              <object class="TextField" id="text">
+                <binding name="readonly-text">
+                  <lookup name="readonly-text" type="gaphor+ui+treemodel+TreeItem">
                     <lookup name="item">expander</lookup>
                   </lookup>
                 </binding>
-                <child>
-                  <object class="GtkStackPage">
-                    <property name="name">default</property>
-                    <property name="child">
-                      <object class="GtkLabel" id="label">
-                        <property name="xalign">0</property>
-                        <property name="hexpand">yes</property>
-                        <binding name="attributes">
-                          <lookup name="attributes" type="gaphor+ui+treemodel+TreeItem">
-                            <lookup name="item">expander</lookup>
-                          </lookup>
-                        </binding>
-                        <binding name="label">
-                          <lookup name="text" type="gaphor+ui+treemodel+TreeItem">
-                            <lookup name="item">expander</lookup>
-                          </lookup>
-                        </binding>
-                      </object>
-                    </property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkStackPage">
-                    <property name="name">editing</property>
-                    <property name="child">
-                      <object class="GtkText" id="text">
-                        <property name="propagate-text-width">yes</property>
-                        <property name="buffer">buffer</property>
-                        <style>
-                          <class name="editing"/>
-                        </style>
-                      </object>
-                    </property>
-                  </object>
-                </child>
+                <binding name="editable-text">
+                  <lookup name="editable-text" type="gaphor+ui+treemodel+TreeItem">
+                    <lookup name="item">expander</lookup>
+                  </lookup>
+                </binding>
+                <binding name="attributes">
+                  <lookup name="attributes" type="gaphor+ui+treemodel+TreeItem">
+                    <lookup name="item">expander</lookup>
+                  </lookup>
+                </binding>
+                <binding name="editing">
+                  <lookup name="editing" type="gaphor+ui+treemodel+TreeItem">
+                    <lookup name="item">expander</lookup>
+                  </lookup>
+                </binding>
+                <binding name="can-edit">
+                  <lookup name="can-edit" type="gaphor+ui+treemodel+TreeItem">
+                    <lookup name="item">expander</lookup>
+                  </lookup>
+                </binding>
               </object>
             </child>
           </object>
@@ -77,11 +62,4 @@
       </object>
     </property>
   </template>
-  <object class="GtkEntryBuffer" id="buffer">
-    <binding name="text">
-      <lookup name="edit_text" type="gaphor+ui+treemodel+TreeItem">
-        <lookup name="item">expander</lookup>
-      </lookup>
-    </binding>
-  </object>
 </interface>

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -36,7 +36,6 @@ class TreeItem(GObject.Object):
         return "" if self.read_only() else (self.element.name or "")
 
     @editable_text.setter  # type: ignore[no-redef]
-    # @transactional
     def editable_text(self, text):
         if not self.read_only():
             self.element.name = text or ""
@@ -63,7 +62,7 @@ class RelationshipItem(TreeItem):
         super().__init__(None)
         self.child_model = child_model
         self.readonly_text = gettext("<Relationships>")
-        self.can_editing = False
+        self.can_edit = False
 
 
 class Branch:

--- a/gaphor/ui/treesearch.py
+++ b/gaphor/ui/treesearch.py
@@ -25,7 +25,7 @@ def search(search_text, tree_walker: Iterable[TreeItem]):
     search_text = normalize("NFC", search_text).casefold()
 
     for tree_item in tree_walker:
-        text = normalize("NFC", tree_item.text).casefold()
+        text = normalize("NFC", tree_item.readonly_text).casefold()
         if tree_item.element and search_text in text:
             return tree_item
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

**This PR should only be merged if we're sure it does not cause any crashes.**

### What is the current behavior?

The Activity Parameter property page had been reverted to `Gtk.TreeView`, since the `Gtk.EditableLabel` caused the app to crash.

Issue Number: #2433 

### What is the new behavior?

We want to get rid of deprecated API's.

`Gtk.EditableLabel` exposes some behavior that we currently have differently (e.g. the text should not change to editable state when a row is selected, only after a double click).

We have a new widget: `TextField`, that contains the text edit logic we use in the model browser. This widget looks more stable and works for the Parameter ListView too.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Added a placeholder text to the Parameter table, so it's more clear what a user can do in the box:

<img width="270" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/aba34316-aec4-4afe-b238-9c8718fceaaa">
