### PR TITLE
Toggle visibility of ProxyPort.type

### DIFF
--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -14,6 +14,7 @@ from gaphor.diagram.propertypages import (
 )
 from gaphor.SysML import sysml
 from gaphor.SysML.blocks.block import BlockItem
+from gaphor.SysML.blocks.proxyport import ProxyPortItem
 from gaphor.SysML.requirements.requirement import RequirementItem
 from gaphor.UML.classes.classespropertypages import AttributesPage, OperationsPage
 
@@ -87,7 +88,6 @@ class CompartmentPage(PropertyPageBase):
     def __init__(self, item):
         super().__init__()
         self.item = item
-        self.watcher = item.subject and item.subject.watcher()
 
     def construct(self):
         if not self.item.subject:
@@ -180,6 +180,35 @@ class PropertyPropertyPage(PropertyPageBase):
             self.subject.type = element
         else:
             del self.subject.type
+
+
+@PropertyPages.register(ProxyPortItem)
+class ProxyPortPropertyPage(PropertyPageBase):
+    order = 31
+
+    def __init__(self, item):
+        super().__init__()
+        self.item = item
+
+    def construct(self):
+        if not self.item.subject:
+            return
+
+        builder = new_builder(
+            "proxyport-editor",
+            signals={
+                "show-type-changed": (self._on_show_type_change,),
+            },
+        )
+
+        show_type = builder.get_object("show-type")
+        show_type.set_active(self.item.show_type)
+
+        return builder.get_object("proxyport-editor")
+
+    @transactional
+    def _on_show_type_change(self, button, _gparam):
+        self.item.show_type = button.get_active()
 
 
 @PropertyPages.register(UML.Association)

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -139,7 +139,7 @@ class PropertyPropertyPage(PropertyPageBase):
         self.subject = subject
 
     def construct(self):
-        if not self.subject:
+        if not self.subject or isinstance(self.subject, UML.Port):
             return
 
         builder = new_builder(

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -157,7 +157,7 @@
     </style>
   </object>
 
-  <object class="GtkBox" id="property-editor">
+  <object class="GtkBox" id="property-aggregation-editor">
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkLabel" id="label3">
@@ -182,6 +182,13 @@
         <signal name="notify::selected" handler="aggregation-changed" swapped="no" />
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+  <object class="GtkBox" id="property-type-editor">
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Type</property>
@@ -199,22 +206,20 @@
         </property>
       </object>
     </child>
-    <style>
-      <class name="propertypage"/>
-    </style>
-  </object>
-
-  <object class="GtkBox" id="proxyport-editor">
     <child>
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Show Type</property>
-        <property name="halign">start</property>
-        <property name="hexpand">yes</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkSwitch" id="show-type">
-        <signal name="notify::active" handler="show-type-changed" swapped="no" />
+      <object class="GtkBox" id="type-toggle-box">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Type</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-type">
+            <signal name="notify::active" handler="show-type-changed" swapped="no" />
+          </object>
+        </child>
       </object>
     </child>
     <style>

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -186,6 +186,9 @@
       <object class="GtkLabel">
         <property name="label" translatable="yes">Type</property>
         <property name="xalign">0</property>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
@@ -194,6 +197,24 @@
         <property name="expression">
           <lookup type="LabelValue" name="label" />
         </property>
+      </object>
+    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+  <object class="GtkBox" id="proxyport-editor">
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Show Type</property>
+        <property name="halign">start</property>
+        <property name="hexpand">yes</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="show-type">
+        <signal name="notify::active" handler="show-type-changed" swapped="no" />
       </object>
     </child>
     <style>

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -7,6 +7,7 @@ from gaphor.SysML.propertypages import (
     CompartmentPage,
     ItemFlowPropertyPage,
     PropertyPropertyPage,
+    ProxyPortPropertyPage,
     RequirementPropertyPage,
 )
 
@@ -45,6 +46,20 @@ def test_requirement_property_page_text(diagram, element_factory):
     requirement_text.get_buffer().set_text("test")
 
     assert subject.text == "test"
+
+
+def test_proxyport_property_page_show_type(diagram, element_factory):
+    item = diagram.create(
+        SysML.blocks.ProxyPortItem,
+        subject=element_factory.create(SysML.sysml.ProxyPort),
+    )
+    property_page = ProxyPortPropertyPage(item)
+
+    widget = property_page.construct()
+    show_parts = find(widget, "show-type")
+    show_parts.set_active(True)
+
+    assert item.show_type
 
 
 def test_compartment_property_page_show_parts(diagram, element_factory):

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -6,8 +6,8 @@ from gaphor.diagram.tests.fixtures import find
 from gaphor.SysML.propertypages import (
     CompartmentPage,
     ItemFlowPropertyPage,
-    PropertyPropertyPage,
-    ProxyPortPropertyPage,
+    PropertyAggregationPropertyPage,
+    PropertyTypePropertyPage,
     RequirementPropertyPage,
 )
 
@@ -48,12 +48,12 @@ def test_requirement_property_page_text(diagram, element_factory):
     assert subject.text == "test"
 
 
-def test_proxyport_property_page_show_type(diagram, element_factory):
+def test_property_type_property_page_show_type(diagram, element_factory):
     item = diagram.create(
         SysML.blocks.ProxyPortItem,
         subject=element_factory.create(SysML.sysml.ProxyPort),
     )
-    property_page = ProxyPortPropertyPage(item)
+    property_page = PropertyTypePropertyPage(item)
 
     widget = property_page.construct()
     show_parts = find(widget, "show-type")
@@ -101,9 +101,9 @@ def test_compartment_property_page_show_values(diagram, element_factory):
     assert item.show_values
 
 
-def test_property_property_page(element_factory):
+def test_property_aggregation_page(element_factory):
     subject = element_factory.create(SysML.sysml.Property)
-    property_page = PropertyPropertyPage(subject)
+    property_page = PropertyAggregationPropertyPage(subject)
 
     widget = property_page.construct()
     show_references = find(widget, "aggregation")
@@ -112,20 +112,24 @@ def test_property_property_page(element_factory):
     assert subject.aggregation == "composite"
 
 
-def test_no_property_property_page_for_ports(element_factory):
+def test_no_property_aggregation_page_for_ports(element_factory):
     subject = element_factory.create(UML.Port)
-    property_page = PropertyPropertyPage(subject)
+    property_page = PropertyAggregationPropertyPage(subject)
 
     widget = property_page.construct()
 
     assert not widget
 
 
-def test_property_type(element_factory):
-    subject = element_factory.create(SysML.sysml.Property)
+def test_property_type(diagram, element_factory):
+    item = diagram.create(
+        SysML.blocks.PropertyItem,
+        subject=element_factory.create(UML.Property),
+    )
+
     type = element_factory.create(UML.Class)
     type.name = "Bar"
-    property_page = PropertyPropertyPage(subject)
+    property_page = PropertyTypePropertyPage(item)
 
     widget = property_page.construct()
     dropdown = find(widget, "property-type")
@@ -135,7 +139,7 @@ def test_property_type(element_factory):
     dropdown.set_selected(bar_index)
 
     assert dropdown.get_selected_item().label == "Bar"
-    assert subject.type is type
+    assert item.subject.type is type
 
 
 def test_association_item_flow(association):

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -112,6 +112,15 @@ def test_property_property_page(element_factory):
     assert subject.aggregation == "composite"
 
 
+def test_no_property_property_page_for_ports(element_factory):
+    subject = element_factory.create(UML.Port)
+    property_page = PropertyPropertyPage(subject)
+
+    widget = property_page.construct()
+
+    assert not widget
+
+
 def test_property_type(element_factory):
     subject = element_factory.create(SysML.sysml.Property)
     type = element_factory.create(UML.Class)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Type of proxy ports is not shown

Issue Number: Fixes #2424

### What is the new behavior?

ProxyPort type is now shown if the "show-type" property is set.
