### PR TITLE
Pin type multiplicity

### DIFF
--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -248,3 +248,27 @@ class FlowPropertyPageAbstract(PropertyPageBase):
     def _on_guard_change(self, entry):
         value = entry.get_text().strip()
         self.subject.guard = value
+
+@PropertyPages.register(UML.Pin)
+class PinPropertyPage(PropertyPageBase):
+    """Pin element editor."""
+
+    order = 15
+
+    subject: UML.Pin
+
+    def __init__(self, subject):
+        self.subject = subject
+        self.watcher = subject and subject.watcher()
+
+    def construct(self):
+        subject = self.subject
+
+        if not subject:
+            return
+
+        builder = new_builder(
+            "pin-editor",
+        )
+
+        return builder.get_object("pin-editor")

--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -249,6 +249,7 @@ class FlowPropertyPageAbstract(PropertyPageBase):
         value = entry.get_text().strip()
         self.subject.guard = value
 
+
 @PropertyPages.register(UML.Pin)
 class PinPropertyPage(PropertyPageBase):
     """Pin element editor."""
@@ -281,11 +282,7 @@ class PinPropertyPage(PropertyPageBase):
 
         if subject.type:
             dropdown.set_selected(
-                next(
-                    n
-                    for n, lv in enumerate(model)
-                    if lv.value == subject.type.id
-                )
+                next(n for n, lv in enumerate(model) if lv.value == subject.type.id)
             )
 
         dropdown.connect("notify::selected", self._on_type_changed)

--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -269,6 +269,63 @@ class PinPropertyPage(PropertyPageBase):
 
         builder = new_builder(
             "pin-editor",
+            signals={
+                "multiplicity-lower-changed": (self._on_multiplicity_lower_change,),
+                "multiplicity-upper-changed": (self._on_multiplicity_upper_change,),
+            },
         )
 
+        dropdown = builder.get_object("type")
+        model = self.list_of_classifiers(subject.model)
+        dropdown.set_model(model)
+
+        if subject.type:
+            dropdown.set_selected(
+                next(
+                    n
+                    for n, lv in enumerate(model)
+                    if lv.value == subject.type.id
+                )
+            )
+
+        dropdown.connect("notify::selected", self._on_type_changed)
+
+        multiplicity_lower = builder.get_object("multiplicity-lower")
+        multiplicity_lower.set_text(subject.lowerValue or "")
+
+        multiplicity_upper = builder.get_object("multiplicity-upper")
+        multiplicity_upper.set_text(subject.upperValue or "")
+
         return builder.get_object("pin-editor")
+
+    def list_of_classifiers(self, element_factory):
+        options = Gio.ListStore.new(LabelValue)
+        options.append(LabelValue("", None))
+
+        for c in sorted(
+            (c for c in element_factory.select(UML.Classifier) if c.name),
+            key=lambda c: c.name or "",
+        ):
+            options.append(LabelValue(c.name, c.id))
+
+        return options
+
+    @transactional
+    def _on_type_changed(self, dropdown, _pspec):
+        subject = self.subject
+        if id := dropdown.get_selected_item().value:
+            element = subject.model.lookup(id)
+            assert isinstance(element, UML.Type)
+            subject.type = element
+        else:
+            del subject.type
+
+    @transactional
+    def _on_multiplicity_lower_change(self, entry):
+        value = entry.get_text().strip()
+        self.subject.lowerValue = value
+
+    @transactional
+    def _on_multiplicity_upper_change(self, entry):
+        value = entry.get_text().strip()
+        self.subject.upperValue = value

--- a/gaphor/UML/actions/pin.py
+++ b/gaphor/UML/actions/pin.py
@@ -25,6 +25,9 @@ class PinItem(Named, AttachedPresentation[UML.Pin]):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=16, height=16)
         self.watch("subject[NamedElement].name")
+        self.watch("subject[TypedElement].type")
+        self.watch("subject[MultiplicityElement].lowerValue")
+        self.watch("subject[MultiplicityElement].upperValue")
 
     def pin_type(self):
         return ""

--- a/gaphor/UML/actions/pin.py
+++ b/gaphor/UML/actions/pin.py
@@ -47,10 +47,18 @@ class PinItem(Named, AttachedPresentation[UML.Pin]):
                     self.subject, [] if self.subject else [self.pin_type()]
                 )
             ),
-            Text(text=lambda: self.subject and self.subject.name or ""),
+            Text(text=self._format_name),
             style=text_position(self.connected_side()),
         )
 
+    def _format_name(self):
+        if not self.subject:
+            return ""
+
+        name = self.subject.name or ""
+        if self.show_type and self.subject.type:
+            return f"{name}: {self.subject.type.name or ''}"
+        return name
 
 @represents(UML.InputPin)
 class InputPinItem(PinItem):

--- a/gaphor/UML/actions/pin.py
+++ b/gaphor/UML/actions/pin.py
@@ -10,7 +10,7 @@ from gaphor.diagram.shapes import (
 )
 from gaphor.diagram.support import represents
 from gaphor.UML.recipes import stereotypes_str
-
+from gaphor.UML.umlfmt import format_pin
 
 def text_position(position):
     return {
@@ -47,18 +47,9 @@ class PinItem(Named, AttachedPresentation[UML.Pin]):
                     self.subject, [] if self.subject else [self.pin_type()]
                 )
             ),
-            Text(text=self._format_name),
+            Text(text=lambda: format_pin(self.subject)),
             style=text_position(self.connected_side()),
         )
-
-    def _format_name(self):
-        if not self.subject:
-            return ""
-
-        name = self.subject.name or ""
-        if self.show_type and self.subject.type:
-            return f"{name}: {self.subject.type.name or ''}"
-        return name
 
 @represents(UML.InputPin)
 class InputPinItem(PinItem):

--- a/gaphor/UML/actions/pin.py
+++ b/gaphor/UML/actions/pin.py
@@ -12,6 +12,7 @@ from gaphor.diagram.support import represents
 from gaphor.UML.recipes import stereotypes_str
 from gaphor.UML.umlfmt import format_pin
 
+
 def text_position(position):
     return {
         "text-align": TextAlign.LEFT if position == "left" else TextAlign.RIGHT,
@@ -53,6 +54,7 @@ class PinItem(Named, AttachedPresentation[UML.Pin]):
             Text(text=lambda: format_pin(self.subject)),
             style=text_position(self.connected_side()),
         )
+
 
 @represents(UML.InputPin)
 class InputPinItem(PinItem):

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk" version="4.0"/>
+  <requires lib="gtk" version="4.0" />
 
   <object class="GtkBox" id="decision-node-editor">
     <property name="orientation">vertical</property>
@@ -16,13 +16,13 @@
         <child>
           <object class="GtkSwitch" id="show-type">
             <property name="focusable">1</property>
-            <signal name="notify::active" handler="show-type-changed" swapped="no"/>
+            <signal name="notify::active" handler="show-type-changed" swapped="no" />
           </object>
         </child>
       </object>
     </child>
     <style>
-      <class name="propertypage"/>
+      <class name="propertypage" />
     </style>
   </object>
 
@@ -42,13 +42,13 @@
         <child>
           <object class="GtkSwitch" id="horizontal">
             <property name="focusable">1</property>
-            <signal name="notify::active" handler="horizontal-changed" swapped="no"/>
+            <signal name="notify::active" handler="horizontal-changed" swapped="no" />
           </object>
         </child>
       </object>
     </child>
     <style>
-      <class name="propertypage"/>
+      <class name="propertypage" />
     </style>
   </object>
 
@@ -59,18 +59,18 @@
         <property name="label" translatable="yes">Join Specification</property>
         <property name="xalign">0</property>
         <style>
-          <class name="title"/>
+          <class name="title" />
         </style>
       </object>
     </child>
     <child>
       <object class="GtkEntry" id="join-spec">
         <property name="focusable">1</property>
-        <signal name="changed" handler="join-spec-changed" swapped="no"/>
+        <signal name="changed" handler="join-spec-changed" swapped="no" />
       </object>
     </child>
     <style>
-      <class name="propertypage"/>
+      <class name="propertypage" />
     </style>
   </object>
 
@@ -89,7 +89,7 @@
         <property name="label" translatable="yes">Swimlanes</property>
         <property name="xalign">0</property>
         <style>
-          <class name="title"/>
+          <class name="title" />
         </style>
       </object>
     </child>
@@ -107,7 +107,7 @@
             <property name="focusable">1</property>
             <property name="adjustment">num-partitions-adjustment</property>
             <property name="numeric">1</property>
-            <signal name="value-changed" handler="partitions-changed" swapped="no"/>
+            <signal name="value-changed" handler="partitions-changed" swapped="no" />
           </object>
         </child>
       </object>
@@ -119,7 +119,7 @@
       </object>
     </child>
     <style>
-      <class name="propertypage"/>
+      <class name="propertypage" />
     </style>
   </object>
 
@@ -130,14 +130,14 @@
         <property name="label" translatable="yes">Upper Bound</property>
         <property name="xalign">0</property>
         <style>
-          <class name="title"/>
+          <class name="title" />
         </style>
       </object>
     </child>
     <child>
       <object class="GtkEntry" id="upper-bound">
         <property name="focusable">1</property>
-        <signal name="changed" handler="upper-bound-changed" swapped="no"/>
+        <signal name="changed" handler="upper-bound-changed" swapped="no" />
       </object>
     </child>
     <child>
@@ -152,7 +152,7 @@
         <child>
           <object class="GtkSwitch" id="show-ordering">
             <property name="focusable">1</property>
-            <signal name="notify::active" handler="show-ordering-changed" swapped="no"/>
+            <signal name="notify::active" handler="show-ordering-changed" swapped="no" />
           </object>
         </child>
       </object>
@@ -169,11 +169,11 @@
             </items>
           </object>
         </property>
-        <signal name="notify::selected" handler="ordering-changed" swapped="no"/>
+        <signal name="notify::selected" handler="ordering-changed" swapped="no" />
       </object>
     </child>
     <style>
-      <class name="propertypage"/>
+      <class name="propertypage" />
     </style>
   </object>
 
@@ -197,7 +197,7 @@
         <child>
           <object class="GtkEntry" id="partition-name">
             <property name="focusable">1</property>
-            <signal name="changed" handler="partition-name-changed" swapped="no"/>
+            <signal name="changed" handler="partition-name-changed" swapped="no" />
           </object>
         </child>
         <child>
@@ -215,7 +215,7 @@
           </object>
         </child>
         <style>
-          <class name="propertypage"/>
+          <class name="propertypage" />
         </style>
       </object>
     </child>
@@ -228,7 +228,7 @@
         <property name="label" translatable="yes">Behavior</property>
         <property name="xalign">0</property>
         <style>
-          <class name="title"/>
+          <class name="title" />
         </style>
       </object>
     </child>
@@ -241,7 +241,7 @@
       </object>
     </child>
     <style>
-      <class name="propertypage"/>
+      <class name="propertypage" />
     </style>
   </object>
 
@@ -252,7 +252,7 @@
         <property name="label" translatable="yes">Guard</property>
         <property name="xalign">0</property>
         <style>
-          <class name="title"/>
+          <class name="title" />
         </style>
       </object>
     </child>
@@ -262,7 +262,7 @@
       </object>
     </child>
     <style>
-      <class name="propertypage"/>
+      <class name="propertypage" />
     </style>
   </object>
 
@@ -273,7 +273,7 @@
       <object class="GtkLabel">
         <property name="label" translatable="yes">Parameter Nodes</property>
         <style>
-          <class name="title"/>
+          <class name="title" />
         </style>
       </object>
     </child>
@@ -291,7 +291,7 @@
                 <property name="show-expanders">0</property>
                 <property name="enable-grid-lines">horizontal</property>
                 <child internal-child="selection">
-                  <object class="GtkTreeSelection"/>
+                  <object class="GtkTreeSelection" />
                 </child>
                 <child>
                   <object class="GtkTreeViewColumn">
@@ -304,7 +304,7 @@
                         <property name="ypad">2</property>
                         <property name="xalign">0</property>
                         <property name="editable">1</property>
-                        <signal name="edited" handler="parameter-edited" swapped="no"/>
+                        <signal name="edited" handler="parameter-edited" swapped="no" />
                       </object>
                       <attributes>
                         <attribute name="text">0</attribute>
@@ -338,21 +338,77 @@ Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;De
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
                     <property name="use-markup">1</property>
                     <style>
-                      <class name="info-popover"/>
+                      <class name="info-popover" />
                     </style>
                   </object>
                 </property>
               </object>
             </child>
             <style>
-              <class name="info"/>
+              <class name="info" />
             </style>
           </object>
         </child>
       </object>
     </child>
     <style>
-      <class name="propertypage"/>
+      <class name="propertypage" />
+    </style>
+  </object>
+
+  <object class="GtkBox" id="pin-editor">
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Type</property>
+        <property name="xalign">0</property>
+        <style>
+          <class name="title" />
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="type">
+        <property name="enable-search">1</property>
+        <property name="expression">
+          <lookup type="LabelValue" name="label" />
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Multiplicity</property>
+        <property name="xalign">0</property>
+        <style>
+          <class name="title" />
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkEntry" id="multiplicity-lower">
+            <property name="focusable">1</property>
+            <!--<signal name="changed" handler="pin-multiplicity-lower-changed" swapped="no" />-->
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="label"> .. </property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkEntry" id="multiplicity-upper">
+            <property name="focusable">1</property>
+            <!--<signal name="changed" handler="pin-multiplicity-upper-changed" swapped="no" />-->
+          </object>
+        </child>
+      </object>
+    </child>
+    <style>
+      <class name="propertypage" />
     </style>
   </object>
 

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -389,7 +389,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <child>
           <object class="GtkEntry" id="multiplicity-lower">
             <property name="focusable">1</property>
-            <!--<signal name="changed" handler="pin-multiplicity-lower-changed" swapped="no" />-->
+            <signal name="changed" handler="multiplicity-lower-changed" swapped="no" />
           </object>
         </child>
         <child>
@@ -402,7 +402,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <child>
           <object class="GtkEntry" id="multiplicity-upper">
             <property name="focusable">1</property>
-            <!--<signal name="changed" handler="pin-multiplicity-upper-changed" swapped="no" />-->
+            <signal name="changed" handler="multiplicity-upper-changed" swapped="no" />
           </object>
         </child>
       </object>

--- a/gaphor/UML/tests/test_umlfmt.py
+++ b/gaphor/UML/tests/test_umlfmt.py
@@ -153,4 +153,10 @@ def test_pin(factory):
     pin = factory.create(UML.InputPin)
     pin.name = "foo"
 
-    assert format(pin) == "foo"
+    pin.type = factory.create(UML.Class)
+    pin.type.name = "MyClass"
+
+    pin.lowerValue = "1"
+    pin.upperValue = "*"
+
+    assert format(pin) == "foo: MyClass[1..*]"

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -189,6 +189,7 @@ def format_pin(el, **kwargs):
     if not el:
         return ""
 
+
     s = []
 
     s.append(el.name or "")

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -180,10 +180,26 @@ def format_slot(el):
 
 
 @format.register(UML.NamedElement)
-@format.register(UML.Pin)
 def format_namedelement(el, **kwargs):
     return el.name or ""
 
+@format.register(UML.Pin)
+def format_pin(el, **kwargs):
+
+    if not el:
+        return ""
+
+    s = []
+
+    s.append(el.name or "")
+
+    if el.typeValue:
+        s.append(f": {el.typeValue}")
+    
+    if el.upperValue or el.lowerValue:
+        s.append(format_multiplicity(el))
+    
+    return "".join(s)
 
 @format.register(UML.MultiplicityElement)
 def format_multiplicity(el, bare=False):

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -183,12 +183,11 @@ def format_slot(el):
 def format_namedelement(el, **kwargs):
     return el.name or ""
 
+
 @format.register(UML.Pin)
 def format_pin(el, **kwargs):
-
     if not el:
         return ""
-
 
     s = []
 
@@ -196,11 +195,12 @@ def format_pin(el, **kwargs):
 
     if el.type and el.type.name:
         s.append(f": {el.type.name}")
-    
+
     if el.upperValue or el.lowerValue:
         s.append(format_multiplicity(el))
-    
+
     return "".join(s)
+
 
 @format.register(UML.MultiplicityElement)
 def format_multiplicity(el, bare=False):

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -194,8 +194,8 @@ def format_pin(el, **kwargs):
 
     s.append(el.name or "")
 
-    if el.typeValue:
-        s.append(f": {el.typeValue}")
+    if el.type and el.type.name:
+        s.append(f": {el.type.name}")
     
     if el.upperValue or el.lowerValue:
         s.append(format_multiplicity(el))

--- a/poetry.lock
+++ b/poetry.lock
@@ -680,13 +680,13 @@ test = ["objgraph", "psutil"]
 
 [[package]]
 name = "hypothesis"
-version = "6.81.2"
+version = "6.82.0"
 description = "A library for property-based testing"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "hypothesis-6.81.2-py3-none-any.whl", hash = "sha256:4dafc0d3fc0e802ee5fa863e05e2cde54b9336e300d6c46f4e78b23b00cfa67a"},
-    {file = "hypothesis-6.81.2.tar.gz", hash = "sha256:e35165a73064370d30d476d7218f600d2bf861ff218192c9e994cb36aa190ae7"},
+    {file = "hypothesis-6.82.0-py3-none-any.whl", hash = "sha256:fa8eee429b99f7d3c953fb2b57de415fd39b472b09328b86c1978f12669ef395"},
+    {file = "hypothesis-6.82.0.tar.gz", hash = "sha256:ffece8e40a34329e7112f7408f2c45fe587761978fdbc6f4f91bf0d683a7d4d9"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->

Add ability to set the pin type and multiplicity.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Pin types and multiplicities cannot be set for a particular pin.

Issue Number: #2485 

### What is the new behavior?

When selecting a pin a properties panel is displayed where the type and multiplicity of the pin can be set. The modification is displayed on the diagram and in the tree as well.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

