### PR TITLE
Display type of element in the properties panel

### DIFF
--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -281,7 +281,7 @@ class NamePropertyPage(PropertyPageBase):
         entry.set_text(subject and subject.name or "")
 
         type = builder.get_object("type-label")
-        type.set_markup(f"<b><i>{subject.__class__.__name__}</i></b>")
+        type.set_text(subject.__class__.__name__)
 
         @handler_blocking(entry, "changed", self._on_name_changed)
         def handler(event):

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -280,6 +280,9 @@ class NamePropertyPage(PropertyPageBase):
         entry = builder.get_object("name-entry")
         entry.set_text(subject and subject.name or "")
 
+        type = builder.get_object("type-label")
+        type.set_markup(f"<b><i>{subject.__class__.__name__}</i></b>")
+
         @handler_blocking(entry, "changed", self._on_name_changed)
         def handler(event):
             if event.element is subject and event.new_value != entry.get_text():

--- a/gaphor/diagram/propertypages.ui
+++ b/gaphor/diagram/propertypages.ui
@@ -32,6 +32,17 @@
     <property name="orientation">vertical</property>
     <property name="baseline-position">top</property>
     <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel" id="type-label">
+            <property name="label" translatable="no">[[name]]</property>
+            <property name="halign">center</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+      </object>
+    </child>  
+    <child>
       <object class="GtkLabel" id="label1">
         <property name="label" translatable="yes">Name</property>
         <property name="xalign">0</property>
@@ -253,4 +264,3 @@
   </object>
 
 </interface>
-

--- a/gaphor/diagram/propertypages.ui
+++ b/gaphor/diagram/propertypages.ui
@@ -35,9 +35,11 @@
       <object class="GtkBox">
         <child>
           <object class="GtkLabel" id="type-label">
-            <property name="label">[[name]]</property>
             <property name="halign">center</property>
             <property name="hexpand">yes</property>
+            <style>
+              <class name="title"/>
+            </style>
           </object>
         </child>
       </object>

--- a/gaphor/diagram/propertypages.ui
+++ b/gaphor/diagram/propertypages.ui
@@ -41,7 +41,7 @@
           </object>
         </child>
       </object>
-    </child>  
+    </child>
     <child>
       <object class="GtkLabel" id="label1">
         <property name="label" translatable="yes">Name</property>

--- a/gaphor/diagram/propertypages.ui
+++ b/gaphor/diagram/propertypages.ui
@@ -35,7 +35,7 @@
       <object class="GtkBox">
         <child>
           <object class="GtkLabel" id="type-label">
-            <property name="label" translatable="no">[[name]]</property>
+            <property name="label">[[name]]</property>
             <property name="halign">center</property>
             <property name="hexpand">yes</property>
           </object>


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The type of the selected element is not visible. 

Issue Number: #2607 

### What is the new behavior?

The type of the selected element is displayed in the properties panel.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
