### PR TITLE
Deep copy for packages and diagrams

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,4 +226,9 @@ epub_exclude_files = ["search.html"]
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {
+    "gnome": ("https://amolenaar.pages.gitlab.gnome.org/pygobject-docs", None),
+    "pygobject": ("https://pygobject.readthedocs.io/en/latest", None),
+    "gaphas": ("https://gaphas.readthedocs.io/en/stable", None),
+    "python": ("https://docs.python.org/3", None),
+}

--- a/docs/modeling_language.md
+++ b/docs/modeling_language.md
@@ -70,41 +70,37 @@ Sometimes items need more than one model element to work. For example an Associa
 In those specific cases you need to implement your own copy and paste functions. To create such a thing you'll need to create
 two functions: one for copying and one for pasting.
 
-```{eval-rst}
-.. function:: gaphor.diagram.copypaste.copy(obj: Element) -> Iterator[tuple[Id, Opaque]]
+```{function} gaphor.diagram.copypaste.copy(obj: ~gaphor.core.modeling.Element) -> ~typing.Iterator[tuple[Id, Opaque]]
 
-   Create a copy of an element (or list of elements).
-   The returned type should be distinct, so the `paste()`
-   function can properly dispatch.
-
-.. function:: gaphor.diagram.copypaste.paste(copy_data: T, diagram: Diagram, lookup: Callable[[str], Element | None]) -> Iterator[Element]
-
-   Paste previously copied data. Based on the data type created in the
-   ``copy()`` function, try to duplicate the copied elements.
-   Returns the newly created item or element
-
-.. function:: gaphor.diagram.copypaste.paste_link(copy_data: CopyData, diagram: Diagram, lookup: Callable[[str], Element | None]) -> set[Presentation]:
-
-   Create a copy of the Presentation element, but try to link the underlying model element.
-   A shallow copy.
-
-.. function:: gaphor.diagram.copypaste.paste_full(copy_data: CopyData, diagram: Diagram, lookup: Callable[[str], Element | None]) -> set[Presentation]:
-
-   Create a copy of both Presentation and model element. A deep copy.
+Create a copy of an element (or list of elements).
+The returned type should be distinct, so the `paste()`
+function can properly dispatch.
+A copy function normally copies only the element and mandatory related elements. E.g. an Association needs two association ends.
 ```
 
-To serialize the copied elements and deserialize them again, there are two functions available:
+```{function} gaphor.diagram.copypaste.paste(copy_data: T, diagram: ~gaphor.core.modeling.Diagram, lookup: ~typing.Callable[[str], ~gaphor.core.modeling.Element | None]) -> ~typing.Iterator[~gaphor.core.modeling.Element]
 
-```{eval-rst}
-.. function:: gaphor.diagram.copypaste.serialize(value)
+Paste previously copied data. Based on the data type created in the
+``copy()`` function, try to duplicate the copied elements.
+Returns the newly created item or element
+```
 
-   Return a serialized version of a value. If the ``value`` is an element,
-   it's referenced.
+Gaphor provides some convenience functions:
 
-.. function:: gaphor.diagram.copypaste.deserialize(ser, lookup)
+```{function} copy_full(items: ~typing.Collection, lookup: ~typing.Callable[[Id], ~gaphor.core.modeling.Element | None] | None = None) -> CopyData:
 
-   Deserialize a value previously serialized with ``serialize()``. The
-   ``lookup`` function is used to resolve references to other elements.
+Copy ``items``. The ``lookup`` function is used to look up owned elements (shown as child nodes in the Model Browser).
+```
+
+```{function} gaphor.diagram.copypaste.paste_link(copy_data: CopyData, diagram: ~gaphor.core.modeling.Diagram) -> set[~gaphor.core.modeling.Presentation]:
+
+Paste a copy of the Presentation element to the diagram, but try to link the underlying model element.
+A shallow copy.
+```
+
+```{function} gaphor.diagram.copypaste.paste_full(copy_data: CopyData, diagram: ~gaphor.core.modeling.Diagram) -> set[~gaphor.core.modeling.Presentation]:
+
+Paste a copy of both Presentation and model element. A deep copy.
 ```
 
 ## Grouping

--- a/docs/modeling_language.md
+++ b/docs/modeling_language.md
@@ -78,16 +78,16 @@ function can properly dispatch.
 A copy function normally copies only the element and mandatory related elements. E.g. an Association needs two association ends.
 ```
 
-```{function} gaphor.diagram.copypaste.paste(copy_data: T, diagram: ~gaphor.core.modeling.Diagram, lookup: ~typing.Callable[[str], ~gaphor.core.modeling.Element | None]) -> ~typing.Iterator[~gaphor.core.modeling.Element]
+```{function} gaphor.diagram.copypaste.paste(copy_data: Opaque, diagram: ~gaphor.core.modeling.Diagram, lookup: ~typing.Callable[[str], ~gaphor.core.modeling.Element | None]) -> ~typing.Iterator[~gaphor.core.modeling.Element]
 
 Paste previously copied data. Based on the data type created in the
 ``copy()`` function, try to duplicate the copied elements.
-Returns the newly created item or element
+Returns the newly created item or element.
 ```
 
 Gaphor provides some convenience functions:
 
-```{function} copy_full(items: ~typing.Collection, lookup: ~typing.Callable[[Id], ~gaphor.core.modeling.Element | None] | None = None) -> CopyData:
+```{function} gaphor.diagram.copypaste.copy_full(items: ~typing.Collection[~gaphor.core.modeling.Element], lookup: ~typing.Callable[[Id], ~gaphor.core.modeling.Element | None] | None = None) -> CopyData:
 
 Copy ``items``. The ``lookup`` function is used to look up owned elements (shown as child nodes in the Model Browser).
 ```
@@ -107,22 +107,23 @@ Paste a copy of both Presentation and model element. A deep copy.
 
 Grouping is done by dragging one item on top of another, in a diagram or in the tree view.
 
-```{eval-rst}
-.. function:: gaphor.diagram.group.group(parent: Element, element: Element) -> bool
+```{function} gaphor.diagram.group.group(parent: ~gaphor.core.modeling.Element, element: ~gaphor.core.modeling.Element) -> bool
 
-   Group an element in a parent element. The grouping can be based on ownership,
-   but other types of grouping are also possible.
+Group an element in a parent element. The grouping can be based on ownership,
+but other types of grouping are also possible.
+```
 
-.. function:: gaphor.diagram.group.ungroup(parent: Element, element: Element) -> bool
+```{function} gaphor.diagram.group.ungroup(parent: ~gaphor.core.modeling.Element, element: ~gaphor.core.modeling.Element) -> bool
 
-   Remove the grouping from an element.
-   The function needs to check if the provided `parent` node is the right one.
+Remove the grouping from an element.
+The function needs to check if the provided `parent` node is the right one.
+```
 
-.. function:: gaphor.diagram.group.can_group(parent_type: Type[Element], element_or_type: Type[Element] | Element) -> bool
+```{function} gaphor.diagram.group.can_group(parent_type: type[~gaphor.core.modeling.Element], element_or_type: type[~gaphor.core.modeling.Element] | ~gaphor.core.modeling.Element) -> bool
 
-   This function tries to determine if grouping is possible,
-   without actually performing a group operation.
-   This is not 100% accurate.
+This function tries to determine if grouping is possible,
+without actually performing a group operation.
+This is not 100% accurate.
 ```
 
 ## Dropping
@@ -130,16 +131,15 @@ Grouping is done by dragging one item on top of another, in a diagram or in the 
 Dropping is performed by dragging an element from the tree view and drop it on a diagram.
 This is an easy way to extend a diagram with already existing model elements.
 
-```{eval-rst}
-.. function:: gaphor.diagram.drop.drop(element: Element, diagram: Diagram, x: float, y: float) -> Presentation | None
+```{function} gaphor.diagram.drop.drop(element: ~gaphor.core.modeling.Element, diagram: ~gaphor.core.modeling.Diagram, x: float, y: float) -> ~gaphor.core.modeling.Presentation | None
 
-   The drop function creates a new presentation for an element on the diagram.
-   For relationships, a drop only works if both connected elements are present in the
-   same diagram.
+The drop function creates a new presentation for an element on the diagram.
+For relationships, a drop only works if both connected elements are present in the
+same diagram.
 
-   The big difference with dragging an element from the toolbox, is that dragging from the toolbox
-   will actually place a new ``Presentation`` element on the diagram. ``drop`` works the other way
-   around: it starts with a model element and creates an accompanying ``Presentation``.
+The big difference with dragging an element from the toolbox, is that dragging from the toolbox
+will actually place a new ``Presentation`` element on the diagram. ``drop`` works the other way
+around: it starts with a model element and creates an accompanying ``Presentation``.
 ```
 
 ## Automated model cleanup
@@ -148,10 +148,9 @@ Gaphor wants to keep the model in sync with the diagrams.
 
 A little dispatch function is used to determine if a model element can be removed.
 
-```{eval-rst}
-.. function:: gaphor.diagram.deletable.deletable(element: Element) -> bool
+```{function} gaphor.diagram.deletable.deletable(element: ~gaphor.core.modeling.Element) -> bool
 
-   Determine if a model element can safely be removed.
+Determine if a model element can safely be removed.
 ```
 
 ## Editor property pages
@@ -172,12 +171,11 @@ When you double click on an item in a diagram, a popup can show up so you can ea
 
 By default this works for any named element. You can register your own inline editor function if you need to.
 
-```{eval-rst}
-.. function:: gaphor.diagram.instanteditors.instant_editor(item: Item, view, event_manager, pos: Optional[Tuple[int, int]] = None) -> bool
+```{function} gaphor.diagram.instanteditors.instant_editor(item: ~gaphas.item.Item, view, event_manager: ~gaphor.core.eventmanager.EventManager, pos: tuple[int, int] | None = None) -> bool
 
-   Show a small editor popup in the diagram. Makes for
-   easy editing without resorting to the Element editor.
+Show a small editor popup in the diagram. Makes for
+easy editing without resorting to the Element editor.
 
-   In case of a mouse press event, the mouse position
-   (relative to the element) are also provided.
+In case of a mouse press event, the mouse position
+(relative to the element) are also provided.
 ```

--- a/gaphor/UML/actions/copypaste.py
+++ b/gaphor/UML/actions/copypaste.py
@@ -6,7 +6,7 @@ from gaphor.UML.copypaste import copy_named_element
 
 
 @copy.register
-def copy_class(element: PartitionItem):
+def copy_partition_item(element: PartitionItem):
     yield element.id, copy_presentation(element)
     for partition in element.partition:
         yield from copy(partition)

--- a/gaphor/UML/actions/tests/test_copypaste.py
+++ b/gaphor/UML/actions/tests/test_copypaste.py
@@ -13,7 +13,7 @@ def test_shallow_copy_activity_with_parameter(diagram, element_factory):
 
     copy_data = copy_full({activity_item})
 
-    new_elements = paste_link(copy_data, diagram, element_factory.lookup)
+    new_elements = paste_link(copy_data, diagram)
     new_activity_item = next(
         (e for e in new_elements if isinstance(e, ActivityItem)), None
     )
@@ -33,7 +33,7 @@ def test_deep_copy_activity_with_parameter(diagram, element_factory):
     node.parameter.name = "Name"
 
     copy_data = copy_full({activity_item})
-    new_elements = paste_full(copy_data, diagram, element_factory.lookup)
+    new_elements = paste_full(copy_data, diagram)
     new_activity_item = next(
         (e for e in new_elements if isinstance(e, ActivityItem)), None
     )

--- a/gaphor/UML/actions/tests/test_copypaste.py
+++ b/gaphor/UML/actions/tests/test_copypaste.py
@@ -1,4 +1,4 @@
-from gaphor.diagram.copypaste import copy, paste_full, paste_link
+from gaphor.diagram.copypaste import copy_full, paste_full, paste_link
 from gaphor.UML import Activity, ActivityParameterNode, Parameter
 from gaphor.UML.actions.activity import ActivityItem
 
@@ -11,8 +11,8 @@ def test_shallow_copy_activity_with_parameter(diagram, element_factory):
     activity_item.subject.node = node
     node.parameter = element_factory.create(Parameter)
 
-    copy_data = copy({activity_item})
-    print(copy_data)
+    copy_data = copy_full({activity_item})
+
     new_elements = paste_link(copy_data, diagram, element_factory.lookup)
     new_activity_item = next(
         (e for e in new_elements if isinstance(e, ActivityItem)), None
@@ -32,7 +32,7 @@ def test_deep_copy_activity_with_parameter(diagram, element_factory):
     node.parameter = element_factory.create(Parameter)
     node.parameter.name = "Name"
 
-    copy_data = copy({activity_item})
+    copy_data = copy_full({activity_item})
     new_elements = paste_full(copy_data, diagram, element_factory.lookup)
     new_activity_item = next(
         (e for e in new_elements if isinstance(e, ActivityItem)), None
@@ -52,7 +52,7 @@ def test_do_not_copy_activity_parameter_node(diagram, element_factory):
     activity_item.subject.node = node
     node.parameter = element_factory.create(Parameter)
 
-    copy_data = copy(activity_item.children)
+    copy_data = copy_full(activity_item.children)
 
     assert activity_item.children
     assert not copy_data.elements

--- a/gaphor/UML/tests/test_copypaste.py
+++ b/gaphor/UML/tests/test_copypaste.py
@@ -8,7 +8,7 @@ def test_copy_connected_item(diagram, element_factory):
     )
 
     buffer = copy_full({spc_cls_item})
-    (new_cls_item,) = paste_full(buffer, diagram, element_factory.lookup)
+    (new_cls_item,) = paste_full(buffer, diagram)
 
     assert new_cls_item.subject
     assert gen_item.subject.general is gen_cls_item.subject

--- a/gaphor/UML/tests/test_copypaste.py
+++ b/gaphor/UML/tests/test_copypaste.py
@@ -1,4 +1,4 @@
-from gaphor.diagram.copypaste import copy, paste_full
+from gaphor.diagram.copypaste import copy_full, paste_full
 from gaphor.diagram.tests.test_copypaste_link import two_classes_and_a_generalization
 
 
@@ -7,7 +7,7 @@ def test_copy_connected_item(diagram, element_factory):
         diagram, element_factory
     )
 
-    buffer = copy({spc_cls_item})
+    buffer = copy_full({spc_cls_item})
     (new_cls_item,) = paste_full(buffer, diagram, element_factory.lookup)
 
     assert new_cls_item.subject

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -61,16 +61,12 @@ def copy_full(
     return CopyData(elements=elements)
 
 
-def paste_link(
-    copy_data: Opaque, diagram: Diagram, lookup: Callable[[Id], Element | None]
-) -> set[Presentation]:
-    return _paste(copy_data, diagram, lookup, full=False)
+def paste_link(copy_data: Opaque, diagram: Diagram) -> set[Presentation]:
+    return _paste(copy_data, diagram, full=False)
 
 
-def paste_full(
-    copy_data: Opaque, diagram: Diagram, lookup: Callable[[Id], Element | None]
-) -> set[Presentation]:
-    return _paste(copy_data, diagram, lookup, full=True)
+def paste_full(copy_data: Opaque, diagram: Diagram) -> set[Presentation]:
+    return _paste(copy_data, diagram, full=True)
 
 
 @singledispatch
@@ -195,16 +191,17 @@ def paste_presentation(copy_data: PresentationCopy, diagram, lookup):
     diagram.update_now((item,))
 
 
-def _paste(copy_data, diagram, lookup, full) -> set[Presentation]:
+def _paste(copy_data: Opaque, diagram: Diagram, full: bool) -> set[Presentation]:
     assert isinstance(copy_data, CopyData)
 
     new_elements: dict[Id, Element | None] = {}
+    model = diagram.model
 
     def element_lookup(ref: Id):
         if ref in new_elements:
             return new_elements[ref]
 
-        looked_up = lookup(ref)
+        looked_up = model.lookup(ref)
         if not full and looked_up and not isinstance(looked_up, Presentation):
             return looked_up
 

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -36,6 +36,16 @@ def copy(obj: Element | Iterable) -> Iterator[tuple[Id, Opaque]]:
     raise ValueError(f"No copier for {obj}")
 
 
+class CopyData(NamedTuple):
+    elements: dict[Id, Opaque]
+
+
+def copy_full(items: Iterable) -> CopyData:
+    """Copy items, including owned elements."""
+    elements = itertools.chain.from_iterable(copy(item) for item in items)
+    return CopyData(elements=dict(elements))
+
+
 def paste_link(
     copy_data: Opaque, diagram: Diagram, lookup: Callable[[Id], Element | None]
 ) -> set[Presentation]:
@@ -168,16 +178,6 @@ def paste_presentation(copy_data: PresentationCopy, diagram, lookup):
         for value in deserialize(ser, lookup):
             item.load(name, value)
     diagram.update_now((item,))
-
-
-class CopyData(NamedTuple):
-    elements: dict[Id, Opaque]
-
-
-@copy.register  # type: ignore[arg-type]
-def _copy_all(items: Iterable) -> CopyData:
-    elements = itertools.chain.from_iterable(copy(item) for item in items)
-    return CopyData(elements=dict(elements))
 
 
 def _paste(copy_data, diagram, lookup, full) -> set[Presentation]:

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -37,20 +37,20 @@ def copy(obj: Element | Iterable) -> Iterator[tuple[Id, Opaque]]:
 
 
 def paste_link(
-    copy_data: Opaque, diagram: Diagram, lookup: Callable[[str], Element | None]
+    copy_data: Opaque, diagram: Diagram, lookup: Callable[[Id], Element | None]
 ) -> set[Presentation]:
     return _paste(copy_data, diagram, lookup, full=False)
 
 
 def paste_full(
-    copy_data: Opaque, diagram: Diagram, lookup: Callable[[str], Element | None]
+    copy_data: Opaque, diagram: Diagram, lookup: Callable[[Id], Element | None]
 ) -> set[Presentation]:
     return _paste(copy_data, diagram, lookup, full=True)
 
 
 @singledispatch
 def paste(
-    copy_data: Opaque, diagram: Diagram, lookup: Callable[[str], Element | None]
+    copy_data: Opaque, diagram: Diagram, lookup: Callable[[Id], Element | None]
 ) -> Iterator[Element]:
     """Paste previously copied data.
 
@@ -85,7 +85,7 @@ def deserialize(ser, lookup):
 
 class ElementCopy(NamedTuple):
     cls: type[Element]
-    id: str | bool
+    id: Id
     data: dict[str, tuple[str, str]]
 
 
@@ -134,7 +134,7 @@ def _copy_diagram(element: Diagram) -> Iterator[tuple[Id, ElementCopy]]:
 class PresentationCopy(NamedTuple):
     cls: type[Element]
     data: dict[str, tuple[str, str]]
-    parent: str | None
+    parent: Id | None
 
 
 def copy_presentation(item: Presentation) -> PresentationCopy:
@@ -171,7 +171,7 @@ def paste_presentation(copy_data: PresentationCopy, diagram, lookup):
 
 
 class CopyData(NamedTuple):
-    elements: dict[str, object]
+    elements: dict[Id, Opaque]
 
 
 @copy.register  # type: ignore[arg-type]
@@ -183,9 +183,9 @@ def _copy_all(items: Iterable) -> CopyData:
 def _paste(copy_data, diagram, lookup, full) -> set[Presentation]:
     assert isinstance(copy_data, CopyData)
 
-    new_elements: dict[str, Element | None] = {}
+    new_elements: dict[Id, Element | None] = {}
 
-    def element_lookup(ref: str):
+    def element_lookup(ref: Id):
         if ref in new_elements:
             return new_elements[ref]
 

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -25,16 +25,6 @@ from gaphor.core.modeling.element import Element, Id
 Opaque = object
 
 
-@singledispatch
-def copy(obj: Element | Iterable) -> Iterator[tuple[Id, Opaque]]:
-    """Create a copy of an element (or list of elements).
-
-    The returned type should be distinct, so the `paste()` function can
-    properly dispatch.
-    """
-    raise ValueError(f"No copier for {obj}")
-
-
 class CopyData(NamedTuple):
     elements: dict[Id, Opaque]
     diagram_refs: set[Id]
@@ -70,6 +60,16 @@ def paste_link(copy_data: Opaque, diagram: Diagram) -> set[Presentation]:
 
 def paste_full(copy_data: Opaque, diagram: Diagram) -> set[Presentation]:
     return _paste(copy_data, diagram, full=True)
+
+
+@singledispatch
+def copy(obj: Element | Iterable) -> Iterator[tuple[Id, Opaque]]:
+    """Create a copy of an element (or list of elements).
+
+    The returned type should be distinct, so the `paste()` function can
+    properly dispatch.
+    """
+    raise ValueError(f"No copier for {obj}")
 
 
 @singledispatch

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -4,6 +4,8 @@ To register property pages implemented in this module, it is imported in
 gaphor.adapter package.
 """
 
+from __future__ import annotations
+
 import abc
 from typing import Callable, List, Tuple, Type
 
@@ -83,7 +85,7 @@ class PropertyPageBase(metaclass=abc.ABCMeta):
         super().__init__()
 
     @abc.abstractmethod
-    def construct(self):
+    def construct(self) -> Gtk.Widget | None:
         """Create the page (Gtk.Widget) that belongs to the Property page.
 
         Returns the page's toplevel widget (Gtk.Widget).

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -56,7 +56,7 @@ def copy_and_paste_link(items, diagram, element_factory, retain=None):
     if retain is None:
         retain = []
     buffer = copy_full(items)
-    return paste_link(buffer, diagram, element_factory.lookup)
+    return paste_link(buffer, diagram)
 
 
 def copy_clear_and_paste_link(items, diagram, element_factory, retain=None):
@@ -64,7 +64,7 @@ def copy_clear_and_paste_link(items, diagram, element_factory, retain=None):
         retain = []
     buffer = copy_full(items)
     clear_model(diagram, element_factory, retain)
-    return paste_link(buffer, diagram, element_factory.lookup)
+    return paste_link(buffer, diagram)
 
 
 def find(widget, name):

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -1,7 +1,7 @@
 from gi.repository import Gtk
 
 from gaphor.diagram.connectors import Connector
-from gaphor.diagram.copypaste import copy, paste_link
+from gaphor.diagram.copypaste import copy_full, paste_link
 from gaphor.diagram.presentation import connect as _connect
 
 
@@ -55,14 +55,14 @@ def clear_model(diagram, element_factory, retain=None):
 def copy_and_paste_link(items, diagram, element_factory, retain=None):
     if retain is None:
         retain = []
-    buffer = copy(items)
+    buffer = copy_full(items)
     return paste_link(buffer, diagram, element_factory.lookup)
 
 
 def copy_clear_and_paste_link(items, diagram, element_factory, retain=None):
     if retain is None:
         retain = []
-    buffer = copy(items)
+    buffer = copy_full(items)
     clear_model(diagram, element_factory, retain)
     return paste_link(buffer, diagram, element_factory.lookup)
 

--- a/gaphor/diagram/tests/test_copypaste.py
+++ b/gaphor/diagram/tests/test_copypaste.py
@@ -1,0 +1,12 @@
+import pytest
+from gaphor.diagram.copypaste import copy, paste
+
+
+def test_copy_unknown_type_raises_exception():
+    with pytest.raises(ValueError):
+        copy(None)
+
+
+def test_paste_unknown_type_raises_exception(diagram, element_factory):
+    with pytest.raises(ValueError):
+        paste(None, diagram, element_factory.lookup)

--- a/gaphor/diagram/tests/test_copypaste_full.py
+++ b/gaphor/diagram/tests/test_copypaste_full.py
@@ -1,5 +1,6 @@
 from gaphor import UML
 from gaphor.core.modeling import Diagram, ElementFactory
+from gaphor.diagram.general import DiagramItem
 from gaphor.diagram.copypaste import copy_full, paste_full
 from gaphor.diagram.tests.test_copypaste_link import two_classes_and_a_generalization
 from gaphor.UML.classes import ClassItem, GeneralizationItem, PackageItem
@@ -66,9 +67,8 @@ def test_copy_element_factory(diagram, element_factory):
     new_diagram = new_element_factory.create(Diagram)
     paste_full(buffer, new_diagram)
 
-    # new element factory has one more diagram:
-    assert len(new_element_factory.lselect(Diagram)) == 2
-    assert element_factory.size() == new_element_factory.size() - 1
+    assert len(new_element_factory.lselect(Diagram)) == 1
+    assert element_factory.size() == new_element_factory.size()
 
 
 def test_copy_package_with_diagram(element_factory):
@@ -119,3 +119,19 @@ def test_full_copy_package_with_owned_package(element_factory):
     assert new_package.nestedPackage
     assert subpackage not in new_package.nestedPackage
     assert new_package.nestedPackage[0].name == "subpackage"
+
+
+def test_copy_diagram_with_elements(diagram, element_factory):
+    other_diagram: Diagram = element_factory.create(Diagram)
+    two_classes_and_a_generalization(other_diagram, element_factory)
+
+    diagram_item = diagram.create(DiagramItem, subject=other_diagram)
+
+    copy_buffer = copy_full([diagram_item], element_factory.lookup)
+
+    target_diagram: Diagram = element_factory.create(Diagram)
+    (new_diagram_item, *other) = paste_full(copy_buffer, target_diagram)
+
+    new_diagram = new_diagram_item.subject
+
+    assert new_diagram.ownedPresentation

--- a/gaphor/diagram/tests/test_copypaste_full.py
+++ b/gaphor/diagram/tests/test_copypaste_full.py
@@ -12,7 +12,7 @@ def test_copied_item_references_new_model_element(diagram, element_factory):
 
     buffer = copy_full({cls_item})
 
-    all(paste_full(buffer, diagram, element_factory.lookup))
+    all(paste_full(buffer, diagram))
 
     assert len(list(diagram.get_all_items())) == 2
     item1, item2 = diagram.get_all_items()
@@ -32,7 +32,7 @@ def test_copy_multiple_items(diagram, element_factory):
 
     buffer = copy_full({cls_item1, cls_item2})
 
-    paste_full(buffer, diagram, element_factory.lookup)
+    paste_full(buffer, diagram)
 
     assert len(list(diagram.get_all_items())) == 4
     assert len(element_factory.lselect(UML.Class)) == 2
@@ -44,7 +44,7 @@ def test_copy_items_with_connections(diagram, element_factory):
     )
 
     buffer = copy_full({gen_cls_item, gen_item, spc_cls_item})
-    new_items = paste_full(buffer, diagram, element_factory.lookup)
+    new_items = paste_full(buffer, diagram)
     (new_cls1, new_cls2) = (ci.subject for ci in new_items if isinstance(ci, ClassItem))
     (new_gen,) = (gi.subject for gi in new_items if isinstance(gi, GeneralizationItem))
 
@@ -64,7 +64,7 @@ def test_copy_element_factory(diagram, element_factory):
 
     new_element_factory = ElementFactory()
     new_diagram = new_element_factory.create(Diagram)
-    paste_full(buffer, new_diagram, new_element_factory.lookup)
+    paste_full(buffer, new_diagram)
 
     # new element factory has one more diagram:
     assert len(new_element_factory.lselect(Diagram)) == 2
@@ -78,7 +78,7 @@ def test_copy_package_with_diagram(element_factory):
     package_item = diagram.create(PackageItem, subject=package)
 
     copy_buffer = copy_full([package_item])
-    (new_package_item,) = paste_full(copy_buffer, diagram, element_factory.lookup)
+    (new_package_item,) = paste_full(copy_buffer, diagram)
     new_package = new_package_item.subject
 
     assert diagram in package.ownedDiagram
@@ -94,7 +94,7 @@ def test_shallow_copy_package_with_owned_package(element_factory):
     package_item = diagram.create(PackageItem, subject=package)
 
     copy_buffer = copy_full([package_item])
-    (new_package_item,) = paste_full(copy_buffer, diagram, element_factory.lookup)
+    (new_package_item,) = paste_full(copy_buffer, diagram)
     new_package = new_package_item.subject
 
     assert subpackage in package.nestedPackage
@@ -111,7 +111,7 @@ def test_full_copy_package_with_owned_package(element_factory):
     package_item = diagram.create(PackageItem, subject=package)
 
     copy_buffer = copy_full([package_item], element_factory.lookup)
-    (new_package_item,) = paste_full(copy_buffer, diagram, element_factory.lookup)
+    (new_package_item,) = paste_full(copy_buffer, diagram)
     new_package = new_package_item.subject
 
     assert subpackage in package.nestedPackage

--- a/gaphor/diagram/tests/test_copypaste_full.py
+++ b/gaphor/diagram/tests/test_copypaste_full.py
@@ -1,6 +1,6 @@
 from gaphor import UML
 from gaphor.core.modeling import Diagram, ElementFactory
-from gaphor.diagram.copypaste import copy, paste_full
+from gaphor.diagram.copypaste import copy_full, paste_full
 from gaphor.diagram.tests.test_copypaste_link import two_classes_and_a_generalization
 from gaphor.UML.classes import ClassItem, GeneralizationItem, PackageItem
 
@@ -10,7 +10,7 @@ def test_copied_item_references_new_model_element(diagram, element_factory):
     cls.name = "Name"
     cls_item = diagram.create(ClassItem, subject=cls)
 
-    buffer = copy({cls_item})
+    buffer = copy_full({cls_item})
 
     all(paste_full(buffer, diagram, element_factory.lookup))
 
@@ -30,7 +30,7 @@ def test_copy_multiple_items(diagram, element_factory):
     cls_item1 = diagram.create(ClassItem, subject=cls)
     cls_item2 = diagram.create(ClassItem, subject=cls)
 
-    buffer = copy({cls_item1, cls_item2})
+    buffer = copy_full({cls_item1, cls_item2})
 
     paste_full(buffer, diagram, element_factory.lookup)
 
@@ -43,7 +43,7 @@ def test_copy_items_with_connections(diagram, element_factory):
         diagram, element_factory
     )
 
-    buffer = copy({gen_cls_item, gen_item, spc_cls_item})
+    buffer = copy_full({gen_cls_item, gen_item, spc_cls_item})
     new_items = paste_full(buffer, diagram, element_factory.lookup)
     (new_cls1, new_cls2) = (ci.subject for ci in new_items if isinstance(ci, ClassItem))
     (new_gen,) = (gi.subject for gi in new_items if isinstance(gi, GeneralizationItem))
@@ -60,7 +60,7 @@ def test_copy_element_factory(diagram, element_factory):
     """
     two_classes_and_a_generalization(diagram, element_factory)
 
-    buffer = copy(element_factory)
+    buffer = copy_full(element_factory)
 
     new_element_factory = ElementFactory()
     new_diagram = new_element_factory.create(Diagram)
@@ -77,7 +77,7 @@ def test_copy_package_with_diagram(element_factory):
     package.ownedDiagram = diagram
     package_item = diagram.create(PackageItem, subject=package)
 
-    copy_buffer = copy([package_item])
+    copy_buffer = copy_full([package_item])
     (new_package_item,) = paste_full(copy_buffer, diagram, element_factory.lookup)
     new_package = new_package_item.subject
 
@@ -93,7 +93,7 @@ def test_copy_package_with_owned_package(element_factory):
     subpackage.package = package
     package_item = diagram.create(PackageItem, subject=package)
 
-    copy_buffer = copy([package_item])
+    copy_buffer = copy_full([package_item])
     (new_package_item,) = paste_full(copy_buffer, diagram, element_factory.lookup)
     new_package = new_package_item.subject
 

--- a/gaphor/diagram/tests/test_copypaste_full.py
+++ b/gaphor/diagram/tests/test_copypaste_full.py
@@ -86,7 +86,7 @@ def test_copy_package_with_diagram(element_factory):
     assert diagram.element is package
 
 
-def test_copy_package_with_owned_package(element_factory):
+def test_shallow_copy_package_with_owned_package(element_factory):
     diagram: Diagram = element_factory.create(Diagram)
     package = element_factory.create(UML.Package)
     subpackage = element_factory.create(UML.Package)
@@ -100,3 +100,22 @@ def test_copy_package_with_owned_package(element_factory):
     assert subpackage in package.nestedPackage
     assert subpackage.package is package
     assert subpackage not in new_package.nestedPackage
+
+
+def test_full_copy_package_with_owned_package(element_factory):
+    diagram: Diagram = element_factory.create(Diagram)
+    package = element_factory.create(UML.Package)
+    subpackage = element_factory.create(UML.Package)
+    subpackage.package = package
+    subpackage.name = "subpackage"
+    package_item = diagram.create(PackageItem, subject=package)
+
+    copy_buffer = copy_full([package_item], element_factory.lookup)
+    (new_package_item,) = paste_full(copy_buffer, diagram, element_factory.lookup)
+    new_package = new_package_item.subject
+
+    assert subpackage in package.nestedPackage
+    assert subpackage.package is package
+    assert new_package.nestedPackage
+    assert subpackage not in new_package.nestedPackage
+    assert new_package.nestedPackage[0].name == "subpackage"

--- a/gaphor/diagram/tests/test_copypaste_grouping.py
+++ b/gaphor/diagram/tests/test_copypaste_grouping.py
@@ -22,24 +22,22 @@ def node_with_artifact(diagram, element_factory):
     return node_item, artifact_item
 
 
-def test_copy_paste_of_nested_item(diagram, element_factory, node_with_artifact):
+def test_copy_paste_of_nested_item(diagram, node_with_artifact):
     node_item, artifact_item = node_with_artifact
 
     buffer = copy_full({artifact_item})
 
-    (new_comp_item,) = paste_link(buffer, diagram, element_factory.lookup)
+    (new_comp_item,) = paste_link(buffer, diagram)
 
     assert new_comp_item.parent is node_item
 
 
-def test_copy_paste_of_item_with_nested_item(
-    diagram, element_factory, node_with_artifact
-):
+def test_copy_paste_of_item_with_nested_item(diagram, node_with_artifact):
     node_item, artifact_item = node_with_artifact
 
     buffer = copy_full(set(node_with_artifact))
 
-    new_items = paste_link(buffer, diagram, element_factory.lookup)
+    new_items = paste_link(buffer, diagram)
 
     new_node_item = next(i for i in new_items if isinstance(i, NodeItem))
     new_comp_item = next(i for i in new_items if isinstance(i, ArtifactItem))

--- a/gaphor/diagram/tests/test_copypaste_grouping.py
+++ b/gaphor/diagram/tests/test_copypaste_grouping.py
@@ -1,7 +1,7 @@
 import pytest
 
 from gaphor import UML
-from gaphor.diagram.copypaste import copy, paste_link
+from gaphor.diagram.copypaste import copy_full, paste_link
 from gaphor.diagram.group import group
 from gaphor.diagram.tests.fixtures import copy_clear_and_paste_link
 from gaphor.UML.deployments import ArtifactItem, NodeItem
@@ -25,7 +25,7 @@ def node_with_artifact(diagram, element_factory):
 def test_copy_paste_of_nested_item(diagram, element_factory, node_with_artifact):
     node_item, artifact_item = node_with_artifact
 
-    buffer = copy({artifact_item})
+    buffer = copy_full({artifact_item})
 
     (new_comp_item,) = paste_link(buffer, diagram, element_factory.lookup)
 
@@ -37,7 +37,7 @@ def test_copy_paste_of_item_with_nested_item(
 ):
     node_item, artifact_item = node_with_artifact
 
-    buffer = copy(set(node_with_artifact))
+    buffer = copy_full(set(node_with_artifact))
 
     new_items = paste_link(buffer, diagram, element_factory.lookup)
 

--- a/gaphor/diagram/tests/test_copypaste_link.py
+++ b/gaphor/diagram/tests/test_copypaste_link.py
@@ -1,6 +1,6 @@
 from gaphor import UML
 from gaphor.core.modeling import Diagram
-from gaphor.diagram.copypaste import copy, paste, paste_link
+from gaphor.diagram.copypaste import copy, copy_full, paste, paste_link
 from gaphor.diagram.general.simpleitem import Box, Ellipse, Line
 from gaphor.diagram.tests.fixtures import connect, copy_clear_and_paste_link
 from gaphor.UML.classes import ClassItem, GeneralizationItem
@@ -37,7 +37,7 @@ def test_copy_multiple_items(diagram, element_factory):
     cls_item1 = diagram.create(ClassItem, subject=cls)
     cls_item2 = diagram.create(ClassItem, subject=cls)
 
-    buffer = copy({cls_item1, cls_item2})
+    buffer = copy_full({cls_item1, cls_item2})
 
     paste_link(buffer, diagram, element_factory.lookup)
 
@@ -51,7 +51,7 @@ def test_copy_item_without_copying_connection(diagram, element_factory):
     gen_item = diagram.create(GeneralizationItem)
     connect(gen_item, gen_item.handles()[0], cls_item)
 
-    buffer = copy({cls_item})
+    buffer = copy_full({cls_item})
 
     new_items = paste_link(buffer, diagram, element_factory.lookup)
 
@@ -77,7 +77,7 @@ def test_copy_item_with_connection(diagram, element_factory):
     gen_cls_item, spc_cls_item, gen_item = two_classes_and_a_generalization(
         diagram, element_factory
     )
-    buffer = copy({gen_cls_item, gen_item, spc_cls_item})
+    buffer = copy_full({gen_cls_item, gen_item, spc_cls_item})
 
     new_items = paste_link(buffer, diagram, element_factory.lookup)
     new_gen_item = next(i for i in new_items if isinstance(i, GeneralizationItem))
@@ -109,7 +109,7 @@ def test_copy_item_when_subject_has_been_removed(diagram, element_factory):
     orig_cls_id = cls.id
     cls_item = diagram.create(ClassItem, subject=cls)
 
-    buffer = copy({cls_item})
+    buffer = copy_full({cls_item})
 
     cls_item.unlink()
     cls.unlink()  # normally handled by the sanitizer service
@@ -181,7 +181,7 @@ def test_copy_to_new_diagram(diagram, element_factory):
     cls = element_factory.create(UML.Class)
     cls_item = diagram.create(ClassItem, subject=cls)
 
-    buffer = copy({cls_item})
+    buffer = copy_full({cls_item})
 
     paste_link(buffer, new_diagram, element_factory.lookup)
 

--- a/gaphor/diagram/tests/test_copypaste_link.py
+++ b/gaphor/diagram/tests/test_copypaste_link.py
@@ -39,7 +39,7 @@ def test_copy_multiple_items(diagram, element_factory):
 
     buffer = copy_full({cls_item1, cls_item2})
 
-    paste_link(buffer, diagram, element_factory.lookup)
+    paste_link(buffer, diagram)
 
     assert len(list(diagram.get_all_items())) == 4
     assert len(element_factory.lselect(UML.Class)) == 1
@@ -53,7 +53,7 @@ def test_copy_item_without_copying_connection(diagram, element_factory):
 
     buffer = copy_full({cls_item})
 
-    new_items = paste_link(buffer, diagram, element_factory.lookup)
+    new_items = paste_link(buffer, diagram)
 
     assert len(list(diagram.get_all_items())) == 3
     assert len(element_factory.lselect(UML.Class)) == 1
@@ -79,7 +79,7 @@ def test_copy_item_with_connection(diagram, element_factory):
     )
     buffer = copy_full({gen_cls_item, gen_item, spc_cls_item})
 
-    new_items = paste_link(buffer, diagram, element_factory.lookup)
+    new_items = paste_link(buffer, diagram)
     new_gen_item = next(i for i in new_items if isinstance(i, GeneralizationItem))
 
     new_cls_item1 = diagram.connections.get_connection(
@@ -119,7 +119,7 @@ def test_copy_item_when_subject_has_been_removed(diagram, element_factory):
     assert cls not in element_factory.select()
     assert not element_factory.lookup(orig_cls_id)
 
-    paste_link(buffer, diagram, element_factory.lookup)
+    paste_link(buffer, diagram)
     new_cls = element_factory.lselect(UML.Class)[0]
     (new_cls_item,) = diagram.get_all_items()
     assert new_cls.package is package
@@ -183,7 +183,7 @@ def test_copy_to_new_diagram(diagram, element_factory):
 
     buffer = copy_full({cls_item})
 
-    paste_link(buffer, new_diagram, element_factory.lookup)
+    paste_link(buffer, new_diagram)
 
     assert len(list(new_diagram.get_all_items())) == 1
     assert next(new_diagram.get_all_items()).diagram is new_diagram

--- a/gaphor/ui/copyservice.py
+++ b/gaphor/ui/copyservice.py
@@ -7,7 +7,7 @@ from gi.repository import Gdk, GLib, GObject
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import Transaction, action
 from gaphor.core.modeling import Presentation
-from gaphor.diagram.copypaste import copy, paste_full, paste_link
+from gaphor.diagram.copypaste import copy_full, paste_full, paste_link
 
 
 class CopyBuffer(GObject.Object):
@@ -45,7 +45,7 @@ class CopyService(Service, ActionProvider):
 
     def copy(self, items):
         if items:
-            copy_buffer = copy(items)
+            copy_buffer = copy_full(items)
             v = GObject.Value(CopyBuffer.__gtype__, CopyBuffer(buffer=copy_buffer))
             self.clipboard.set_content(Gdk.ContentProvider.new_for_value(v))
 

--- a/gaphor/ui/copyservice.py
+++ b/gaphor/ui/copyservice.py
@@ -1,13 +1,14 @@
 """Copy / Paste functionality."""
 
-from typing import Set
+from __future__ import annotations
+from typing import Callable, Collection
 
 from gi.repository import Gdk, GLib, GObject
 
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import Transaction, action
-from gaphor.core.modeling import Presentation
-from gaphor.diagram.copypaste import copy_full, paste_full, paste_link
+from gaphor.core.modeling import Diagram, Presentation
+from gaphor.diagram.copypaste import copy_full, paste_full, paste_link, Opaque
 
 
 class CopyBuffer(GObject.Object):
@@ -43,18 +44,45 @@ class CopyService(Service, ActionProvider):
     def shutdown(self):
         pass
 
-    def copy(self, items):
+    def copy(self, items: Collection[Presentation]) -> None:
         if items:
             copy_buffer = copy_full(items, self.element_factory.lookup)
             v = GObject.Value(CopyBuffer.__gtype__, CopyBuffer(buffer=copy_buffer))
             self.clipboard.set_content(Gdk.ContentProvider.new_for_value(v))
 
-    def _paste(self, diagram, paster, callback):
+    def paste_link(
+        self,
+        diagram: Diagram,
+        callback: Callable[[set[Presentation]], None] | None = None,
+    ) -> None:
+        self._paste(diagram, paste_link, callback)
+
+    def paste_full(
+        self,
+        diagram: Diagram,
+        callback: Callable[[set[Presentation]], None] | None = None,
+    ) -> None:
+        self._paste(diagram, paste_full, callback)
+
+    def _paste(
+        self,
+        diagram: Diagram,
+        paster: Callable[[Opaque, Diagram], set[Presentation]],
+        callback: Callable[[set[Presentation]], None] | None,
+    ) -> None:
         def on_paste(_source_object, result):
             copy_buffer = self.clipboard.read_value_finish(result)
-            items = self._paste_internal(diagram, copy_buffer.buffer, paster)
+            with Transaction(self.event_manager):
+                # Create new id's that have to be used to create the items:
+                new_items = paster(copy_buffer.buffer, diagram)
+
+                # move pasted items a bit, so user can see result of his action :)
+                for item in new_items:
+                    if item.parent not in new_items:
+                        item.matrix.translate(10, 10)
+
             if callback:
-                callback(items)
+                callback(new_items)
 
         self.clipboard.read_value_async(
             CopyBuffer.__gtype__,
@@ -62,26 +90,6 @@ class CopyService(Service, ActionProvider):
             cancellable=None,
             callback=on_paste,
         )
-
-    def paste_link(self, diagram, callback=None):
-        self._paste(diagram, paste_link, callback)
-
-    def paste_full(self, diagram, callback=None):
-        self._paste(diagram, paste_full, callback)
-
-    def _paste_internal(self, diagram, copy_buffer, paster):
-        with Transaction(self.event_manager):
-            # Create new id's that have to be used to create the items:
-            new_items: Set[Presentation] = paster(
-                copy_buffer, diagram, self.element_factory.lookup
-            )
-
-            # move pasted items a bit, so user can see result of his action :)
-            for item in new_items:
-                if item.parent not in new_items:
-                    item.matrix.translate(10, 10)
-
-        return new_items
 
     @action(
         name="edit-copy",

--- a/gaphor/ui/copyservice.py
+++ b/gaphor/ui/copyservice.py
@@ -45,7 +45,7 @@ class CopyService(Service, ActionProvider):
 
     def copy(self, items):
         if items:
-            copy_buffer = copy_full(items)
+            copy_buffer = copy_full(items, self.element_factory.lookup)
             v = GObject.Value(CopyBuffer.__gtype__, CopyBuffer(buffer=copy_buffer))
             self.clipboard.set_content(Gdk.ContentProvider.new_for_value(v))
 

--- a/gaphor/ui/tests/test_copyservice.py
+++ b/gaphor/ui/tests/test_copyservice.py
@@ -1,8 +1,10 @@
 import pytest
 
+from gaphor import UML
 from gaphor.core.modeling import Comment, Diagram
 from gaphor.diagram.general import CommentItem
 from gaphor.ui.copyservice import CopyService
+from gaphor.UML.classes import PackageItem
 
 
 class DiagramsStub:
@@ -51,3 +53,17 @@ def test_copy_link(copy_service, element_factory):
     copy_service.paste_link(diagram)
 
     assert len(list(diagram.get_all_items())) == 2, list(diagram.get_all_items())
+
+
+def test_copy_full_with_owned_element(copy_service, element_factory):
+    diagram = element_factory.create(Diagram)
+    package_item = diagram.create(
+        PackageItem, subject=element_factory.create(UML.Package)
+    )
+    package_item.subject.nestedPackage = element_factory.create(UML.Package)
+
+    copy_service.copy({package_item})
+
+    copy_service.paste_full(diagram)
+
+    assert len(element_factory.lselect(UML.Package)) == 4

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -258,14 +258,14 @@ class ModelConsistency(RuleBasedStateMachine):
         assume(self.copy_buffer)
         diagram = data.draw(self.diagrams())
         with self.transaction:
-            paste_link(self.copy_buffer, diagram, self.model.lookup)
+            paste_link(self.copy_buffer, diagram)
 
     @rule(data=data())
     def paste_full(self, data):
         assume(self.copy_buffer)
         diagram = data.draw(self.diagrams())
         with self.transaction:
-            new_items = paste_full(self.copy_buffer, diagram, self.model.lookup)
+            new_items = paste_full(self.copy_buffer, diagram)
         self.fully_pasted_items.update(new_items)
 
     @invariant()

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -47,7 +47,7 @@ from gaphor.C4Model.toolbox import c4
 from gaphor.core import Transaction
 from gaphor.core.modeling import Diagram, ElementFactory, Presentation, StyleSheet
 from gaphor.core.modeling.element import Element, generate_id, uuid_generator
-from gaphor.diagram.copypaste import copy, paste_full, paste_link
+from gaphor.diagram.copypaste import copy_full, paste_full, paste_link
 from gaphor.diagram.deletable import deletable
 from gaphor.diagram.drop import drop
 from gaphor.diagram.group import can_group
@@ -251,7 +251,7 @@ class ModelConsistency(RuleBasedStateMachine):
                 unique=True,
             )
         )
-        self.copy_buffer = copy(items)
+        self.copy_buffer = copy_full(items)
 
     @rule(data=data())
     def paste_link(self, data):

--- a/tests/test_multiple_associations.py
+++ b/tests/test_multiple_associations.py
@@ -20,7 +20,7 @@ from gaphor import UML
 from gaphor.application import Session
 from gaphor.core import Transaction
 from gaphor.core.modeling import Diagram
-from gaphor.diagram.copypaste import copy, paste_link
+from gaphor.diagram.copypaste import copy_full, paste_link
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML import diagramitems
 from gaphor.UML.recipes import set_navigability
@@ -62,7 +62,7 @@ def class_and_association_with_copy(diagram, event_manager, element_factory):
 
         set_navigability(a.subject, a.subject.memberEnd[0], True)
 
-        copy_buffer = copy({a, c})
+        copy_buffer = copy_full({a, c})
         new_diagram = element_factory.create(Diagram)
         pasted_items = paste_link(copy_buffer, new_diagram, element_factory.lookup)
 

--- a/tests/test_multiple_associations.py
+++ b/tests/test_multiple_associations.py
@@ -64,7 +64,7 @@ def class_and_association_with_copy(diagram, event_manager, element_factory):
 
         copy_buffer = copy_full({a, c})
         new_diagram = element_factory.create(Diagram)
-        pasted_items = paste_link(copy_buffer, new_diagram, element_factory.lookup)
+        pasted_items = paste_link(copy_buffer, new_diagram)
 
     aa = pasted_items.pop()
     if not isinstance(aa, diagramitems.AssociationItem):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Packages are only copied as is, without content.
Diagrams can be put on a diagram, and they can be copied. However, the contents of the diagram is not copied.

This is especially useful if you copy content between models.

Issue Number: #2422

### What is the new behavior?

* Elements are copied with their owned elements. So if you copy a package and do a full paste, the element and all owned elements are copied.
* Diagrams copy the elements in the diagram. You can now copy a diagram (from a diagram) and full-paste it. This will result in a copy of the diagram
* Update Modeling language docs with the (new) copy/paste interface and did some general improvements as well.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Cleaned up the copy and paste interfaces.

Copying is now done via the `copy_full()` function. This function copies the elements, and their owned elements.

NB. Copying is still supposed to happen from diagram to diagram. You cannot copy content in the model browser. This is something we can support in the future, but I deliberately kept it out of scope for this feature.