### PR TITLE
Fix Parameter Node and Execution Specification with Dark mode

### DIFF
--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -29,7 +29,7 @@ class ProxyPortItem(Named, AttachedPresentation[sysml.ProxyPort]):
 
     def update_shapes(self):
         self.shape = IconBox(
-            Box(style={"background-color": (1, 1, 1, 1)}, draw=draw_border),
+            Box(draw=draw_border),
             Text(
                 text=lambda: stereotypes_str(
                     self.subject, [self.diagram.gettext("proxy")]

--- a/gaphor/UML/actions/activity.py
+++ b/gaphor/UML/actions/activity.py
@@ -90,7 +90,7 @@ class ActivityParameterNodeItem(AttachedPresentation[UML.ActivityParameterNode])
                 Text(
                     text=lambda: self.subject.parameter.name or "",
                 ),
-                style={"padding": (4, 12, 4, 12), "background-color": (1, 1, 1, 1)},
+                style={"padding": (4, 12, 4, 12)},
                 draw=draw_border,
             ),
             width=100,

--- a/gaphor/UML/actions/pin.py
+++ b/gaphor/UML/actions/pin.py
@@ -41,7 +41,7 @@ class PinItem(Named, AttachedPresentation[UML.Pin]):
         )
 
         self.shape = IconBox(
-            Box(style={"background-color": (1, 1, 1, 1)}, draw=draw_border),
+            Box(draw=draw_border),
             Text(
                 text=lambda: stereotypes_str(
                     self.subject, [] if self.subject else [self.pin_type()]

--- a/gaphor/UML/interactions/executionspecification.py
+++ b/gaphor/UML/interactions/executionspecification.py
@@ -80,9 +80,7 @@ class ExecutionSpecificationItem(
 
         self._ports = [BetweenPort(nw, sw), BetweenPort(ne, se)]
 
-        self._shape = Box(
-            style={"background-color": (1.0, 1.0, 1.0, 1.0)}, draw=draw_border
-        )
+        self._shape = Box(draw=draw_border)
 
     def handles(self):
         return self._handles

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -43,7 +43,7 @@ from gaphor.i18n import translation
 
 log = logging.getLogger(__name__)
 
-# Not all styles are requires: "background-color", "font-weight",
+# Not all styles are required: "background-color", "font-weight",
 # "text-color", and "text-decoration" are optional (can default to None)
 FALLBACK_STYLE: Style = {
     "color": (0, 0, 0, 1),

--- a/gaphor/core/modeling/stylesheet.py
+++ b/gaphor/core/modeling/stylesheet.py
@@ -10,6 +10,7 @@ from gaphor.core.styling import CompiledStyleSheet, Style, StyleNode
 SYSTEM_STYLE_SHEET = textwrap.dedent(
     """\
     * {
+     --opaque-background-color: white;
      background-color: transparent;
      color: black;
      font-size: 14;
@@ -26,8 +27,15 @@ SYSTEM_STYLE_SHEET = textwrap.dedent(
      opacity: 0.5;
     }
 
+    @media light-mode {
+     * {
+      --opaque-background-color: #fafafa;
+     }
+    }
+
     @media dark-mode {
      * {
+      --opaque-background-color: #242424;
       color: white;
      }
 
@@ -48,6 +56,12 @@ SYSTEM_STYLE_SHEET = textwrap.dedent(
 
     controlflow {
         dash-style: 9 3;
+    }
+
+    proxyport,
+    activityparameternode,
+    executionspecification {
+     background-color: var(--opaque-background-color);
     }
     """
 )


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Elements such as Parameters and Execution Specifications have a white background when used with dark mode.

Issue Number: #2437

### What is the new behavior?

The background color of overlaying elements changes with the color scheme.

Light mode:

![image](https://github.com/gaphor/gaphor/assets/96249/50e93edd-205d-4ba9-9bb1-8ecb5d4f1d2b)


Dark mode:

![image](https://github.com/gaphor/gaphor/assets/96249/c3002cfc-3a39-4aab-be93-0ff56a18f6b8)

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
