### PR TITLE
Disallow disconnection by dragging for proxy port, activity pin after connection; ensure that activity parameter node is always stuck to the activity when moving.

### DIFF
--- a/gaphor/SysML/blocks/__init__.py
+++ b/gaphor/SysML/blocks/__init__.py
@@ -1,3 +1,4 @@
+import gaphor.SysML.blocks.blockmove
 import gaphor.SysML.blocks.connectors
 import gaphor.SysML.blocks.datatype
 import gaphor.SysML.blocks.group

--- a/gaphor/SysML/blocks/blockmove.py
+++ b/gaphor/SysML/blocks/blockmove.py
@@ -1,0 +1,10 @@
+from gaphas.handlemove import HandleMove
+from gaphas.move import Move
+from gaphor.diagram.tools.handlemove import (
+    StickyAttachedHandleMove,
+    sticky_attached_move,
+)
+from gaphor.SysML.blocks.proxyport import ProxyPortItem
+
+HandleMove.register(ProxyPortItem, StickyAttachedHandleMove)
+Move.register(ProxyPortItem, sticky_attached_move)

--- a/gaphor/UML/actions/activitymove.py
+++ b/gaphor/UML/actions/activitymove.py
@@ -1,33 +1,15 @@
-from gaphas.guide import GuidedItemHandleMoveMixin
-from gaphas.handlemove import HandleMove, ItemHandleMove
+from gaphas.handlemove import HandleMove
 from gaphas.move import Move
-from gaphas.types import Pos
-
-from gaphor.diagram.presentation import connect
-from gaphor.diagram.tools.handlemove import GrayOutLineHandleMoveMixin
+from gaphor.diagram.tools.handlemove import (
+    StickyAttachedHandleMove,
+    sticky_attached_move,
+)
 from gaphor.UML.actions.activity import ActivityParameterNodeItem
+from gaphor.UML.actions.pin import PinItem
 
 
-@HandleMove.register(ActivityParameterNodeItem)
-class ActivityParameterNodeItemHandleMove(
-    GrayOutLineHandleMoveMixin, GuidedItemHandleMoveMixin, ItemHandleMove
-):
-    """We use a custom tool for moving parameter nodes.
+HandleMove.register(ActivityParameterNodeItem, StickyAttachedHandleMove)
+Move.register(ActivityParameterNodeItem, sticky_attached_move)
 
-    Parameter nodes always connect to their parent (Activity).
-    """
-
-    def connect(self, pos: Pos) -> None:
-        item = self.item
-        connect(item, self.handle, item.parent)
-        self.view.model.request_update(item)
-
-
-@Move.register(ActivityParameterNodeItem)
-def activity_parameter_node_move(item, view):
-    """We use a custom tool for moving parameter nodes.
-
-    They can be moved while handle is connected and will automatically
-    connect to a side of its parent.
-    """
-    return ActivityParameterNodeItemHandleMove(item, item.handles()[0], view)
+HandleMove.register(PinItem, StickyAttachedHandleMove)
+Move.register(PinItem, sticky_attached_move)


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->

I added StickyAttachedHandleMove which can be registered to the items that once connected, can not be disconnected via dragging and can only be moved along the border.

I added this behavior to activity parameters (only dragging functionality; otherwise was already there inability to disconnect); pins (both input and output); proxyport.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2484, #2450 (only point 3 from the initially proposed solution)

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

From the both related issues, not having free floating port/pin at all is not yet addressed - it is still possible to have free floating port/pin if it has never been attached to anything, but at least it is not possible to detach it anymore other than explicitly deleting.