### PR TITLE
Avoid copy cycles when fully pasting diagram items

### DIFF
--- a/gaphor/UML/copypaste.py
+++ b/gaphor/UML/copypaste.py
@@ -41,8 +41,12 @@ def paste_named_element(copy_data: NamedElementCopy, diagram, lookup):
     element = next(paster)
     yield element
     next(paster, None)
-    if not element.namespace and isinstance(element, (Type, Package)):
-        element.package = owner_package(diagram.owner)
+    if (
+        not element.namespace
+        and isinstance(element, (Type, Package))
+        and (package := owner_package(diagram.owner)) is not element
+    ):
+        element.package = package
 
 
 paste.register(NamedElementCopy, paste_named_element)

--- a/gaphor/UML/tests/test_copypaste.py
+++ b/gaphor/UML/tests/test_copypaste.py
@@ -1,5 +1,8 @@
+from gaphor.core.modeling import Diagram
 from gaphor.diagram.copypaste import copy_full, paste_full
 from gaphor.diagram.tests.test_copypaste_link import two_classes_and_a_generalization
+from gaphor.UML.classes import PackageItem
+from gaphor import UML
 
 
 def test_copy_connected_item(diagram, element_factory):
@@ -13,3 +16,40 @@ def test_copy_connected_item(diagram, element_factory):
     assert new_cls_item.subject
     assert gen_item.subject.general is gen_cls_item.subject
     assert gen_item.subject.specific is spc_cls_item.subject
+
+
+def test_full_copy_package_from_owned_diagram(element_factory):
+    diagram: Diagram = element_factory.create(Diagram)
+    package_item = diagram.create(
+        PackageItem, subject=element_factory.create(UML.Package)
+    )
+    package_item.subject.ownedDiagram = diagram
+
+    copy_buffer = copy_full([package_item], element_factory.lookup)
+
+    new_diagram: Diagram = element_factory.create(Diagram)
+
+    (new_package_item,) = paste_full(copy_buffer, new_diagram)
+
+    assert new_package_item.subject
+    assert new_package_item.subject is not package_item.subject
+
+
+def test_full_copy_package_from_owned_diagram_in_super_package(element_factory):
+    diagram: Diagram = element_factory.create(Diagram)
+    package_item = diagram.create(
+        PackageItem, subject=element_factory.create(UML.Package)
+    )
+    package_item.subject.ownedDiagram = diagram
+
+    copy_buffer = copy_full([package_item], element_factory.lookup)
+
+    new_diagram: Diagram = element_factory.create(Diagram)
+    new_diagram.element = element_factory.create(UML.Package)
+
+    (new_package_item,) = paste_full(copy_buffer, new_diagram)
+
+    assert diagram.owner is package_item.subject
+    assert new_package_item.subject
+    assert new_package_item.subject is not package_item.subject
+    assert new_package_item.subject.owner is new_diagram.owner

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -1075,7 +1075,6 @@
 <ref refid="DCE:522B0894-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:18E7456A-4697-11D7-B567-379CA7034986"/>
 <ref refid="DCE:7876B574-4A87-11D7-B089-133D836EF880"/>
-<ref refid="DCE:BCEB5704-4B32-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:79C3FCAA-4695-11D7-B567-379CA7034986"/>
 <ref refid="DCE:6A5E8372-4A87-11D7-B089-133D836EF880"/>
 <ref refid="DCE:8F7C5ED8-464D-11D7-AA08-1B85D5275D8A"/>
@@ -20217,7 +20216,7 @@
 </reflist>
 </memberEnd>
 <package>
-<ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
+<ref refid="4b38edd7-e18a-11ea-b7ab-f5b4c130f24e"/>
 </package>
 <presentation>
 <reflist>
@@ -50282,6 +50281,7 @@ association:not([memberEnd.navigability*=true]) {
 <ref refid="81d0d822-909f-11ea-85c4-7f4489bdcce3"/>
 <ref refid="aa683154-e897-11ea-96dc-bf74f1f80424"/>
 <ref refid="dc16637e-e897-11ea-96dc-bf74f1f80424"/>
+<ref refid="DCE:BCEB5704-4B32-11D7-B391-02BBFE4396CE"/>
 </reflist>
 </ownedType>
 <presentation>


### PR DESCRIPTION
This is a follow-up PR on #2475 

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?



Issue Number: #2536, #2475

### What is the new behavior?

Do not error if we copy complex structures.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
