### PR TITLE
Ensure a newly placed item is no longer a dropzone item.

### DIFF
--- a/gaphor/diagram/tools/placement.py
+++ b/gaphor/diagram/tools/placement.py
@@ -104,6 +104,8 @@ def on_drag_end(gesture, offset_x, offset_y, placement_state):
         placement_state.moving.stop_move((x + offset_x, y + offset_y))
         connect_opposite_handle(view, item, x, y, placement_state.handle_index)
         placement_state.event_manager.handle(DiagramItemPlaced(item))
+        view.selection.dropzone_item = None
+        view.model.request_update(item)
         open_editor(item, view, placement_state.event_manager)
 
 


### PR DESCRIPTION
So you cannot accentally drop another new item on the wrong parent.

<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

To reproduce:

1. Open a diagram
2. hit `c` (for Class)
3. place class on the diagram (left-click)
4. While the instant editor is up, move the mouse cursor to a different place on the diagram
5. Close the instant editor by hitting `Enter`
6. hit `c` (for Class)
7. place class on the diagram (left-click)
8. See the new class being placed as a child of the first class

### What is the new behavior?

Item is no longer a dropzone item after placement.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
