### PR TITLE
Type selection for Lifelines

### DIFF
--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -201,7 +201,7 @@ class ItemFlowPropertyPage(PropertyPageBase):
         self.entry = builder.get_object("item-flow-name")
 
         dropdown = builder.get_object("item-flow-type")
-        model = list_of_classifiers(self.subject.model)
+        model = list_of_classifiers(self.subject.model, UML.Classifier)
         dropdown.set_model(model)
 
         use_flow.set_active(isinstance(self.information_flow, sysml.ItemFlow))

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -187,46 +187,6 @@
     </style>
   </object>
 
-  <object class="GtkBox" id="property-type-editor">
-    <property name="orientation">vertical</property>
-    <child>
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Type</property>
-        <property name="xalign">0</property>
-        <style>
-          <class name="title"/>
-        </style>
-      </object>
-    </child>
-    <child>
-      <object class="GtkDropDown" id="property-type">
-        <property name="enable-search">1</property>
-        <property name="expression">
-          <lookup type="LabelValue" name="label" />
-        </property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox" id="type-toggle-box">
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Show Type</property>
-            <property name="halign">start</property>
-            <property name="hexpand">yes</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSwitch" id="show-type">
-            <signal name="notify::active" handler="show-type-changed" swapped="no" />
-          </object>
-        </child>
-      </object>
-    </child>
-    <style>
-      <class name="propertypage"/>
-    </style>
-  </object>
-
   <object class="GtkTextBuffer" id="requirement-text-buffer" />
 
   <object class="GtkBox" id="requirement-editor">

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -132,7 +132,7 @@ def test_property_type(diagram, element_factory):
     property_page = TypedElementPropertyPage(item)
 
     widget = property_page.construct()
-    dropdown = find(widget, "property-type")
+    dropdown = find(widget, "element-type")
     bar_index = next(
         n for n, lv in enumerate(dropdown.get_model()) if lv.value == type.id
     )

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -7,7 +7,7 @@ from gaphor.SysML.propertypages import (
     CompartmentPage,
     ItemFlowPropertyPage,
     PropertyAggregationPropertyPage,
-    PropertyTypePropertyPage,
+    TypedElementPropertyPage,
     RequirementPropertyPage,
 )
 
@@ -53,7 +53,7 @@ def test_property_type_property_page_show_type(diagram, element_factory):
         SysML.blocks.ProxyPortItem,
         subject=element_factory.create(SysML.sysml.ProxyPort),
     )
-    property_page = PropertyTypePropertyPage(item)
+    property_page = TypedElementPropertyPage(item)
 
     widget = property_page.construct()
     show_parts = find(widget, "show-type")
@@ -129,7 +129,7 @@ def test_property_type(diagram, element_factory):
 
     type = element_factory.create(UML.Class)
     type.name = "Bar"
-    property_page = PropertyTypePropertyPage(item)
+    property_page = TypedElementPropertyPage(item)
 
     widget = property_page.construct()
     dropdown = find(widget, "property-type")

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -167,7 +167,7 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
                 text=lambda: stereotypes_str(self.subject),
             ),
             Text(
-                text=lambda: self.subject.name or "",
+                text=self._format_name,
                 style={"font-weight": FontWeight.BOLD},
             ),
             draw=self.draw_lifeline,
@@ -175,6 +175,7 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
 
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
+        self.watch("subject[Lifeline].represents.name")
         self.setup_constraints()
 
     is_destroyed: attribute[int] = attribute("is_destroyed", int, default=False)
@@ -223,6 +224,15 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
             self._lifetime.top.pos.x = self._lifetime.bottom.pos.x = (
                 self._handles[NW].pos.x + self.width / 2
             )
+
+    def _format_name(self):
+        if not self.subject:
+            return ""
+
+        name = self.subject.name or ""
+        if self.subject.represents:
+            return f"{name}: {self.subject.represents.name or ''}"
+        return name
 
     def draw_lifeline(self, box, context, bounding_box):
         """Draw lifeline.

--- a/gaphor/UML/interactions/propertypages.ui
+++ b/gaphor/UML/interactions/propertypages.ui
@@ -35,4 +35,28 @@
     </style>
   </object>
 
+  <object class="GtkBox" id="lifeline-editor">
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Connectable Element</property>
+        <property name="xalign">0</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="element-type">
+        <property name="enable-search">1</property>
+        <property name="expression">
+          <lookup type="LabelValue" name="label" />
+        </property>
+      </object>
+    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
 </interface>

--- a/gaphor/UML/interactions/tests/test_interactionspropertypages.py
+++ b/gaphor/UML/interactions/tests/test_interactionspropertypages.py
@@ -1,6 +1,27 @@
 from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
-from gaphor.UML.interactions.interactionspropertypages import MessagePropertyPage
+from gaphor.UML.interactions.interactionspropertypages import (
+    LifelinePropertyPage,
+    MessagePropertyPage,
+)
+
+
+def test_lifeline_property_page(diagram, element_factory):
+    subject = element_factory.create(UML.Lifeline)
+
+    type = element_factory.create(UML.Interface)
+    type.name = "Bar"
+    property_page = LifelinePropertyPage(subject)
+
+    widget = property_page.construct()
+    dropdown = find(widget, "element-type")
+    bar_index = next(
+        n for n, lv in enumerate(dropdown.get_model()) if lv.value == type.id
+    )
+    dropdown.set_selected(bar_index)
+
+    assert dropdown.get_selected_item().label == "Bar"
+    assert subject.represents is type
 
 
 def test_message_property_page(diagram, element_factory):

--- a/gaphor/UML/propertypages.py
+++ b/gaphor/UML/propertypages.py
@@ -1,0 +1,79 @@
+from gi.repository import Gio
+
+from gaphor.core import transactional
+from gaphor.diagram.propertypages import (
+    LabelValue,
+    PropertyPageBase,
+    new_resource_builder,
+)
+from gaphor import UML
+
+
+new_builder = new_resource_builder("gaphor.UML")
+
+
+class TypedElementPropertyPage(PropertyPageBase):
+    order = 31
+
+    def __init__(self, item):
+        super().__init__()
+        self.item = item
+
+    def construct(self):
+        if not self.item.subject:
+            return
+
+        builder = new_builder(
+            "typed-element-editor",
+            signals={
+                "show-type-changed": (self._on_show_type_change,),
+            },
+        )
+
+        dropdown = builder.get_object("property-type")
+        model = list_of_classifiers(self.item.subject.model)
+        dropdown.set_model(model)
+
+        if self.item.subject.type:
+            dropdown.set_selected(
+                next(
+                    n
+                    for n, lv in enumerate(model)
+                    if lv.value == self.item.subject.type.id
+                )
+            )
+
+        dropdown.connect("notify::selected", self._on_property_type_changed)
+
+        if hasattr(self.item, "show_type"):
+            show_type = builder.get_object("show-type")
+            show_type.set_active(self.item.show_type)
+        else:
+            builder.get_object("type-toggle-box").unparent()
+
+        return builder.get_object("typed-element-editor")
+
+    @transactional
+    def _on_property_type_changed(self, dropdown, _pspec):
+        subject = self.item.subject
+        if id := dropdown.get_selected_item().value:
+            element = subject.model.lookup(id)
+            assert isinstance(element, UML.Type)
+            subject.type = element
+        else:
+            del subject.type
+
+    @transactional
+    def _on_show_type_change(self, button, _gparam):
+        self.item.show_type = button.get_active()
+
+
+def list_of_classifiers(element_factory):
+    model = Gio.ListStore.new(LabelValue)
+    model.append(LabelValue("", None))
+    for c in sorted(
+        (c for c in element_factory.select(UML.Classifier) if c.name),
+        key=lambda c: c.name or "",
+    ):
+        model.append(LabelValue(c.name, c.id))
+    return model

--- a/gaphor/UML/propertypages.py
+++ b/gaphor/UML/propertypages.py
@@ -16,6 +16,9 @@ class TypedElementPropertyPage(PropertyPageBase):
     order = 31
 
     def __init__(self, item):
+        assert (not item.subject) or isinstance(
+            item.subject, UML.TypedElement
+        ), item.subject
         super().__init__()
         self.item = item
 
@@ -30,8 +33,8 @@ class TypedElementPropertyPage(PropertyPageBase):
             },
         )
 
-        dropdown = builder.get_object("property-type")
-        model = list_of_classifiers(self.item.subject.model)
+        dropdown = builder.get_object("element-type")
+        model = list_of_classifiers(self.item.subject.model, UML.Classifier)
         dropdown.set_model(model)
 
         if self.item.subject.type:
@@ -68,11 +71,11 @@ class TypedElementPropertyPage(PropertyPageBase):
         self.item.show_type = button.get_active()
 
 
-def list_of_classifiers(element_factory):
+def list_of_classifiers(element_factory, required_type):
     model = Gio.ListStore.new(LabelValue)
     model.append(LabelValue("", None))
     for c in sorted(
-        (c for c in element_factory.select(UML.Classifier) if c.name),
+        (c for c in element_factory.select(required_type) if c.name),
         key=lambda c: c.name or "",
     ):
         model.append(LabelValue(c.name, c.id))

--- a/gaphor/UML/propertypages.ui
+++ b/gaphor/UML/propertypages.ui
@@ -14,7 +14,7 @@
       </object>
     </child>
     <child>
-      <object class="GtkDropDown" id="property-type">
+      <object class="GtkDropDown" id="element-type">
         <property name="enable-search">1</property>
         <property name="expression">
           <lookup type="LabelValue" name="label" />

--- a/gaphor/UML/propertypages.ui
+++ b/gaphor/UML/propertypages.ui
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0" />
+
+  <object class="GtkBox" id="typed-element-editor">
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Type</property>
+        <property name="xalign">0</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="property-type">
+        <property name="enable-search">1</property>
+        <property name="expression">
+          <lookup type="LabelValue" name="label" />
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox" id="type-toggle-box">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Type</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-type">
+            <signal name="notify::active" handler="show-type-changed" swapped="no" />
+          </object>
+        </child>
+      </object>
+    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+</interface>

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -278,6 +278,7 @@ class Component(Class):
 
 class ConnectableElement(TypedElement):
     end: relation_many[ConnectorEnd]
+    lifeline: relation_many[Lifeline]
 
 
 class Interface(Classifier, ConnectableElement):
@@ -524,6 +525,8 @@ class StateInvariant(InteractionFragment):
 class Lifeline(NamedElement):
     coveredBy: relation_many[InteractionFragment]
     interaction: relation_one[Interaction]
+    represents: relation_one[ConnectableElement]
+    selector: _attribute[str] = _attribute("selector", str)
     parse: Callable[[Lifeline, str], None]
     render: Callable[[Lifeline], str]
 
@@ -992,6 +995,7 @@ Component.packagedElement = association("packagedElement", PackageableElement, c
 Component.realization = redefine(Component, "realization", ComponentRealization, NamedElement.supplierDependency)
 Namespace.ownedMember.add(Component.packagedElement)  # type: ignore[attr-defined]
 ConnectableElement.end = association("end", ConnectorEnd, opposite="role")
+ConnectableElement.lifeline = association("lifeline", Lifeline, opposite="represents")
 Interface.ownedOperation = association("ownedOperation", Operation, composite=True, opposite="interface_")
 Interface.nestedClassifier = association("nestedClassifier", Classifier, composite=True)
 Interface.redefinedInterface = association("redefinedInterface", Interface)
@@ -1195,6 +1199,7 @@ StateInvariant.covered = redefine(StateInvariant, "covered", Lifeline, Interacti
 Element.ownedElement.add(StateInvariant.invariant)  # type: ignore[attr-defined]
 Lifeline.interaction = association("interaction", Interaction, upper=1, opposite="lifeline")
 Lifeline.coveredBy = association("coveredBy", InteractionFragment, opposite="covered")
+Lifeline.represents = association("represents", ConnectableElement, upper=1, opposite="lifeline")
 NamedElement.namespace.add(Lifeline.interaction)  # type: ignore[attr-defined]
 # 98: override Message.messageKind: property
 # defined in umloverrides.py

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -60,10 +60,13 @@ class _PropertyPages:
             Tuple[Type[Element], Callable[[Element], PropertyPageBase]]
         ] = []
 
-    def register(self, subject_type):
+    def register(self, subject_type, func=None):
         def reg(func):
             self.pages.append((subject_type, func))
             return func
+
+        if func:
+            return reg(func)
 
         return reg
 

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -65,10 +65,7 @@ class _PropertyPages:
             self.pages.append((subject_type, func))
             return func
 
-        if func:
-            return reg(func)
-
-        return reg
+        return reg(func) if func else reg
 
     def __call__(self, subject):
         for subject_type, func in self.pages:

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -18450,6 +18450,7 @@
 <ownedAttribute>
 <reflist>
 <ref refid="a55f35d7-909a-11ea-9685-03ae027faeeb"/>
+<ref refid="45e25468-28cb-11ee-a57e-0456e5e540ed"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -18471,6 +18472,7 @@
 <ref refid="99faaf4a-909a-11ea-9685-03ae027faeeb"/>
 <ref refid="47cb979f-e20d-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="785c0495-e971-11ea-96dc-bf74f1f80424"/>
+<ref refid="3c61905c-28cb-11ee-a57e-0456e5e540ed"/>
 </reflist>
 </presentation>
 <specialization>
@@ -27019,6 +27021,8 @@ directly in a model.</val>
 <ref refid="8a6fabc8-55b9-11ea-8c7d-fd01dce16f0a"/>
 <ref refid="8ed4600a-55b9-11ea-8c7d-fd01dce16f0a"/>
 <ref refid="4f377b36-63c7-11eb-9492-9757bcbe474b"/>
+<ref refid="45e1f018-28cb-11ee-a57e-0456e5e540ed"/>
+<ref refid="b6d6f5d4-28cb-11ee-a57e-0456e5e540ed"/>
 </reflist>
 </ownedType>
 <presentation>
@@ -27851,17 +27855,19 @@ directly in a model.</val>
 <ref refid="DCE:FF9B63F4-3B14-11D9-83CE-A0BAF22E8A12"/>
 <ref refid="DCE:082A25AA-3B15-11D9-83CE-A0BAF22E8A12"/>
 <ref refid="DCE:39E47B92-3B16-11D9-83CE-A0BAF22E8A12"/>
-<ref refid="DCE:E396E118-3B16-11D9-83CE-A0BAF22E8A12"/>
 <ref refid="e5b35db0-5562-11ea-8c7d-fd01dce16f0a"/>
 <ref refid="005d0062-5563-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="3c61905c-28cb-11ee-a57e-0456e5e540ed"/>
+<ref refid="b1228a86-28cb-11ee-a57e-0456e5e540ed"/>
 <ref refid="DCE:601A2BCC-3B15-11D9-83CE-A0BAF22E8A12"/>
 <ref refid="DCE:790AB410-3B15-11D9-83CE-A0BAF22E8A12"/>
 <ref refid="DCE:58B19668-3B16-11D9-83CE-A0BAF22E8A12"/>
-<ref refid="DCE:035425C4-3B17-11D9-83CE-A0BAF22E8A12"/>
 <ref refid="14637c20-5563-11ea-8c7d-fd01dce16f0a"/>
 <ref refid="1f320aaf-5563-11ea-8c7d-fd01dce16f0a"/>
 <ref refid="86b56eb0-5563-11ea-8c7d-fd01dce16f0a"/>
 <ref refid="8a30e282-5563-11ea-8c7d-fd01dce16f0a"/>
+<ref refid="43c2a4ee-28cb-11ee-a57e-0456e5e540ed"/>
+<ref refid="b5681ade-28cb-11ee-a57e-0456e5e540ed"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
@@ -28065,49 +28071,6 @@ directly in a model.</val>
 <ref refid="DCE:39E47B92-3B16-11D9-83CE-A0BAF22E8A12"/>
 </tail-connection>
 </GeneralizationItem>
-<CommentItem id="DCE:E396E118-3B16-11D9-83CE-A0BAF22E8A12">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 185.0, 486.003173828125)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>384.0</val>
-</width>
-<height>
-<val>50.0</val>
-</height>
-<diagram>
-<ref refid="DCE:EA8890EA-3B14-11D9-83CE-A0BAF22E8A12"/>
-</diagram>
-<subject>
-<ref refid="DCE:E39B1C38-3B16-11D9-83CE-A0BAF22E8A12"/>
-</subject>
-</CommentItem>
-<CommentLineItem id="DCE:035425C4-3B17-11D9-83CE-A0BAF22E8A12">
-<diagram>
-<ref refid="DCE:EA8890EA-3B14-11D9-83CE-A0BAF22E8A12"/>
-</diagram>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 234.31162157490314, 434.15999999999997)</val>
-</matrix>
-<points>
-<val>[(0.0, 0.0), (37.903278138563905, 51.84317382812503)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:FF9B63F4-3B14-11D9-83CE-A0BAF22E8A12"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:E396E118-3B16-11D9-83CE-A0BAF22E8A12"/>
-</tail-connection>
-</CommentLineItem>
 <ClassItem id="e5b35db0-5562-11ea-8c7d-fd01dce16f0a">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 527.3213427734376, 160.5)</val>
@@ -28277,11 +28240,6 @@ directly in a model.</val>
 </tail-connection>
 </AssociationItem>
 <Class id="DCE:FF9F4292-3B14-11D9-83CE-A0BAF22E8A12">
-<comment>
-<reflist>
-<ref refid="DCE:E39B1C38-3B16-11D9-83CE-A0BAF22E8A12"/>
-</reflist>
-</comment>
 <generalization>
 <reflist>
 <ref refid="DCE:5B1ADE52-3B16-11D9-83CE-A0BAF22E8A12"/>
@@ -28294,6 +28252,8 @@ directly in a model.</val>
 <reflist>
 <ref refid="DCE:7A18AFBC-3B15-11D9-83CE-A0BAF22E8A12"/>
 <ref refid="DCE:61E56BCA-3B15-11D9-83CE-A0BAF22E8A12"/>
+<ref refid="45e2ab48-28cb-11ee-a57e-0456e5e540ed"/>
+<ref refid="b6d77388-28cb-11ee-a57e-0456e5e540ed"/>
 </reflist>
 </ownedAttribute>
 <ownedOperation>
@@ -28454,21 +28414,6 @@ directly in a model.</val>
 <ref refid="DCE:FF9F4292-3B14-11D9-83CE-A0BAF22E8A12"/>
 </specific>
 </Generalization>
-<Comment id="DCE:E39B1C38-3B16-11D9-83CE-A0BAF22E8A12">
-<annotatedElement>
-<reflist>
-<ref refid="DCE:FF9F4292-3B14-11D9-83CE-A0BAF22E8A12"/>
-</reflist>
-</annotatedElement>
-<body>
-<val>Add relationship to connectableElement from InternalStructures.</val>
-</body>
-<presentation>
-<reflist>
-<ref refid="DCE:E396E118-3B16-11D9-83CE-A0BAF22E8A12"/>
-</reflist>
-</presentation>
-</Comment>
 <Diagram id="DCE:14C6D1BC-3B17-11D9-83CE-A0BAF22E8A12">
 <element>
 <ref refid="DCE:2AF6FCEA-3B13-11D9-83CE-A0BAF22E8A12"/>
@@ -30690,6 +30635,7 @@ directly in a model.</val>
 <ownedAttribute>
 <reflist>
 <ref refid="DCE:203459A0-34CE-11DA-B93C-00306EB655C9"/>
+<ref refid="b6d73148-28cb-11ee-a57e-0456e5e540ed"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -30701,6 +30647,7 @@ directly in a model.</val>
 <ref refid="92207e4a-e95e-11ea-87d1-cbf2d1fcaed0"/>
 <ref refid="DCE:812AEDBC-5FD3-11D9-89DE-0050040A5923"/>
 <ref refid="65c6b270-4066-11e0-b382-0019d2b28af0"/>
+<ref refid="b1228a86-28cb-11ee-a57e-0456e5e540ed"/>
 </reflist>
 </presentation>
 <specialization>
@@ -57033,4 +56980,253 @@ have an opposite end.
 <val>input</val>
 </value>
 </Slot>
+<ClassItem id="3c61905c-28cb-11ee-a57e-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 517.7143320262966, 553.721923828125)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>190.56646728515625</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="DCE:EA8890EA-3B14-11D9-83CE-A0BAF22E8A12"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="DCE:5BACF5C0-4A87-11D7-B089-133D836EF880"/>
+</subject>
+</ClassItem>
+<AssociationItem id="43c2a4ee-28cb-11ee-a57e-0456e5e540ed">
+<diagram>
+<ref refid="DCE:EA8890EA-3B14-11D9-83CE-A0BAF22E8A12"/>
+</diagram>
+<head_subject>
+<ref refid="45e25468-28cb-11ee-a57e-0456e5e540ed"/>
+</head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="45e1f018-28cb-11ee-a57e-0456e5e540ed"/>
+</subject>
+<tail_subject>
+<ref refid="45e2ab48-28cb-11ee-a57e-0456e5e540ed"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 612.442928697585, 419.4921875)</val>
+</matrix>
+<points>
+<val>[(0.5546369712897103, 14.667812499999968), (-0.017598136132164655, 134.229736328125)]</val>
+</points>
+<head-connection>
+<ref refid="DCE:FF9B63F4-3B14-11D9-83CE-A0BAF22E8A12"/>
+</head-connection>
+<tail-connection>
+<ref refid="3c61905c-28cb-11ee-a57e-0456e5e540ed"/>
+</tail-connection>
+</AssociationItem>
+<Association id="45e1f018-28cb-11ee-a57e-0456e5e540ed">
+<memberEnd>
+<reflist>
+<ref refid="45e25468-28cb-11ee-a57e-0456e5e540ed"/>
+<ref refid="45e2ab48-28cb-11ee-a57e-0456e5e540ed"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="DCE:2AF6FCEA-3B13-11D9-83CE-A0BAF22E8A12"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="43c2a4ee-28cb-11ee-a57e-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="45e25468-28cb-11ee-a57e-0456e5e540ed">
+<association>
+<ref refid="45e1f018-28cb-11ee-a57e-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="DCE:5BACF5C0-4A87-11D7-B089-133D836EF880"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>lifeline</val>
+</name>
+<type>
+<ref refid="DCE:FF9F4292-3B14-11D9-83CE-A0BAF22E8A12"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<Property id="45e2ab48-28cb-11ee-a57e-0456e5e540ed">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="45e1f018-28cb-11ee-a57e-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="DCE:FF9F4292-3B14-11D9-83CE-A0BAF22E8A12"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>selector</val>
+</name>
+<type>
+<ref refid="DCE:5BACF5C0-4A87-11D7-B089-133D836EF880"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<ClassItem id="b1228a86-28cb-11ee-a57e-0456e5e540ed">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 174.2617700195313, 553.721923828125)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>178.18500389289744</val>
+</width>
+<height>
+<val>64.216538687747</val>
+</height>
+<diagram>
+<ref refid="DCE:EA8890EA-3B14-11D9-83CE-A0BAF22E8A12"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="DCE:812B6CD0-5FD3-11D9-89DE-0050040A5923"/>
+</subject>
+</ClassItem>
+<AssociationItem id="b5681ade-28cb-11ee-a57e-0456e5e540ed">
+<diagram>
+<ref refid="DCE:EA8890EA-3B14-11D9-83CE-A0BAF22E8A12"/>
+</diagram>
+<head_subject>
+<ref refid="b6d73148-28cb-11ee-a57e-0456e5e540ed"/>
+</head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="b6d6f5d4-28cb-11ee-a57e-0456e5e540ed"/>
+</subject>
+<tail_subject>
+<ref refid="b6d77388-28cb-11ee-a57e-0456e5e540ed"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 243.09913292121783, 420.6405944824219)</val>
+</matrix>
+<points>
+<val>[(20.25513904476219, 13.519405517578093), (20.25513904476219, 133.08132934570312)]</val>
+</points>
+<head-connection>
+<ref refid="DCE:FF9B63F4-3B14-11D9-83CE-A0BAF22E8A12"/>
+</head-connection>
+<tail-connection>
+<ref refid="b1228a86-28cb-11ee-a57e-0456e5e540ed"/>
+</tail-connection>
+</AssociationItem>
+<Association id="b6d6f5d4-28cb-11ee-a57e-0456e5e540ed">
+<memberEnd>
+<reflist>
+<ref refid="b6d73148-28cb-11ee-a57e-0456e5e540ed"/>
+<ref refid="b6d77388-28cb-11ee-a57e-0456e5e540ed"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="DCE:2AF6FCEA-3B13-11D9-83CE-A0BAF22E8A12"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="b5681ade-28cb-11ee-a57e-0456e5e540ed"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="b6d73148-28cb-11ee-a57e-0456e5e540ed">
+<association>
+<ref refid="b6d6f5d4-28cb-11ee-a57e-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="DCE:812B6CD0-5FD3-11D9-89DE-0050040A5923"/>
+</class_>
+<name>
+<val>lifeline</val>
+</name>
+<type>
+<ref refid="DCE:FF9F4292-3B14-11D9-83CE-A0BAF22E8A12"/>
+</type>
+<upperValue>
+<val>*</val>
+</upperValue>
+<upperValue>
+<val>*</val>
+</upperValue>
+</Property>
+<Property id="b6d77388-28cb-11ee-a57e-0456e5e540ed">
+<association>
+<ref refid="b6d6f5d4-28cb-11ee-a57e-0456e5e540ed"/>
+</association>
+<class_>
+<ref refid="DCE:FF9F4292-3B14-11D9-83CE-A0BAF22E8A12"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>represents</val>
+</name>
+<type>
+<ref refid="DCE:812B6CD0-5FD3-11D9-89DE-0050040A5923"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
 </gaphor>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Lifelines cannot have a type

Issue Number: #2514

### What is the new behavior?

Be able to select a type (`ConnectableElement`) and show it on the element.

A lifeline represents a ConnectableElement, however, Classifiers are not connectable elements, except for Interface, Prpoerty and Parameter. Not sure how to assign a Block to a Lifeline.

![image](https://github.com/gaphor/gaphor/assets/96249/2cbbc8a6-b416-47d4-8b96-6f04339bc08d)
