### PR TITLE
Fix: resolve CSS style variables before using the values

### DIFF
--- a/gaphor/core/styling/__init__.py
+++ b/gaphor/core/styling/__init__.py
@@ -78,17 +78,19 @@ def merge_styles(*styles: Style) -> Style:
             abs_font_size = font_size
         style.update(s)
 
-    if abs_font_size and style["font-size"] in FONT_SIZE_VALUES:
-        style["font-size"] = abs_font_size * FONT_SIZE_VALUES[style["font-size"]]  # type: ignore[index,operator]
+    resolved_style = resolve_variables(style, styles)
 
-    if "opacity" in style:
-        opacity = style["opacity"]
+    if abs_font_size and resolved_style["font-size"] in FONT_SIZE_VALUES:
+        resolved_style["font-size"] = abs_font_size * FONT_SIZE_VALUES[resolved_style["font-size"]]  # type: ignore[index,operator]
+
+    if "opacity" in resolved_style:
+        opacity = resolved_style["opacity"]
         for color_prop in ("color", "background-color", "text-color"):
-            color: Color | None = style.get(color_prop)  # type: ignore[assignment]
+            color: Color | None = resolved_style.get(color_prop)  # type: ignore[assignment]
             if color and color[3] > 0.0:
-                style[color_prop] = color[:3] + (color[3] * opacity,)  # type: ignore[literal-required]
+                resolved_style[color_prop] = color[:3] + (color[3] * opacity,)  # type: ignore[literal-required]
 
-    return resolve_variables(style, styles)
+    return resolved_style
 
 
 def resolve_variables(style: Style, style_layers: Sequence[Style]) -> Style:

--- a/gaphor/core/styling/tests/test_cascading.py
+++ b/gaphor/core/styling/tests/test_cascading.py
@@ -1,6 +1,7 @@
 import pytest
 
 from gaphor.core.styling import merge_styles
+from gaphor.core.styling.declarations import Var
 
 
 def test_merge_opacity():
@@ -47,3 +48,12 @@ def test_font_size_override_with_relative_size():
     style = merge_styles({"font-size": 10}, {"font-size": 24}, {"font-size": "x-small"})
 
     assert style["font-size"] == 24 * 3 / 4
+
+
+def test_color_override_with_variables():
+    style = merge_styles(
+        {"--my-color": "white", "--my-opacity": 0.5},
+        {"color": Var("--my-color"), "opacity": Var("--my-opacity")},
+    )
+
+    assert style["color"] == (1.0, 1.0, 1.0, 0.5)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Rendering throws exception when an element with a solid background is on the diagram

In #2439 we introduced variables for the background color, so solid items could change the background color in dark mode.

Issue Number: #2452

### What is the new behavior?

CSS variables are evaluated before font-size and color (with opacity) is finally calculated.


### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
