### PR TITLE
Extend model preferences section in getting started guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -154,4 +154,27 @@ The properties that are shown depend on the item that is selected.
 ## Model Preferences
 
 The Property Editor also contains model preferences: Click the ![document-properties-symbolic](images/document-properties-symbolic.svg)
-button. Here you can set a few model related settings and edit the [style sheet](style_sheets).
+button. 
+
+### Reset Tool Automatically
+
+By default the pointer tool is selected after an element is placed from the toolbox. If this option is turned off, the same type of element will be placed by clicking in the diagram until another element is selected in the toolbox.
+
+### Remove Unused Elements
+
+By default elements that are not part of any diagram in the model will be removed. If this option is turned off, elements remain in the model and may be found in the model browser.
+
+### Language
+
+The language modifier is only applicable to the loaded model and how it is shown in the diagram. The language setting is saved as part of the model and defaults to English.
+
+The UI language of Gaphor is controlled by the operating system. 
+
+```{note}
+Gaphor considers the ``LANG`` environment variable on Linux, Windows and macOS. 
+
+On Windows and macOS it can be set independently of the operating system's language settings to a different language.
+```
+### Style Sheet
+
+The [style sheet](style_sheets) allows to change the visual appearance of diagrams and model elements.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -154,7 +154,7 @@ The properties that are shown depend on the item that is selected.
 ## Model Preferences
 
 The Property Editor also contains model preferences: Click the ![document-properties-symbolic](images/document-properties-symbolic.svg)
-button. 
+button.
 
 ### Reset Tool Automatically
 
@@ -168,10 +168,10 @@ By default elements that are not part of any diagram in the model will be remove
 
 The language modifier is only applicable to the loaded model and how it is shown in the diagram. The language setting is saved as part of the model and defaults to English.
 
-The UI language of Gaphor is controlled by the operating system. 
+The UI language of Gaphor is controlled by the operating system.
 
 ```{note}
-Gaphor considers the ``LANG`` environment variable on Linux, Windows and macOS. 
+Gaphor considers the ``LANG`` environment variable on Linux, Windows and macOS.
 
 On Windows and macOS it can be set independently of the operating system's language settings to a different language.
 ```


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->

This PR extends the Model Preferences section in the Getting Started guide of the documentation with explanations of the current options.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [X] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Model Preferences are currently not explained, including what the expected behavior of the language selector is. 

Issue Number: #2461

### What is the new behavior?

Added explanations of the current options.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->