### PR TITLE
Fix Picaso mode

### DIFF
--- a/gaphor/C4Model/diagramitems/database.py
+++ b/gaphor/C4Model/diagramitems/database.py
@@ -61,4 +61,4 @@ def draw_database(box, context, bounding_box):
     cr.curve_to(x1, y1, width / 2, y1 + height * d, x, y1)
     cr.line_to(x, y)
 
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/C4Model/diagramitems/person.py
+++ b/gaphor/C4Model/diagramitems/person.py
@@ -66,4 +66,4 @@ def draw_person(box, context, bounding_box):
 
     cr.close_path()
 
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/andgate.py
+++ b/gaphor/RAAML/fta/andgate.py
@@ -86,4 +86,4 @@ def draw_and_gate(box, context: DrawContext, bounding_box: Rectangle):
     center = bounding_box.width / 2.0
     cr.move_to(center, wall_top - ry / 2.0)
     cr.line_to(center, 0)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/basicevent.py
+++ b/gaphor/RAAML/fta/basicevent.py
@@ -54,4 +54,4 @@ def draw_basic_event(box, context: DrawContext, bounding_box: Rectangle):
     cr = context.cairo
     cr.move_to(bounding_box.width, bounding_box.height)
     ellipse(cr, *bounding_box)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/houseevent.py
+++ b/gaphor/RAAML/fta/houseevent.py
@@ -62,4 +62,4 @@ def draw_house_event(box, context: DrawContext, bounding_box: Rectangle):
     cr.line_to(bounding_box.width / 2.0, 0)
     cr.line_to(left, wall_top)
     cr.line_to(left, wall_bottom)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/inhibitgate.py
+++ b/gaphor/RAAML/fta/inhibitgate.py
@@ -80,4 +80,4 @@ def draw_inhibit_gate(box, context: DrawContext, bounding_box: Rectangle):
     middle_height = bounding_box.height / 2.0
     cr.move_to(right, middle_height)
     cr.line_to(bounding_box.width, middle_height)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/majorityvotegate.py
+++ b/gaphor/RAAML/fta/majorityvotegate.py
@@ -106,4 +106,4 @@ def draw_majority_vote_gate(box, context: DrawContext, bounding_box: Rectangle):
     cr.move_to(x, y)
     cr.show_text(text)
 
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/notgate.py
+++ b/gaphor/RAAML/fta/notgate.py
@@ -60,4 +60,4 @@ def draw_not_gate(box, context: DrawContext, bounding_box: Rectangle):
     cr.line_to(x1, 0)
     cr.line_to(x2, height)
     cr.line_to(x1, height)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/orgate.py
+++ b/gaphor/RAAML/fta/orgate.py
@@ -115,4 +115,4 @@ def draw_or_gate(box, context: DrawContext, bounding_box: Rectangle):
     center = bounding_box.width / 2.0
     cr.move_to(center, point_top)
     cr.line_to(center, 0)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/seqgate.py
+++ b/gaphor/RAAML/fta/seqgate.py
@@ -62,4 +62,4 @@ def draw_seq_gate(box, context: DrawContext, bounding_box: Rectangle):
     ry = bounding_box.height * 2.0 / 3.0
     cr.line_to(bounding_box.width / 2.0, wall_top - ry / 2.0)
     cr.line_to(bounding_box.width, wall_bottom)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/transferin.py
+++ b/gaphor/RAAML/fta/transferin.py
@@ -56,4 +56,4 @@ def draw_transfer_in(box, context: DrawContext, bounding_box: Rectangle):
     cr.line_to(bounding_box.width, bounding_box.height)
     cr.line_to(bounding_box.width / 2.0, 0)
     cr.line_to(0, bounding_box.height)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/transferout.py
+++ b/gaphor/RAAML/fta/transferout.py
@@ -56,4 +56,4 @@ def draw_transfer_out(box, context: DrawContext, bounding_box: Rectangle):
     cr = context.cairo
     cr.move_to(bounding_box.width / 4.0, bounding_box.height / 2.0)
     cr.line_to(0, bounding_box.height / 2.0)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/xorgate.py
+++ b/gaphor/RAAML/fta/xorgate.py
@@ -63,4 +63,4 @@ def draw_xor_gate(box, context: DrawContext, bounding_box: Rectangle):
     cr.move_to(0, bottom_points)
     cr.line_to(bounding_box.width / 2.0, point_top)
     cr.line_to(bounding_box.width, bottom_points)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/RAAML/fta/zeroevent.py
+++ b/gaphor/RAAML/fta/zeroevent.py
@@ -60,4 +60,4 @@ def draw_zero_event(box, context: DrawContext, bounding_box: Rectangle):
     wall_bottom = bounding_box.height
     cr.move_to(left, wall_top)
     cr.line_to(right, wall_bottom)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/UML/actions/action.py
+++ b/gaphor/UML/actions/action.py
@@ -82,7 +82,7 @@ class CallBehaviorActionItem(ActionItem):
         cr.line_to(x_offset + half_width, y_offset + half_height)
         cr.close_path()
 
-        stroke(context)
+        stroke(context, fill=True)
 
 
 @represents(UML.SendSignalAction)
@@ -113,7 +113,7 @@ class SendSignalActionItem(Named, ElementPresentation):
         cr.line_to(0, height)
         cr.close_path()
 
-        stroke(context)
+        stroke(context, fill=True)
 
 
 @represents(UML.AcceptEventAction)
@@ -144,4 +144,4 @@ class AcceptEventActionItem(Named, ElementPresentation):
         cr.line_to(d, height / 2)
         cr.close_path()
 
-        stroke(context)
+        stroke(context, fill=True)

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -107,7 +107,7 @@ def draw_activity_final_node(_box, context, _bounding_box):
     ellipse(cr, 0, 0, d, d)
     cr.set_line_width(0.01)
     cr.set_line_width(2)
-    stroke(context)
+    stroke(context, fill=True)
 
     d = inner_radius * 2
     ellipse(cr, 5, 5, d, d)
@@ -145,7 +145,7 @@ def draw_flow_final_node(_box, context, bounding_box):
     r = 10
     d = r * 2
     ellipse(cr, *bounding_box)
-    stroke(context)
+    stroke(context, fill=True)
 
     dr = (1 - math.sin(math.pi / 4)) * r
     cr.move_to(dr, dr)
@@ -205,7 +205,7 @@ def draw_decision_node(_box, context, _bounding_box):
     cr.line_to(r2, r * 2)
     cr.line_to(0, r)
     cr.close_path()
-    stroke(context)
+    stroke(context, fill=True)
 
 
 @represents(UML.ForkNode)

--- a/gaphor/UML/actions/partition.py
+++ b/gaphor/UML/actions/partition.py
@@ -124,4 +124,4 @@ class PartitionItem(ElementPresentation):
         cr.line_to(0 + bounding_box.width, 0)
         cr.move_to(0, header_height)
         cr.line_to(0 + bounding_box.width, header_height)
-        stroke(context)
+        stroke(context, fill=True)

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -292,10 +292,10 @@ def draw_tail_composite(context):
     at association tail."""
     cr = context.cairo
     cr.line_to(20, 0)
-    stroke(context)
+    stroke(context, fill=True)
     _draw_diamond(cr)
     cr.fill_preserve()
-    stroke(context)
+    stroke(context, fill=True)
 
 
 def draw_head_shared(context):

--- a/gaphor/UML/classes/containment.py
+++ b/gaphor/UML/classes/containment.py
@@ -22,6 +22,6 @@ def draw_crossed_circle_head(context: DrawContext):
     cr.line_to(2 * radius, 0)
     cr.move_to(radius, radius)
     cr.line_to(radius, -radius)
-    stroke(context, dash=False)
+    stroke(context, fill=False, dash=False)
     cr.restore()
     cr.move_to(0, 0)

--- a/gaphor/UML/classes/dependency.py
+++ b/gaphor/UML/classes/dependency.py
@@ -104,5 +104,5 @@ class DependencyItem(Named, LinePresentation):
             cr.move_to(15, -6)
             cr.line_to(0, 0)
             cr.line_to(15, 6)
-            stroke(context, dash=False)
+            stroke(context, fill=False, dash=False)
         cr.move_to(0, 0)

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -369,4 +369,4 @@ class InterfaceItem(Classified, ElementPresentation):
             cr.move_to(cx + self.RADIUS_PROVIDED, cy)
             cr.arc(cx, cy, self.RADIUS_PROVIDED, 0, pi * 2)
 
-        stroke(context)
+        stroke(context, fill=True)

--- a/gaphor/UML/classes/interfacerealization.py
+++ b/gaphor/UML/classes/interfacerealization.py
@@ -53,5 +53,5 @@ class InterfaceRealizationItem(Named, LinePresentation):
             cr.line_to(15, -10)
             cr.line_to(15, 10)
             cr.close_path()
-            stroke(context, dash=False)
+            stroke(context, fill=False, dash=False)
             cr.move_to(15, 0)

--- a/gaphor/UML/classes/package.py
+++ b/gaphor/UML/classes/package.py
@@ -61,4 +61,4 @@ def draw_package(box, context, bounding_box):
         cr.line_to(w, h)
         cr.line_to(w, y)
         cr.line_to(o, y)
-        stroke(context)
+        stroke(context, fill=True)

--- a/gaphor/UML/deployments/node.py
+++ b/gaphor/UML/deployments/node.py
@@ -91,4 +91,4 @@ def draw_node(box, context, bounding_box):
     cr.move_to(w, 0)
     cr.line_to(w + d, -d)
 
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/UML/interactions/interaction.py
+++ b/gaphor/UML/interactions/interaction.py
@@ -43,7 +43,7 @@ class InteractionItem(Named, ElementPresentation):
 def draw_interaction(box, context, bounding_box):
     cr = context.cairo
     cr.rectangle(0, 0, bounding_box.width, bounding_box.height)
-    stroke(context)
+    stroke(context, fill=True)
     # draw pentagon
     w, h = box.sizes[0]
     h2 = h / 2.0

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -232,7 +232,7 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
         """
         cr = context.cairo
         cr.rectangle(0, 0, self.width, self.height)
-        stroke(context)
+        stroke(context, fill=True)
 
         if (
             context.hovered
@@ -248,7 +248,7 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
                 top = self._lifetime.top
                 cr.move_to(top.pos.x - x, top.pos.y)
                 cr.line_to(bottom.pos.x - x, bottom.pos.y)
-                stroke(context, dash=False)
+                stroke(context, fill=True, dash=False)
 
             # draw destruction event
             if self.is_destroyed:

--- a/gaphor/UML/interactions/message.py
+++ b/gaphor/UML/interactions/message.py
@@ -173,7 +173,7 @@ class MessageItem(Named, LinePresentation[UML.Message]):
             cr.set_dash((7.0, 5.0), 0)
 
         cr.line_to(0, 0)
-        stroke(context, dash=False)
+        stroke(context, fill=False, dash=False)
 
         cr.set_dash((), 0)
 
@@ -190,7 +190,7 @@ class MessageItem(Named, LinePresentation[UML.Message]):
         else:
             self._draw_arrow(cr)
 
-        stroke(context)
+        stroke(context, fill=False)
 
     def _draw_decorating_arrow(self, cr, inverted=False):
         with cairo_state(cr):

--- a/gaphor/UML/states/finalstate.py
+++ b/gaphor/UML/states/finalstate.py
@@ -34,7 +34,7 @@ def draw_final_state(box, context, bounding_box):
     ellipse(cr, *bounding_box)
     cr.set_line_width(0.01)
     cr.set_line_width(2)
-    stroke(context)
+    stroke(context, fill=True)
 
     if stroke_color := context.style["color"]:
         cr.set_source_rgba(*stroke_color)

--- a/gaphor/UML/states/state.py
+++ b/gaphor/UML/states/state.py
@@ -109,4 +109,4 @@ def draw_state(box, context, bounding_box):
     cr.curve_to(ddx, height, 0, height - ddy, 0, height - dy)
     cr.close_path()
 
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/diagram/general/comment.py
+++ b/gaphor/diagram/general/comment.py
@@ -45,4 +45,4 @@ def draw_border(box, context, bounding_box, ear):
     line_to(x, h)
     line_to(w, h)
     line_to(w, y + ear)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/diagram/general/diagramitem.py
+++ b/gaphor/diagram/general/diagramitem.py
@@ -46,4 +46,4 @@ def draw_diagram(box, context, bounding_box):
     cr.move_to(17, 9)
     cr.line_to(8, 9)
     cr.line_to(8, 12)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -294,7 +294,7 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
 
         draw_line_end(context, handles[-1], handles[-2], self.draw_tail)
 
-        stroke(context)
+        stroke(context, fill=False)
 
         for shape, rect in (
             (self._shape_head, self._shape_head_rect),

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -31,7 +31,7 @@ class cairo_state:
         self._cr.restore()
 
 
-def stroke(context: DrawContext, fill=True, dash=True):
+def stroke(context: DrawContext, fill: bool, dash=True):
     style = context.style
     cr = context.cairo
     fill_color = style.get("background-color")
@@ -72,7 +72,7 @@ def draw_border(box, context: DrawContext, bounding_box: Rectangle):
 
     cr.close_path()
 
-    stroke(context)
+    stroke(context, fill=True)
 
 
 def draw_top_separator(box: Box, context: DrawContext, bounding_box: Rectangle):
@@ -96,7 +96,7 @@ def draw_left_separator(box: Box, context: DrawContext, bounding_box: Rectangle)
 def draw_ellipse(box: Box, context: DrawContext, bounding_box: Rectangle):
     ellipse(context.cairo, *bounding_box)
 
-    stroke(context)
+    stroke(context, fill=True)
 
 
 def ellipse(cr, x, y, w, h, dc=None):
@@ -497,4 +497,4 @@ def draw_diamond(
     cr.line_to(x2, center_y)
     cr.line_to(center_x, y1)
     cr.line_to(x1, center_y)
-    stroke(context)
+    stroke(context, fill=True)

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -467,7 +467,7 @@ def draw_arrow_head(context: DrawContext):
     cr.move_to(15, -6)
     cr.line_to(0, 0)
     cr.line_to(15, 6)
-    stroke(context, dash=False)
+    stroke(context, fill=False, dash=False)
     cr.restore()
     cr.move_to(0, 0)
 
@@ -475,13 +475,13 @@ def draw_arrow_head(context: DrawContext):
 def draw_arrow_tail(context: DrawContext):
     cr = context.cairo
     cr.line_to(0, 0)
-    stroke(context)
+    stroke(context, fill=False)
     cr.save()
     cr.set_dash((), 0)
     cr.move_to(15, -6)
     cr.line_to(0, 0)
     cr.line_to(15, 6)
-    stroke(context, dash=False)
+    stroke(context, fill=False, dash=False)
     cr.restore()
 
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Lines render a background.

Issue Number: fixes #2537

### What is the new behavior?

Before:

![image](https://github.com/gaphor/gaphor/assets/96249/07eba131-30eb-42ea-aadb-fa67426c8acd)

After:

![image](https://github.com/gaphor/gaphor/assets/96249/1b98c707-7b0a-468c-9eda-6593d0a097b9)

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

The fill option on `stroke()` is now mandatory.