### PR TITLE
Fix operations in Blocks missing top separator

### DIFF
--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -203,4 +203,5 @@ class BlockItem(Classified, ElementPresentation[Block]):
                 "min-height": 8,
                 "justify-content": JustifyContent.START,
             },
+            draw=draw_top_separator,
         )


### PR DESCRIPTION
When drawing the operations compartment in Blocks, it was missing the top separator.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Top separator was missing

Issue Number: N/A

### What is the new behavior?
Top separator is restored

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
