### PR TITLE
Fix derive-reqt modelbrowser icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 2.20.1
 ------
-(unreleased)
+- Fix missing derive relationship icon in the model browser
 
 2.20.0
 ------

--- a/gaphor/SysML/requirements/requirementstoolbox.py
+++ b/gaphor/SysML/requirements/requirementstoolbox.py
@@ -34,7 +34,7 @@ requirements = ToolSection(
         ToolDef(
             "toolbox-derive-reqt-dependency",
             gettext("Derive Requirement"),
-            "gaphor-derive-symbolic",
+            "gaphor-derive-reqt-symbolic",
             "<Shift>D",
             new_item_factory(sysml_items.DeriveReqtItem),
         ),

--- a/gaphor/ui/icons/Makefile
+++ b/gaphor/ui/icons/Makefile
@@ -87,7 +87,7 @@ ICONS=diagram \
 	item-flow \
 	requirement \
 	satisfy \
-	derive \
+	derive-reqt \
 	trace \
 	refine \
 	verify \

--- a/gaphor/ui/icons/hicolor/scalable/actions/gaphor-derive-reqt-symbolic.svg
+++ b/gaphor/ui/icons/hicolor/scalable/actions/gaphor-derive-reqt-symbolic.svg
@@ -24,7 +24,7 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="derive"
+     id="derive-reqt"
      style="display:inline"
      transform="translate(-85.724827,9.7805867)">
     <path

--- a/gaphor/ui/icons/stencil.svg
+++ b/gaphor/ui/icons/stencil.svg
@@ -2480,8 +2480,8 @@
   </g>
   <g
      inkscape:groupmode="layer"
-     id="derive"
-     inkscape:label="derive"
+     id="derive-reqt"
+     inkscape:label="derive-reqt"
      style="display:inline">
     <path
        style="color:#000000;fill:#000000;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"


### PR DESCRIPTION
* Changed icon id in stencil.svg derive → derive-reqt
* Ran makefile to re-generate icons from the stencil
* Made necessary changes in hardcoded icon paths in requirementstoolbox

The bug most probably originated by a previous makefile run removing derive-reqt icon because it was not in the stencil.

<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/gaphor/gaphor/issues/2622

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
