### PR TITLE
Do not remove unused Packages with childen

### DIFF
--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -63,7 +63,12 @@ class SanitizerService(Service):
             return
 
         old_subject = event.old_value
-        if old_subject and not old_subject.presentation and deletable(old_subject):
+        if (
+            old_subject
+            and deletable(old_subject)
+            and not old_subject.presentation
+            and not old_subject.ownedElement
+        ):
             old_subject.unlink()
 
             self.event_manager.handle(

--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -62,22 +62,19 @@ class SanitizerService(Service):
         ):
             return
 
-        old_subject = event.old_value
-        if (
-            old_subject
-            and deletable(old_subject)
-            and not old_subject.presentation
-            and not old_subject.ownedElement
-        ):
-            old_subject.unlink()
+        if old_subject := event.old_value:
+            if isinstance(old_subject, UML.Package) and old_subject.ownedElement:
+                return
+            elif deletable(old_subject) and not old_subject.presentation:
+                old_subject.unlink()
 
-            self.event_manager.handle(
-                Notification(
-                    gettext(
-                        "Removed unused elements from the model: they are not used in any other diagram."
+                self.event_manager.handle(
+                    Notification(
+                        gettext(
+                            "Removed unused elements from the model: they are not used in any other diagram."
+                        )
                     )
                 )
-            )
 
     @event_handler(AssociationSet)
     @undo_guard

--- a/gaphor/UML/tests/test_sanitizerservice.py
+++ b/gaphor/UML/tests/test_sanitizerservice.py
@@ -4,7 +4,7 @@ from gaphor import UML
 from gaphor.core.modeling import Comment, Diagram
 from gaphor.diagram.general import CommentItem, CommentLineItem
 from gaphor.diagram.tests.fixtures import connect
-from gaphor.UML.classes import ClassItem, GeneralizationItem
+from gaphor.UML.classes import ClassItem, GeneralizationItem, PackageItem
 from gaphor.UML.profiles import ExtensionItem
 from gaphor.UML.sanitizerservice import SanitizerService
 
@@ -52,7 +52,7 @@ def test_connect_element_with_comments(create_item, diagram):
 
 
 def test_presentation_delete(create_item, element_factory):
-    """Remove element if the last instance of an item is deleted."""
+    """Remove element if the last presentation of an item is deleted."""
     klassitem = create_item(ClassItem, UML.Class)
     klass = klassitem.subject
 
@@ -65,6 +65,26 @@ def test_presentation_delete(create_item, element_factory):
 
     assert not klassitem.diagram
     assert klass not in element_factory
+
+
+def test_no_presentation_delete_with_owned_element(create_item, element_factory):
+    """Do not remove element if it has children."""
+    package_item = create_item(PackageItem, UML.Package)
+    package = package_item.subject
+    class_item = create_item(ClassItem, UML.Class)
+    klass = class_item.subject
+    klass.package = package
+
+    assert class_item.subject.presentation[0] is class_item
+    assert class_item.diagram
+    assert package.ownedElement[0] == klass
+
+    # Delete presentation here:
+
+    package_item.unlink()
+
+    assert not package_item.diagram
+    assert package in element_factory
 
 
 def test_stereotype_attribute_delete(element_factory):

--- a/tests/test_package_removal.py
+++ b/tests/test_package_removal.py
@@ -39,9 +39,10 @@ def test_package_removal(session, event_manager, element_factory):
     # Check the profile has 1 presentation
     assert len(profiles[0].presentation) == 1
 
-    # Unlink the presentation
+    # Unlink the presentation and profile
     with Transaction(event_manager):
         profiles[0].presentation[0].unlink()
+        profiles[0].unlink()
 
     assert not element_factory.lselect(UML.Profile)
 


### PR DESCRIPTION
This PR fixes a bug that would allow for large portions of the model to be deleted if the last presentation of the owning Package was deleted.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
If the Remove Unused Elements option is selected, and you delete the last usage of a Package that has children like a package or activity, all the children are also deleted.

Issue Number: #2181 

### What is the new behavior?
Packages with children aren't removed automatically.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
