### PR TITLE
Only use mature translations for release

### DIFF
--- a/.github/actions/setup_and_test/action.yml
+++ b/.github/actions/setup_and_test/action.yml
@@ -37,8 +37,13 @@ runs:
         poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\PyGObject*.whl)
         poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\pycairo*.whl)
       shell: pwsh
-    - name: Compile translations
-      run: poetry run poe gettext-mo
+    - name: Compile all translations
+      if: github.event_name != 'release'
+      run: poetry run poe gettext-mo-all
+      shell: bash
+    - name: Compile release translations
+      if: github.event_name == 'release'
+      run: poetry run poe gettext-mo-release
       shell: bash
     - name: Test with Pytest
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 2.19.2
 ------
+- Add SysML Requirements trace derived unions
 - Fix Parameter Node and Execution Specification with Dark mode
+- Scale parameter nodes to contain long names
 - Lenient derived unions
 - Fix segfault by reverting Gtk.ListVew for Parameters
 - Fix connect interaction fragments
@@ -12,6 +14,7 @@
 - Add Python 3.12 Support, Update Poetry to version 1.5.1
 - Apply security best practices to GitHub Actions
 - Create a Security Policy and Run Scorecard Checks
+- Only use mature translations for released versions of Gaphor
 - Update Spanish, Hungarian, and Finnish translations
 - Fix scaling of Activity Parameter nodes
 

--- a/po/build-babel.py
+++ b/po/build-babel.py
@@ -23,20 +23,29 @@ def update_po_files():
         run_babel("update", pot_path, path, path.stem)
 
 
-def compile_mo_files():
+def compile_mo_file(path: Path):
+    mo_path = (
+        po_path.parent / "gaphor" / "locale" / path.stem / "LC_MESSAGES" / "gaphor.mo"
+    )
+    mo_path.parent.mkdir(parents=True, exist_ok=True)
+    run_babel("compile", path, mo_path, path.stem)
+
+
+def compile_mo_all():
     for path in (path for path in po_path.iterdir() if path.suffix == ".po"):
-        mo_path = (
-            po_path.parent
-            / "gaphor"
-            / "locale"
-            / path.stem
-            / "LC_MESSAGES"
-            / "gaphor.mo"
-        )
-        mo_path.parent.mkdir(parents=True, exist_ok=True)
-        run_babel("compile", path, mo_path, path.stem)
+        compile_mo_file(path)
+
+
+def compile_mo_release():
+    mature_translations = ["cs", "es", "de", "nl", "fi", "hr", "hu", "ru"]
+    for path in (
+        path
+        for path in po_path.iterdir()
+        if path.stem in mature_translations and path.suffix == ".po"
+    ):
+        compile_mo_file(path)
 
 
 if __name__ == "__main__":
     update_po_files()
-    compile_mo_files()
+    compile_mo_all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,8 +184,9 @@ package = { "cwd" = "_packaging", shell = "pyinstaller -y gaphor.spec"}
 win-installer = { "script" = "_packaging.windows.build-win-installer:main" }
 gettext-pot = "pybabel extract -o po/gaphor.pot -F po/babel.ini -k i18nize gaphor"
 gettext-po = { "script" = "po.build-babel:update_po_files" }
-gettext-mo = { "script" = "po.build-babel:compile_mo_files" }
-translations = ["gettext-pot", "gettext-po", "gettext-mo"]
+gettext-mo-all = { "script" = "po.build-babel:compile_mo_all" }
+gettext-mo-release = { "script" = "po.build-babel:compile_mo_release" }
+translations = ["gettext-pot", "gettext-po", "gettext-mo-all"]
 icons = { "shell" = "make -C gaphor/ui/icons" }
 
 [tool.poe.executor]


### PR DESCRIPTION
Proposal for closing #2346.

- For all pre-releases, we build mo files for all translations
- For releases, we only create mo files for a subset (cs, es, de, nl, fi, hr, hu, and ru). These are the languages that are majorly complete, and we can add additional ones to the list as they progress. It isn't automatic, but shouldn't require too much maintenance.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
All translations are used, even if only a few strings are translated

Issue Number: #2346

### What is the new behavior?
Only mature translations are used for release versions of Gaphor

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
