### PR TITLE
Fix blocks not showing references

### DIFF
--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -103,8 +103,7 @@ class BlockItem(Classified, ElementPresentation[Block]):
                 and [
                     self.block_compartment(
                         self.diagram.gettext("parts"),
-                        lambda a: a.aggregation
-                        and a.aggregation in ("composite", "shared"),
+                        lambda a: a.aggregation and a.aggregation == "composite",
                     )
                 ]
                 or []
@@ -115,7 +114,7 @@ class BlockItem(Classified, ElementPresentation[Block]):
                 and [
                     self.block_compartment(
                         self.diagram.gettext("references"),
-                        lambda a: not a.association and a.aggregation != "composite",
+                        lambda a: a.aggregation and a.aggregation == "shared",
                     )
                 ]
                 or []


### PR DESCRIPTION
This is a follow-up to #2628 that ensures references are displayed as well as parts. Closes #2613.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Shared associations are shown as parts
![image](https://github.com/gaphor/gaphor/assets/10014976/37b658f2-0cf3-4055-b534-c81b8141603e)

Issue Number: #2613

### What is the new behavior?
Shared associations are shown as references
![image](https://github.com/gaphor/gaphor/assets/10014976/1a723c64-2209-435c-955b-985000fc574c)


### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
