### PR TITLE
Allow only changing element ownership in the same model

### DIFF
--- a/gaphor/diagram/group.py
+++ b/gaphor/diagram/group.py
@@ -17,6 +17,9 @@ from gaphor.core.modeling import Diagram, Element, self_and_owners
 
 
 def change_owner(new_parent, element):
+    if element.model is not new_parent.model:
+        return False
+
     if element.owner is new_parent:
         return False
 

--- a/gaphor/diagram/tests/test_group.py
+++ b/gaphor/diagram/tests/test_group.py
@@ -1,5 +1,5 @@
-from gaphor.core.modeling import Diagram, Element
-from gaphor.diagram.group import can_group, group, ungroup
+from gaphor.core.modeling import Diagram, Element, ElementFactory
+from gaphor.diagram.group import can_group, group, ungroup, change_owner
 
 
 def test_group_diagram(element_factory):
@@ -49,3 +49,11 @@ def test_can_group_with_instance(element_factory):
     parent = element_factory.create(Element)
 
     assert can_group(parent, diagram)
+
+
+def test_cannot_change_owner_from_different_models(element_factory):
+    other_element_factory = ElementFactory()
+    diagram = element_factory.create(Diagram)
+    parent = other_element_factory.create(Element)
+
+    assert not change_owner(parent, diagram)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Currently an exception is raised when you drag elements from one session and drop them in the model browser of another session

Issue Number: #2504

### What is the new behavior?

This PR fixes the exception by explcitly checking if elements are part of the same model.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

To support DnD between models we need to use the internal copy functionality. But for that the copy functionality should be improved, as described in #2422.
