### PR TITLE
Support `gaphor.__version__`

### DIFF
--- a/gaphor/__init__.py
+++ b/gaphor/__init__.py
@@ -23,3 +23,11 @@ if sys.platform == "win32":
     from gaphor.windowsshim import gi_init
 
     gi_init()
+
+
+def __getattr__(name: str):
+    if name == "__version__":
+        import gaphor.application
+
+        return gaphor.application.distribution().version
+    raise AttributeError(f"module '{__name__!r}' has no attribute '{name!r}'")

--- a/gaphor/tests/test_version.py
+++ b/gaphor/tests/test_version.py
@@ -1,0 +1,5 @@
+import gaphor
+
+
+def test_dunder_version():
+    assert "." in gaphor.__version__


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the new behavior?

Most libraries have a `__version__` attribute that contains the library version.

Since Gaphor is also a library, it seems reasonable to support a `__version__` in our toplevel module:

```python
>>> import gaphor
>>> gaphor.__version__
'2.19.3'
```
