### PR TITLE
Constrain SysML diagram creation in the model explorer to conform with SysML 1.6 specification

### DIFF
--- a/gaphor/SysML/diagramtype.py
+++ b/gaphor/SysML/diagramtype.py
@@ -1,0 +1,42 @@
+from gaphor.diagram.diagramtoolbox import DiagramType
+from gaphor.SysML.sysml import SysMLDiagram
+from gaphor.diagram.group import change_owner
+
+
+class DiagramDefault:
+    def __init__(self, from_type, to_type, name):
+        self.from_type = from_type
+        self.to_type = to_type
+        self.name = name
+
+
+class SysMLDiagramType(DiagramType):
+    def __init__(self, id, name, sections, allowed_types=(), defaults=()):
+        super().__init__(id, name, sections)
+        self._allowed_types = allowed_types
+        assert all(d.to_type in allowed_types for d in defaults)
+        self._defaults = defaults
+
+    def allowed(self, element) -> bool:
+        if isinstance(element, self._allowed_types):
+            return True
+
+        return any(isinstance(element, d.from_type) for d in self._defaults)
+
+    def create(self, element_factory, element):
+        if not isinstance(element, self._allowed_types):
+            d = next(d for d in self._defaults if isinstance(element, d.from_type))
+            assert d.to_type in self._allowed_types
+            new_element = element_factory.create(d.to_type)
+            new_element.name = d.name
+            if element:
+                change_owner(element, new_element)
+            element = new_element
+
+        diagram = element_factory.create(SysMLDiagram)
+        diagram.name = diagram.gettext(self.name)
+        diagram.diagramType = self.id
+        if element:
+            change_owner(element, diagram)
+
+        return diagram

--- a/gaphor/SysML/tests/test_diagramtype.py
+++ b/gaphor/SysML/tests/test_diagramtype.py
@@ -1,0 +1,39 @@
+from gaphor.SysML.diagramtype import SysMLDiagramType, DiagramDefault
+from gaphor.UML.uml import NamedElement
+
+
+class MockElementA(NamedElement):
+    pass
+
+
+class MockElementB(NamedElement):
+    pass
+
+
+def test_sysml_diagram_type(element_factory):
+    diagram_type = SysMLDiagramType(
+        "abc",
+        "Defghi",
+        (),
+        (MockElementA,),
+        (DiagramDefault(type(None), MockElementA, "New mock element A"),),
+    )
+
+    assert diagram_type.allowed(MockElementA())
+    assert diagram_type.allowed(None)
+    assert not diagram_type.allowed(MockElementB())
+
+    mock_a = element_factory.create(MockElementA)
+    mock_a.name = "Mock A"
+
+    diagram = diagram_type.create(element_factory, mock_a)
+    assert diagram.diagramType == "abc"
+    assert diagram.name == "Defghi"
+    assert isinstance(diagram.element, MockElementA)
+    assert diagram.element.name == "Mock A"
+
+    diagram = diagram_type.create(element_factory, None)
+    assert diagram.diagramType == "abc"
+    assert diagram.name == "Defghi"
+    assert isinstance(diagram.element, MockElementA)
+    assert diagram.element.name == "New mock element A"

--- a/gaphor/SysML/toolbox.py
+++ b/gaphor/SysML/toolbox.py
@@ -3,7 +3,6 @@
 from gaphor import UML
 from gaphor.i18n import gettext, i18nize
 from gaphor.diagram.diagramtoolbox import (
-    DiagramType,
     DiagramTypes,
     ToolboxDefinition,
     ToolDef,
@@ -12,7 +11,6 @@ from gaphor.diagram.diagramtoolbox import (
     new_item_factory,
 )
 from gaphor.SysML import diagramitems as sysml_items
-from gaphor.SysML.sysml import SysMLDiagram
 from gaphor.SysML.blocks.blockstoolbox import blocks
 from gaphor.SysML.requirements.requirementstoolbox import requirements
 from gaphor.UML import diagramitems as uml_items
@@ -21,6 +19,9 @@ from gaphor.UML.interactions.interactionstoolbox import interactions
 from gaphor.UML.states.statestoolbox import states
 from gaphor.UML.toolboxconfig import named_element_config
 from gaphor.UML.usecases.usecasetoolbox import use_cases
+from gaphor.SysML.sysml import Block, ConstraintBlock, Requirement
+from gaphor.UML.uml import Package, Activity, Interaction, StateMachine
+from gaphor.SysML.diagramtype import SysMLDiagramType, DiagramDefault
 
 internal_blocks = ToolSection(
     gettext("Internal Blocks"),
@@ -63,21 +64,89 @@ sysml_toolbox_actions: ToolboxDefinition = (
     use_cases,
 )
 
+root = type(None)
 
 # Not implemented: Parameter Diagram
 sysml_diagram_types: DiagramTypes = (
-    DiagramType(
-        "bdd", i18nize("New Block Definition Diagram"), (blocks,), SysMLDiagram
+    SysMLDiagramType(
+        "bdd",
+        i18nize("New Block Definition Diagram"),
+        (blocks,),
+        (Block, Package, ConstraintBlock, Activity),
+        (DiagramDefault(root, Package, i18nize("New Package")),),
     ),
-    DiagramType(
-        "ibd", i18nize("New Internal Block Diagram"), (internal_blocks,), SysMLDiagram
+    SysMLDiagramType(
+        "ibd",
+        i18nize("New Internal Block Diagram"),
+        (internal_blocks,),
+        (
+            Block,
+            ConstraintBlock,
+        ),
+        (
+            DiagramDefault(Package, Block, i18nize("New Block")),
+            DiagramDefault(root, Block, i18nize("New Block")),
+        ),
     ),
-    DiagramType("pkg", i18nize("New Package Diagram"), (blocks,), SysMLDiagram),
-    DiagramType(
-        "req", i18nize("New Requirement Diagram"), (requirements,), SysMLDiagram
+    SysMLDiagramType(
+        "pkg",
+        i18nize("New Package Diagram"),
+        (blocks,),
+        (Package,),  # model, modelLibrary, profile
+        (DiagramDefault(root, Package, i18nize("New Package")),),
     ),
-    DiagramType("act", i18nize("New Activity Diagram"), (actions,), SysMLDiagram),
-    DiagramType("sd", i18nize("New Sequence Diagram"), (interactions,), SysMLDiagram),
-    DiagramType("stm", i18nize("New State Machine Diagram"), (states,), SysMLDiagram),
-    DiagramType("uc", i18nize("New Use Case Diagram"), (use_cases,), SysMLDiagram),
+    SysMLDiagramType(
+        "req",
+        i18nize("New Requirement Diagram"),
+        (requirements,),
+        (
+            Package,
+            Requirement,
+            # model,
+            # modelLibrary
+        ),
+        (DiagramDefault(root, Package, i18nize("New Package")),),
+    ),
+    SysMLDiagramType(
+        "act",
+        i18nize("New Activity Diagram"),
+        (actions,),
+        (Activity,),
+        (
+            DiagramDefault(Package, Activity, i18nize("New Activity")),
+            DiagramDefault(root, Activity, i18nize("New Activity")),
+        ),
+    ),
+    SysMLDiagramType(
+        "sd",
+        i18nize("New Sequence Diagram"),
+        (interactions,),
+        (Interaction,),
+        (
+            DiagramDefault(Package, Interaction, i18nize("New Interaction")),
+            DiagramDefault(root, Interaction, i18nize("New Interaction")),
+        ),
+    ),
+    SysMLDiagramType(
+        "stm",
+        i18nize("New State Machine Diagram"),
+        (states,),
+        (StateMachine,),
+        (
+            DiagramDefault(Package, StateMachine, i18nize("New State Machine")),
+            DiagramDefault(root, StateMachine, i18nize("New State Machine")),
+        ),
+    ),
+    SysMLDiagramType(
+        "uc",
+        i18nize("New Use Case Diagram"),
+        (use_cases,),
+        (
+            Package,
+            Block,
+            # model,
+            # modelLibrary
+        ),
+        (DiagramDefault(root, Package, i18nize("New Package")),),
+    ),
 )

--- a/gaphor/diagram/diagramtoolbox.py
+++ b/gaphor/diagram/diagramtoolbox.py
@@ -47,11 +47,26 @@ class ToolSection(NamedTuple):
 ToolboxDefinition = Sequence[ToolSection]
 
 
-class DiagramType(NamedTuple):
+class DiagramType:
     id: str
     name: str
     sections: Collection[ToolSection]
-    diagram_type: Type[Diagram] = Diagram
+
+    def __init__(self, id, name, sections):
+        self.id = id
+        self.name = name
+        self.sections = sections
+
+    def allowed(self, element: Type[Element]) -> bool:
+        return True
+
+    def create(self, element_factory, element):
+        diagram = element_factory.create(Diagram)
+        diagram.element = element
+        diagram.name = diagram.gettext(self.name)
+        diagram.diagramType = self.id
+
+        return diagram
 
 
 DiagramTypes = Sequence[DiagramType]

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -121,9 +121,9 @@ class Toolbox(UIComponent):
         expanded_property = f"toolbox-{self.modeling_language.active_modeling_language}-{diagram_type}-expanded"
         expanded_sections = next(
             (
-                sections
-                for id, _, sections, _ in self.modeling_language.diagram_types
-                if id == diagram_type
+                diagram.sections
+                for diagram in self.modeling_language.diagram_types
+                if diagram.id == diagram_type
             ),
             (),
         )


### PR DESCRIPTION
Allows creating diagrams in SysML profile such that they conform with the specification. This is achieved through showing new diagram creation options which are legal; or have a default defined which would autocreate necessary element which can contain the diagram.

<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2544

### What is the new behavior?

https://github.com/gaphor/gaphor/assets/45357878/1998239b-2f38-4234-b207-dc0fb8b2bff4




### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Once this gets accepted, #2544 can be resolved.

A known issue with this solution is that it is still possible to drag the diagrams around and create a configuration of the model where they are not conforming with the standard.