### PR TITLE
Support diagram model element type in SysML

### DIFF
--- a/gaphor/C4Model/modelinglanguage.py
+++ b/gaphor/C4Model/modelinglanguage.py
@@ -24,3 +24,6 @@ class C4ModelLanguage(ModelingLanguage):
 
     def lookup_element(self, name):
         return getattr(c4model, name, None) or getattr(diagramitems, name, None)
+
+    def format_diagram_label(self, diagram) -> str:
+        return str(diagram.name)

--- a/gaphor/RAAML/modelinglanguage.py
+++ b/gaphor/RAAML/modelinglanguage.py
@@ -25,3 +25,6 @@ class RAAMLModelingLanguage(ModelingLanguage):
 
     def lookup_element(self, name):
         return getattr(raaml, name, None) or getattr(diagramitems, name, None)
+
+    def format_diagram_label(self, diagram) -> str:
+        return str(diagram.name)

--- a/gaphor/SysML/modelinglanguage.py
+++ b/gaphor/SysML/modelinglanguage.py
@@ -25,3 +25,6 @@ class SysMLModelingLanguage(ModelingLanguage):
 
     def lookup_element(self, name):
         return getattr(sysml, name, None) or getattr(diagramitems, name, None)
+
+    def format_diagram_label(self, diagram) -> str:
+        return str(diagram.name)

--- a/gaphor/SysML/modelinglanguage.py
+++ b/gaphor/SysML/modelinglanguage.py
@@ -8,6 +8,8 @@ from gaphor.core import gettext
 from gaphor.diagram.diagramtoolbox import DiagramType, ToolboxDefinition
 from gaphor.SysML import diagramitems, sysml
 from gaphor.SysML.toolbox import sysml_diagram_types, sysml_toolbox_actions
+from gaphor.SysML.sysml import Block, ConstraintBlock, Requirement
+from gaphor.UML.uml import Activity, Interaction, Package, Profile, StateMachine
 
 
 class SysMLModelingLanguage(ModelingLanguage):
@@ -27,4 +29,30 @@ class SysMLModelingLanguage(ModelingLanguage):
         return getattr(sysml, name, None) or getattr(diagramitems, name, None)
 
     def format_diagram_label(self, diagram) -> str:
-        return str(diagram.name)
+        if not diagram.element:
+            # The diagram is created under the root
+            return str(diagram.name)
+
+        options = [
+            ("activity", Activity),
+            (
+                "constraint block",
+                ConstraintBlock,
+            ),  # Must be before block, because constraint block is derived from block
+            ("block", Block),
+            ("interaction", Interaction),
+            (
+                "profile",
+                Profile,
+            ),  # Must be before package, because profile is derived from package
+            ("package", Package),
+            ("requirement", Requirement),
+            ("state machine", StateMachine),
+        ]
+
+        model_element_type = next(
+            name for name, kind in options if isinstance(diagram.element, kind)
+        )
+        model_element_name = diagram.element.name or ""
+
+        return f"[{model_element_type}] {model_element_name} [{diagram.name}]"

--- a/gaphor/SysML/tests/test_sysml_modeling_language.py
+++ b/gaphor/SysML/tests/test_sysml_modeling_language.py
@@ -1,0 +1,51 @@
+from gaphor.SysML.modelinglanguage import SysMLModelingLanguage
+from gaphor.core.modeling.diagram import Diagram
+from gaphor.SysML.sysml import Block, ConstraintBlock, Requirement
+from gaphor.UML.uml import Activity, Interaction, Package, Profile, StateMachine
+
+
+def test_format_diagram_label(modeling_language):
+    def _diagram(elementType):
+        element = elementType()
+        element.name = "Efghi"
+
+        diagram = Diagram()
+        diagram.name = "Abcd"
+        diagram.element = element
+
+        return diagram
+
+    modeling_language = SysMLModelingLanguage()
+
+    assert (
+        modeling_language.format_diagram_label(_diagram(Activity))
+        == "[activity] Efghi [Abcd]"
+    )
+    assert (
+        modeling_language.format_diagram_label(_diagram(Block))
+        == "[block] Efghi [Abcd]"
+    )
+    assert (
+        modeling_language.format_diagram_label(_diagram(ConstraintBlock))
+        == "[constraint block] Efghi [Abcd]"
+    )
+    assert (
+        modeling_language.format_diagram_label(_diagram(Interaction))
+        == "[interaction] Efghi [Abcd]"
+    )
+    assert (
+        modeling_language.format_diagram_label(_diagram(Package))
+        == "[package] Efghi [Abcd]"
+    )
+    assert (
+        modeling_language.format_diagram_label(_diagram(Profile))
+        == "[profile] Efghi [Abcd]"
+    )
+    assert (
+        modeling_language.format_diagram_label(_diagram(Requirement))
+        == "[requirement] Efghi [Abcd]"
+    )
+    assert (
+        modeling_language.format_diagram_label(_diagram(StateMachine))
+        == "[state machine] Efghi [Abcd]"
+    )

--- a/gaphor/UML/modelinglanguage.py
+++ b/gaphor/UML/modelinglanguage.py
@@ -26,3 +26,6 @@ class UMLModelingLanguage(ModelingLanguage):
 
     def lookup_element(self, name):
         return getattr(uml, name, None) or getattr(diagramitems, name, None)
+
+    def format_diagram_label(self, diagram) -> str:
+        return str(diagram.name)

--- a/gaphor/abc.py
+++ b/gaphor/abc.py
@@ -47,3 +47,7 @@ class ModelingLanguage(metaclass=ABCMeta):
     @abstractmethod
     def lookup_element(self, name: str) -> type[Element] | None:
         """Look up a model element type by (class) name."""
+
+    @abstractmethod
+    def format_diagram_label(self, diagram) -> str:
+        """Format diagram type modeling language specific way"""

--- a/gaphor/core/modeling/modelinglanguage.py
+++ b/gaphor/core/modeling/modelinglanguage.py
@@ -20,6 +20,9 @@ class CoreModelingLanguage(ModelingLanguage):
     def lookup_element(self, name):
         return getattr(coremodel, name, None)
 
+    def format_diagram_label(self, diagram) -> str:
+        return str(diagram.name)
+
 
 class MockModelingLanguage(ModelingLanguage):
     """This class can be used to instantly combine modeling languages."""
@@ -50,3 +53,6 @@ class MockModelingLanguage(ModelingLanguage):
             ),
             None,
         )
+
+    def format_diagram_label(self, diagram) -> str:
+        return str(diagram.name)

--- a/gaphor/diagram/export.py
+++ b/gaphor/diagram/export.py
@@ -13,15 +13,17 @@ def escape_filename(diagram_name):
     return re.sub("\\W+", "_", diagram_name)
 
 
-def render(diagram, new_surface, padding=8, write_to_png=None) -> None:
+def render(
+    diagram, modeling_language, new_surface, padding=8, write_to_png=None
+) -> None:
     diagram.update_now(diagram.get_all_items())
 
-    painter = new_painter(diagram)
+    painter = new_painter(diagram, modeling_language)
 
     # Update bounding boxes with a temporary Cairo Context
     # (used for stuff like calculating font metrics)
     bounding_box = calc_bounding_box(diagram, painter)
-    type_padding = diagram_type_height(diagram)
+    type_padding = diagram_type_height(diagram, modeling_language)
 
     w, h = (
         bounding_box.width + 2 * padding,
@@ -47,11 +49,13 @@ def render(diagram, new_surface, padding=8, write_to_png=None) -> None:
             surface.write_to_png(write_to_png)
 
 
-def diagram_type_height(diagram):
+def diagram_type_height(diagram, modeling_language):
     if not diagram.diagramType:
         return 0
 
-    bounding_box = calc_bounding_box(diagram, DiagramTypePainter(diagram))
+    bounding_box = calc_bounding_box(
+        diagram, DiagramTypePainter(diagram, modeling_language)
+    )
 
     return bounding_box.height
 
@@ -67,35 +71,40 @@ def calc_bounding_box(diagram, painter):
     return bounding_box
 
 
-def save_svg(filename, diagram):
-    render(diagram, lambda w, h: cairo.SVGSurface(filename, w, h))
+def save_svg(filename, diagram, modeling_language):
+    render(diagram, modeling_language, lambda w, h: cairo.SVGSurface(filename, w, h))
 
 
-def save_png(filename, diagram):
+def save_png(filename, diagram, modeling_language):
     render(
         diagram,
+        modeling_language,
         lambda w, h: cairo.ImageSurface(cairo.FORMAT_ARGB32, int(w + 1), int(h + 1)),
         write_to_png=filename,
     )
 
 
-def save_pdf(filename, diagram):
-    render(diagram, lambda w, h: cairo.PDFSurface(filename, w, h))
+def save_pdf(filename, diagram, modeling_language):
+    render(diagram, modeling_language, lambda w, h: cairo.PDFSurface(filename, w, h))
 
 
-def save_eps(filename, diagram):
+def save_eps(filename, diagram, modeling_language):
     def new_surface(w, h):
         surface = cairo.PSSurface(filename, w, h)
         surface.set_eps(True)
         return surface
 
-    render(diagram, new_surface)
+    render(diagram, modeling_language, new_surface)
 
 
-def new_painter(diagram):
+def new_painter(diagram, modeling_language):
     style = diagram.style(StyledDiagram(diagram))
     sloppiness = style.get("line-style", 0.0)
     item_painter = (
         FreeHandPainter(ItemPainter(), sloppiness) if sloppiness else ItemPainter()
     )
-    return PainterChain().append(item_painter).append(DiagramTypePainter(diagram))
+    return (
+        PainterChain()
+        .append(item_painter)
+        .append(DiagramTypePainter(diagram, modeling_language))
+    )

--- a/gaphor/diagram/painter.py
+++ b/gaphor/diagram/painter.py
@@ -56,8 +56,9 @@ class ItemPainter:
 
 
 class DiagramTypePainter:
-    def __init__(self, diagram):
+    def __init__(self, diagram, modeling_language):
         self.diagram = diagram
+        self.modeling_language = modeling_language
 
     def paint(self, _items, cr):
         diagram = self.diagram
@@ -67,7 +68,8 @@ class DiagramTypePainter:
         layout = PangoCairo.create_layout(cr)
         escape = GLib.markup_escape_text
         layout.set_markup(
-            f"<b>{escape(diagram.diagramType)}</b> {escape(diagram.name)}", length=-1
+            f"<b>{escape(diagram.diagramType)}</b> {escape(self.modeling_language.format_diagram_label(diagram))}",
+            length=-1,
         )
 
         font_family = style.get("font-family")

--- a/gaphor/diagram/tests/test_export.py
+++ b/gaphor/diagram/tests/test_export.py
@@ -8,6 +8,7 @@ from gaphor.diagram.export import (
     save_svg,
 )
 from gaphor.diagram.general import Box
+from gaphor.services.modelinglanguage import ModelingLanguageService
 
 
 @pytest.fixture
@@ -19,7 +20,7 @@ def diagram_with_box(diagram):
 def test_export_to_svg(diagram_with_box, tmp_path):
     f = tmp_path / "test.svg"
 
-    save_svg(f, diagram_with_box)
+    save_svg(f, diagram_with_box, ModelingLanguageService())
     content = f.read_text(encoding="utf-8")
 
     assert "<svg" in content
@@ -28,7 +29,7 @@ def test_export_to_svg(diagram_with_box, tmp_path):
 def test_export_to_png(diagram_with_box, tmp_path):
     f = tmp_path / "test.png"
 
-    save_png(f, diagram_with_box)
+    save_png(f, diagram_with_box, ModelingLanguageService())
     content = f.read_bytes()
 
     assert b"PNG" in content
@@ -37,7 +38,7 @@ def test_export_to_png(diagram_with_box, tmp_path):
 def test_export_to_pdf(diagram_with_box, tmp_path):
     f = tmp_path / "test.pdf"
 
-    save_pdf(f, diagram_with_box)
+    save_pdf(f, diagram_with_box, ModelingLanguageService())
     content = f.read_bytes()
 
     assert b"%PDF" in content
@@ -46,7 +47,7 @@ def test_export_to_pdf(diagram_with_box, tmp_path):
 def test_export_to_eps(diagram_with_box, tmp_path):
     f = tmp_path / "test.eps"
 
-    save_eps(f, diagram_with_box)
+    save_eps(f, diagram_with_box, ModelingLanguageService())
     content = f.read_bytes()
 
     assert b"%!PS-Adobe-3.0 EPSF-3.0" in content

--- a/gaphor/extensions/ipython.py
+++ b/gaphor/extensions/ipython.py
@@ -7,6 +7,7 @@ from IPython.display import SVG, DisplayObject, Image
 from gaphor.core.modeling import Diagram
 from gaphor.diagram.export import save_png, save_svg
 from gaphor.plugins.autolayout import AutoLayout
+from gaphor.services.modelinglanguage import ModelingLanguageService
 
 
 def auto_layout(diagram: Diagram) -> None:
@@ -16,11 +17,13 @@ def auto_layout(diagram: Diagram) -> None:
 
 def draw(diagram: Diagram, format="png") -> DisplayObject:
     buffer = BytesIO()
+    modeling_language = ModelingLanguageService()
+
     if format == "svg":
-        save_svg(buffer, diagram)
+        save_svg(buffer, diagram, modeling_language)
         return SVG(buffer.getvalue())
     elif format == "png":
-        save_png(buffer, diagram)
+        save_png(buffer, diagram, modeling_language)
         return Image(buffer.getvalue())
     else:
         raise ValueError(

--- a/gaphor/extensions/sphinx.py
+++ b/gaphor/extensions/sphinx.py
@@ -91,8 +91,9 @@ class DiagramDirective(sphinx.util.docutils.SphinxDirective):
             )
 
         outfile = outdir / f"{diagram.id}"
-        save_svg(outfile.with_suffix(".svg"), diagram)
-        save_pdf(outfile.with_suffix(".pdf"), diagram)
+        modeling_language = ModelingLanguageService()
+        save_svg(outfile.with_suffix(".svg"), diagram, modeling_language)
+        save_pdf(outfile.with_suffix(".pdf"), diagram, modeling_language)
 
         # Image needs a relative path. Make our outfile path relative to the doc
         outdir = outdir.relative_to(self.env.srcdir)

--- a/gaphor/plugins/diagramexport/__init__.py
+++ b/gaphor/plugins/diagramexport/__init__.py
@@ -18,10 +18,13 @@ from gaphor.ui.filedialog import save_file_dialog
 class DiagramExport(Service, ActionProvider):
     """Service for exporting diagrams as images (SVG, PNG, PDF)."""
 
-    def __init__(self, diagrams=None, export_menu=None, main_window=None):
+    def __init__(
+        self, diagrams=None, export_menu=None, main_window=None, modeling_language=None
+    ):
         self.diagrams = diagrams
         self.export_menu = export_menu
         self.main_window = main_window
+        self.modeling_language = modeling_language
         if export_menu:
             export_menu.add_actions(self)
         self.filename: Path = Path("export").absolute()
@@ -35,10 +38,11 @@ class DiagramExport(Service, ActionProvider):
         filename = self.filename.with_name(
             escape_filename(diagram.name) or "export"
         ).with_suffix(dot_ext)
+        modeling_language = self.modeling_language
 
         def save_handler(filename):
             self.filename = filename
-            handler(filename, diagram)
+            handler(filename, diagram, modeling_language)
 
         save_file_dialog(
             title,

--- a/gaphor/plugins/diagramexport/exportcli.py
+++ b/gaphor/plugins/diagramexport/exportcli.py
@@ -108,10 +108,10 @@ def export_command(args):
             log.debug("rendering: %s -> %s...", pname, outfilename)
 
             if args.format == "pdf":
-                save_pdf(outfilename, diagram)
+                save_pdf(outfilename, diagram, modeling_language)
             elif args.format == "svg":
-                save_svg(outfilename, diagram)
+                save_svg(outfilename, diagram, modeling_language)
             elif args.format == "png":
-                save_png(outfilename, diagram)
+                save_png(outfilename, diagram, modeling_language)
             else:
                 raise RuntimeError(f"Unknown file format: {args.format}")

--- a/gaphor/services/modelinglanguage.py
+++ b/gaphor/services/modelinglanguage.py
@@ -67,6 +67,9 @@ class ModelingLanguageService(Service, ActionProvider, ModelingLanguage):
     def diagram_types(self):
         return self._modeling_language().diagram_types
 
+    def format_diagram_label(self, diagram) -> str:
+        return self._modeling_language().format_diagram_label(diagram)
+
     def lookup_element(self, name):
         return next(
             filter(


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2444

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

From #2444 description, technically, you can have all kinds of diagram element types, even those that are illegal according to the SysML, with these changes. I would like to do a follow-up pull request that would additionally constrain diagram creation to avoid creating illegal diagrams. The current solution works by taking the diagram owning element as diagram model element. This seems to be the common way to define the model element based on how Cameo, and Enco SOX handle it. For example, activity diagram should always be within activity, not outside for it to be considered valid SysML (unenforced at the moment).

Most of the changes are related to providing necessary context to the diagram header rendering in various use contexts. I am not very satisfied with the solution; so feel free to offer alternative suggestions on how to make diagram header modeling language customizable.