### PR TITLE
Support SysMLDiagram type and diagram type specific header formatting

### DIFF
--- a/gaphor/C4Model/iconname.py
+++ b/gaphor/C4Model/iconname.py
@@ -1,8 +1,8 @@
 from gaphor.C4Model.c4model import C4Container, C4Database
-from gaphor.diagram.iconname import get_default_icon_name, get_icon_name
+from gaphor.diagram.iconname import get_default_icon_name, icon_name
 
 
-@get_icon_name.register(C4Container)
+@icon_name.register(C4Container)
 def get_name_for_class(element):
     if element.type == "Software System":
         return "gaphor-c4-software-system-symbolic"
@@ -12,6 +12,6 @@ def get_name_for_class(element):
         return get_default_icon_name(element)
 
 
-@get_icon_name.register(C4Database)
+@icon_name.register(C4Database)
 def get_database_name(element):
     return get_default_icon_name(element)

--- a/gaphor/SysML/__init__.py
+++ b/gaphor/SysML/__init__.py
@@ -1,2 +1,4 @@
+import gaphor.SysML.diagramlabel
 import gaphor.SysML.drop
+import gaphor.SysML.iconname
 import gaphor.SysML.modelinglanguage

--- a/gaphor/SysML/diagramlabel.py
+++ b/gaphor/SysML/diagramlabel.py
@@ -1,0 +1,33 @@
+from gaphor.diagram.diagramlabel import diagram_label
+from gaphor.SysML.sysml import SysMLDiagram, Block, ConstraintBlock, Requirement
+from gaphor.UML.uml import Activity, Package, Interaction, Profile, StateMachine
+
+
+@diagram_label.register(SysMLDiagram)
+def sysml_diagram_label(diagram):
+    def element_type(el):
+        if isinstance(el, Activity):
+            return "activity"
+        if isinstance(el, ConstraintBlock):
+            return "constraint block"
+        if isinstance(el, Block):
+            return "block"
+        if isinstance(el, Interaction):
+            return "interaction"
+        if isinstance(el, Profile):
+            return "profile"
+        if isinstance(el, Package):
+            return "package"
+        if isinstance(el, Requirement):
+            return "requirement"
+        if isinstance(el, StateMachine):
+            return "state machine"
+        return ""
+
+    if diagram.element:
+        return (
+            f"[{element_type(diagram.element)}] {diagram.element.name} [{diagram.name}]"
+        )
+    else:
+        # TODO: SysML specification does not allow parentless elements, but since it is not constrained (yet), it may happen.
+        return diagram.name

--- a/gaphor/SysML/iconname.py
+++ b/gaphor/SysML/iconname.py
@@ -1,7 +1,7 @@
-from gaphor.diagram.iconname import get_icon_name
+from gaphor.diagram.iconname import icon_name
 from gaphor.SysML.sysml import SysMLDiagram
 
 
-@get_icon_name.register(SysMLDiagram)
+@icon_name.register(SysMLDiagram)
 def get_name_for_class(element):
     return "gaphor-diagram-symbolic"

--- a/gaphor/SysML/iconname.py
+++ b/gaphor/SysML/iconname.py
@@ -1,0 +1,7 @@
+from gaphor.diagram.iconname import get_icon_name
+from gaphor.SysML.sysml import SysMLDiagram
+
+
+@get_icon_name.register(SysMLDiagram)
+def get_name_for_class(element):
+    return "gaphor-diagram-symbolic"

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -293,6 +293,12 @@ class ItemFlow(InformationFlow):
     itemProperty: relation_one[Property]
 
 
+from gaphor.core.modeling.diagram import Diagram
+from gaphor.UML.uml import Class
+class SysMLDiagram(Diagram):
+    pass
+
+
 
 # 23: override AbstractRequirement.derived: derived[AbstractRequirement]
 

--- a/gaphor/SysML/tests/test_diagramlabel.py
+++ b/gaphor/SysML/tests/test_diagramlabel.py
@@ -1,0 +1,31 @@
+from gaphor.diagram.diagramlabel import diagram_label
+from gaphor.SysML.sysml import Block, ConstraintBlock, Requirement, SysMLDiagram
+from gaphor.UML.uml import Activity, Interaction, Package, Profile, StateMachine
+
+
+def test_diagram_label():
+    def _diagram(elementType):
+        element = elementType()
+        element.name = "Efghi"
+
+        diagram = SysMLDiagram()
+        diagram.name = "Abcd"
+        diagram.element = element
+
+        return diagram
+
+    assert diagram_label(_diagram(Activity)) == "[activity] Efghi [Abcd]"
+    assert diagram_label(_diagram(Block)) == "[block] Efghi [Abcd]"
+    assert diagram_label(_diagram(ConstraintBlock)) == "[constraint block] Efghi [Abcd]"
+    assert diagram_label(_diagram(Interaction)) == "[interaction] Efghi [Abcd]"
+    assert diagram_label(_diagram(Package)) == "[package] Efghi [Abcd]"
+    assert diagram_label(_diagram(Profile)) == "[profile] Efghi [Abcd]"
+    assert diagram_label(_diagram(Requirement)) == "[requirement] Efghi [Abcd]"
+    assert diagram_label(_diagram(StateMachine)) == "[state machine] Efghi [Abcd]"
+
+
+def test_uncontained_diagram_label():
+    diagram = SysMLDiagram()
+    diagram.name = "Abcd"
+
+    assert diagram_label(diagram) == "Abcd"

--- a/gaphor/SysML/toolbox.py
+++ b/gaphor/SysML/toolbox.py
@@ -12,6 +12,7 @@ from gaphor.diagram.diagramtoolbox import (
     new_item_factory,
 )
 from gaphor.SysML import diagramitems as sysml_items
+from gaphor.SysML.sysml import SysMLDiagram
 from gaphor.SysML.blocks.blockstoolbox import blocks
 from gaphor.SysML.requirements.requirementstoolbox import requirements
 from gaphor.UML import diagramitems as uml_items
@@ -65,12 +66,18 @@ sysml_toolbox_actions: ToolboxDefinition = (
 
 # Not implemented: Parameter Diagram
 sysml_diagram_types: DiagramTypes = (
-    DiagramType("bdd", i18nize("New Block Definition Diagram"), (blocks,)),
-    DiagramType("ibd", i18nize("New Internal Block Diagram"), (internal_blocks,)),
-    DiagramType("pkg", i18nize("New Package Diagram"), (blocks,)),
-    DiagramType("req", i18nize("New Requirement Diagram"), (requirements,)),
-    DiagramType("act", i18nize("New Activity Diagram"), (actions,)),
-    DiagramType("sd", i18nize("New Sequence Diagram"), (interactions,)),
-    DiagramType("stm", i18nize("New State Machine Diagram"), (states,)),
-    DiagramType("uc", i18nize("New Use Case Diagram"), (use_cases,)),
+    DiagramType(
+        "bdd", i18nize("New Block Definition Diagram"), (blocks,), SysMLDiagram
+    ),
+    DiagramType(
+        "ibd", i18nize("New Internal Block Diagram"), (internal_blocks,), SysMLDiagram
+    ),
+    DiagramType("pkg", i18nize("New Package Diagram"), (blocks,), SysMLDiagram),
+    DiagramType(
+        "req", i18nize("New Requirement Diagram"), (requirements,), SysMLDiagram
+    ),
+    DiagramType("act", i18nize("New Activity Diagram"), (actions,), SysMLDiagram),
+    DiagramType("sd", i18nize("New Sequence Diagram"), (interactions,), SysMLDiagram),
+    DiagramType("stm", i18nize("New State Machine Diagram"), (states,), SysMLDiagram),
+    DiagramType("uc", i18nize("New Use Case Diagram"), (use_cases,), SysMLDiagram),
 )

--- a/gaphor/UML/iconname.py
+++ b/gaphor/UML/iconname.py
@@ -1,8 +1,8 @@
-from gaphor.diagram.iconname import get_default_icon_name, get_icon_name, to_kebab_case
+from gaphor.diagram.iconname import get_default_icon_name, icon_name, to_kebab_case
 from gaphor.UML import uml as UML
 
 
-@get_icon_name.register(UML.Class)
+@icon_name.register(UML.Class)
 def get_name_for_class(element):
     if element.extension:
         return "gaphor-metaclass-symbolic"
@@ -10,6 +10,6 @@ def get_name_for_class(element):
         return get_default_icon_name(element)
 
 
-@get_icon_name.register(UML.Pseudostate)
+@icon_name.register(UML.Pseudostate)
 def get_name_for_pseudostate(element):
     return f"gaphor-{to_kebab_case(element.kind or 'initial')}-pseudostate-symbolic"

--- a/gaphor/diagram/diagramlabel.py
+++ b/gaphor/diagram/diagramlabel.py
@@ -1,0 +1,6 @@
+from functools import singledispatch
+
+
+@singledispatch
+def diagram_label(diagram):
+    return diagram.name

--- a/gaphor/diagram/diagramtoolbox.py
+++ b/gaphor/diagram/diagramtoolbox.py
@@ -51,6 +51,7 @@ class DiagramType(NamedTuple):
     id: str
     name: str
     sections: Collection[ToolSection]
+    diagram_type: Type[Diagram] = Diagram
 
 
 DiagramTypes = Sequence[DiagramType]

--- a/gaphor/diagram/iconname.py
+++ b/gaphor/diagram/iconname.py
@@ -1,4 +1,4 @@
-"""With `get_icon_name` you can retrieve an icon name for a model element."""
+"""With `icon_name` you can retrieve an icon name for a model element."""
 
 import re
 from functools import singledispatch
@@ -15,4 +15,4 @@ def get_default_icon_name(element):
     return f"gaphor-{to_kebab_case(element.__class__.__name__)}-symbolic"
 
 
-get_icon_name = singledispatch(get_default_icon_name)
+icon_name = singledispatch(get_default_icon_name)

--- a/gaphor/diagram/painter.py
+++ b/gaphor/diagram/painter.py
@@ -13,6 +13,7 @@ from gi.repository import GLib, Pango, PangoCairo
 
 from gaphor.core.modeling.diagram import DrawContext, StyledDiagram, StyledItem
 from gaphor.diagram.selection import Selection
+from gaphor.diagram.diagramlabel import diagram_label
 
 
 class ItemPainter:
@@ -67,7 +68,8 @@ class DiagramTypePainter:
         layout = PangoCairo.create_layout(cr)
         escape = GLib.markup_escape_text
         layout.set_markup(
-            f"<b>{escape(diagram.diagramType)}</b> {escape(diagram.name)}", length=-1
+            f"<b>{escape(diagram.diagramType)}</b> {escape(diagram_label(diagram))}",
+            length=-1,
         )
 
         font_family = style.get("font-family")

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -122,7 +122,7 @@ class Toolbox(UIComponent):
         expanded_sections = next(
             (
                 sections
-                for id, _, sections in self.modeling_language.diagram_types
+                for id, _, sections, _ in self.modeling_language.diagram_types
                 if id == diagram_type
             ),
             (),

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -7,7 +7,7 @@ from gi.repository import Gio, GObject, Pango
 from gaphor import UML
 from gaphor.core.format import format
 from gaphor.core.modeling import Diagram, Element
-from gaphor.diagram.iconname import get_icon_name
+from gaphor.diagram.iconname import icon_name
 from gaphor.i18n import gettext
 
 _no_value = object()
@@ -43,7 +43,7 @@ class TreeItem(GObject.Object):
         if element := self.element:
             self.text = format(element) or gettext("<None>")
             self.notify("edit-text")
-            self.icon = get_icon_name(element)
+            self.icon = icon_name(element)
             self.icon_visible = bool(
                 self.icon
                 and not isinstance(

--- a/models/SysML.gaphor
+++ b/models/SysML.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.7.1">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.19.3">
 <Diagram id="7273ceab-20df-11ea-9209-e76c3117c943">
 <name>
 <val>Profiles</val>
@@ -15,6 +15,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 236.45440673828125, 53.65794372558594)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>102.0</val>
 </width>
@@ -32,6 +35,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 71.83560180664062, 53.65794372558594)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>102.0</val>
 </width>
@@ -72,6 +78,7 @@
 <ref refid="3f40e394-2141-11ea-ab0b-c72c0738acd2"/>
 <ref refid="3b0d35d4-2141-11ea-ab0b-c72c0738acd2"/>
 <ref refid="3165eeb9-2141-11ea-ab0b-c72c0738acd2"/>
+<ref refid="f6ed61ee-292a-11ee-aad9-e38f5215237c"/>
 </reflist>
 </ownedType>
 <package>
@@ -404,6 +411,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 939.1725158691406, 485.800048828125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -427,6 +437,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 537.8790283203125, 414.54583740234375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>313.0</val>
 </width>
@@ -447,6 +460,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="57282c66-4bc3-11ec-8e7f-0456e5e540ed"/>
 </subject>
@@ -467,6 +483,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 235.26336669921875, 165.71823854799626)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>114.73663330078125</val>
 </width>
@@ -516,6 +535,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 15.194732666015625, 307.9800109863281)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -539,6 +561,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 157.671875, 307.9800109863281)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -562,6 +587,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 304.4944305419922, 307.9800109863281)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -585,6 +613,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 443.7465430365668, 307.9800109863281)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -712,6 +743,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 666.448974609375, 165.71823854799626)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -735,6 +769,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 323.3546142578125, 26.540008544921875)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>283.0</val>
 </width>
@@ -758,6 +795,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 24.433624267578118, 56.541419700340015)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>112.0</val>
 </width>
@@ -847,6 +887,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 619.3197021484375, 307.9800109863281)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>131.0</val>
 </width>
@@ -922,6 +965,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 237.74654303656678, 417.300048828125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>283.0</val>
 </width>
@@ -945,6 +991,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 138.84187486436633, 550.0587158203125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -971,6 +1020,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="69d6200c-4bc3-11ec-8e7f-0456e5e540ed"/>
 </subject>
@@ -1040,6 +1092,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 428.96002197265625, 149.78439331054688)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1057,6 +1112,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 632.3790283203125, 18.030868530273438)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1080,6 +1138,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 754.3642578125, 20.235916137695312)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1103,6 +1164,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 908.4630126953125, 322.5091552734375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1126,6 +1190,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 844.939453125, 136.38253784179688)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1166,6 +1233,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 177.671875, 26.540008544921875)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>107.0</val>
 </width>
@@ -1189,6 +1259,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 80.43362426757812, 417.300048828125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>107.0</val>
 </width>
@@ -1599,6 +1672,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 56.54949951171875, 186.78518676757812)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>253.0</val>
 </width>
@@ -1619,6 +1695,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 133.04949951171875, 49.66029357910156)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1668,6 +1747,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 426.32470703125, 64.62176513671875)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1736,6 +1818,7 @@
 <ref refid="51d95c76-20e1-11ea-9209-e76c3117c943"/>
 <ref refid="5e99006a-20e1-11ea-9209-e76c3117c943"/>
 <ref refid="682de294-20e1-11ea-9209-e76c3117c943"/>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
 </reflist>
 </nestedPackage>
 <ownedDiagram>
@@ -1773,6 +1856,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 57.0, 46.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>99.0</val>
 </width>
@@ -1790,6 +1876,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 262.0253601074219, 46.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>112.0</val>
 </width>
@@ -1807,6 +1896,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 439.01275634765625, 46.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>75.0</val>
 </width>
@@ -1824,6 +1916,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 57.0, 160.14193725585938)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>158.0</val>
 </width>
@@ -1841,6 +1936,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 262.0253601074219, 160.14193725585938)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>94.0</val>
 </width>
@@ -1858,6 +1956,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 439.01275634765625, 160.14193725585938)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>148.0</val>
 </width>
@@ -1875,6 +1976,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 57.0, 283.88873291015625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>143.0</val>
 </width>
@@ -1892,6 +1996,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 262.0253601074219, 283.88873291015625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>137.0</val>
 </width>
@@ -2347,6 +2454,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 16.2373046875, 210.88978576660156)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>198.0</val>
 </width>
@@ -2390,6 +2500,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 250.59881591796875, 46.026131100124815)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -2413,6 +2526,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 423.3226318359375, 210.88978576660156)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>169.0</val>
 </width>
@@ -2459,6 +2575,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 230.37677001953125, 210.88978576660156)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>165.0</val>
 </width>
@@ -2479,6 +2598,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 502.77569580078125, 46.06089782714844)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -2496,6 +2618,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 262.87677001953125, 361.1194763183594)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -2555,6 +2680,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 106.06613159179705, 132.81593322753918)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>118.16522216796866</val>
 </width>
@@ -2578,6 +2706,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 334.7011854383681, 189.21839904785168)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>177.0</val>
 </width>
@@ -2601,6 +2732,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 112.8262939453124, 13.549880981445312)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -2627,6 +2761,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="c4e10aaa-2101-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -2656,9 +2793,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="a940fca8-2104-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -2691,9 +2825,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="cc0b4f19-2104-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -2717,6 +2848,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 503.6070556640625, 25.549880981445312)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -2906,6 +3040,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 153.53610229492188, 41.721282958984375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -2929,6 +3066,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 118.53610229492188, 164.1598358154297)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>181.0</val>
 </width>
@@ -2955,6 +3095,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="aeac47e4-4bc1-11ec-8e7f-0456e5e540ed"/>
 </subject>
@@ -2984,9 +3127,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="b6f05de8-2105-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -3010,6 +3150,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 553.496826171875, 39.17491149902344)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -3027,6 +3170,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 110.90985107421875, 312.3345947265625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>177.0</val>
 </width>
@@ -3050,6 +3196,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 63.90985107421875, 437.00482177734375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>283.0</val>
 </width>
@@ -3108,9 +3257,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="e7945aae-210e-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -3143,9 +3289,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="b5026068-2109-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -3178,9 +3321,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="bb09a980-2109-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -3204,6 +3344,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 502.51361083984375, 170.91763305664062)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>376.43707275390625</val>
 </width>
@@ -3236,9 +3379,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="0d347fdc-210f-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -3262,6 +3402,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 566.9383544921875, 521.7815551757812)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -3659,6 +3802,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 112.35217163085935, 66.93183898925781)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -3682,6 +3828,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 84.94598388671875, 185.31765747070312)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>151.0</val>
 </width>
@@ -3731,6 +3880,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 279.38494873046875, 66.93183898925781)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>120.0</val>
 </width>
@@ -3754,6 +3906,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 252.88494873046875, 185.31765747070312)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>177.0</val>
 </width>
@@ -3829,6 +3984,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 665.4474487304688, 71.66299438476562)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -3846,6 +4004,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 441.19158935546875, 66.93183898925781)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>181.0</val>
 </width>
@@ -3972,6 +4133,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 173.70184326171875, 48.635894775390625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -3995,6 +4159,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 138.70184326171875, 156.26348876953125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>176.0</val>
 </width>
@@ -4044,6 +4211,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 428.08624267578125, 51.17437744140625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -4177,6 +4347,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 37.846690838153535, 187.82733154296875)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>295.0</val>
 </width>
@@ -4197,6 +4370,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 77.84669083815353, 342.94573974609375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>215.0</val>
 </width>
@@ -4220,6 +4396,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="30de1374-4bc1-11ec-8e7f-0456e5e540ed"/>
 </subject>
@@ -4243,6 +4422,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="26071de2-4bc1-11ec-8e7f-0456e5e540ed"/>
 </subject>
@@ -4263,6 +4445,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 332.84669083815356, 366.44573974609375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -4280,6 +4465,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 433.88189697265625, 43.56126403808594)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -4297,6 +4485,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 135.58328247070312, 74.06126403808594)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -4454,6 +4645,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 149.08868408203125, 47.21185302734375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -4477,6 +4671,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 178.323974609375, 210.05072021484375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>131.0</val>
 </width>
@@ -4552,6 +4749,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 454.2381591796875, 210.05072021484375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -4584,9 +4784,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="4947e53f-210c-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -4610,6 +4807,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 423.018798828125, 18.206619262695312)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -4627,6 +4827,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 67.76644897460938, 323.3824157714844)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>221.0</val>
 </width>
@@ -4947,6 +5150,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 114.58270263671875, 57.81294250488281)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -4970,6 +5176,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 18.49920654296875, 192.60968017578125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>120.2657470703125</val>
 </width>
@@ -4993,6 +5202,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 179.79837036132812, 192.60968017578125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -5068,6 +5280,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 327.81201171875, 180.49368286132812)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>299.0</val>
 </width>
@@ -5114,6 +5329,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 25.307403564453125, 323.0774841308594)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>120.55322265625</val>
 </width>
@@ -5137,6 +5355,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 203.81201171875, 325.5774841308594)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -5160,6 +5381,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 393.1116943359375, 317.0774841308594)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>209.0</val>
 </width>
@@ -5183,6 +5407,9 @@
 <horizontal>
 <val>1</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="a7ffb56a-4bc2-11ec-8e7f-0456e5e540ed"/>
 </subject>
@@ -5206,6 +5433,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="b88a42ec-4bc2-11ec-8e7f-0456e5e540ed"/>
 </subject>
@@ -5226,6 +5456,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 610.5427856445312, 40.31294250488281)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -5243,6 +5476,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 427.31201171875, 57.81294250488281)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -5266,6 +5502,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 649.129638671875, 118.32058715820312)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>156.0</val>
 </width>
@@ -5453,6 +5692,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 63.902679443359375, -21.4681396484375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>142.0</val>
 </width>
@@ -5476,6 +5718,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 595.1039428710938, 341.4381408691406)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -5499,6 +5744,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 280.8352302268697, 295.4446690877279)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>177.24789513481988</val>
 </width>
@@ -5522,6 +5770,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 170.5, 95.35202026367188)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>276.0</val>
 </width>
@@ -5545,6 +5796,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 13.87640974256727, 401.7130313449437)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>255.0</val>
 </width>
@@ -5568,6 +5822,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 521.4585819950811, 475.7130313449437)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>178.0</val>
 </width>
@@ -5591,6 +5848,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 141.47081332736548, 199.50276240596065)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>355.0</val>
 </width>
@@ -5669,6 +5929,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="52635eb8-4bc2-11ec-8e7f-0456e5e540ed"/>
 </subject>
@@ -5776,9 +6039,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="2bab4616-2115-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -5811,9 +6071,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="30fab908-2115-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -5837,6 +6094,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 622.6099853515625, -47.46086474609376)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -5854,6 +6114,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 238.81569000048512, -34.4681396484375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>181.0</val>
 </width>
@@ -6277,6 +6540,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 70.81521606445312, 45.51988220214844)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>113.0</val>
 </width>
@@ -6300,6 +6566,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 7.315216064453125, 167.92181396484375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>248.0</val>
 </width>
@@ -6349,6 +6618,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 371.2249755859375, 178.64263916015625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>150.0</val>
 </width>
@@ -6381,9 +6653,6 @@
 <orthogonal>
 <val>1</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="0b62591a-2117-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -6407,6 +6676,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 626.4810791015625, 61.97352600097656)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>159.0</val>
 </width>
@@ -6430,6 +6702,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 531.9810791015625, 170.14263916015625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>360.0</val>
 </width>
@@ -6479,6 +6754,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 333.75457763671875, 64.82534790039062)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -6745,6 +7023,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 114.96652221679688, 46.44122314453125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -6768,6 +7049,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 13.966522216796875, 191.92340087890625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>319.0</val>
 </width>
@@ -6814,6 +7098,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 300.88848876953125, 35.94261169433594)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -6831,6 +7118,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 344.0592041015625, 137.92340087890625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>180.0</val>
 </width>
@@ -7009,6 +7299,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 24.63897705078125, 48.73731994628906)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -7032,6 +7325,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 24.63897705078125, 172.91275024414062)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -7055,6 +7351,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 176.51416015625, 172.91275024414062)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>242.0</val>
 </width>
@@ -7075,6 +7374,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 444.258056640625, 172.91275024414062)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>237.0</val>
 </width>
@@ -7095,6 +7397,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 710.56298828125, 172.91275024414062)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>219.0</val>
 </width>
@@ -7115,6 +7420,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 124.01416015625, 410.06524658203125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -7138,6 +7446,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 214.51416015625, 549.775634765625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -7161,6 +7472,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 396.585205078125, 549.775634765625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -7184,6 +7498,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 578.06298828125, 549.775634765625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>242.0</val>
 </width>
@@ -7204,6 +7521,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 408.585205078125, 397.06524658203125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -7221,6 +7541,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 132.51416015625, 292.5617980957031)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>107.0</val>
 </width>
@@ -7325,6 +7648,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="2da459e2-4bc2-11ec-8e7f-0456e5e540ed"/>
 </subject>
@@ -7449,6 +7775,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 858.758056640625, 556.6875610351562)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>112.0</val>
 </width>
@@ -7489,6 +7818,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 370.14935302734375, 7.0590362548828125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -7506,6 +7838,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 233.51416015625, 46.55743408203125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -7529,6 +7864,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 521.758056640625, 46.55743408203125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -7552,6 +7890,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 775.4461669921875, 46.55743408203125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -8396,6 +8737,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 229.99166870117188, 43.21104431152344)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>120.2926025390625</val>
 </width>
@@ -8419,6 +8763,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 223.13796997070312, 205.12457275390625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>134.0</val>
 </width>
@@ -8445,6 +8792,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="f7aad898-4bc1-11ec-8e7f-0456e5e540ed"/>
 </subject>
@@ -8465,6 +8815,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 458.375, 27.497055053710938)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -8550,6 +8903,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 124.66095641807276, 48.43752022731451)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -8573,6 +8929,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 321.1383056640625, 48.43752022731451)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>109.0</val>
 </width>
@@ -8596,6 +8955,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 503.5732421875, 48.43752022731451)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>119.0</val>
 </width>
@@ -8619,6 +8981,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 17.791900634765625, 188.5296936035156)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>120.226318359375</val>
 </width>
@@ -8639,6 +9004,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 165.1856689453125, 188.5296936035156)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>214.0</val>
 </width>
@@ -8659,6 +9027,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 394.0732421875, 188.52969360351562)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>240.0</val>
 </width>
@@ -8679,6 +9050,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 112.66095641807277, 345.2327575683594)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -8702,6 +9076,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 270.9138793945313, 345.2327575683594)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -8725,6 +9102,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 88.01821899414062, 456.94769287109375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -8748,6 +9128,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 224.66095641807271, 456.94769287109375)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -8771,6 +9154,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 543.7131958007812, 452.95184326171875)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>102.0</val>
 </width>
@@ -8794,6 +9180,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 138.01821899414062, 585.4248046875)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>139.0</val>
 </width>
@@ -8814,6 +9203,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 449.02178955078125, 585.4248046875)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -8834,6 +9226,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 600.5545043945312, 585.4248046875)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -9134,6 +9529,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 681.1941528320314, 25.518890380859382)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -9151,6 +9549,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 300.42181396484375, 590.0079956054688)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>117.3060302734375</val>
 </width>
@@ -9885,6 +10286,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 84.8564453125, 34.768798828125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>283.0</val>
 </width>
@@ -9908,6 +10312,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 383.4012451171875, 41.268798828125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -9931,6 +10338,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 290.8564453125, 177.10122680664062)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>124.0</val>
 </width>
@@ -10006,6 +10416,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 526.8547973632812, 6.42626953125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -10090,6 +10503,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 161.91912841796875, 46.59141540527344)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>139.0</val>
 </width>
@@ -10113,6 +10529,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 131.41912841796875, 165.49346923828125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>204.0</val>
 </width>
@@ -10162,6 +10581,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 410.83795166015625, 26.383804321289062)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -10353,6 +10775,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 118.6231689453125, 74.40559387207031)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>186.0</val>
 </width>
@@ -10370,6 +10795,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 364.06512451171875, 74.40559387207031)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>135.0</val>
 </width>
@@ -10387,6 +10815,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 562.5750122070312, 74.40559387207031)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>193.0</val>
 </width>
@@ -10488,6 +10919,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 167.0, 73.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -10511,6 +10945,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 147.0, 242.31454467773438)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>140.0</val>
 </width>
@@ -10554,6 +10991,12 @@
 </tail-connection>
 </ExtensionItem>
 <Stereotype id="03bf0cd4-2357-11ea-ab0b-c72c0738acd2">
+<instanceSpecification>
+<reflist>
+<ref refid="7f0d0fec-633a-11ec-ad85-0456e5e540ed"/>
+<ref refid="e31c7a9a-633a-11ec-ad85-0456e5e540ed"/>
+</reflist>
+</instanceSpecification>
 <name>
 <val>Tagged</val>
 </name>
@@ -11331,6 +11774,9 @@ otherwise MRO can not be resolved.</val>
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 247.0, 407.0)</val>
 </matrix>
@@ -12129,6 +12575,9 @@ otherwise MRO can not be resolved.</val>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 181.0, 192.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>140.0</val>
 </width>
@@ -12171,6 +12620,9 @@ otherwise MRO can not be resolved.</val>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 221.0, 373.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>220.0</val>
 </width>
@@ -12191,6 +12643,9 @@ otherwise MRO can not be resolved.</val>
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="996a85fe-5921-11ec-befa-0456e5e540ed"/>
 </subject>
@@ -12258,6 +12713,9 @@ otherwise MRO can not be resolved.</val>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 271.0, 576.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -12297,6 +12755,9 @@ otherwise MRO can not be resolved.</val>
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="5a9cebd2-633a-11ec-ad85-0456e5e540ed"/>
 </subject>
@@ -12437,4 +12898,185 @@ otherwise MRO can not be resolved.</val>
 <val>ownedElement</val>
 </value>
 </Slot>
+<Package id="c8ae59c8-292a-11ee-aad9-e38f5215237c">
+<name>
+<val>Core</val>
+</name>
+<ownedType>
+<reflist>
+<ref refid="d95aaea2-292a-11ee-aad9-e38f5215237c"/>
+</reflist>
+</ownedType>
+</Package>
+<Class id="d95aaea2-292a-11ee-aad9-e38f5215237c">
+<name>
+<val>Diagram</val>
+</name>
+<package>
+<ref refid="c8ae59c8-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="05044ba8-292b-11ee-aad9-e38f5215237c"/>
+</reflist>
+</presentation>
+<specialization>
+<reflist>
+<ref refid="19ddfa39-292b-11ee-aad9-e38f5215237c"/>
+</reflist>
+</specialization>
+</Class>
+<Class id="f6ed61ee-292a-11ee-aad9-e38f5215237c">
+<name>
+<val>Class</val>
+</name>
+<package>
+<ref refid="2b8d10da-20e1-11ea-9209-e76c3117c943"/>
+</package>
+</Class>
+<Package id="fd10d6be-292a-11ee-aad9-e38f5215237c">
+<name>
+<val>Diagrams</val>
+</name>
+<ownedDiagram>
+<reflist>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</reflist>
+</ownedDiagram>
+<ownedType>
+<reflist>
+<ref refid="0ccaf652-292b-11ee-aad9-e38f5215237c"/>
+</reflist>
+</ownedType>
+<package>
+<ref refid="00555550-20e9-11ea-9209-e76c3117c943"/>
+</package>
+</Package>
+<Diagram id="0210b378-292b-11ee-aad9-e38f5215237c">
+<diagramType>
+<val></val>
+</diagramType>
+<element>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</element>
+<name>
+<val>Diagrams</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="05044ba8-292b-11ee-aad9-e38f5215237c"/>
+<ref refid="0ccaf653-292b-11ee-aad9-e38f5215237c"/>
+<ref refid="19ddfa38-292b-11ee-aad9-e38f5215237c"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<ClassItem id="05044ba8-292b-11ee-aad9-e38f5215237c">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 192.610595703125, 141.22471618652344)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>69.0</val>
+</height>
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="d95aaea2-292a-11ee-aad9-e38f5215237c"/>
+</subject>
+</ClassItem>
+<Stereotype id="0ccaf652-292b-11ee-aad9-e38f5215237c">
+<generalization>
+<reflist>
+<ref refid="19ddfa39-292b-11ee-aad9-e38f5215237c"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLDiagram</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="0ccaf653-292b-11ee-aad9-e38f5215237c"/>
+</reflist>
+</presentation>
+</Stereotype>
+<ClassItem id="0ccaf653-292b-11ee-aad9-e38f5215237c">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 208.98838806152344, 306.383056640625)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>115.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="0ccaf652-292b-11ee-aad9-e38f5215237c"/>
+</subject>
+</ClassItem>
+<GeneralizationItem id="19ddfa38-292b-11ee-aad9-e38f5215237c">
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="19ddfa39-292b-11ee-aad9-e38f5215237c"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 247.76829528808594, 198.07798767089844)</val>
+</matrix>
+<points>
+<val>[(22.867182270841113, 108.30506896972656), (18.7200927734375, 12.146728515625)]</val>
+</points>
+<head-connection>
+<ref refid="0ccaf653-292b-11ee-aad9-e38f5215237c"/>
+</head-connection>
+<tail-connection>
+<ref refid="05044ba8-292b-11ee-aad9-e38f5215237c"/>
+</tail-connection>
+</GeneralizationItem>
+<Generalization id="19ddfa39-292b-11ee-aad9-e38f5215237c">
+<general>
+<ref refid="d95aaea2-292a-11ee-aad9-e38f5215237c"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="19ddfa38-292b-11ee-aad9-e38f5215237c"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="0ccaf652-292b-11ee-aad9-e38f5215237c"/>
+</specific>
+</Generalization>
 </gaphor>


### PR DESCRIPTION
* Adds SysMLDiagram which extends regular Diagram
* Adds diagram type specific header formatting
* All SysML diagrams created under SysML profile (modeling language) will be created as SysMLDiagram and treated as such throughout the model.

<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2444

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

As a follow-up, it may be good to also have "refactor" option for regular diagrams which should be SysML diagrams.

This change and the ability to differentiate SysML diagrams opens up a large possibility to address SysML specific constraints and defaults more gracefully.