### PR TITLE
Tree view should not collapse when an element is deleted

### DIFF
--- a/gaphor/ui/tests/test_modelbrowser.py
+++ b/gaphor/ui/tests/test_modelbrowser.py
@@ -288,6 +288,28 @@ def test_drop_multiple_elements(model_browser, element_factory, event_manager):
     assert class_a not in model_browser.get_selected_elements()
 
 
+def test_unlink_element_should_not_collapse_branch(
+    model_browser, element_factory, event_manager
+):
+    package = element_factory.create(UML.Package)
+    package.name = "p"
+    class_a = element_factory.create(UML.Class)
+    class_a.package = package
+    class_a.name = "a"
+    class_b = element_factory.create(UML.Class)
+    class_b.package = package
+    class_b.name = "b"
+
+    row0 = model_browser.selection.get_item(0)
+    row0.set_expanded(True)
+
+    class_a.unlink()
+
+    assert row0.get_item().element is package
+    assert row0.get_expanded()
+    assert model_browser.selection.get_item(1).get_item().element is class_b
+
+
 class MockRowItem:
     def __init__(self, list_item):
         self.list_item = list_item

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -237,7 +237,10 @@ class TreeModel:
     def notify_child_model(self, element):
         # Only notify the change, the branch is created in child_model()
         owner_tree_item = self.tree_item_for_element(element.owner)
-        if (owner_branch := self.branches.get(owner_tree_item)) is not None:
+        if (
+            not self.branches.get(self.tree_item_for_element(element))
+            and (owner_branch := self.branches.get(owner_tree_item)) is not None
+        ):
             owner_branch.changed(element)
 
     def clear(self) -> None:


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When you delete an element, the parent node in the model browser collapses (closes).

Issue Number: fixes #2488

### What is the new behavior?

Tree view does not collapse the node when an element changes inside.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
