### PR TITLE
Rename the Language setting to Diagram Language

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -164,9 +164,9 @@ By default the pointer tool is selected after an element is placed from the tool
 
 By default elements that are not part of any diagram in the model will be removed. If this option is turned off, elements remain in the model and may be found in the model browser.
 
-### Language
+### Diagram Language
 
-The language modifier is only applicable to the loaded model and how it is shown in the diagram. The language setting is saved as part of the model and defaults to English.
+The diagram language modifier is only applicable to the loaded model and how it is shown in the diagram. The diagram language setting is saved as part of the model and defaults to English.
 
 The UI language of Gaphor is controlled by the operating system.
 

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -292,9 +292,9 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Language</property>
+                            <property name="label" translatable="yes">Diagram Language</property>
                             <property name="xalign">0</property>
-                            <property name="tooltip-text" translatable="yes">The (spoken) language used in this model.</property>
+                            <property name="tooltip-text" translatable="yes">The (natural) language used in this model.</property>
                           </object>
                         </child>
                         <child>
@@ -302,7 +302,7 @@
                             <property name="model">
                               <object class="GtkStringList" id="language-model" />
                             </property>
-                            <property name="tooltip-text" translatable="yes">The (spoken) language used in this model.</property>
+                            <property name="tooltip-text" translatable="yes">The (natural) language used in this model.</property>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
Rename the "Language" setting in the model properties to "Diagram Language" and update documentation. 

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [X] Documentation content changes

### What is the current behavior?

The setting "Language" in the model properties is a bit ambiguous. 

Issue Number: #2461

### What is the new behavior?

Setting renamed to "Diagram Language".  Together with extended documentation this should hopefully make it a bit more clear to the users what influences the (natural) language presented by Gaphor in the UI and Diagrams. 

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
