### PR TITLE
Format pins by their name

### DIFF
--- a/gaphor/UML/tests/test_umlfmt.py
+++ b/gaphor/UML/tests/test_umlfmt.py
@@ -147,3 +147,10 @@ def test_slot(factory):
     slot = add_tag_is_foo_metadata_field(a, factory)
 
     assert 'tag = "foo"' == format(slot)
+
+
+def test_pin(factory):
+    pin = factory.create(UML.InputPin)
+    pin.name = "foo"
+
+    assert format(pin) == "foo"

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -180,8 +180,8 @@ def format_slot(el):
 
 
 @format.register(UML.NamedElement)
+@format.register(UML.Pin)
 def format_namedelement(el, **kwargs):
-    """Format named element."""
     return el.name or ""
 
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When the name of a pin is changed, the change is not reflected in the model browser.

A Pin is also a MultiplicityElement, and that's how it's formatted.

Issue Number: fixes #2487 

### What is the new behavior?

Pin name is shown in the model browser.

