### PR TITLE
Providing value for 'Show value' in properties page

### DIFF
--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -109,6 +109,9 @@ class CompartmentPage(PropertyPageBase):
         show_references = builder.get_object("show-references")
         show_references.set_active(self.item.show_references)
 
+        show_values = builder.get_object("show-values")
+        show_values.set_active(self.item.show_values)
+
         return builder.get_object("compartment-editor")
 
     @transactional


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The state 'Show values' of a SysML block is not applied in properties page.

Issue Number: 2511

### What is the new behavior?

It is applied as expected.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
