### PR TITLE
Add interface block to element creation menu

### DIFF
--- a/gaphor/SysML/toolbox.py
+++ b/gaphor/SysML/toolbox.py
@@ -15,6 +15,7 @@ from gaphor.SysML import diagramitems as sysml_items
 from gaphor.SysML.sysml import (
     Block,
     ConstraintBlock,
+    InterfaceBlock,
     Requirement,
     ValueType,
 )
@@ -174,6 +175,9 @@ sysml_element_types = (
     ),
     ElementCreateInfo(
         "interaction", i18nize("New Interaction"), Interaction, (Package,)
+    ),
+    ElementCreateInfo(
+        "interfaceblock", i18nize("New Interface Block"), InterfaceBlock, (Package,)
     ),
     ElementCreateInfo(
         "requirement",


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Interface blocks cannot be added using the elements creation feature in the tree.

Issue Number: #2606 

### What is the new behavior?

Interface blocks can be added using the elements creation feature in modeling tree.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
