### PR TITLE
Add Initial Data Models for SysML v2

### DIFF
--- a/gaphor/KerML/__init__.py
+++ b/gaphor/KerML/__init__.py
@@ -1,0 +1,365 @@
+from gaphor.KerML.kerml import (
+    eClassifiers,
+    LiteralString,
+    EndFeatureMembership,
+    Structure,
+    Class,
+    DataType,
+    LibraryPackage,
+    LiteralExpression,
+    LiteralRational,
+    LiteralInteger,
+    SelectExpression,
+    CollectExpression,
+    LiteralBoolean,
+    NullExpression,
+    LiteralInfinity,
+    AssociationStructure,
+    Invariant,
+    ReturnParameterMembership,
+    SuccessionItemFlow,
+    BindingConnector,
+    Comment,
+)
+from gaphor.KerML.kerml import eClass
+from gaphor.KerML.kerml import (
+    Dependency,
+    Relationship,
+    Element,
+    OwningMembership,
+    Membership,
+    Namespace,
+    Import,
+    VisibilityKind,
+    Documentation,
+    AnnotatingElement,
+    Annotation,
+    TextualRepresentation,
+    NamespaceImport,
+    MembershipImport,
+    Subclassification,
+    Specialization,
+    Type,
+    FeatureMembership,
+    Featuring,
+    Feature,
+    Redefinition,
+    Subsetting,
+    FeatureTyping,
+    TypeFeaturing,
+    FeatureInverting,
+    FeatureChaining,
+    FeatureDirectionKind,
+    ReferenceSubsetting,
+    Conjugation,
+    Multiplicity,
+    Intersecting,
+    Unioning,
+    Disjoining,
+    Differencing,
+    Classifier,
+    Package,
+    Expression,
+    Step,
+    Behavior,
+    Function,
+    ElementFilterMembership,
+    FeatureReferenceExpression,
+    InvocationExpression,
+    OperatorExpression,
+    FeatureChainExpression,
+    MetadataAccessExpression,
+    MetadataFeature,
+    Metaclass,
+    ParameterMembership,
+    FeatureValue,
+    Association,
+    BooleanExpression,
+    Predicate,
+    ResultExpressionMembership,
+    ItemFlow,
+    Connector,
+    ItemFlowEnd,
+    ItemFeature,
+    Interaction,
+    Succession,
+    MultiplicityRange,
+)
+
+from gaphor.KerML import kerml
+
+__all__ = [
+    "Dependency",
+    "Relationship",
+    "Element",
+    "OwningMembership",
+    "Membership",
+    "Namespace",
+    "Import",
+    "VisibilityKind",
+    "Documentation",
+    "Comment",
+    "AnnotatingElement",
+    "Annotation",
+    "TextualRepresentation",
+    "NamespaceImport",
+    "MembershipImport",
+    "Subclassification",
+    "Specialization",
+    "Type",
+    "FeatureMembership",
+    "Featuring",
+    "Feature",
+    "Redefinition",
+    "Subsetting",
+    "FeatureTyping",
+    "TypeFeaturing",
+    "FeatureInverting",
+    "FeatureChaining",
+    "FeatureDirectionKind",
+    "ReferenceSubsetting",
+    "Conjugation",
+    "Multiplicity",
+    "Intersecting",
+    "Unioning",
+    "Disjoining",
+    "Differencing",
+    "Classifier",
+    "EndFeatureMembership",
+    "Structure",
+    "Class",
+    "DataType",
+    "LibraryPackage",
+    "Package",
+    "Expression",
+    "Step",
+    "Behavior",
+    "Function",
+    "ElementFilterMembership",
+    "LiteralString",
+    "LiteralExpression",
+    "LiteralRational",
+    "FeatureReferenceExpression",
+    "LiteralInteger",
+    "InvocationExpression",
+    "SelectExpression",
+    "OperatorExpression",
+    "CollectExpression",
+    "LiteralBoolean",
+    "NullExpression",
+    "LiteralInfinity",
+    "FeatureChainExpression",
+    "MetadataAccessExpression",
+    "MetadataFeature",
+    "Metaclass",
+    "ParameterMembership",
+    "FeatureValue",
+    "Association",
+    "AssociationStructure",
+    "BooleanExpression",
+    "Predicate",
+    "ResultExpressionMembership",
+    "Invariant",
+    "ReturnParameterMembership",
+    "ItemFlow",
+    "Connector",
+    "ItemFlowEnd",
+    "ItemFeature",
+    "Interaction",
+    "SuccessionItemFlow",
+    "Succession",
+    "BindingConnector",
+    "MultiplicityRange",
+]
+
+Dependency.client.eType = Element
+Dependency.supplier.eType = Element
+Relationship.relatedElement.eType = Element
+Relationship.target.eType = Element
+Relationship.source.eType = Element
+Membership.memberElement.eType = Element
+Namespace.membership.eType = Membership
+Namespace.member.eType = Element
+Namespace.importedMembership.eType = Membership
+Import._importedElement.eType = Element
+AnnotatingElement.annotatedElement.eType = Element
+Annotation.annotatedElement.eType = Element
+NamespaceImport.importedNamespace.eType = Namespace
+MembershipImport.importedMembership.eType = Membership
+Subclassification.superclassifier.eType = Classifier
+Subclassification.subclassifier.eType = Classifier
+Specialization.general.eType = Type
+Specialization.specific.eType = Type
+Type.feature.eType = Feature
+Type.input.eType = Feature
+Type.output.eType = Feature
+Type.inheritedMembership.eType = Membership
+Type.endFeature.eType = Feature
+Type.inheritedFeature.eType = Feature
+Type._multiplicity.eType = Multiplicity
+Type.unioningType.eType = Type
+Type.intersectingType.eType = Type
+Type.featureMembership.eType = FeatureMembership
+Type.differencingType.eType = Type
+Type.directedFeature.eType = Feature
+Featuring.type.eType = Type
+Featuring.feature.eType = Feature
+Feature.type.eType = Type
+Feature.ownedRedefinition.eType = Redefinition
+Feature.featuringType.eType = Type
+Feature.chainingFeature.eType = Feature
+Redefinition.redefiningFeature.eType = Feature
+Redefinition.redefinedFeature.eType = Feature
+Subsetting.subsettedFeature.eType = Feature
+Subsetting.subsettingFeature.eType = Feature
+FeatureTyping.typedFeature.eType = Feature
+FeatureTyping.type.eType = Type
+TypeFeaturing.featureOfType.eType = Feature
+TypeFeaturing.featuringType.eType = Type
+FeatureInverting.featureInverted.eType = Feature
+FeatureInverting.invertingFeature.eType = Feature
+FeatureChaining.chainingFeature.eType = Feature
+ReferenceSubsetting.referencedFeature.eType = Feature
+Conjugation.originalType.eType = Type
+Conjugation.conjugatedType.eType = Type
+Intersecting.intersectingType.eType = Type
+Unioning.unioningType.eType = Type
+Disjoining.typeDisjoined.eType = Type
+Disjoining.disjoiningType.eType = Type
+Differencing.differencingType.eType = Type
+Package.filterCondition.eType = Expression
+Expression._function.eType = Function
+Expression._result.eType = Feature
+Step.behavior.eType = Behavior
+Step.parameter.eType = Feature
+Behavior.step.eType = Step
+Behavior.parameter.eType = Feature
+Function.expression.eType = Expression
+Function._result.eType = Feature
+ElementFilterMembership._condition.eType = Expression
+FeatureReferenceExpression._referent.eType = Feature
+InvocationExpression.argument.eType = Expression
+OperatorExpression.operand.eType = Expression
+FeatureChainExpression._targetFeature.eType = Feature
+MetadataAccessExpression.referencedElement.eType = Element
+MetadataFeature._metaclass.eType = Metaclass
+ParameterMembership._ownedMemberParameter.eType = Feature
+FeatureValue._featureWithValue.eType = Feature
+FeatureValue._value.eType = Expression
+Association.relatedType.eType = Type
+Association._sourceType.eType = Type
+Association.targetType.eType = Type
+Association.associationEnd.eType = Feature
+BooleanExpression._predicate.eType = Predicate
+ResultExpressionMembership._ownedResultExpression.eType = Expression
+ItemFlow.itemType.eType = Classifier
+ItemFlow._targetInputFeature.eType = Feature
+ItemFlow._sourceOutputFeature.eType = Feature
+ItemFlow.itemFlowEnd.eType = ItemFlowEnd
+ItemFlow._itemFeature.eType = ItemFeature
+ItemFlow.interaction.eType = Interaction
+Connector.relatedFeature.eType = Feature
+Connector.association.eType = Association
+Connector.connectorEnd.eType = Feature
+Connector._sourceFeature.eType = Feature
+Connector.targetFeature.eType = Feature
+Succession._transitionStep.eType = Step
+Succession.triggerStep.eType = Step
+Succession.effectStep.eType = Step
+Succession.guardExpression.eType = Expression
+MultiplicityRange._lowerBound.eType = Expression
+MultiplicityRange._upperBound.eType = Expression
+MultiplicityRange.bound.eType = Expression
+Relationship.ownedRelatedElement.eType = Element
+Relationship.owningRelatedElement.eType = Element
+Element._owningMembership.eType = OwningMembership
+Element._owningNamespace.eType = Namespace
+Element.owningRelationship.eType = Relationship
+Element.owningRelationship.eOpposite = Relationship.ownedRelatedElement
+Element.ownedRelationship.eType = Relationship
+Element.ownedRelationship.eOpposite = Relationship.owningRelatedElement
+Element._owner.eType = Element
+Element.ownedElement.eType = Element
+Element.ownedElement.eOpposite = Element._owner
+Element.documentation.eType = Documentation
+Element.ownedAnnotation.eType = Annotation
+Element.textualRepresentation.eType = TextualRepresentation
+OwningMembership._ownedMemberElement.eType = Element
+OwningMembership._ownedMemberElement.eOpposite = Element._owningMembership
+Membership._membershipOwningNamespace.eType = Namespace
+Namespace.ownedImport.eType = Import
+Namespace.ownedMember.eType = Element
+Namespace.ownedMember.eOpposite = Element._owningNamespace
+Namespace.ownedMembership.eType = Membership
+Namespace.ownedMembership.eOpposite = Membership._membershipOwningNamespace
+Import._importOwningNamespace.eType = Namespace
+Import._importOwningNamespace.eOpposite = Namespace.ownedImport
+Documentation._documentedElement.eType = Element
+Documentation._documentedElement.eOpposite = Element.documentation
+AnnotatingElement.annotation.eType = Annotation
+Annotation._owningAnnotatedElement.eType = Element
+Annotation._owningAnnotatedElement.eOpposite = Element.ownedAnnotation
+Annotation.annotatingElement.eType = AnnotatingElement
+Annotation.annotatingElement.eOpposite = AnnotatingElement.annotation
+TextualRepresentation._representedElement.eType = Element
+TextualRepresentation._representedElement.eOpposite = Element.textualRepresentation
+Subclassification._owningClassifier.eType = Classifier
+Specialization._owningType.eType = Type
+Type.ownedFeatureMembership.eType = FeatureMembership
+Type.ownedFeature.eType = Feature
+Type.ownedEndFeature.eType = Feature
+Type._ownedConjugator.eType = Conjugation
+Type.ownedIntersecting.eType = Intersecting
+Type.ownedUnioning.eType = Unioning
+Type.ownedDisjoining.eType = Disjoining
+Type.ownedDifferencing.eType = Differencing
+Type.ownedSpecialization.eType = Specialization
+Type.ownedSpecialization.eOpposite = Specialization._owningType
+FeatureMembership._ownedMemberFeature.eType = Feature
+FeatureMembership._owningType.eType = Type
+FeatureMembership._owningType.eOpposite = Type.ownedFeatureMembership
+Feature._owningType.eType = Type
+Feature._owningType.eOpposite = Type.ownedFeature
+Feature.ownedSubsetting.eType = Subsetting
+Feature._owningFeatureMembership.eType = FeatureMembership
+Feature._owningFeatureMembership.eOpposite = FeatureMembership._ownedMemberFeature
+Feature._endOwningType.eType = Type
+Feature._endOwningType.eOpposite = Type.ownedEndFeature
+Feature.ownedTyping.eType = FeatureTyping
+Feature.ownedTypeFeaturing.eType = TypeFeaturing
+Feature.ownedFeatureInverting.eType = FeatureInverting
+Feature.ownedFeatureChaining.eType = FeatureChaining
+Feature._ownedReferenceSubsetting.eType = ReferenceSubsetting
+Subsetting._owningFeature.eType = Feature
+Subsetting._owningFeature.eOpposite = Feature.ownedSubsetting
+FeatureTyping._owningFeature.eType = Feature
+FeatureTyping._owningFeature.eOpposite = Feature.ownedTyping
+TypeFeaturing._owningFeatureOfType.eType = Feature
+TypeFeaturing._owningFeatureOfType.eOpposite = Feature.ownedTypeFeaturing
+FeatureInverting._owningFeature.eType = Feature
+FeatureInverting._owningFeature.eOpposite = Feature.ownedFeatureInverting
+FeatureChaining._featureChained.eType = Feature
+FeatureChaining._featureChained.eOpposite = Feature.ownedFeatureChaining
+ReferenceSubsetting._referencingFeature.eType = Feature
+ReferenceSubsetting._referencingFeature.eOpposite = Feature._ownedReferenceSubsetting
+Conjugation._owningType.eType = Type
+Conjugation._owningType.eOpposite = Type._ownedConjugator
+Intersecting._typeIntersected.eType = Type
+Intersecting._typeIntersected.eOpposite = Type.ownedIntersecting
+Unioning._typeUnioned.eType = Type
+Unioning._typeUnioned.eOpposite = Type.ownedUnioning
+Disjoining._owningType.eType = Type
+Disjoining._owningType.eOpposite = Type.ownedDisjoining
+Differencing._typeDifferenced.eType = Type
+Differencing._typeDifferenced.eOpposite = Type.ownedDifferencing
+Classifier.ownedSubclassification.eType = Subclassification
+Classifier.ownedSubclassification.eOpposite = Subclassification._owningClassifier
+
+otherClassifiers = [VisibilityKind, FeatureDirectionKind]
+
+for classif in otherClassifiers:
+    eClassifiers[classif.name] = classif
+    classif.ePackage = eClass
+
+for classif in eClassifiers.values():
+    eClass.eClassifiers.append(classif.eClass)

--- a/gaphor/KerML/kerml.py
+++ b/gaphor/KerML/kerml.py
@@ -1,0 +1,4413 @@
+"""Definition of meta model for KerML."""
+# ruff: noqa: C901
+from functools import partial
+import pyecore.ecore as Ecore
+from pyecore.ecore import (
+    EReference,
+    EDerivedCollection,
+    EAttribute,
+    abstract,
+    EEnum,
+    EPackage,
+    EObject,
+    MetaEClass,
+)
+from gaphor.UMLTypes.uml_types import String, Real, Boolean, Integer
+
+
+name = "kerml"
+nsURI = "https://www.omg.org/spec/KerML/20230201"
+nsPrefix = "kerml"
+
+eClass = EPackage(name=name, nsURI=nsURI, nsPrefix=nsPrefix)
+
+eClassifiers = {}  # type: ignore
+getEClassifier = partial(Ecore.getEClassifier, searchspace=eClassifiers)
+VisibilityKind = EEnum("VisibilityKind", literals=["private", "protected", "public"])
+
+FeatureDirectionKind = EEnum("FeatureDirectionKind", literals=["in_", "inout", "out"])
+
+
+class DerivedOwnedelement(EDerivedCollection):
+    pass
+
+
+class DerivedDocumentation(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedannotation(EDerivedCollection):
+    pass
+
+
+class DerivedTextualrepresentation(EDerivedCollection):
+    pass
+
+
+@abstract
+class Element(EObject, metaclass=MetaEClass):
+    """<p>An <code>Element</code> is a constituent of a model that is uniquely identified relative to all other <code>Elements</code>. It can have <code>Relationships</code> with other <code>Elements</code>. Some of these <code>Relationships</code> might imply ownership of other <code>Elements</code>, which means that if an <code>Element</code> is deleted from a model, then so are all the <code>Elements</code> that it owns.</p>
+
+    ownedElement = ownedRelationship.ownedRelatedElement
+    owner = owningRelationship.owningRelatedElement
+    qualifiedName =
+        if owningNamespace = null then null
+        else if owningNamespace.owner = null then escapedName()
+        else if owningNamespace.qualifiedName = null or
+                escapedName() = null then null
+        else owningNamespace.qualifiedName + '::' + escapedName()
+        endif endif endif
+    documentation = ownedElement->selectByKind(Documentation)
+    ownedAnnotation = ownedRelationship->
+        selectByKind(Annotation)->
+        select(a | a.annotatedElement = self)
+    name = effectiveName()
+    ownedRelationship->exists(isImplied) implies isImpliedIncluded
+    isLibraryElement = libraryNamespace() <>null
+
+    shortName = effectiveShortName()
+    owningNamespace =
+        if owningMembership = null then null
+        else owningMembership.membershipOwningNamespace
+        endif
+    textualRepresentation = ownedElement->selectByKind(TextualRepresentation)"""
+
+    elementId = EAttribute(
+        eType=String, unique=True, derived=False, changeable=True, iD=True
+    )
+    aliasIds = EAttribute(
+        eType=String, unique=True, derived=False, changeable=True, upper=-1
+    )
+    declaredShortName = EAttribute(
+        eType=String, unique=True, derived=False, changeable=True
+    )
+    declaredName = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+    _shortName = EAttribute(
+        eType=String,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="shortName",
+        transient=True,
+    )
+    _name = EAttribute(
+        eType=String,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="name",
+        transient=True,
+    )
+    _qualifiedName = EAttribute(
+        eType=String,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="qualifiedName",
+        transient=True,
+    )
+    isImpliedIncluded = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    _isLibraryElement = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="isLibraryElement",
+        transient=True,
+    )
+    _owningMembership = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningMembership",
+        transient=True,
+    )
+    _owningNamespace = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningNamespace",
+        transient=True,
+    )
+    owningRelationship = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    ownedRelationship = EReference(
+        ordered=True, unique=True, containment=True, derived=False, upper=-1
+    )
+    _owner = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owner",
+        transient=True,
+    )
+    ownedElement = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedelement,
+    )
+    documentation = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedDocumentation,
+    )
+    ownedAnnotation = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedannotation,
+    )
+    textualRepresentation = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedTextualrepresentation,
+    )
+
+    @property
+    def owningMembership(self):
+        raise NotImplementedError("Missing implementation for owningMembership")
+
+    @owningMembership.setter
+    def owningMembership(self, value):
+        raise NotImplementedError("Missing implementation for owningMembership")
+
+    @property
+    def owningNamespace(self):
+        raise NotImplementedError("Missing implementation for owningNamespace")
+
+    @owningNamespace.setter
+    def owningNamespace(self, value):
+        raise NotImplementedError("Missing implementation for owningNamespace")
+
+    @property
+    def owner(self):
+        raise NotImplementedError("Missing implementation for owner")
+
+    @owner.setter
+    def owner(self, value):
+        raise NotImplementedError("Missing implementation for owner")
+
+    @property
+    def shortName(self):
+        raise NotImplementedError("Missing implementation for shortName")
+
+    @shortName.setter
+    def shortName(self, value):
+        raise NotImplementedError("Missing implementation for shortName")
+
+    @property
+    def name(self):
+        raise NotImplementedError("Missing implementation for name")
+
+    @name.setter
+    def name(self, value):
+        raise NotImplementedError("Missing implementation for name")
+
+    @property
+    def qualifiedName(self):
+        raise NotImplementedError("Missing implementation for qualifiedName")
+
+    @qualifiedName.setter
+    def qualifiedName(self, value):
+        raise NotImplementedError("Missing implementation for qualifiedName")
+
+    @property
+    def isLibraryElement(self):
+        raise NotImplementedError("Missing implementation for isLibraryElement")
+
+    @isLibraryElement.setter
+    def isLibraryElement(self, value):
+        raise NotImplementedError("Missing implementation for isLibraryElement")
+
+    def __init__(
+        self,
+        *,
+        owningMembership=None,
+        owningNamespace=None,
+        owningRelationship=None,
+        elementId=None,
+        ownedRelationship=None,
+        owner=None,
+        ownedElement=None,
+        documentation=None,
+        ownedAnnotation=None,
+        textualRepresentation=None,
+        aliasIds=None,
+        declaredShortName=None,
+        declaredName=None,
+        shortName=None,
+        name=None,
+        qualifiedName=None,
+        isImpliedIncluded=None,
+        isLibraryElement=None
+    ):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+        if elementId is not None:
+            self.elementId = elementId
+
+        if aliasIds:
+            self.aliasIds.extend(aliasIds)
+
+        if declaredShortName is not None:
+            self.declaredShortName = declaredShortName
+
+        if declaredName is not None:
+            self.declaredName = declaredName
+
+        if shortName is not None:
+            self.shortName = shortName
+
+        if name is not None:
+            self.name = name
+
+        if qualifiedName is not None:
+            self.qualifiedName = qualifiedName
+
+        if isImpliedIncluded is not None:
+            self.isImpliedIncluded = isImpliedIncluded
+
+        if isLibraryElement is not None:
+            self.isLibraryElement = isLibraryElement
+
+        if owningMembership is not None:
+            self.owningMembership = owningMembership
+
+        if owningNamespace is not None:
+            self.owningNamespace = owningNamespace
+
+        if owningRelationship is not None:
+            self.owningRelationship = owningRelationship
+
+        if ownedRelationship:
+            self.ownedRelationship.extend(ownedRelationship)
+
+        if owner is not None:
+            self.owner = owner
+
+        if ownedElement:
+            self.ownedElement.extend(ownedElement)
+
+        if documentation:
+            self.documentation.extend(documentation)
+
+        if ownedAnnotation:
+            self.ownedAnnotation.extend(ownedAnnotation)
+
+        if textualRepresentation:
+            self.textualRepresentation.extend(textualRepresentation)
+
+    def escapedName(self):
+        """<p>Return <code>name</code>, if that is not null, otherwise the <code>shortName</code>, if that is not null, otherwise null. If the returned value is non-null, it is returned as-is if it has the form of a basic name, or, otherwise, represented as a restricted name according to the lexical structure of the KerML textual notation (i.e., surrounded by single quote characters and with special characters escaped).</p>"""
+        raise NotImplementedError("operation escapedName(...) not yet implemented")
+
+    def effectiveShortName(self):
+        """<p>Return an effective <code>shortName</code> for this <code>Element</code>. By default this is the same as its <code>declaredShortName</code>.</p>"""
+        raise NotImplementedError(
+            "operation effectiveShortName(...) not yet implemented"
+        )
+
+    def effectiveName(self):
+        """<p>Return an effective <code>name</code> for this <code>Element</code>. By default this is the same as its <code>declaredName</code>.</p>"""
+        raise NotImplementedError("operation effectiveName(...) not yet implemented")
+
+    def libraryNamespace(self):
+        """<p>By default, return the library Namespace of the <code>owningRelationship</code> of this Element, if it has one.</p>"""
+        raise NotImplementedError("operation libraryNamespace(...) not yet implemented")
+
+
+class DerivedRelatedelement(EDerivedCollection):
+    pass
+
+
+@abstract
+class Relationship(Element):
+    """<p>A <code>Relationship</code> is an <code>Element</code> that relates other <code>Element</code>. Some of its <code>relatedElements</code> may be owned, in which case those <code>ownedRelatedElements</code> will be deleted from a model if their <code>owningRelationship</code> is. A <code>Relationship</code> may also be owned by another <code>Element</code>, in which case the <code>ownedRelatedElements</code> of the <code>Relationship</code> are also considered to be transitively owned by the <code>owningRelatedElement</code> of the <code>Relationship</code>.</p>
+
+    <p>The <code>relatedElements</code> of a <code>Relationship</code> are divided into <code>source</code> and <code>target</code> <code>Elements</code>. The <code>Relationship</code> is considered to be directed from the <code>source</code> to the <code>target</code> <code>Elements</code>. An undirected <code>Relationship</code> may have either all <code>source</code> or all <code>target</code> <code>Elements</code>.</p>
+
+    <p>A &quot;relationship <code>Element</code>&quot; in the abstract syntax is generically any <code>Element</code> that is an instance of either <code>Relationship</code> or a direct or indirect specialization of <code>Relationship</code>. Any other kind of <code>Element</code> is a &quot;non-relationship <code>Element</code>&quot;. It is a convention of that non-relationship <code>Elements</code> are <em>only</em> related via reified relationship <code>Elements</code>. Any meta-associations directly between non-relationship <code>Elements</code> must be derived from underlying reified <code>Relationship</code>.</p>
+
+    relatedElement = source->union(target)"""
+
+    isImplied = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    ownedRelatedElement = EReference(
+        ordered=True, unique=True, containment=True, derived=False, upper=-1
+    )
+    owningRelatedElement = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    relatedElement = EReference(
+        ordered=True,
+        unique=False,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedRelatedelement,
+    )
+    target = EReference(
+        ordered=True, unique=True, containment=False, derived=False, upper=-1
+    )
+    source = EReference(
+        ordered=True, unique=True, containment=False, derived=False, upper=-1
+    )
+
+    def __init__(
+        self,
+        *,
+        ownedRelatedElement=None,
+        owningRelatedElement=None,
+        relatedElement=None,
+        target=None,
+        source=None,
+        isImplied=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isImplied is not None:
+            self.isImplied = isImplied
+
+        if ownedRelatedElement:
+            self.ownedRelatedElement.extend(ownedRelatedElement)
+
+        if owningRelatedElement is not None:
+            self.owningRelatedElement = owningRelatedElement
+
+        if relatedElement:
+            self.relatedElement.extend(relatedElement)
+
+        if target:
+            self.target.extend(target)
+
+        if source:
+            self.source.extend(source)
+
+
+class DerivedMembership(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedimport(EDerivedCollection):
+    pass
+
+
+class DerivedMember(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedmember(EDerivedCollection):
+    pass
+
+
+class DerivedImportedmembership(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedmembership(EDerivedCollection):
+    pass
+
+
+class Namespace(Element):
+    """<p>A <code>Namespace</code> is an <code>Element</code> that contains other <code>Element</code>, known as its <code>members</code>, via <code>Membership</code> <code>Relationships</code> with those <code>Elements</code>. The <code>members</code> of a <code>Namespace</code> may be owned by the <code>Namespace</code>, aliased in the <code>Namespace</code>, or imported into the <code>Namespace</code> via <code>Import</code> <code>Relationships</code> with other <code>Namespace</code>.</p>
+
+    <p>A <code>Namespace</code> can provide names for its <code>members</code> via the <code>memberNames</code> and <code>memberShortNames</code> specified by the <code>Memberships</code> in the <code>Namespace</code>. If a <code>Membership</code> specifies a <code>memberName</code> and/or <code>memberShortName</code>, then that those are names of the corresponding <code>memberElement</code> relative to the <code>Namespace</code>. For an <code>OwningMembership</code>, the <code>owningMemberName</code> and <code>owningMemberShortName</code> are given by the <code>Element</code> <code>name</code> and <code>shortName</code>. Note that the same <code>Element</code> may be the <code>memberElement</code> of multiple <code>Memberships</code> in a <code>Namespace</code> (though it may be owned at most once), each of which may define a separate alias for the <code>Element</code> relative to the <code>Namespace</code>.</p>
+
+    membership->forAll(m1 |
+        membership->forAll(m2 |
+            m1 <> m2 implies m1.isDistinguishableFrom(m2)))
+    member = membership.memberElement
+    ownedMember = ownedMembership->selectByKind(OwningMembership).ownedMemberElement
+    importedMembership = importedMemberships(Set{})
+    ownedImport = ownedRelationship->selectByKind(Import)
+    ownedMembership = ownedRelationship->selectByKind(Membership)"""
+
+    membership = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedMembership,
+    )
+    ownedImport = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedimport,
+    )
+    member = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedMember,
+    )
+    ownedMember = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedmember,
+    )
+    importedMembership = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedImportedmembership,
+    )
+    ownedMembership = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedmembership,
+    )
+
+    def __init__(
+        self,
+        *,
+        membership=None,
+        ownedImport=None,
+        member=None,
+        ownedMember=None,
+        importedMembership=None,
+        ownedMembership=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if membership:
+            self.membership.extend(membership)
+
+        if ownedImport:
+            self.ownedImport.extend(ownedImport)
+
+        if member:
+            self.member.extend(member)
+
+        if ownedMember:
+            self.ownedMember.extend(ownedMember)
+
+        if importedMembership:
+            self.importedMembership.extend(importedMembership)
+
+        if ownedMembership:
+            self.ownedMembership.extend(ownedMembership)
+
+    def namesOf(self, element=None):
+        """<p>Return the names of the given <code>element</code> as it is known in this <code>Namespace</code>.</p>"""
+        raise NotImplementedError("operation namesOf(...) not yet implemented")
+
+    def visibilityOf(self, mem=None):
+        """<p>Returns this visibility of <code>mem</code> relative to this <code>Namespace</code>. If <code>mem</code> is an <code>importedMembership</code>, this is the <code>visibility</code> of its Import. Otherwise it is the <code>visibility</code> of the <code>Membership</code> itself.</p>"""
+        raise NotImplementedError("operation visibilityOf(...) not yet implemented")
+
+    def visibleMemberships(self, excluded=None, isRecursive=None, includeAll=None):
+        """<p>If <code>includeAll = true</code>, then return all the <code>Memberships</code> of this <code>Namespace</code>. Otherwise, return only the publicly visible <code>Memberships</code> of this <code>Namespace</code> (which includes those <code>ownedMemberships</code> that have a <code>visibility</code> of <code>public</code> and those <code>importedMemberships</code> imported with a <code>visibility</code> of <code>public</code>). If <code>isRecursive = true</code>, also recursively include all visible <code>Memberships</code> of any visible owned <code>Namespaces</code>.</p>"""
+        raise NotImplementedError(
+            "operation visibleMemberships(...) not yet implemented"
+        )
+
+    def importedMemberships(self, excluded=None):
+        """<p>Derive the imported <code>Memberships</code> of this <code>Namespace</code> as the <code>importedMembership</code> of all <code>ownedImports</code>, excluding those Imports whose <code>importOwningNamespace</code> is in the <code>excluded</code> set, and excluding <code>Memberships</code> that have distinguisibility collisions with each other or with any <code>ownedMembership</code>.</p>"""
+        raise NotImplementedError(
+            "operation importedMemberships(...) not yet implemented"
+        )
+
+    def resolve(self, qualifiedName=None):
+        """<p>Resolve the given qualified name to the named <code>Membership</code> (if any), starting with this <code>Namespace</code> as the local scope. The qualified name string must conform to the concrete syntax of the KerML textual notation. According to the KerML name resolution rules every qualified name will resolve to either a single <code>Membership</code>, or to none.</p>"""
+        raise NotImplementedError("operation resolve(...) not yet implemented")
+
+    def resolveGlobal(self, qualifiedName=None):
+        """<p>Resolve the given qualified name to the named <code>Membership</code> (if any) in the effective global <code>Namespace</code> that is the outermost naming scope. The qualified name string must conform to the concrete syntax of the KerML textual notation.</p>"""
+        raise NotImplementedError("operation resolveGlobal(...) not yet implemented")
+
+    def resolveLocal(self, name=None):
+        """<p>Resolve a simple <code>name</code> starting with this <code>Namespace</code> as the local scope, and continuing with containing outer scopes as necessary. However, if this <code>Namespace</code> is a root <code>Namespace</code>, then the resolution is done directly in global scope.</p>"""
+        raise NotImplementedError("operation resolveLocal(...) not yet implemented")
+
+    def resolveVisible(self, name=None):
+        """<p>Resolve a simple name from the visible <code>Memberships</code> of this <code>Namespace</code>.</p>"""
+        raise NotImplementedError("operation resolveVisible(...) not yet implemented")
+
+    def qualificationOf(self, qualifiedName=None):
+        """<p>Return a string with valid KerML syntax representing the qualification part of a given <code>qualifiedName</code>, that is, a qualified name with all the segment names of the given name except the last. If the given <code>qualifiedName</code> has only one segment, then return null.</p>"""
+        raise NotImplementedError("operation qualificationOf(...) not yet implemented")
+
+    def unqualifiedNameOf(self, qualifiedName=None):
+        """<p>Return the simple name that is the last segment name of the given <code>qualifiedName</code>. If this segment name has the form of a KerML unrestricted name, then "unescape" it by removing the surrounding single quotes and replacing all escape sequences with the specified character.</p>"""
+        raise NotImplementedError(
+            "operation unqualifiedNameOf(...) not yet implemented"
+        )
+
+
+class DerivedAnnotatedelement(EDerivedCollection):
+    pass
+
+
+class AnnotatingElement(Element):
+    """<p>An <code>AnnotatingElement</code> is an <code>Element</code> that provides additional description of or metadata on some other <code>Element</code>. An <code>AnnotatingElement</code> is either attached to its <code>annotatedElements</code> by <code>Annotation</code> <code>Relationships</code>, or it implicitly annotates its <code>owningNamespace</code>.</p>
+
+    annotatedElement =
+     if annotation->notEmpty() then annotation.annotatedElement
+     else Sequence{owningNamespace} endif"""
+
+    annotation = EReference(
+        ordered=True, unique=True, containment=False, derived=False, upper=-1
+    )
+    annotatedElement = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedAnnotatedelement,
+    )
+
+    def __init__(self, *, annotation=None, annotatedElement=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if annotation:
+            self.annotation.extend(annotation)
+
+        if annotatedElement:
+            self.annotatedElement.extend(annotatedElement)
+
+
+class Dependency(Relationship):
+    """<p>A <code>Dependency</code> is a <code>Relationship</code> that indicates that one or more <code>client</code> <code>Elements</code> require one more <code>supplier</code> <code>Elements</code> for their complete specification. In general, this means that a change to one of the <code>supplier</code> <code>Elements</code> may necessitate a change to, or re-specification of, the <code>client</code> <code>Elements</code>.</p>
+
+    <p>Note that a <code>Dependency</code> is entirely a model-level <code>Relationship</code>, without instance-level semantics.</p>
+    """
+
+    client = EReference(
+        ordered=True, unique=True, containment=False, derived=False, upper=-1
+    )
+    supplier = EReference(
+        ordered=True, unique=True, containment=False, derived=False, upper=-1
+    )
+
+    def __init__(self, *, client=None, supplier=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if client:
+            self.client.extend(client)
+
+        if supplier:
+            self.supplier.extend(supplier)
+
+
+class Membership(Relationship):
+    """<p>A <code>Membership</code> is a <code>Relationship</code> between a <code>Namespace</code> and an <code>Element</code> that indicates the <code>Element</code> is a <code>member</code> of (i.e., is contained in) the Namespace. Any <code>memberNames</code> specify how the <code>memberElement</code> is identified in the <code>Namespace</code> and the <code>visibility</code> specifies whether or not the <code>memberElement</code> is publicly visible from outside the <code>Namespace</code>.</p>
+
+    <p>If a <code>Membership</code> is an <code>OwningMembership</code>, then it owns its <code>memberElement</code>, which becomes an <code>ownedMember</code> of the <code>membershipOwningNamespace</code>. Otherwise, the <code>memberNames</code> of a <code>Membership</code> are effectively aliases within the <code>membershipOwningNamespace</code> for an <code>Element</code> with a separate <code>OwningMembership</code> in the same or a different <code>Namespace</code>.</p>
+
+    <p>&nbsp;</p>
+
+    memberElementId = memberElement.elementId"""
+
+    _memberElementId = EAttribute(
+        eType=String,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="memberElementId",
+        transient=True,
+    )
+    memberShortName = EAttribute(
+        eType=String, unique=True, derived=False, changeable=True
+    )
+    memberName = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+    visibility = EAttribute(
+        eType=VisibilityKind,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value=VisibilityKind.public,
+    )
+    _membershipOwningNamespace = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="membershipOwningNamespace",
+        transient=True,
+    )
+    memberElement = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+
+    @property
+    def memberElementId(self):
+        raise NotImplementedError("Missing implementation for memberElementId")
+
+    @memberElementId.setter
+    def memberElementId(self, value):
+        raise NotImplementedError("Missing implementation for memberElementId")
+
+    @property
+    def membershipOwningNamespace(self):
+        raise NotImplementedError(
+            "Missing implementation for membershipOwningNamespace"
+        )
+
+    @membershipOwningNamespace.setter
+    def membershipOwningNamespace(self, value):
+        raise NotImplementedError(
+            "Missing implementation for membershipOwningNamespace"
+        )
+
+    def __init__(
+        self,
+        *,
+        memberElementId=None,
+        membershipOwningNamespace=None,
+        memberShortName=None,
+        memberElement=None,
+        memberName=None,
+        visibility=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if memberElementId is not None:
+            self.memberElementId = memberElementId
+
+        if memberShortName is not None:
+            self.memberShortName = memberShortName
+
+        if memberName is not None:
+            self.memberName = memberName
+
+        if visibility is not None:
+            self.visibility = visibility
+
+        if membershipOwningNamespace is not None:
+            self.membershipOwningNamespace = membershipOwningNamespace
+
+        if memberElement is not None:
+            self.memberElement = memberElement
+
+    def isDistinguishableFrom(self, other=None):
+        """<p>Whether this <code>Membership</code> is distinguishable from a given <code>other</code> <code>Membership</code>. By default, this is true if this <code>Membership</code> has no <code>memberShortName</code> or <code>memberName</code>; or each of the <code>memberShortName</code> and <code>memberName</code> are different than both of those of the <code>other</code> <code>Membership</code>; or neither of the metaclasses of the <code>memberElement</code> of this <code>Membership</code> and the <code>memberElement</code> of the <code>other</code> <code>Membership</code> conform to the other. But this may be overridden in specializations of <code>Membership</code>.</p>"""
+        raise NotImplementedError(
+            "operation isDistinguishableFrom(...) not yet implemented"
+        )
+
+
+@abstract
+class Import(Relationship):
+    """<p>An <code>Import</code> is an <code>Relationship</code> between its <code>importOwningNamespace</code> and either a <code>Membership</code> (for a <code>MembershipImport</code>) or another <code>Namespace</code> (for a <code>NamespaceImport</code>), which determines a set of <code>Memberships</code> that become <code>importedMemberships</code> of the <code>importOwningNamespace</code>. If <code>isImportAll = false</code> (the default), then only public <code>Memberships</code> are considered &quot;visible&quot;. If <code>isImportAll = true</code>, then all <code>Memberships</code> are considered &quot;visible&quot;, regardless of their declared <code>visibility</code>. If <code>isRecursive = true</code>, then visible <code>Memberships</code> are also recursively imported from owned sub-<code>Namespaces</code>.</p>"""
+
+    visibility = EAttribute(
+        eType=VisibilityKind,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value=VisibilityKind.public,
+    )
+    isRecursive = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    isImportAll = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    _importedElement = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="importedElement",
+        transient=True,
+    )
+    _importOwningNamespace = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="importOwningNamespace",
+        transient=True,
+    )
+
+    @property
+    def importedElement(self):
+        raise NotImplementedError("Missing implementation for importedElement")
+
+    @importedElement.setter
+    def importedElement(self, value):
+        raise NotImplementedError("Missing implementation for importedElement")
+
+    @property
+    def importOwningNamespace(self):
+        raise NotImplementedError("Missing implementation for importOwningNamespace")
+
+    @importOwningNamespace.setter
+    def importOwningNamespace(self, value):
+        raise NotImplementedError("Missing implementation for importOwningNamespace")
+
+    def __init__(
+        self,
+        *,
+        visibility=None,
+        isRecursive=None,
+        isImportAll=None,
+        importedElement=None,
+        importOwningNamespace=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if visibility is not None:
+            self.visibility = visibility
+
+        if isRecursive is not None:
+            self.isRecursive = isRecursive
+
+        if isImportAll is not None:
+            self.isImportAll = isImportAll
+
+        if importedElement is not None:
+            self.importedElement = importedElement
+
+        if importOwningNamespace is not None:
+            self.importOwningNamespace = importOwningNamespace
+
+    def importedMemberships(self, excluded=None):
+        """<p>Returns Memberships that are to become <code>importedMemberships</code> of the <code>importOwningNamespace</code>. (The <code>excluded</code> parameter is used to handle the possibility of circular Import Relationships.)</p>"""
+        raise NotImplementedError(
+            "operation importedMemberships(...) not yet implemented"
+        )
+
+
+class Comment(AnnotatingElement):
+    """<p>A <code>Comment</code> is an <code>AnnotatingElement</code> whose <code>body</code> in some way describes its <code>annotatedElements</code>.</p>"""
+
+    locale = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+    body = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, locale=None, body=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if locale is not None:
+            self.locale = locale
+
+        if body is not None:
+            self.body = body
+
+
+class Annotation(Relationship):
+    """<p>An <code>Annotation</code> is a Relationship between an <code>AnnotatingElement</code> and the <code>Element</code> that is annotated by that <code>AnnotatingElement</code>.</p>"""
+
+    annotatedElement = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _owningAnnotatedElement = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningAnnotatedElement",
+        transient=True,
+    )
+    annotatingElement = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+
+    @property
+    def owningAnnotatedElement(self):
+        raise NotImplementedError("Missing implementation for owningAnnotatedElement")
+
+    @owningAnnotatedElement.setter
+    def owningAnnotatedElement(self, value):
+        raise NotImplementedError("Missing implementation for owningAnnotatedElement")
+
+    def __init__(
+        self,
+        *,
+        annotatedElement=None,
+        owningAnnotatedElement=None,
+        annotatingElement=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if annotatedElement is not None:
+            self.annotatedElement = annotatedElement
+
+        if owningAnnotatedElement is not None:
+            self.owningAnnotatedElement = owningAnnotatedElement
+
+        if annotatingElement is not None:
+            self.annotatingElement = annotatingElement
+
+
+class TextualRepresentation(AnnotatingElement):
+    """<p>A <code>TextualRepresentation</code> is an <code>AnnotatingElement</code> whose <code>body</code> represents the <code>representedElement</code> in a given <code>language</code>. The <code>representedElement</code> must be the <code>owner</code> of the <code>TextualRepresentation</code>. The named <code>language</code> can be a natural language, in which case the <code>body</code> is an informal representation, or an artificial language, in which case the <code>body</code> is expected to be a formal, machine-parsable representation.</p>
+
+    <p>If the named <code>language</code> of a <code>TextualRepresentation</code> is machine-parsable, then the <code>body</code> text should be legal input text as defined for that <code>language</code>. The interpretation of the named language string shall be case insensitive. The following <code>language</code> names are defined to correspond to the given standard languages:</p>
+
+    <table border="1" cellpadding="1" cellspacing="1" width="498">
+            <thead>
+            </thead>
+            <tbody>
+                    <tr>
+                            <td style="text-align: center; width: 154px;"><code>kerml</code></td>
+                            <td style="width: 332px;">Kernel Modeling Language</td>
+                    </tr>
+                    <tr>
+                            <td style="text-align: center; width: 154px;"><code>ocl</code></td>
+                            <td style="width: 332px;">Object Constraint Language</td>
+                    </tr>
+                    <tr>
+                            <td style="text-align: center; width: 154px;"><code>alf</code></td>
+                            <td style="width: 332px;">Action Language for fUML</td>
+                    </tr>
+            </tbody>
+    </table>
+
+    <p>Other specifications may define specific <code>language</code> strings, other than those shown above, to be used to indicate the use of languages from those specifications in KerML <code>TextualRepresentation</code>.</p>
+
+    <p>If the <code>language</code> of a <code>TextualRepresentation</code> is &quot;<code>kerml</code>&quot;, then the <code>body</code> text shall be a legal representation of the <code>representedElement</code> in the KerML textual concrete syntax. A conforming tool can use such a <code>TextualRepresentation</code> <code>Annotation</code> to record the original KerML concrete syntax text from which an <code>Element</code> was parsed. In this case, it is a tool responsibility to ensure that the <code>body</code> of the <code>TextualRepresentation</code> remains correct (or the Annotation is removed) if the annotated <code>Element</code> changes other than by re-parsing the <code>body</code> text.</p>
+
+    <p>An <code>Element</code> with a <code>TextualRepresentation</code> in a language other than KerML is essentially a semantically &quot;opaque&quot; <code>Element</code> specified in the other language. However, a conforming KerML tool may interpret such an element consistently with the specification of the named language.</p>
+    """
+
+    language = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+    body = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+    _representedElement = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="representedElement",
+        transient=True,
+    )
+
+    @property
+    def representedElement(self):
+        raise NotImplementedError("Missing implementation for representedElement")
+
+    @representedElement.setter
+    def representedElement(self, value):
+        raise NotImplementedError("Missing implementation for representedElement")
+
+    def __init__(self, *, language=None, body=None, representedElement=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if language is not None:
+            self.language = language
+
+        if body is not None:
+            self.body = body
+
+        if representedElement is not None:
+            self.representedElement = representedElement
+
+
+class Specialization(Relationship):
+    """<p><code>Specialization</code> is a <code>Relationship</code> between two <code>Types</code> that requires all instances of the <code>specific</code> type to also be instances of the <code>general</code> Type (i.e., the set of instances of the <code>specific</code> Type is a <em>subset</em> of those of the <code>general</code> Type, which might be the same set).</p>
+
+    not specific.isConjugated"""
+
+    _owningType = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningType",
+        transient=True,
+    )
+    general = EReference(ordered=False, unique=True, containment=False, derived=False)
+    specific = EReference(ordered=False, unique=True, containment=False, derived=False)
+
+    @property
+    def owningType(self):
+        raise NotImplementedError("Missing implementation for owningType")
+
+    @owningType.setter
+    def owningType(self, value):
+        raise NotImplementedError("Missing implementation for owningType")
+
+    def __init__(self, *, owningType=None, general=None, specific=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if owningType is not None:
+            self.owningType = owningType
+
+        if general is not None:
+            self.general = general
+
+        if specific is not None:
+            self.specific = specific
+
+
+class DerivedOwnedfeaturemembership(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedfeature(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedendfeature(EDerivedCollection):
+    pass
+
+
+class DerivedFeature(EDerivedCollection):
+    pass
+
+
+class DerivedInput(EDerivedCollection):
+    pass
+
+
+class DerivedOutput(EDerivedCollection):
+    pass
+
+
+class DerivedInheritedmembership(EDerivedCollection):
+    pass
+
+
+class DerivedEndfeature(EDerivedCollection):
+    pass
+
+
+class DerivedInheritedfeature(EDerivedCollection):
+    pass
+
+
+class DerivedUnioningtype(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedintersecting(EDerivedCollection):
+    pass
+
+
+class DerivedIntersectingtype(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedunioning(EDerivedCollection):
+    pass
+
+
+class DerivedOwneddisjoining(EDerivedCollection):
+    pass
+
+
+class DerivedFeaturemembership(EDerivedCollection):
+    pass
+
+
+class DerivedDifferencingtype(EDerivedCollection):
+    pass
+
+
+class DerivedOwneddifferencing(EDerivedCollection):
+    pass
+
+
+class DerivedDirectedfeature(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedspecialization(EDerivedCollection):
+    pass
+
+
+class Type(Namespace):
+    """<p>A <code>Type</code> is a <code>Namespace</code> that is the most general kind of <code>Element</code> supporting the semantics of classification. A <code>Type</code> may be a <code>Classifier</code> or a <code>Feature</code>, defining conditions on what is classified by the <code>Type</code> (see also the description of <code>isSufficient</code>).</p>
+
+    ownedSpecialization = ownedRelationship->selectByKind(Specialization)->
+        select(s | s.special = self)
+
+    multiplicity =
+        let ownedMultiplicities: Sequence(Multiplicity) =
+            ownedMember->selectByKind(Multiplicity) in
+        if ownedMultiplicities->isEmpty() then null
+        else ownedMultiplicities->first()
+        endif
+    ownedFeatureMembership = ownedRelationship->selectByKind(FeatureMembership)
+    let ownedConjugators: Sequence(Conjugator) =
+        ownedRelationship->selectByKind(Conjugation) in
+        ownedConjugator =
+            if ownedConjugators->isEmpty() then null
+            else ownedConjugators->at(1) endif
+    output =
+        if isConjugated then
+            conjugator.originalType.input
+        else
+            feature->select(direction = out or direction = inout)
+        endif
+    input =
+        if isConjugated then
+            conjugator.originalType.output
+        else
+            feature->select(direction = _'in' or direction = inout)
+        endif
+    inheritedMembership = inheritedMemberships(Set{})
+    specializesFromLibrary('Base::Anything')
+    directedFeature = feature->select(f | directionOf(f) <> null)
+    feature = featureMembership.ownedMemberFeature
+    featureMembership = ownedMembership->union(
+        inheritedMembership->selectByKind(FeatureMembership))
+    ownedFeature = ownedFeatureMembership.ownedMemberFeature
+    differencingType = ownedDifferencing.differencingType
+    intersectingType->excludes(self)
+    differencingType->excludes(self)
+    unioningType = ownedUnioning.unioningType
+    unioningType->excludes(self)
+    intersectingType = ownedIntersecting.intersectingType
+    ownedRelationship->selectByKind(Conjugator)->size() <= 1
+    ownedMember->selectByKind(Multiplicity)->size() <= 1
+    endFeature = feature->select(isEnd)
+    ownedRelationship->selectByKind(Disjoining)
+    ownedRelationship->selectByKind(Unioning)
+    ownedRelationship->selectByKind(Intersecting)
+    ownedRelationship->selectByKind(Differencing)
+    ownedEndFeature = ownedFeature->select(isEnd)
+    inheritedFeature = inheritedMemberships->
+        selectByKind(FeatureMembership).memberFeature"""
+
+    isAbstract = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    isSufficient = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    _isConjugated = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="isConjugated",
+        transient=True,
+    )
+    ownedFeatureMembership = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedfeaturemembership,
+    )
+    ownedFeature = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedfeature,
+    )
+    ownedEndFeature = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedendfeature,
+    )
+    feature = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedFeature,
+    )
+    input = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedInput,
+    )
+    output = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOutput,
+    )
+    inheritedMembership = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedInheritedmembership,
+    )
+    endFeature = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedEndfeature,
+    )
+    _ownedConjugator = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedConjugator",
+        transient=True,
+    )
+    inheritedFeature = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedInheritedfeature,
+    )
+    _multiplicity = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="multiplicity",
+        transient=True,
+    )
+    unioningType = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedUnioningtype,
+    )
+    ownedIntersecting = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedintersecting,
+    )
+    intersectingType = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedIntersectingtype,
+    )
+    ownedUnioning = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedunioning,
+    )
+    ownedDisjoining = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwneddisjoining,
+    )
+    featureMembership = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedFeaturemembership,
+    )
+    differencingType = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedDifferencingtype,
+    )
+    ownedDifferencing = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwneddifferencing,
+    )
+    directedFeature = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedDirectedfeature,
+    )
+    ownedSpecialization = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedspecialization,
+    )
+
+    @property
+    def ownedConjugator(self):
+        raise NotImplementedError("Missing implementation for ownedConjugator")
+
+    @ownedConjugator.setter
+    def ownedConjugator(self, value):
+        raise NotImplementedError("Missing implementation for ownedConjugator")
+
+    @property
+    def isConjugated(self):
+        raise NotImplementedError("Missing implementation for isConjugated")
+
+    @isConjugated.setter
+    def isConjugated(self, value):
+        raise NotImplementedError("Missing implementation for isConjugated")
+
+    @property
+    def multiplicity(self):
+        raise NotImplementedError("Missing implementation for multiplicity")
+
+    @multiplicity.setter
+    def multiplicity(self, value):
+        raise NotImplementedError("Missing implementation for multiplicity")
+
+    def __init__(
+        self,
+        *,
+        ownedFeatureMembership=None,
+        ownedFeature=None,
+        ownedEndFeature=None,
+        feature=None,
+        input=None,
+        output=None,
+        isAbstract=None,
+        inheritedMembership=None,
+        endFeature=None,
+        isSufficient=None,
+        ownedConjugator=None,
+        isConjugated=None,
+        inheritedFeature=None,
+        multiplicity=None,
+        unioningType=None,
+        ownedIntersecting=None,
+        intersectingType=None,
+        ownedUnioning=None,
+        ownedDisjoining=None,
+        featureMembership=None,
+        differencingType=None,
+        ownedDifferencing=None,
+        directedFeature=None,
+        ownedSpecialization=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isAbstract is not None:
+            self.isAbstract = isAbstract
+
+        if isSufficient is not None:
+            self.isSufficient = isSufficient
+
+        if isConjugated is not None:
+            self.isConjugated = isConjugated
+
+        if ownedFeatureMembership:
+            self.ownedFeatureMembership.extend(ownedFeatureMembership)
+
+        if ownedFeature:
+            self.ownedFeature.extend(ownedFeature)
+
+        if ownedEndFeature:
+            self.ownedEndFeature.extend(ownedEndFeature)
+
+        if feature:
+            self.feature.extend(feature)
+
+        if input:
+            self.input.extend(input)
+
+        if output:
+            self.output.extend(output)
+
+        if inheritedMembership:
+            self.inheritedMembership.extend(inheritedMembership)
+
+        if endFeature:
+            self.endFeature.extend(endFeature)
+
+        if ownedConjugator is not None:
+            self.ownedConjugator = ownedConjugator
+
+        if inheritedFeature:
+            self.inheritedFeature.extend(inheritedFeature)
+
+        if multiplicity is not None:
+            self.multiplicity = multiplicity
+
+        if unioningType:
+            self.unioningType.extend(unioningType)
+
+        if ownedIntersecting:
+            self.ownedIntersecting.extend(ownedIntersecting)
+
+        if intersectingType:
+            self.intersectingType.extend(intersectingType)
+
+        if ownedUnioning:
+            self.ownedUnioning.extend(ownedUnioning)
+
+        if ownedDisjoining:
+            self.ownedDisjoining.extend(ownedDisjoining)
+
+        if featureMembership:
+            self.featureMembership.extend(featureMembership)
+
+        if differencingType:
+            self.differencingType.extend(differencingType)
+
+        if ownedDifferencing:
+            self.ownedDifferencing.extend(ownedDifferencing)
+
+        if directedFeature:
+            self.directedFeature.extend(directedFeature)
+
+        if ownedSpecialization:
+            self.ownedSpecialization.extend(ownedSpecialization)
+
+    def inheritedMemberships(self, excluded=None):
+        """<p>Return the inherited <code>Memberships</code> of this <code>Type</code>, excluding those supertypes in the <code>excluded</code> set.</p>"""
+        raise NotImplementedError(
+            "operation inheritedMemberships(...) not yet implemented"
+        )
+
+    def directionOf(self, feature=None):
+        """<p>If the given <code>feature</code> is a <code>feature</code> of this <code>Type</code>, then return its direction relative to this <code>Type</code>, taking conjugation into account.</p>"""
+        raise NotImplementedError("operation directionOf(...) not yet implemented")
+
+    def allSupertypes(self):
+        """<p>Return all <code>Types</code> related to this <code>Type</code> as supertypes directly or transitively by <code>Specialization</code> <code>Relationships</code>.</p>"""
+        raise NotImplementedError("operation allSupertypes(...) not yet implemented")
+
+    def specializes(self, supertype=None):
+        """<p>Check whether this <code>Type</code> is a direct or indirect specialization of the given <code>supertype<code>.</p>"""
+        raise NotImplementedError("operation specializes(...) not yet implemented")
+
+    def specializesFromLibrary(self, libraryTypeName=None):
+        """<p>Check whether this <code>Type</code> is a direct or indirect specialization of the named library <code>Type</code>. <code>libraryTypeName</code> must conform to the syntax of a KerML qualified name and must resolve to a <code>Type</code> in global scope.</p>"""
+        raise NotImplementedError(
+            "operation specializesFromLibrary(...) not yet implemented"
+        )
+
+
+@abstract
+class Featuring(Relationship):
+    """<p><code>Featuring</code> is a <code>Relationship</code> between a <code>Type</code> and a <code>Feature</code> that is featured by that <code>Type</code>. It asserts that every instance in the domain of the <code>feature</code> must be classified by the <code>type</code>.</p>
+
+    <p><code>Featuring</code> is abstract and does not commit to which of <code>feature</code> or <code>type</code> are the <code>source</code> or <code>target</code> of the <code>Relationship</code>. This commitment is made in the subclasses of <code>Featuring</code>, <code>TypeFeaturing</code> and <code>FeatureMembership</code>, which have opposite directions.</p>
+    """
+
+    type = EReference(ordered=False, unique=True, containment=False, derived=False)
+    feature = EReference(ordered=False, unique=True, containment=False, derived=False)
+
+    def __init__(self, *, type=None, feature=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if type is not None:
+            self.type = type
+
+        if feature is not None:
+            self.feature = feature
+
+
+class FeatureInverting(Relationship):
+    """<p>A <code>FeatureInverting</code> is a <code>Relationship</code> between <code>Features</code> asserting that their interpretations (sequences) are the reverse of each other, identified as <code>featureInverted</code> and <code>invertingFeature</code>. For example, a <code>Feature</code> identifying each person&#39;s parents is the inverse of a <code>Feature</code> identifying each person&#39;s children. A person identified as a parent of another will identify that other as one of their children.</p>"""
+
+    featureInverted = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    invertingFeature = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _owningFeature = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningFeature",
+        transient=True,
+    )
+
+    @property
+    def owningFeature(self):
+        raise NotImplementedError("Missing implementation for owningFeature")
+
+    @owningFeature.setter
+    def owningFeature(self, value):
+        raise NotImplementedError("Missing implementation for owningFeature")
+
+    def __init__(
+        self,
+        *,
+        featureInverted=None,
+        invertingFeature=None,
+        owningFeature=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if featureInverted is not None:
+            self.featureInverted = featureInverted
+
+        if invertingFeature is not None:
+            self.invertingFeature = invertingFeature
+
+        if owningFeature is not None:
+            self.owningFeature = owningFeature
+
+
+class FeatureChaining(Relationship):
+    """<p><code>FeatureChaining</code> is a <code>Relationship</code> that makes its target <code>Feature</code> one of the <code>chainingFeatures</code> of its owning <code>Feature</code>.</p>"""
+
+    chainingFeature = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _featureChained = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="featureChained",
+        transient=True,
+    )
+
+    @property
+    def featureChained(self):
+        raise NotImplementedError("Missing implementation for featureChained")
+
+    @featureChained.setter
+    def featureChained(self, value):
+        raise NotImplementedError("Missing implementation for featureChained")
+
+    def __init__(self, *, chainingFeature=None, featureChained=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if chainingFeature is not None:
+            self.chainingFeature = chainingFeature
+
+        if featureChained is not None:
+            self.featureChained = featureChained
+
+
+class Conjugation(Relationship):
+    """<p><code>Conjugation</code> is a <code>Relationship</code> between two types in which the <code>conjugatedType</code> inherits all the <code>Features</code> of the <code>originalType</code>, but with all <code>input</code> and <code>output</code> <code>Features</code> reversed. That is, any <code>Features</code> with a <code>FeatureMembership</code> with <code>direction</code> <em>in</em> relative to the <code>originalType</code> are considered to have an effective <code>direction</code> of <em>out</em> relative to the <code>conjugatedType</code> and, similarly, <code>Features</code> with <code>direction</code> <em>out</em> in the <code>originalType</code> are considered to have an effective <code>direction</code> of <em>in</em> in the <code>originalType</code>. <code>Features</code> with <code>direction</code> <em>inout</em>, or with no <code>direction</code>, in the <code>originalType</code>, are inherited without change.</p>
+
+    <p>A <code>Type</code> may participate as a <code>conjugatedType</code> in at most one <code>Conjugation</code> relationship, and such a <code>Type</code> may not also be the <code>specific</code> <code>Type</code> in any <code>Specialization</code> relationship.</p>
+    """
+
+    originalType = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    conjugatedType = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _owningType = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningType",
+        transient=True,
+    )
+
+    @property
+    def owningType(self):
+        raise NotImplementedError("Missing implementation for owningType")
+
+    @owningType.setter
+    def owningType(self, value):
+        raise NotImplementedError("Missing implementation for owningType")
+
+    def __init__(
+        self, *, originalType=None, conjugatedType=None, owningType=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if originalType is not None:
+            self.originalType = originalType
+
+        if conjugatedType is not None:
+            self.conjugatedType = conjugatedType
+
+        if owningType is not None:
+            self.owningType = owningType
+
+
+class Intersecting(Relationship):
+    """<p><code>Intersecting</code> is a <code>Relationship</code> that makes its <code>intersectingType</code> one of the <code>intersectingTypes</code> of its <code>typeIntersected</code>.</p>"""
+
+    intersectingType = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _typeIntersected = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="typeIntersected",
+        transient=True,
+    )
+
+    @property
+    def typeIntersected(self):
+        raise NotImplementedError("Missing implementation for typeIntersected")
+
+    @typeIntersected.setter
+    def typeIntersected(self, value):
+        raise NotImplementedError("Missing implementation for typeIntersected")
+
+    def __init__(self, *, intersectingType=None, typeIntersected=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if intersectingType is not None:
+            self.intersectingType = intersectingType
+
+        if typeIntersected is not None:
+            self.typeIntersected = typeIntersected
+
+
+class Unioning(Relationship):
+    """<p><code>Unioning</code> is a <code>Relationship</code> that makes its <code>unioningType</code> one of the <code>unioningTypes</code> of its <code>typeUnioned</code>.</p>"""
+
+    unioningType = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _typeUnioned = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="typeUnioned",
+        transient=True,
+    )
+
+    @property
+    def typeUnioned(self):
+        raise NotImplementedError("Missing implementation for typeUnioned")
+
+    @typeUnioned.setter
+    def typeUnioned(self, value):
+        raise NotImplementedError("Missing implementation for typeUnioned")
+
+    def __init__(self, *, unioningType=None, typeUnioned=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if unioningType is not None:
+            self.unioningType = unioningType
+
+        if typeUnioned is not None:
+            self.typeUnioned = typeUnioned
+
+
+class Disjoining(Relationship):
+    """<p>A <code>Disjoining</code> is a <code>Relationship</code> between <code>Types</code> asserted to have interpretations that are not shared (disjoint) between them, identified as <code>typeDisjoined</code> and <code>disjoiningType</code>. For example, a <code>Classifier</code> for mammals is disjoint from a <code>Classifier</code> for minerals, and a <code>Feature</code> for people&#39;s parents is disjoint from a <code>Feature</code> for their children.</p>"""
+
+    typeDisjoined = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    disjoiningType = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _owningType = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningType",
+        transient=True,
+    )
+
+    @property
+    def owningType(self):
+        raise NotImplementedError("Missing implementation for owningType")
+
+    @owningType.setter
+    def owningType(self, value):
+        raise NotImplementedError("Missing implementation for owningType")
+
+    def __init__(
+        self, *, typeDisjoined=None, disjoiningType=None, owningType=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if typeDisjoined is not None:
+            self.typeDisjoined = typeDisjoined
+
+        if disjoiningType is not None:
+            self.disjoiningType = disjoiningType
+
+        if owningType is not None:
+            self.owningType = owningType
+
+
+class Differencing(Relationship):
+    """<p><code>Differencing</code> is a <code>Relationship</code> that makes its <code>differencingType</code> one of the <code>differencingTypes</code> of its <code>typeDifferenced</code>.</p>"""
+
+    differencingType = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _typeDifferenced = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="typeDifferenced",
+        transient=True,
+    )
+
+    @property
+    def typeDifferenced(self):
+        raise NotImplementedError("Missing implementation for typeDifferenced")
+
+    @typeDifferenced.setter
+    def typeDifferenced(self, value):
+        raise NotImplementedError("Missing implementation for typeDifferenced")
+
+    def __init__(self, *, differencingType=None, typeDifferenced=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if differencingType is not None:
+            self.differencingType = differencingType
+
+        if typeDifferenced is not None:
+            self.typeDifferenced = typeDifferenced
+
+
+class DerivedFiltercondition(EDerivedCollection):
+    pass
+
+
+class Package(Namespace):
+    """<p>A <code>Package</code> is a <code>Namespace</code> used to group <code>Elements</code>, without any instance-level semantics. It may have one or more model-level evaluable <code>filterCondition</code> <code>Expressions</code> used to filter its <code>importedMemberships</code>. Any imported <code>member</code> must meet all of the <code>filterConditions</code>.</p>
+    filterCondition = ownedMembership->
+        selectByKind(ElementFilterMembership).condition"""
+
+    filterCondition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedFiltercondition,
+    )
+
+    def __init__(self, *, filterCondition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if filterCondition:
+            self.filterCondition.extend(filterCondition)
+
+    def includeAsMember(self, element=None):
+        """<p>Determine whether the given <code>element</code> meets all the <code>filterConditions</code>.</p>"""
+        raise NotImplementedError("operation includeAsMember(...) not yet implemented")
+
+
+class OwningMembership(Membership):
+    """<p>An <code>OwningMembership</code> is a <code>Membership</code> that owns its <code>memberElement</code> as a <code>ownedRelatedElement</code>. The <code>ownedMemberElementM</code> becomes an <code>ownedMember</code> of the <code>membershipOwningNamespace</code>.</p>
+
+    ownedMemberName = ownedMemberElement.name
+    ownedMemberShortName = ownedMemberElement.shortName"""
+
+    _ownedMemberElementId = EAttribute(
+        eType=String,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="ownedMemberElementId",
+        transient=True,
+    )
+    _ownedMemberShortName = EAttribute(
+        eType=String,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="ownedMemberShortName",
+        transient=True,
+    )
+    _ownedMemberName = EAttribute(
+        eType=String,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="ownedMemberName",
+        transient=True,
+    )
+    _ownedMemberElement = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedMemberElement",
+        transient=True,
+    )
+
+    @property
+    def ownedMemberElementId(self):
+        raise NotImplementedError("Missing implementation for ownedMemberElementId")
+
+    @ownedMemberElementId.setter
+    def ownedMemberElementId(self, value):
+        raise NotImplementedError("Missing implementation for ownedMemberElementId")
+
+    @property
+    def ownedMemberShortName(self):
+        raise NotImplementedError("Missing implementation for ownedMemberShortName")
+
+    @ownedMemberShortName.setter
+    def ownedMemberShortName(self, value):
+        raise NotImplementedError("Missing implementation for ownedMemberShortName")
+
+    @property
+    def ownedMemberName(self):
+        raise NotImplementedError("Missing implementation for ownedMemberName")
+
+    @ownedMemberName.setter
+    def ownedMemberName(self, value):
+        raise NotImplementedError("Missing implementation for ownedMemberName")
+
+    @property
+    def ownedMemberElement(self):
+        raise NotImplementedError("Missing implementation for ownedMemberElement")
+
+    @ownedMemberElement.setter
+    def ownedMemberElement(self, value):
+        raise NotImplementedError("Missing implementation for ownedMemberElement")
+
+    def __init__(
+        self,
+        *,
+        ownedMemberElementId=None,
+        ownedMemberShortName=None,
+        ownedMemberName=None,
+        ownedMemberElement=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if ownedMemberElementId is not None:
+            self.ownedMemberElementId = ownedMemberElementId
+
+        if ownedMemberShortName is not None:
+            self.ownedMemberShortName = ownedMemberShortName
+
+        if ownedMemberName is not None:
+            self.ownedMemberName = ownedMemberName
+
+        if ownedMemberElement is not None:
+            self.ownedMemberElement = ownedMemberElement
+
+
+class Documentation(Comment):
+    """<p><code>Documentation</code> is a <code>Comment</code> that specifically documents a <code>documentedElement</code>, which must be its <code>owner</code>.</p>"""
+
+    _documentedElement = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="documentedElement",
+        transient=True,
+    )
+
+    @property
+    def documentedElement(self):
+        raise NotImplementedError("Missing implementation for documentedElement")
+
+    @documentedElement.setter
+    def documentedElement(self, value):
+        raise NotImplementedError("Missing implementation for documentedElement")
+
+    def __init__(self, *, documentedElement=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if documentedElement is not None:
+            self.documentedElement = documentedElement
+
+
+class NamespaceImport(Import):
+    """<p>A <code>NamespaceImport</code> is an Import that imports <code>Memberships</code> from its <code>importedNamespace</code> into the <code>importOwningNamespace</code>. If <code> isRecursive = false</code>, then only the visible <code>Memberships</code> of the <code>importOwningNamespace</code> are imported. If <code> isRecursive = true</code>, then, in addition, <code>Memberships</code> are recursively imported from any <code>ownedMembers</code> of the <code>importedNamespace</code> that are <code>Namespaces</code>.</p>
+
+    importedElement = importedNamespace"""
+
+    importedNamespace = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+
+    def __init__(self, *, importedNamespace=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if importedNamespace is not None:
+            self.importedNamespace = importedNamespace
+
+
+class MembershipImport(Import):
+    """<p>A <code>MembershipImport</code> is an <code>Import</code> that imports its <code>importedMembership</code> into the <code>importOwningNamespace</code>. If <code>isRecursive = true</code> and the <code>memberElement</code> of the <code>importedMembership</code> is a <code>Namespace</code>, then the equivalent of a recursive <code>NamespaceImport</code> is also performed on that <code>Namespace</code>.</p>
+
+    importedElement = importedMembership.memberElement"""
+
+    importedMembership = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+
+    def __init__(self, *, importedMembership=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if importedMembership is not None:
+            self.importedMembership = importedMembership
+
+
+class Subclassification(Specialization):
+    """<p><code>Subclassification</code> is <code>Specialization</code> in which both the <code>specific</code> and <code>general</code> <code>Types</code> are <code>Classifier</code>. This means all instances of the specific <code>Classifier</code> are also instances of the general <code>Classifier</code>.</p>"""
+
+    superclassifier = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _owningClassifier = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningClassifier",
+        transient=True,
+    )
+    subclassifier = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+
+    @property
+    def owningClassifier(self):
+        raise NotImplementedError("Missing implementation for owningClassifier")
+
+    @owningClassifier.setter
+    def owningClassifier(self, value):
+        raise NotImplementedError("Missing implementation for owningClassifier")
+
+    def __init__(
+        self,
+        *,
+        superclassifier=None,
+        owningClassifier=None,
+        subclassifier=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if superclassifier is not None:
+            self.superclassifier = superclassifier
+
+        if owningClassifier is not None:
+            self.owningClassifier = owningClassifier
+
+        if subclassifier is not None:
+            self.subclassifier = subclassifier
+
+
+class DerivedType(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedredefinition(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedsubsetting(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedtyping(EDerivedCollection):
+    pass
+
+
+class DerivedFeaturingtype(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedtypefeaturing(EDerivedCollection):
+    pass
+
+
+class DerivedChainingfeature(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedfeatureinverting(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedfeaturechaining(EDerivedCollection):
+    pass
+
+
+class Feature(Type):
+    """<p>A <code>Feature</code> is a <code>Type</code> that classifies relations between multiple things (in the universe). The domain of the relation is the intersection of the <code>featuringTypes</code> of the <code>Feature</code>. (The domain of a <code>Feature</code> with no <code>featuringTyps</code> is implicitly the most general <code>Type</code> <em><code>Base::Anything</code></em> from the Kernel Semantic Library.) The co-domain of the relation is the intersection of the <code>types</code> of the <code>Feature</code>.
+
+    <p>In the simplest cases, the <code>featuringTypes</code> and <code>types</code> are <code>Classifiers</code> and the <code>Feature</code> relates two things, one from the domain and one from the range. Examples include cars paired with wheels, people paired with other people, and cars paired with numbers representing the car length.</p>
+
+    <p>Since <code>Features</code> are <code>Types</code>, their <code>featuringTypes</code> and <code>types</code> can be <code>Features</code>. In this case, the <code>Feature</code> effectively classifies relations between relations, which can be interpreted as the sequence of things related by the domain <code>Feature</code> concatenated with the sequence of things related by the co-domain <code>Feature</code>.</p>
+
+    <p>The <em>values</em> of a <code>Feature</code> for a given instance of its domain are all the instances of its co-domain that are related to that domain instance by the <code>Feature</code>. The values of a <code>Feature</code> with <code>chainingFeatures</code> are the same as values of the last <code>Feature</code> in the chain, which can be found by starting with values of the first <code>Feature</code>, then using those values as domain instances to obtain valus of the second <code>Feature</code>, and so on, to values of the last <code>Feature</code>.</p>
+
+    ownedRedefinition = ownedSubsetting->selectByKind(Redefinition)
+    ownedTypeFeaturing = ownedRelationship->selectByKind(TypeFeaturing)->
+        select(tf | tf.featureOfType = self)
+    ownedSubsetting = ownedSpecialization->selectByKind(Subsetting)
+    ownedTyping = ownedGeneralization->selectByKind(FeatureTyping)
+    type =
+        let types : OrderedSet(Type) = typing.type->
+            union(subsetting.subsettedFeature.type)->
+            asOrderedSet() in
+        if chainingFeature->isEmpty() then types
+        else
+            types->union(chainingFeature->last().type)->
+            asOrderedSet()
+        endif
+    multiplicity <> null implies multiplicity.featuringType = featuringType
+    specializesFromLibrary("Base::things")
+    chainingFeatures->excludes(self)
+    ownedFeatureChaining = ownedRelationship->selectByKind(FeatureChaining)
+    chainingFeature = ownedFeatureChaining.chainingFeature
+    chainingFeatures->size() <> 1
+    isEnd and owningType <> null implies
+        let i : Integer =
+            owningType.ownedFeature->select(isEnd) in
+        owningType.ownedSpecialization.general->
+            forAll(supertype |
+                let ownedEndFeatures : Sequence(Feature) =
+                    supertype.ownedFeature->select(isEnd) in
+                ownedEndFeatures->size() >= i implies
+                    redefines(ownedEndFeatures->at(i))
+    ownedMembership->
+        selectByKind(FeatureValue)->
+        forAll(fv | specializes(fv.value.result))
+    isEnd and owningType <> null and
+    owningType.oclIsKindOf(Association) implies
+        specializesFromLibrary("Links::Link::participants")
+    isComposite and
+    ownedTyping.type->includes(oclIsKindOf(Structure)) and
+    owningType <> null and
+    (owningType.oclIsKindOf(Structure) or
+     owningType.type->includes(oclIsKindOf(Structure))) implies
+        specializesFromLibrary("Occurrence::Occurrence::suboccurrences")
+    owningType <> null and
+    (owningType.oclIsKindOf(LiteralExpression) or
+     owningType.oclIsKindOf(FeatureReferenceExpression)) implies
+        if owningType.oclIsKindOf(LiteralString) then
+            specializesFromLibrary("ScalarValues::String")
+        else if owningType.oclIsKindOf(LiteralBoolean) then
+            specializesFromLibrary("ScalarValues::Boolean")
+        else if owningType.oclIsKindOf(LiteralInteger) then
+            specializesFromLibrary("ScalarValues::Rational")
+        else if owningType.oclIsKindOf(LiteralBoolean) then
+            specializesFromLibrary("ScalarValues::Rational")
+        else if owningType.oclIsKindOf(LiteralBoolean) then
+            specializesFromLibrary("ScalarValues::Real")
+        else specializes(
+            owningType.oclAsType(FeatureReferenceExpression).referent)
+        endif endif endif endif endif
+
+    ownedTyping.type->exists(selectByKind(Class)) implies
+        specializesFromLibrary("Occurrences::occurrences")
+    isComposite and
+    ownedTyping.type->includes(oclIsKindOf(Class)) and
+    owningType <> null and
+    (owningType.oclIsKindOf(Class) or
+     owningType.oclIsKindOf(Feature) and
+        owningType.oclAsType(Feature).type->
+            exists(oclIsKindOf(Class))) implies
+        specializesFromLibrary("Occurrence::Occurrence::suboccurrences")
+    ownedTyping.type->exists(selectByKind(DataType)) implies
+        specializesFromLibary("Base::dataValues")
+    owningType <> null and
+    owningType.oclIsKindOf(ItemFlowEnd) and
+    owningType.ownedFeature->at(1) = self implies
+        let flowType : Type = owningType.owningType in
+        flowType <> null implies
+            let i : Integer =
+                flowType.ownedFeature.indexOf(owningType) in
+            (i = 1 implies
+                redefinesFromLibrary("Transfers::Transfer::source::sourceOutput")) and
+            (i = 2 implies
+                redefinesFromLibrary("Transfers::Transfer::source::targetInput"))
+
+    owningType <> null and
+    (owningType.oclIsKindOf(Behavior) or
+     owningType.oclIsKindOf(Step)) implies
+        let i : Integer =
+            owningType.ownedFeature->select(direction <> null) in
+        owningType.ownedSpecialization.general->
+            forAll(supertype |
+                let ownedParameters : Sequence(Feature) =
+                    supertype.ownedFeature->select(direction <> null) in
+                ownedParameters->size() >= i implies
+                    redefines(ownedParameters->at(i))
+    ownedTyping.type->exists(selectByKind(Structure)) implies
+        specializesFromLibary("Objects::objects")
+    owningType <> null and
+    (owningType.oclIsKindOf(Function) and
+        self = owningType.oclAsType(Function).result or
+     owningType.oclIsKindOf(Expression) and
+        self = owningType.oclAsType(Expression).result) implies
+        owningType.ownedSpecialization.general->
+            select(oclIsKindOf(Function) or oclIsKindOf(Expression))->
+            forAll(supertype |
+                redefines(
+                    if superType.oclIsKindOf(Function) then
+                        superType.oclAsType(Function).result
+                    else
+                        superType.oclAsType(Expression).result
+                    endif)
+    ownedFeatureInverting = ownedRelationship->selectByKind(FeatureInverting)->
+        select(fi | fi.featureInverted = self)
+    featuringType =
+        let featuringTypes : OrderedSet(Type) =
+            typeFeaturing.featuringType->asOrderedSet() in
+        if chainingFeature->isEmpty() then featuringTypes
+        else
+            featuringTypes->
+                union(chainingFeature->first().featuringType)->
+                asOrderedSet()
+        endif
+    ownedReferenceSubsetting =
+        let referenceSubsettings : OrderedSet(ReferenceSubsetting) =
+            ownedSubsetting->selectByKind(ReferenceSubsetting) in
+        if referenceSubsettings->isEmpty() then null
+        else referenceSubsettings->first() endif
+    ownedSubsetting->selectByKind(ReferenceSubsetting)->size() <= 1"""
+
+    isUnique = EAttribute(
+        eType=Boolean, unique=True, derived=False, changeable=True, default_value="true"
+    )
+    isOrdered = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    isComposite = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    isEnd = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    isDerived = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    isReadOnly = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    isPortion = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    direction = EAttribute(
+        eType=FeatureDirectionKind, unique=True, derived=False, changeable=True
+    )
+    _isNonunique = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="isNonunique",
+        default_value="false",
+        transient=True,
+    )
+    _owningType = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningType",
+        transient=True,
+    )
+    type = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedType,
+    )
+    ownedRedefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedredefinition,
+    )
+    ownedSubsetting = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedsubsetting,
+    )
+    _owningFeatureMembership = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningFeatureMembership",
+        transient=True,
+    )
+    _endOwningType = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="endOwningType",
+        transient=True,
+    )
+    ownedTyping = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedtyping,
+    )
+    featuringType = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedFeaturingtype,
+    )
+    ownedTypeFeaturing = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedtypefeaturing,
+    )
+    chainingFeature = EReference(
+        ordered=True,
+        unique=False,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedChainingfeature,
+    )
+    ownedFeatureInverting = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedfeatureinverting,
+    )
+    ownedFeatureChaining = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedfeaturechaining,
+    )
+    _ownedReferenceSubsetting = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedReferenceSubsetting",
+        transient=True,
+    )
+
+    @property
+    def owningType(self):
+        raise NotImplementedError("Missing implementation for owningType")
+
+    @owningType.setter
+    def owningType(self, value):
+        raise NotImplementedError("Missing implementation for owningType")
+
+    @property
+    def owningFeatureMembership(self):
+        raise NotImplementedError("Missing implementation for owningFeatureMembership")
+
+    @owningFeatureMembership.setter
+    def owningFeatureMembership(self, value):
+        raise NotImplementedError("Missing implementation for owningFeatureMembership")
+
+    @property
+    def endOwningType(self):
+        raise NotImplementedError("Missing implementation for endOwningType")
+
+    @endOwningType.setter
+    def endOwningType(self, value):
+        raise NotImplementedError("Missing implementation for endOwningType")
+
+    @property
+    def ownedReferenceSubsetting(self):
+        raise NotImplementedError("Missing implementation for ownedReferenceSubsetting")
+
+    @ownedReferenceSubsetting.setter
+    def ownedReferenceSubsetting(self, value):
+        raise NotImplementedError("Missing implementation for ownedReferenceSubsetting")
+
+    @property
+    def isNonunique(self):
+        raise NotImplementedError("Missing implementation for isNonunique")
+
+    @isNonunique.setter
+    def isNonunique(self, value):
+        raise NotImplementedError("Missing implementation for isNonunique")
+
+    def __init__(
+        self,
+        *,
+        owningType=None,
+        isUnique=None,
+        isOrdered=None,
+        type=None,
+        ownedRedefinition=None,
+        ownedSubsetting=None,
+        owningFeatureMembership=None,
+        isComposite=None,
+        isEnd=None,
+        endOwningType=None,
+        ownedTyping=None,
+        featuringType=None,
+        ownedTypeFeaturing=None,
+        isDerived=None,
+        chainingFeature=None,
+        ownedFeatureInverting=None,
+        ownedFeatureChaining=None,
+        isReadOnly=None,
+        isPortion=None,
+        direction=None,
+        ownedReferenceSubsetting=None,
+        isNonunique=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isUnique is not None:
+            self.isUnique = isUnique
+
+        if isOrdered is not None:
+            self.isOrdered = isOrdered
+
+        if isComposite is not None:
+            self.isComposite = isComposite
+
+        if isEnd is not None:
+            self.isEnd = isEnd
+
+        if isDerived is not None:
+            self.isDerived = isDerived
+
+        if isReadOnly is not None:
+            self.isReadOnly = isReadOnly
+
+        if isPortion is not None:
+            self.isPortion = isPortion
+
+        if direction is not None:
+            self.direction = direction
+
+        if isNonunique is not None:
+            self.isNonunique = isNonunique
+
+        if owningType is not None:
+            self.owningType = owningType
+
+        if type:
+            self.type.extend(type)
+
+        if ownedRedefinition:
+            self.ownedRedefinition.extend(ownedRedefinition)
+
+        if ownedSubsetting:
+            self.ownedSubsetting.extend(ownedSubsetting)
+
+        if owningFeatureMembership is not None:
+            self.owningFeatureMembership = owningFeatureMembership
+
+        if endOwningType is not None:
+            self.endOwningType = endOwningType
+
+        if ownedTyping:
+            self.ownedTyping.extend(ownedTyping)
+
+        if featuringType:
+            self.featuringType.extend(featuringType)
+
+        if ownedTypeFeaturing:
+            self.ownedTypeFeaturing.extend(ownedTypeFeaturing)
+
+        if chainingFeature:
+            self.chainingFeature.extend(chainingFeature)
+
+        if ownedFeatureInverting:
+            self.ownedFeatureInverting.extend(ownedFeatureInverting)
+
+        if ownedFeatureChaining:
+            self.ownedFeatureChaining.extend(ownedFeatureChaining)
+
+        if ownedReferenceSubsetting is not None:
+            self.ownedReferenceSubsetting = ownedReferenceSubsetting
+
+    def directionFor(self, type=None):
+        """<p>Return the <code>directionOf</code> this <code>Feature</code> relative to the given <code>type</code>.</p>"""
+        raise NotImplementedError("operation directionFor(...) not yet implemented")
+
+    def isFeaturedWithin(self, type=None):
+        """<p>Return whether this Feature has the given <code>type</code> as a direct or indirect <code>featuringType</code>. If <code>type</code> is null, then check if this Feature is implicitly directly or indirectly featured in <em>Base::Anything</em>.</p>"""
+        raise NotImplementedError("operation isFeaturedWithin(...) not yet implemented")
+
+    def namingFeature(self):
+        """<p>By default, the naming <code>Feature</code> of a <code>Feature</code> is given by its first <code>redefinedFeature</code> of its first <code>ownedRedefinition</code>, if any.</p>"""
+        raise NotImplementedError("operation namingFeature(...) not yet implemented")
+
+    def redefines(self, redefinedFeature=None):
+        """<p>Check whether this <code>Feature</code> <em>directly</em> redefines the given <code>redefinedFeature</code>.</p>"""
+        raise NotImplementedError("operation redefines(...) not yet implemented")
+
+    def redefinesFromLibrary(self, libraryFeatureName=None):
+        """<p>Check whether this <code>Feature</code> <em>directly</em> redefines the named library <code>Feature</code>. <code>libraryFeatureName</code> must conform to the syntax of a KerML qualified name and must resolve to a <code>Feature</code> in global scope.</p>"""
+        raise NotImplementedError(
+            "operation redefinesFromLibrary(...) not yet implemented"
+        )
+
+    def subsetsChain(self, first=None, second=None):
+        """<p>Check whether this <code>Feature</code> directly or indirectly specializes a <code>Feature</code> whose last two <code>chainingFeatures</code> are the given <code>Features</code> <code>first</code> and <code>second</code>.</p>"""
+        raise NotImplementedError("operation subsetsChain(...) not yet implemented")
+
+
+class Subsetting(Specialization):
+    """<p><code>Subsetting</code> is <code>Specialization</code> in which the <code>specific</code> and <code>general</code> <code>Types</code> are <code>Features</code>. This means all values of the <code>subsettingFeature</code> (on instances of its domain, i.e., the intersection of its <code>featuringTypes</code>) are values of the <code>subsettedFeature</code> on instances of its domain. To support this the domain of the <code>subsettingFeature</code> must be the same or specialize (at least indirectly) the domain of the <code>subsettedFeature</code> (via <code>Specialization</code>), and the co-domain (intersection of the <code>types</code>) of the <code>subsettingFeature</code> must specialize the co-domain of the <code>subsettedFeature</code>.</p>
+
+    let subsettingFeaturingTypes: OrderedSet(Type) =
+        subsettingFeature.featuringTypes in
+    let subsettedFeaturingTypes: OrderedSet(Type) =
+        subsettedFeature.featuringTypes in
+    let anythingType: Element =
+        subsettingFeature.resolveGlobal('Base::Anything') in
+    subsettedFeaturingTypes->forAll(t |
+        subsettingFeaturingTypes->isEmpty() and t = anythingType or
+        subsettingFeaturingTypes->exists(specializes(t))"""
+
+    subsettedFeature = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    subsettingFeature = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _owningFeature = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningFeature",
+        transient=True,
+    )
+
+    @property
+    def owningFeature(self):
+        raise NotImplementedError("Missing implementation for owningFeature")
+
+    @owningFeature.setter
+    def owningFeature(self, value):
+        raise NotImplementedError("Missing implementation for owningFeature")
+
+    def __init__(
+        self,
+        *,
+        subsettedFeature=None,
+        subsettingFeature=None,
+        owningFeature=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if subsettedFeature is not None:
+            self.subsettedFeature = subsettedFeature
+
+        if subsettingFeature is not None:
+            self.subsettingFeature = subsettingFeature
+
+        if owningFeature is not None:
+            self.owningFeature = owningFeature
+
+
+class FeatureTyping(Specialization):
+    """<p><code>FeatureTyping</code> is <code>Specialization</code> in which the <code>specific</code> <code>Type</code> is a <code>Feature</code>. This means the set of instances of the (specific) <code>typedFeature</code> is a subset of the set of instances of the (general) <code>type</code>. In the simplest case, the <code>type</code> is a <code>Classifier</code>, whereupon the <code>typedFeature</code> has values that are instances of the <code>Classifier</code>.</p>"""
+
+    typedFeature = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    type = EReference(ordered=False, unique=True, containment=False, derived=False)
+    _owningFeature = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningFeature",
+        transient=True,
+    )
+
+    @property
+    def owningFeature(self):
+        raise NotImplementedError("Missing implementation for owningFeature")
+
+    @owningFeature.setter
+    def owningFeature(self, value):
+        raise NotImplementedError("Missing implementation for owningFeature")
+
+    def __init__(self, *, typedFeature=None, type=None, owningFeature=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if typedFeature is not None:
+            self.typedFeature = typedFeature
+
+        if type is not None:
+            self.type = type
+
+        if owningFeature is not None:
+            self.owningFeature = owningFeature
+
+
+class TypeFeaturing(Featuring):
+    """<p>A <code>TypeFeaturing</code> is a <code>Featuring</code> <code>Relationship</code> in which the <code>featureOfType</code> is the <code>source</code> and the <code>featuringType</code> is the <code>target</code>.</p>"""
+
+    featureOfType = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    featuringType = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _owningFeatureOfType = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningFeatureOfType",
+        transient=True,
+    )
+
+    @property
+    def owningFeatureOfType(self):
+        raise NotImplementedError("Missing implementation for owningFeatureOfType")
+
+    @owningFeatureOfType.setter
+    def owningFeatureOfType(self, value):
+        raise NotImplementedError("Missing implementation for owningFeatureOfType")
+
+    def __init__(
+        self,
+        *,
+        featureOfType=None,
+        featuringType=None,
+        owningFeatureOfType=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if featureOfType is not None:
+            self.featureOfType = featureOfType
+
+        if featuringType is not None:
+            self.featuringType = featuringType
+
+        if owningFeatureOfType is not None:
+            self.owningFeatureOfType = owningFeatureOfType
+
+
+class DerivedOwnedsubclassification(EDerivedCollection):
+    pass
+
+
+class Classifier(Type):
+    """<p>A <code>Classifier</code> is a <code>Type</code> that classifies:</p>
+
+    <ul>
+            <li>Things (in the universe) regardless of how <code>Features</code> relate them. (These are interpreted semantically as sequences of exactly one thing.)</li>
+            <li>How the above things are related by <code>Features.</code> (These are interpreted semantically as sequences of multiple things, such that the last thing in the sequence is also classified by the <code>Classifier</code>. Note that his means that a <code>Classifier</code> modeled as specializing a <code>Feature</code> cannot classify anything.)</li>
+    </ul>
+
+
+    ownedSubclassification =
+        ownedSpecialization->selectByKind(Superclassification)
+    multiplicity <> null implies multiplicity.featuringType->isEmpty()"""
+
+    ownedSubclassification = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedsubclassification,
+    )
+
+    def __init__(self, *, ownedSubclassification=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if ownedSubclassification:
+            self.ownedSubclassification.extend(ownedSubclassification)
+
+
+class LibraryPackage(Package):
+    """<p>A <code>LibraryPackage</code> is a <code>Package</code> that is the container for a model library. A <code>LibraryPackage</code> is itself a library <code>Element</code> as are all <code>Elements</code> that are directly or indirectly contained in it.</p>"""
+
+    isStandard = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+
+    def __init__(self, *, isStandard=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if isStandard is not None:
+            self.isStandard = isStandard
+
+
+class Redefinition(Subsetting):
+    """<p><code>Redefinition</code> is a kind of <code>Subsetting</code> that requires the <code>redefinedFeature</code> and the <code>redefiningFeature</code> to have the same values (on each instance of the domain of the <code>redefiningFeature</code>). This means any restrictions on the <code>redefiningFeature</code>, such as <code>type</code> or <code>multiplicity</code>, also apply to the <code>redefinedFeature</code> (on each instance of the domain of the <code>redefiningFeature</code>), and vice versa. The <code>redefinedFeature</code> might have values for instances of the domain of the <code>redefiningFeature</code>, but only as instances of the domain of the <code>redefinedFeature</code> that happen to also be instances of the domain of the <code>redefiningFeature</code>. This is supported by the constraints inherited from <code>Subsetting</code> on the domains of the <code>redefiningFeature</code> and <code>redefinedFeature</code>. However, these constraints are narrowed for <code>Redefinition</code> to require the <code>owningTypes</code> of the <code>redefiningFeature</code> and <code>redefinedFeature</code> to be different and the <code>redefinedFeature</code> to not be inherited into the <code>owningNamespace</code> of the <code>redefiningFeature</code>.This enables the <code>redefiningFeature</code> to have the same name as the <code>redefinedFeature</code>, if desired.</p>
+
+    let anythingType: Type =
+        subsettingFeature.resolveGlobal('Base::Anything').oclAsType(Type) in
+    -- Including "Anything" accounts for implicit featuringType of Features
+    -- with no explicit featuringType.
+    let subsettingFeaturingTypes: Set(Type) =
+        subsettingFeature.featuringTypes->asSet()->including(anythingType) in
+    let subsettedFeaturingTypes: Set(Type) =
+        subsettedFeature.featuringTypes->asSet()->including(anythingType) in
+    subsettingFeaturingTypes <> subsettedFeaturingType"""
+
+    redefiningFeature = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    redefinedFeature = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+
+    def __init__(self, *, redefiningFeature=None, redefinedFeature=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if redefiningFeature is not None:
+            self.redefiningFeature = redefiningFeature
+
+        if redefinedFeature is not None:
+            self.redefinedFeature = redefinedFeature
+
+
+class ReferenceSubsetting(Subsetting):
+    """<p><code>ReferenceSubsetting</code> is a kind of <code>Subsetting</code> in which the <code>referencedFeature</code> is syntactically distinguished from other <code>Features</code> subsetted by the <code>referencingFeature</code>. <code>ReferenceSubsetting</code> has the same semantics as <code>Subsetting</code>, but the <code>referenceFeature</code> may have a special purpose relative to the <code>referencingFeature</code>. For instance, <code>ReferenceSubsetting</code> is used to identify the <code>relatedFeatures</code> of a <code>Connector</code>.</p>
+
+    <p><code>ReferenceSubsetting</code> is always an <code>ownedRelationship</code> of its <code>referencingFeature</code>. A <code>Feature</code> can have at most one <code>ownedReferenceSubsetting</code>.</p>
+    """
+
+    referencedFeature = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+    _referencingFeature = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="referencingFeature",
+        transient=True,
+    )
+
+    @property
+    def referencingFeature(self):
+        raise NotImplementedError("Missing implementation for referencingFeature")
+
+    @referencingFeature.setter
+    def referencingFeature(self, value):
+        raise NotImplementedError("Missing implementation for referencingFeature")
+
+    def __init__(self, *, referencedFeature=None, referencingFeature=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if referencedFeature is not None:
+            self.referencedFeature = referencedFeature
+
+        if referencingFeature is not None:
+            self.referencingFeature = referencingFeature
+
+
+class Multiplicity(Feature):
+    """<p>A <code>Multiplicity</code> is a <code>Feature</code> whose co-domain is a set of natural numbers giving the allowed cardinalities of each <code>typeWithMultiplicity</code>. The <em>cardinality</em> of a <code>Type</code> is defined as follows, depending on whether the <code>Type</code> is a <code>Classifier</code> or <code>Feature</code>.
+    <ul>
+    <li><code>Classifier</code> – The number of basic instances of the <code>Classifier</code>, that is, those instances representing things, which are not instances of any subtypes of the <code>Classifier</code> that are <code>Features</code>.
+    <li><code>Features</code> – The number of instances with the same featuring instances. In the case of a <code>Feature</code> with a <code>Classifier</code> as its <code>featuringType</code>, this is the number of values of <code>Feature</code> for each basic instance of the <code>Classifier</code>. Note that, for non-unique <code>Features</code>, all duplicate values are included in this count.</li>
+    </ul>
+
+    <p><code>Multiplicity</code> co-domains (in models) can be specified by <code>Expression</code> that might vary in their results. If the <code>typeWithMultiplicity</code> is a <code>Classifier</code>, the domain of the <code>Multiplicity</code> shall be <em><code>Base::Anything</code></em>.  If the <code>typeWithMultiplicity</code> is a <code>Feature</code>,  the <code>Multiplicity</code> shall have the same domain as the <code>typeWithMultiplicity</code>.</p>
+
+    if owningType <> null and owningType.oclIsKindOf(Feature) then
+        featuringType =
+            owningType.oclAsType(Feature).featuringType
+    else
+        featuringType->isEmpty()
+    endif
+    specializesFromLibrary("Base::naturals")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class Class(Classifier):
+    """<p>A <code>Class</code> is a <code>Classifier</code> of things (in the universe) that can be distinguished without regard to how they are related to other things (via <code>Features</code>). This means multiple things classified by the same <code>Class</code> can be distinguished, even when they are related other things in exactly the same way.</p>
+
+    specializesFromLibrary('Occurrences::Occurrence')
+    ownedSpecialization.general->
+        forAll(not oclIsKindOf(DataType)) and
+    not oclIsKindOf(AssociationStructure) implies
+        ownedSpecialization.general->
+            forAll(not oclIsKindOf(Association))"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class DataType(Classifier):
+    """<p>A <code>DataType</code> is a <code>Classifier</code> of things (in the universe) that can only be distinguished by how they are related to other things (via Features). This means multiple things classified by the same <code>DataType</code></p>
+
+    <ul>
+            <li>Cannot be distinguished when they are related to other things in exactly the same way, even when they are intended to be about different things.</li>
+            <li>Can be distinguished when they are related to other things in different ways, even when they are intended to be about the same thing.</li>
+    </ul>
+
+    specializesFromLibrary('Base::DataValue')
+    ownedSpecialization.general->
+        forAll(not oclIsKindOf(Class) and
+               not oclIsKindOf(Association))"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class DerivedBehavior(EDerivedCollection):
+    pass
+
+
+class DerivedParameter(EDerivedCollection):
+    pass
+
+
+class Step(Feature):
+    """<p>A <code>Step</code> is a <code>Feature</code> that is typed by one or more <code>Behaviors</code>. <code>Steps</code> may be used by one <code>Behavior</code> to coordinate the performance of other <code>Behaviors</code>, supporting a steady refinement of behavioral descriptions. <code>Steps</code> can be ordered in time and can be connected using <code>ItemFlows</code> to specify things flowing between their <code>parameters</code>.</p>
+
+    allSupertypes()->includes(resolveGlobal("Performances::performances"))
+    owningType <> null and
+        (owningType.oclIsKindOf(Behavior) or
+         owningType.oclIsKindOf(Step)) implies
+        specializesFromLibrary('Performances::Performance::enclosedPerformance')
+    isComposite and owningType <> null and
+    (owningType.oclIsKindOf(Structure) or
+     owningType.oclIsKindOf(Feature) and
+     owningType.oclAsType(Feature).type->
+        exists(oclIsKindOf(Structure)) implies
+        specializesFromLibrary('Objects::Object::ownedPerformance')
+    owningType <> null and
+        (owningType.oclIsKindOf(Behavior) or
+         owningType.oclIsKindOf(Step)) and
+        self.isComposite implies
+        specializesFromLibrary('Performances::Performance::subperformance')
+    behavior = type->selectByKind(Behavior)"""
+
+    behavior = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedBehavior,
+    )
+    parameter = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedParameter,
+    )
+
+    def __init__(self, *, behavior=None, parameter=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if behavior:
+            self.behavior.extend(behavior)
+
+        if parameter:
+            self.parameter.extend(parameter)
+
+
+class ElementFilterMembership(OwningMembership):
+    """<p><code>ElementFilterMembership</code> is a <code>Membership</code> between a <code>Namespace</code> and a model-level evaluable <code><em>Boolean</em></code>-valued <code>Expression</code>, asserting that imported <code>members</code> of the <code>Namespace</code> should be filtered using the <code>condition</code> <code>Expression</code>. A general <code>Namespace</code> does not define any specific filtering behavior, but such behavior may be defined for various specialized kinds of <code>Namespaces</code>.</p>
+
+    condition.isModelLevelEvaluable
+    condition.result.specializesFromLibrary('ScalarValues::Boolean')"""
+
+    _condition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="condition",
+        transient=True,
+    )
+
+    @property
+    def condition(self):
+        raise NotImplementedError("Missing implementation for condition")
+
+    @condition.setter
+    def condition(self, value):
+        raise NotImplementedError("Missing implementation for condition")
+
+    def __init__(self, *, condition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if condition is not None:
+            self.condition = condition
+
+
+class FeatureValue(OwningMembership):
+    """<p>A <code>FeatureValue</code> is a <code>Membership</code> that identifies a particular member <code>Expression</code> that provides the value of the <code>Feature</code> that owns the <code>FeatureValue</code>. The value is specified as either a bound value or an initial value, and as either a concrete or default value. A <code>Feature</code> can have at most one <code>FeatureValue</code>.</p>
+
+    <p>The result of the <code>value</code> <code>Expression</code> is bound to the <code>featureWithValue</code> using a <code>BindingConnector</code>. If <code>isInitial = false</code>, then the <code>featuringType</code> of the <code>BindingConnector</code> is the same as the <code>featuringType</code> of the <code>featureWithValue</code>. If <code>isInitial = true</code>, then the <code>featuringType</code> of the <code>BindingConnector</code> is restricted to its <code>startShot</code>.
+
+    <p>If <code>isDefault = false</code>, then the above semantics of the <code>FeatureValue</code> are realized for the given <code>featureWithValue</code>. Otherwise, the semantics are realized for any individual of the <code>featuringType</code> of the <code>featureWithValue</code>, unless another value is explicitly given for the <code>featureWithValue</code> for that individual.</p>
+
+    not isDefault implies
+        featureWithValue.ownedMember->
+            selectByKind(BindingConnector)->exists(b |
+                b.relatedFeature->includes(featureWithValue) and
+                b.relatedFeature->includes(value.result) and
+                if not isInitial then
+                    b.featuringType = featureWithValue.featuringType
+                else
+                    b.featuringType->exists(t |
+                        t.oclIsKindOf(Feature) and
+                        t.oclAsType(Feature).chainingFeature =
+                            Sequence{
+                                resolveGlobal("Base::things::that"),
+                                resolveGlobal("Occurrences::Occurrence::startShot")
+                            }
+                    )
+                endif)"""
+
+    isInitial = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    isDefault = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    _featureWithValue = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="featureWithValue",
+        transient=True,
+    )
+    _value = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="value",
+        transient=True,
+    )
+
+    @property
+    def featureWithValue(self):
+        raise NotImplementedError("Missing implementation for featureWithValue")
+
+    @featureWithValue.setter
+    def featureWithValue(self, value):
+        raise NotImplementedError("Missing implementation for featureWithValue")
+
+    @property
+    def value(self):
+        raise NotImplementedError("Missing implementation for value")
+
+    @value.setter
+    def value(self, value):
+        raise NotImplementedError("Missing implementation for value")
+
+    def __init__(
+        self,
+        *,
+        featureWithValue=None,
+        value=None,
+        isInitial=None,
+        isDefault=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isInitial is not None:
+            self.isInitial = isInitial
+
+        if isDefault is not None:
+            self.isDefault = isDefault
+
+        if featureWithValue is not None:
+            self.featureWithValue = featureWithValue
+
+        if value is not None:
+            self.value = value
+
+
+class ItemFlowEnd(Feature):
+    """<p>An <code>ItemFlowEnd</code> is a <code>Feature</code> that is one of the <code>connectorEnds</code> giving the <code><em>source</em></code> or <code><em>target</em></code> of an <code>ItemFlow</code>. For <code>ItemFlows</code> typed by <code><em>FlowTransfer</em></code> or its specializations, <code>ItemFlowEnds</code> must have exactly one <code>ownedFeature</code>, which redefines <code><em>Transfer::source::sourceOutput</em></code> or <code><em>Transfer::target::targetInput</em></code> and redefines the corresponding feature of the <code>relatedElement</code> for its end.</p>
+    isEnd
+    ownedFeature->size() = 1
+    owningType <> null and owningType.oclIsKindOf(ItemFlow)"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class ItemFeature(Feature):
+    """<p>An <code>ItemFeature</code> is the <code>ownedFeature</code> of an <code>ItemFlow</code> that identifies the things carried by the kinds of transfers that are instances of the <code>ItemFlow</code>.</p>
+    ownedRedefinition.redefinedFeature->
+        redefinesFromLibrary("Transfers::Transfer::item")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class FeatureMembership(OwningMembership, Featuring):
+    """<p>A <code>FeatureMembership</code> is an <code>OwningMembership</code> between a <code>Feature</code> in an <code>owningType</code> that is also a <code>Featuring</code> <code>Relationship<code? between the <code>Feature</code> and the <code>Type</code>, in which the <code>featuringType</code> is the <code>source</code> and the <code>featureOfType</code> is the <code>target</code>. A <code>FeatureMembership</code> is always owned by its <code>owningType</code>, which is the <code>featuringType</code> for the <code>FeatureMembership</code> considered as a <code>Featuring</code>.</p>"""
+
+    _ownedMemberFeature = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedMemberFeature",
+        transient=True,
+    )
+    _owningType = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningType",
+        transient=True,
+    )
+
+    @property
+    def ownedMemberFeature(self):
+        raise NotImplementedError("Missing implementation for ownedMemberFeature")
+
+    @ownedMemberFeature.setter
+    def ownedMemberFeature(self, value):
+        raise NotImplementedError("Missing implementation for ownedMemberFeature")
+
+    @property
+    def owningType(self):
+        raise NotImplementedError("Missing implementation for owningType")
+
+    @owningType.setter
+    def owningType(self, value):
+        raise NotImplementedError("Missing implementation for owningType")
+
+    def __init__(self, *, ownedMemberFeature=None, owningType=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if ownedMemberFeature is not None:
+            self.ownedMemberFeature = ownedMemberFeature
+
+        if owningType is not None:
+            self.owningType = owningType
+
+
+class Structure(Class):
+    """<p>A <code>Structure</code> is a <code>Class</code> of objects in the modeled universe that are primarily structural in nature. While such an object is not itself behavioral, it may be involved in and acted on by <code>Behaviors</code>, and it may be the performer of some of them.</p>
+
+    specializesFromLibrary('Objects::Object')"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class Expression(Step):
+    """<p>An <code>Expression</code> is a <code>Step</code> that is typed by a <code>Function</code>. An <code>Expression</code> that also has a <code>Function</code> as its <code>featuringType</code> is a computational step within that <code>Function</code>. An <code>Expression</code> always has a single <code>result</code> parameter, which redefines the <code>result</code> parameter of its defining <code>function</code>. This allows <code>Expressions</code> to be interconnected in tree structures, in which inputs to each <code>Expression</code> in the tree are determined as the results of other <code>Expression</code> in the tree.</p>
+
+    isModelLevelEvaluable = modelLevelEvaluable(Set(Element){})
+    specializesFromLibrary("Performances::evaluations")
+    owningMembership <> null and
+    owningMembership.oclIsKindOf(FeatureValue) implies
+        let featureWithValue : Feature =
+            owningMembership.oclAsType(FeatureValue).featureWithValue in
+        featuringType = featureWithValue.featuringType
+    ownedMembership.selectByKind(ResultExpressionMembership)->
+        forAll(mem | ownedFeature.selectByKind(BindingConnector)->
+            exists(binding |
+                binding.relatedFeature->includes(result) and
+                binding.relatedFeature->includes(mem.ownedResultExpression.result)))
+    result =
+        let resultParams : Sequence(Feature) =
+            ownedFeatureMemberships->
+                selectByKind(ReturnParameterMembership).
+                ownedParameterMember in
+        if resultParams->notEmpty() then resultParams->first()
+        else if function <> null then function.result
+        else null
+        endif endif
+    ownedFeatureMembership->
+        selectByKind(ReturnParameterMembership)->
+        size() <= 1"""
+
+    _isModelLevelEvaluable = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="isModelLevelEvaluable",
+        transient=True,
+    )
+    _function = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="function",
+        transient=True,
+    )
+    _result = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="result",
+        transient=True,
+    )
+
+    @property
+    def function(self):
+        raise NotImplementedError("Missing implementation for function")
+
+    @function.setter
+    def function(self, value):
+        raise NotImplementedError("Missing implementation for function")
+
+    @property
+    def result(self):
+        raise NotImplementedError("Missing implementation for result")
+
+    @result.setter
+    def result(self, value):
+        raise NotImplementedError("Missing implementation for result")
+
+    @property
+    def isModelLevelEvaluable(self):
+        raise NotImplementedError("Missing implementation for isModelLevelEvaluable")
+
+    @isModelLevelEvaluable.setter
+    def isModelLevelEvaluable(self, value):
+        raise NotImplementedError("Missing implementation for isModelLevelEvaluable")
+
+    def __init__(
+        self, *, function=None, result=None, isModelLevelEvaluable=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isModelLevelEvaluable is not None:
+            self.isModelLevelEvaluable = isModelLevelEvaluable
+
+        if function is not None:
+            self.function = function
+
+        if result is not None:
+            self.result = result
+
+    def modelLevelEvaluable(self, visited=None):
+        """<p>Return whether this <code>Expression</code> is model-level evaluable. The <code>visited</code> parameter is used to track possible circular <code>Feature</code> references. Such circular references are not allowed in model-level evaluable expressions.</p>
+
+        <p>An <code>Expression</code> that is not otherwise specialized is model-level evaluable if all of it has no <code>ownedSpecialziations</code> and all its (non-implicit) <code>features</code> are either <code>in</code> parameters, the <code>result</code> <code>parameter</code> or a result <code>Expression</code> owned via a <code>ResultExpressionMembership</code>. The <code>parameters</code>  must not have any <code>ownedFeatures</code> or a <code>FeatureValue</code>, and the result <code>Expression</code> must be model-level evaluable.</p>
+        """
+        raise NotImplementedError(
+            "operation modelLevelEvaluable(...) not yet implemented"
+        )
+
+    def evaluate(self, target=None):
+        """<p>If this <code>Expression</code> <code>isModelLevelEvaluable</code>, then evaluate it using the <code>target</code> as the context <code>Element</code> for resolving <code>Feature</code> names and testing classification. The result is a collection of <code>Elements</code>, which, for a fully evaluable <code>Expression</code>, will be a <code>LiteralExpression</code> or a <code>Feature</code> that is not an <code>Expression</code>.</p>"""
+        raise NotImplementedError("operation evaluate(...) not yet implemented")
+
+    def checkCondition(self, target=None):
+        """<p>Model-level evaluate this <code>Expression</code> with the given <code>target</code>. If the result is a <code>LiteralBoolean</code>, return its <code>value</code>. Otherwise return <code>false</code>.</p>"""
+        raise NotImplementedError("operation checkCondition(...) not yet implemented")
+
+
+class DerivedStep(EDerivedCollection):
+    pass
+
+
+class Behavior(Class):
+    """<p>A <code>Behavior </code>coordinates occurrences of other <code>Behaviors</code>, as well as changes in objects. <code>Behaviors</code> can be decomposed into <code>Steps</code> and be characterized by <code>parameters</code>.</p>
+
+    specializesFromLibrary("Performances::Performance")
+    step = feature->selectByKind(Step)"""
+
+    step = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedStep,
+    )
+    parameter = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedParameter,
+    )
+
+    def __init__(self, *, step=None, parameter=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if step:
+            self.step.extend(step)
+
+        if parameter:
+            self.parameter.extend(parameter)
+
+
+class MetadataFeature(Feature, AnnotatingElement):
+    """<p>A <code>MetadataFeature</code> is a <code>Feature</code> that is an <code>AnnotatingElement</code> used to annotate another <code>Element</code> with metadata. It is typed by a <code>Metaclass</code>. All its <code>ownedFeatures</code> must redefine <code>features</code> of its <code>metaclass</code> and any feature bindings must be model-level evaluable.</p>
+
+
+    specializesFromLibrary("Metaobjects::metaobjects")
+    isSemantic() implies
+        let annotatedTypes : Sequence(Type) =
+            annotatedElement->selectAsKind(Type) in
+        let baseTypes : Sequence(MetadataFeature) =
+            evaluateFeature(resolveGlobal(
+                'Metaobjects::SemanticMetadata::baseType').
+                oclAsType(Feature))->
+            selectAsKind(MetadataFeature) in
+        annotatedTypes->notEmpty() and
+        baseTypes()->notEmpty() and
+        baseTypes()->first().isSyntactic() implies
+            let annotatedType : Type = annotatedTypes->first() in
+            let baseType : Element = baseTypes->first().syntaxElement() in
+            if annotatedType.oclIsKindOf(Classifier) and
+                baseType.oclIsKindOf(Feature) then
+                baseType.oclAsType(Feature).type->
+                    forAll(t | annotatedType.specializes(t))
+            else if baseType.oclIsKindOf(Type) then
+                annotatedType.specializes(baseType.oclAsType(Type))
+            else
+                true
+            endif"""
+
+    _metaclass = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="metaclass",
+        transient=True,
+    )
+
+    @property
+    def metaclass(self):
+        raise NotImplementedError("Missing implementation for metaclass")
+
+    @metaclass.setter
+    def metaclass(self, value):
+        raise NotImplementedError("Missing implementation for metaclass")
+
+    def __init__(self, *, metaclass=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if metaclass is not None:
+            self.metaclass = metaclass
+
+    def evaluateFeature(self, baseFeature=None):
+        """<p>If the given <code>baseFeature</code> is a <code>feature</code> of this <code>MetadataFeature</code>, or is directly or indirectly redefined by a <code>feature</code>, then return the result of evaluating the appropriate (model-level evaluable) <code>value</code> <code>Expression</code> for it (if any), with the MetadataFeature as the target.</p>"""
+        raise NotImplementedError("operation evaluateFeature(...) not yet implemented")
+
+    def isSemantic(self):
+        """<p>Check if this <code>MetadataFeature</code> has a <code>metaclass</code> which is a kind of <code><em>SemanticMetadata</code>.<p>"""
+        raise NotImplementedError("operation isSemantic(...) not yet implemented")
+
+    def isSyntactic(self):
+        """<p>Check if this <code>MetadataFeature</code> has a <code>metaclass</code> that is a kind of <code><em>KerML::Element<em></code> (that is, it is from the reflective abstract syntax model).</p>"""
+        raise NotImplementedError("operation isSyntactic(...) not yet implemented")
+
+    def syntaxElement(self):
+        """<p>If this <code>MetadataFeature</code> reflectively represents a model element, then return the corresponding <code>Element<code> instance from the MOF abstract syntax representation of the model.</p>"""
+        raise NotImplementedError("operation syntaxElement(...) not yet implemented")
+
+
+class DerivedRelatedtype(EDerivedCollection):
+    pass
+
+
+class DerivedTargettype(EDerivedCollection):
+    pass
+
+
+class DerivedAssociationend(EDerivedCollection):
+    pass
+
+
+class Association(Classifier, Relationship):
+    """<p>An <code>Association</code> is a <code>Relationship</code> and a <code>Classifier</code> to enable classification of links between things (in the universe). The co-domains (<code>types</code>) of the <code>associationEnd</code> <code>Features</code> are the <code>relatedTypes</code>, as co-domain and participants (linked things) of an <code>Association</code> identify each other.</p>
+
+    relatedType = associationEnd.type
+    specializesFromLibrary("Links::Link")
+    oclIsKindOf(Structure) = oclIsKindOf(AssociationStructure)
+    ownedEndFeature->size() = 2 implies
+        specializesFromLibrary("Links::BinaryLink)
+    not isAbstract implies relatedType->size() >= 2
+    associationEnds->size() > 2 implies
+        not specializesFromLibrary("Links::BinaryLink")
+    sourceType =
+        if relatedType->isEmpty() then null
+        else relatedType->first() endif
+    targetType =
+        if relatedType->size() < 2 then OrderedSet{}
+        else
+            relatedType->
+                subSequence(2, relatedType->size())->
+                asOrderedSet()
+        endif"""
+
+    relatedType = EReference(
+        ordered=True,
+        unique=False,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedRelatedtype,
+    )
+    _sourceType = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="sourceType",
+        transient=True,
+    )
+    targetType = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedTargettype,
+    )
+    associationEnd = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedAssociationend,
+    )
+
+    @property
+    def sourceType(self):
+        raise NotImplementedError("Missing implementation for sourceType")
+
+    @sourceType.setter
+    def sourceType(self, value):
+        raise NotImplementedError("Missing implementation for sourceType")
+
+    def __init__(
+        self,
+        *,
+        relatedType=None,
+        sourceType=None,
+        targetType=None,
+        associationEnd=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if relatedType:
+            self.relatedType.extend(relatedType)
+
+        if sourceType is not None:
+            self.sourceType = sourceType
+
+        if targetType:
+            self.targetType.extend(targetType)
+
+        if associationEnd:
+            self.associationEnd.extend(associationEnd)
+
+
+class DerivedRelatedfeature(EDerivedCollection):
+    pass
+
+
+class DerivedAssociation(EDerivedCollection):
+    pass
+
+
+class DerivedConnectorend(EDerivedCollection):
+    pass
+
+
+class DerivedTargetfeature(EDerivedCollection):
+    pass
+
+
+class Connector(Feature, Relationship):
+    """<p>A <code>Connector</code> is a usage of <code>Associations</code>, with links restricted according to instances of the <code>Type</code> in which they are used (domain of the <code>Connector</code>). The <code>associations</code> of the <code>Connector</code> restrict what kinds of things might be linked. The <code>Connector</code> further restricts these links to be between values of <code>Features</code> on instances of its domain.</p>
+
+    relatedFeature = connectorEnd.ownedReferenceSubsetting->
+        select(s | s <> null).subsettedFeature
+    relatedFeature->forAll(f |
+        if featuringType->isEmpty() then f.isFeaturedWithin(null)
+        else featuringType->exists(t | f.isFeaturedWithin(t))
+        endif)
+    sourceFeature =
+        if relatedFeature->isEmpty() then null
+        else relatedFeature->first()
+        endif
+    targetFeature =
+        if relatedFeature->size() < 2 then OrderedSet{}
+        else
+            relatedFeature->
+                subSequence(2, relatedFeature->size())->
+                asOrderedSet()
+        endif
+    not isAbstract implies relatedFeature->size() >= 2
+    specializesFromLibrary("Links::links")
+    association->exists(oclIsKindOf(AssociationStructure)) implies
+        specializesFromLibrary("Objects::linkObjects")
+    connectorEnds->size() = 2 and
+    association->exists(oclIsKindOf(AssocationStructure)) implies
+        specializesFromLibrary("Objects::binaryLinkObjects")
+    connectorEnd->size() = 2 implies
+        specializesFromLibrary("Links::binaryLinks")
+    connectorEnds->size() > 2 implies
+        not specializesFromLibrary("Links::BinaryLink")"""
+
+    isDirected = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    relatedFeature = EReference(
+        ordered=True,
+        unique=False,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedRelatedfeature,
+    )
+    association = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedAssociation,
+    )
+    connectorEnd = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedConnectorend,
+    )
+    _sourceFeature = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="sourceFeature",
+        transient=True,
+    )
+    targetFeature = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedTargetfeature,
+    )
+
+    @property
+    def sourceFeature(self):
+        raise NotImplementedError("Missing implementation for sourceFeature")
+
+    @sourceFeature.setter
+    def sourceFeature(self, value):
+        raise NotImplementedError("Missing implementation for sourceFeature")
+
+    def __init__(
+        self,
+        *,
+        relatedFeature=None,
+        association=None,
+        isDirected=None,
+        connectorEnd=None,
+        sourceFeature=None,
+        targetFeature=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isDirected is not None:
+            self.isDirected = isDirected
+
+        if relatedFeature:
+            self.relatedFeature.extend(relatedFeature)
+
+        if association:
+            self.association.extend(association)
+
+        if connectorEnd:
+            self.connectorEnd.extend(connectorEnd)
+
+        if sourceFeature is not None:
+            self.sourceFeature = sourceFeature
+
+        if targetFeature:
+            self.targetFeature.extend(targetFeature)
+
+
+class DerivedBound(EDerivedCollection):
+    pass
+
+
+class MultiplicityRange(Multiplicity):
+    """<p>A <code>MultiplicityRange</code> is a <code>Multiplicity</code> whose value is defined to be the (inclusive) range of natural numbers given by the result of a <code>lowerBound</code> <code>Expression</code> and the result of an <code>upperBound</code> <code>Expression</code>. The result of these <code>Expressions</code> shall be of type <code><em>Natural</em></code>. If the result of the <code>upperBound</code> <code>Expression</code> is the unbounded value <code>*</code>, then the specified range includes all natural numbers greater than or equal to the <code>lowerBound</code> value. If no <code>lowerBound</code> <code>Expression</code>, then the default is that the lower bound has the same value as the upper bound, except if the <code>upperBound</code> evaluates to <code>*</code>, in which case the default for the lower bound is 0.</p>
+
+    bound->forAll(b | b.featuringType = self.featuringType)
+    bound.result->forAll(specializesFromLibrary('ScalarValues::Natural'))
+    lowerBound =
+        let ownedMembers : Sequence(Element) =
+            ownedMembership->selectByKind(OwningMembership).ownedMember in
+        if ownedMembers->size() < 2 or
+            not ownedMembers->first().oclIsKindOf(Expression) then null
+        else ownedMembers->first().oclAsType(Expression)
+        endif
+    upperBound =
+        let ownedMembers : Sequence(Element) =
+            ownedMembership->selectByKind(OwningMembership).ownedMember in
+        if ownedMembers->isEmpty() or
+           not ownedMembers->last().oclIsKindOf(Expression)
+        then null
+        else ownedMembers->last().oclAsType(Expression)
+        endif"""
+
+    _lowerBound = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="lowerBound",
+        transient=True,
+    )
+    _upperBound = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="upperBound",
+        transient=True,
+    )
+    bound = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedBound,
+    )
+
+    @property
+    def lowerBound(self):
+        raise NotImplementedError("Missing implementation for lowerBound")
+
+    @lowerBound.setter
+    def lowerBound(self, value):
+        raise NotImplementedError("Missing implementation for lowerBound")
+
+    @property
+    def upperBound(self):
+        raise NotImplementedError("Missing implementation for upperBound")
+
+    @upperBound.setter
+    def upperBound(self, value):
+        raise NotImplementedError("Missing implementation for upperBound")
+
+    def __init__(self, *, lowerBound=None, upperBound=None, bound=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if lowerBound is not None:
+            self.lowerBound = lowerBound
+
+        if upperBound is not None:
+            self.upperBound = upperBound
+
+        if bound:
+            self.bound.extend(bound)
+
+    def hasBounds(self, lower=None, upper=None):
+        """<p>Check whether this <code>MultiplicityRange</code> represents the range bounded by the given values <code>lower</code> and <code>upper</code>, presuming the <code>lowerBound</code> and <code>upperBound</code> <code>Expressions</code> are model-level evaluable.</p>"""
+        raise NotImplementedError("operation hasBounds(...) not yet implemented")
+
+    def valueOf(self, bound=None):
+        """<p>Evaluate the given <code>bound</code> <code>Expression</code> (at model level) and return the result represented as a MOF <code>UnlimitedNatural</code> value.</p>"""
+        raise NotImplementedError("operation valueOf(...) not yet implemented")
+
+
+class EndFeatureMembership(FeatureMembership):
+    """<p><code>EndFeatureMembership</code> is a <code>FeatureMembership</code> that requires its <code>memberFeature</code> be owned and have <code>isEnd = true</code>.</p>
+
+    ownedMemberFeature.isEnd"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class DerivedExpression(EDerivedCollection):
+    pass
+
+
+class Function(Behavior):
+    """<p>A <code>Function</code> is a <code>Behavior</code> that has an <code>out</code> <code>parameter</code> that is identified as its <code>result</code>. A <code>Function</code> represents the performance of a calculation that produces the values of its <code>result</code> <code>parameter</code>. This calculation may be decomposed into <code>Expressions</code? that are <code>steps</code> of the <code>Function</code>.</p>
+
+    ownedMembership.selectByKind(ResultExpressionMembership)->
+        forAll(mem | ownedFeature.selectByKind(BindingConnector)->
+            exists(binding |
+                binding.relatedFeature->includes(result) and
+                binding.relatedFeature->includes(mem.ownedResultExpression.result)))
+    specializesFromLibrary("Performances::Evaluation")
+    result =
+        let resultParams : Sequence(Feature) =
+            ownedFeatureMemberships->
+                selectByKind(ReturnParameterMembership).
+                ownedParameterMember in
+        if resultParams->notEmpty() then resultParams->first()
+        else null
+        endif
+    ownedFeatureMembership->
+        selectByKind(ReturnParameterMembership)->
+        size() <= 1"""
+
+    _isModelLevelEvaluable = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="isModelLevelEvaluable",
+        transient=True,
+    )
+    expression = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedExpression,
+    )
+    _result = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="result",
+        transient=True,
+    )
+
+    @property
+    def result(self):
+        raise NotImplementedError("Missing implementation for result")
+
+    @result.setter
+    def result(self, value):
+        raise NotImplementedError("Missing implementation for result")
+
+    @property
+    def isModelLevelEvaluable(self):
+        raise NotImplementedError("Missing implementation for isModelLevelEvaluable")
+
+    @isModelLevelEvaluable.setter
+    def isModelLevelEvaluable(self, value):
+        raise NotImplementedError("Missing implementation for isModelLevelEvaluable")
+
+    def __init__(
+        self, *, expression=None, result=None, isModelLevelEvaluable=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isModelLevelEvaluable is not None:
+            self.isModelLevelEvaluable = isModelLevelEvaluable
+
+        if expression:
+            self.expression.extend(expression)
+
+        if result is not None:
+            self.result = result
+
+
+class LiteralExpression(Expression):
+    """<p>A <code>LiteralExpression</code> is an <code>Expression</code> that provides a basic <code><em>DataValue</em></code> as a result.</p>
+
+    isModelLevelEvaluable = true
+    specializesFromLibrary("Performances::literalEvaluations")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class FeatureReferenceExpression(Expression):
+    """<p>A <code>FeatureReferenceExpression</code> is an <code>Expression</code> whose <code>result</code> is bound to a <code>referent</code> <code>Feature</code>.</p>
+    referent =
+        let nonParameterMemberships : Sequence(Membership) = ownedMembership->
+            reject(oclIsKindOf(ParameterMembership)) in
+        if nonParameterMemberships->isEmpty() or
+           not nonParameterMemberships->first().memberElement.oclIsKindOf(Feature)
+        then null
+        else nonParameterMemberships->first().memberElement.oclAsType(Feature)
+        endif
+    ownedMember->selectByKind(BindingConnector)->exists(b |
+        b.relatedFeatures->includes(targetFeature) and
+        b.relatedFeatures->includes(result))"""
+
+    _referent = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="referent",
+        transient=True,
+    )
+
+    @property
+    def referent(self):
+        raise NotImplementedError("Missing implementation for referent")
+
+    @referent.setter
+    def referent(self, value):
+        raise NotImplementedError("Missing implementation for referent")
+
+    def __init__(self, *, referent=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if referent is not None:
+            self.referent = referent
+
+
+class DerivedArgument(EDerivedCollection):
+    pass
+
+
+class InvocationExpression(Expression):
+    """<p>An <code>InvocationExpression</code> is an <code>Expression</code> each of whose input <code>parameters</code> are bound to the <code>result</code> of an <code>argument</code> Expression.</p>
+
+    not ownedTyping->exists(oclIsKindOf(Behavior)) and
+    not ownedSubsetting.subsettedFeature.type->exists(oclIsKindOf(Behavior)) implies
+        ownedFeature.selectByKind(BindingConnector)->exists(
+            relatedFeature->includes(self) and
+            relatedFeature->includes(result))
+
+    TBD
+    ownedFeature->
+        select(direction = _'in').valuation->
+        select(v | v <> null).value"""
+
+    argument = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedArgument,
+    )
+
+    def __init__(self, *, argument=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if argument:
+            self.argument.extend(argument)
+
+
+class NullExpression(Expression):
+    """<p>A <code>NullExpression</code> is an <code>Expression</code> that results in a null value.</p>
+
+    specializesFromLibrary("Performances::nullEvaluations")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MetadataAccessExpression(Expression):
+    """<p>A <code>MetadataAccessExpression</code> is an <code>Expression</code> whose <code>result</code> is a sequence of instances of <code>Metaclasses</code> representing all the <code>MetadataFeature</code> annotations of the <code>referencedElement</code>. In addition, the sequence includes an instance of the reflective <code>Metaclass</code> corresponding to the MOF class of the <code>referencedElement</code>, with values for all the abstract syntax properties of the <code>referencedElement</code>.</p>
+    specializesFromLibrary("Performances::metadataAccessEvaluations")"""
+
+    referencedElement = EReference(
+        ordered=False, unique=True, containment=False, derived=False
+    )
+
+    def __init__(self, *, referencedElement=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if referencedElement is not None:
+            self.referencedElement = referencedElement
+
+    def metaclassFeature(self):
+        """<p>Return a <code>MetadataFeature</code> whose <code>annotatedElement</code> is the <code>referencedElement</code>, whose <code>metaclass</code> is the reflective <code>Metaclass</code> corresponding to the MOF class of the <code>referencedElement</code> and whose <code>ownedFeatures</code> are bound to the MOF properties of the <code>referencedElement</code>.</p>"""
+        raise NotImplementedError("operation metaclassFeature(...) not yet implemented")
+
+
+class Metaclass(Structure):
+    """<p>A <code>Metaclass</code> is a <code>Structure</code> used to type <code>MetadataFeatures</code>.</p>
+    specializesFromLibrary("Metaobjects::Metaobject")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class ParameterMembership(FeatureMembership):
+    """<p>A <code>ParameterMembership</code> is a <code>FeatureMembership</code> that identifies its <code>memberFeature</code> as a parameter, which is always owned, and must have a <code>direction</code>. A <code>ParameterMembership</code> must be owned by a <code>Behavior</code> or a <code>Step</code>.</p>
+    ownedMemberParameter.direction <> null
+    owningType.oclIsKindOf(Behavior) or owningType.oclIsKindOf(Step)"""
+
+    _ownedMemberParameter = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedMemberParameter",
+        transient=True,
+    )
+
+    @property
+    def ownedMemberParameter(self):
+        raise NotImplementedError("Missing implementation for ownedMemberParameter")
+
+    @ownedMemberParameter.setter
+    def ownedMemberParameter(self, value):
+        raise NotImplementedError("Missing implementation for ownedMemberParameter")
+
+    def __init__(self, *, ownedMemberParameter=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if ownedMemberParameter is not None:
+            self.ownedMemberParameter = ownedMemberParameter
+
+
+class BooleanExpression(Expression):
+    """<p>A <code>BooleanExpression</code> is a <em><code>Boolean</code></em>-valued <code>Expression</code> whose type is a <code>Predicate</code>. It represents a logical condition resulting from the evaluation of the <code>Predicate</code>.</p>
+
+    specializesFromLibrary("Performances::booleanEvaluations")"""
+
+    _predicate = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="predicate",
+        transient=True,
+    )
+
+    @property
+    def predicate(self):
+        raise NotImplementedError("Missing implementation for predicate")
+
+    @predicate.setter
+    def predicate(self, value):
+        raise NotImplementedError("Missing implementation for predicate")
+
+    def __init__(self, *, predicate=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if predicate is not None:
+            self.predicate = predicate
+
+
+class ResultExpressionMembership(FeatureMembership):
+    """<p>A <code>ResultExpressionMembership</code> is a <code>FeatureMembership</code> that indicates that the <code>ownedResultExpression</code> provides the result values for the <code>Function</code> or <code>Expression</code> that owns it. The owning <code>Function</code> or <code>Expression</code> must contain a <code>BindingConnector</code> between the <code>result</code> <code>parameter</code> of the <code>ownedResultExpression</code> and the <code>result</code> <code>parameter</code> of the owning <code>Function</code> or <code>Expression</code>.</p>
+
+    owningType.oclIsKindOf(Function) or owningType.oclIsKindOf(Expression)"""
+
+    _ownedResultExpression = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedResultExpression",
+        transient=True,
+    )
+
+    @property
+    def ownedResultExpression(self):
+        raise NotImplementedError("Missing implementation for ownedResultExpression")
+
+    @ownedResultExpression.setter
+    def ownedResultExpression(self, value):
+        raise NotImplementedError("Missing implementation for ownedResultExpression")
+
+    def __init__(self, *, ownedResultExpression=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if ownedResultExpression is not None:
+            self.ownedResultExpression = ownedResultExpression
+
+
+class DerivedTriggerstep(EDerivedCollection):
+    pass
+
+
+class DerivedEffectstep(EDerivedCollection):
+    pass
+
+
+class DerivedGuardexpression(EDerivedCollection):
+    pass
+
+
+class Succession(Connector):
+    """<p>A <code>Succession</code> is a binary <code>Connector</code> that requires its <code>relatedFeatures</code> to happen separately in time.</p>
+
+    specializesFromLibrary("Occurences::happensBeforeLinks")
+    transitionStep =
+        if owningNamespace.oclIsKindOf(Step) and
+            owningNamespace.oclAsType(Step).
+                specializesFromLibrary('TransitionPerformances::TransitionPerformance') then
+            owningNamespace.oclAsType(Step)
+        else null
+        endif
+    triggerStep =
+        if transitionStep = null or
+           transitionStep.ownedFeature.size() < 2 or
+           not transitionStep.ownedFeature->at(2).oclIsKindOf(Step)
+        then Set{}
+        else Set{transitionStep.ownedFeature->at(2).oclAsType(Step)}
+        endif
+    effectStep =
+        if transitionStep = null or
+           transitionStep.ownedFeature.size() < 4 or
+           not transitionStep.ownedFeature->at(4).oclIsKindOf(Step)
+        then Set{}
+        else Set{transitionStep.ownedFeature->at(4).oclAsType(Step)}
+        endif
+    guardExpression =
+        if transitionStep = null or
+           transitionStep.ownedFeature.size() < 3 or
+           not transitionStep.ownedFeature->at(3).oclIsKindOf(Expression)
+        then Set{}
+        else Set{transitionStep.ownedFeature->at(3).oclAsType(Expression)}
+        endif"""
+
+    _transitionStep = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="transitionStep",
+        transient=True,
+    )
+    triggerStep = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedTriggerstep,
+    )
+    effectStep = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedEffectstep,
+    )
+    guardExpression = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedGuardexpression,
+    )
+
+    @property
+    def transitionStep(self):
+        raise NotImplementedError("Missing implementation for transitionStep")
+
+    @transitionStep.setter
+    def transitionStep(self, value):
+        raise NotImplementedError("Missing implementation for transitionStep")
+
+    def __init__(
+        self,
+        *,
+        transitionStep=None,
+        triggerStep=None,
+        effectStep=None,
+        guardExpression=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if transitionStep is not None:
+            self.transitionStep = transitionStep
+
+        if triggerStep:
+            self.triggerStep.extend(triggerStep)
+
+        if effectStep:
+            self.effectStep.extend(effectStep)
+
+        if guardExpression:
+            self.guardExpression.extend(guardExpression)
+
+
+class BindingConnector(Connector):
+    """<p>A <code>BindingConnector</code> is a binary <code>Connector</code> that requires its <code>relatedFeatures</code> to identify the same things (have the same values).</p>
+
+    specializesFromLibrary("Links::selfLinks")
+    relatedFeature->size() = 2"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class LiteralString(LiteralExpression):
+    """<p>A <code>LiteralString</code> is a <code>LiteralExpression</code> that provides a <code><em>String</em></code> value as a result. Its <code>result</code> <code>parameter</code> must have the type <code><em>String</em></code>.</p>"""
+
+    value = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, value=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if value is not None:
+            self.value = value
+
+
+class LiteralRational(LiteralExpression):
+    """<p>A <code>LiteralRational</code> is a <code>LiteralExpression</code> that provides a <code><em>Rational</em></code> value as a result. Its <code>result</code> <code>parameter</code> must have the type <code><em>Rational</em></code>.</p>"""
+
+    value = EAttribute(eType=Real, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, value=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if value is not None:
+            self.value = value
+
+
+class LiteralInteger(LiteralExpression):
+    """<p>A <code>LiteralInteger</code> is a <code>LiteralExpression</code> that provides an <code><em>Integer</em></code> value as a result. Its <code>result</code> <code>parameter</code> must have the type <code><em>Integer</em></code>.</p>"""
+
+    value = EAttribute(eType=Integer, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, value=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if value is not None:
+            self.value = value
+
+
+class DerivedOperand(EDerivedCollection):
+    pass
+
+
+class OperatorExpression(InvocationExpression):
+    """<p>An <code>OperatorExpression</code> is an <code>InvocationExpression</code> whose <code>function</code> is determined by resolving its <code>operator</code> in the context of one of the standard packages from the Kernel Function Library.</p>
+    let libFunctions : Sequence(Element) =
+        Sequence{"BaseFunctions", "DataFunctions", "ControlFunctions"}->
+        collect(ns | resolveGlobal(ns + "::'" + operator + "'")) in
+    libFunctions->includes(function)
+    """
+
+    operator = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+    operand = EReference(
+        ordered=True,
+        unique=True,
+        containment=True,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOperand,
+    )
+
+    def __init__(self, *, operator=None, operand=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if operator is not None:
+            self.operator = operator
+
+        if operand:
+            self.operand.extend(operand)
+
+
+class LiteralBoolean(LiteralExpression):
+    """<p><code>LiteralBoolean</code> is a <code>LiteralExpression</code> that provides a <code><em>Boolean</em></code> value as a result. Its <code>result</code> <code>parameter</code> must have type <code><em>Boolean</em></code>.</p>"""
+
+    value = EAttribute(eType=Boolean, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, value=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if value is not None:
+            self.value = value
+
+
+class LiteralInfinity(LiteralExpression):
+    """<p>A <code>LiteralInfinity</code> is a <code>LiteralExpression</code> that provides the positive infinity value (<code>*</code>). It's <code>result</code> must have the type <code><em>Positive</em></code>.</p>"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class Predicate(Function):
+    """<p>A <code>Predicate</code> is a <code>Function</code> whose <code>result</code> <code>parameter</code> has type <code><em>Boolean</em></code> and multiplicity <code>1..1</code>.</p>
+
+    specializesFromLibrary("Performances::BooleanEvaluation")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class Invariant(BooleanExpression):
+    """<p>An <code>Invariant</code> is a <code>BooleanExpression</code> that is asserted to have a specific <code><em>Boolean</em></code> result value. If <code>isNegated = false</code>, then the result is asserted to be true. If <code>isNegated = true</code>, then the result is asserted to be false.</p>
+
+    if isNegated then
+        specializesFromLibrary("Performances::falseEvaluations")
+    else
+        specializesFromLibrary("Performances::trueEvaluations")
+    endif"""
+
+    isNegated = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+
+    def __init__(self, *, isNegated=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if isNegated is not None:
+            self.isNegated = isNegated
+
+
+class ReturnParameterMembership(ParameterMembership):
+    """<p>A <code>ReturnParameterMembership</code> is a <code>ParameterMembership</code> that indicates that the <code>ownedMemberParameter</code> is the <code>result</code> <code>parameter</code> of a <code>Function</code> or <code>Expression</code>. The <code>direction</code> of the <code>ownedMemberParameter</code> must be <code>out</code>.</p>
+
+    owningType.oclIsKindOf(Function) or owningType.oclIsKindOf(Expression)
+    ownedMemberParameter.direction = ParameterDirectionKind::out"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class DerivedItemtype(EDerivedCollection):
+    pass
+
+
+class DerivedItemflowend(EDerivedCollection):
+    pass
+
+
+class DerivedInteraction(EDerivedCollection):
+    pass
+
+
+class ItemFlow(Connector, Step):
+    """<p>An <code>ItemFlow</code> is a <code>Step</code> that represents the transfer of objects or data values from one <code>Feature</code> to another. <code>ItemFlows</code> can take non-zero time to complete.</p>
+
+    if itemFlowEnds->isEmpty() then
+        specializesFromLibrary("Transfers::transfers")
+    else
+        specializesFromLibrary("Transfers::flowTransfers")
+    endif
+    itemType =
+        if itemFeature = null then Sequence{}
+        else itemFeature.type
+        endif
+    sourceOutputFeature =
+        if connectorEnd->isEmpty() or
+            connectorEnd.ownedFeature->isEmpty()
+        then null
+        else connectorEnd.ownedFeature->first()
+        endif
+    targetInputFeature =
+        if connectorEnd->size() < 2 or
+            connectorEnd->at(2).ownedFeature->isEmpty()
+        then null
+        else connectorEnd->at(2).ownedFeature->first()
+        endif
+    itemFlowEnd = connectorEnd->selectByKind(ItemFlowEnd)
+    itemFeature =
+        let itemFeatures : Sequence(ItemFeature) =
+            ownedFeature->selectByKind(ItemFeature) in
+        if itemFeatures->isEmpty() then null
+        else itemFeatures->first()
+        endif
+    ownedFeature->selectByKind(ItemFeature)->size() <= 1"""
+
+    itemType = EReference(
+        ordered=True,
+        unique=False,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedItemtype,
+    )
+    _targetInputFeature = EReference(
+        ordered=True,
+        unique=False,
+        containment=False,
+        derived=True,
+        name="targetInputFeature",
+        transient=True,
+    )
+    _sourceOutputFeature = EReference(
+        ordered=True,
+        unique=False,
+        containment=False,
+        derived=True,
+        name="sourceOutputFeature",
+        transient=True,
+    )
+    itemFlowEnd = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedItemflowend,
+    )
+    _itemFeature = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="itemFeature",
+        transient=True,
+    )
+    interaction = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedInteraction,
+    )
+
+    @property
+    def targetInputFeature(self):
+        raise NotImplementedError("Missing implementation for targetInputFeature")
+
+    @targetInputFeature.setter
+    def targetInputFeature(self, value):
+        raise NotImplementedError("Missing implementation for targetInputFeature")
+
+    @property
+    def sourceOutputFeature(self):
+        raise NotImplementedError("Missing implementation for sourceOutputFeature")
+
+    @sourceOutputFeature.setter
+    def sourceOutputFeature(self, value):
+        raise NotImplementedError("Missing implementation for sourceOutputFeature")
+
+    @property
+    def itemFeature(self):
+        raise NotImplementedError("Missing implementation for itemFeature")
+
+    @itemFeature.setter
+    def itemFeature(self, value):
+        raise NotImplementedError("Missing implementation for itemFeature")
+
+    def __init__(
+        self,
+        *,
+        itemType=None,
+        targetInputFeature=None,
+        sourceOutputFeature=None,
+        itemFlowEnd=None,
+        itemFeature=None,
+        interaction=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if itemType:
+            self.itemType.extend(itemType)
+
+        if targetInputFeature is not None:
+            self.targetInputFeature = targetInputFeature
+
+        if sourceOutputFeature is not None:
+            self.sourceOutputFeature = sourceOutputFeature
+
+        if itemFlowEnd:
+            self.itemFlowEnd.extend(itemFlowEnd)
+
+        if itemFeature is not None:
+            self.itemFeature = itemFeature
+
+        if interaction:
+            self.interaction.extend(interaction)
+
+
+class SelectExpression(OperatorExpression):
+    """<p>A <code>SelectExpression</code> is an <code>OperatorExpression</code> whose operator is <code>"select"</code>, which resolves to the <code>Function</code> <em><code>ControlFunctions::select</code></em> from the Kernel Functions Library.</p>"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class CollectExpression(OperatorExpression):
+    """<p>A <code>CollectExpression</code> is an <code>OperatorExpression</code> whose <code>operator</code> is <code>"collect"</code>, which resolves to the <code>Function</code> <em><code>ControlFunctions::collect</code></em> from the Kernel Functions Library.</p>
+    operator = 'collect'"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class FeatureChainExpression(OperatorExpression):
+    """<p>A <code>FeatureChainExpression</code> is an <code>OperatorExpression</code> whose operator is <code>"."</code>, which resolves to the <code>Function</code> <em><code>ControlFunctions::'.'</code></em> from the Kernel Functions Library. It evaluates to the result of chaining the <code>result</code> <code>Feature</code> of its single <code>argument</code> <code>Expression</code> with its <code>targetFeature</code>.</p>
+    let sourceParameter : Feature = sourceTargetFeature() in
+    sourceTargetFeature <> null and
+    sourceTargetFeature.redefinesFromLibrary("ControlFunctions::'.'::source::target")
+    let sourceParameter : Feature = sourceTargetFeature() in
+    sourceTargetFeature <> null and
+    sourceTargetFeature.redefines(targetFeature)
+    targetFeature =
+        let nonParameterMemberships : Sequence(Membership) = ownedMembership->
+            reject(oclIsKindOf(ParameterMembership)) in
+        if nonParameterMemberships->isEmpty() or
+           not nonParameterMemberships->first().memberElement.oclIsKindOf(Feature)
+        then null
+        else nonParameterMemberships->first().memberElement.oclAsType(Feature)
+        endif"""
+
+    _targetFeature = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="targetFeature",
+        transient=True,
+    )
+
+    @property
+    def targetFeature(self):
+        raise NotImplementedError("Missing implementation for targetFeature")
+
+    @targetFeature.setter
+    def targetFeature(self, value):
+        raise NotImplementedError("Missing implementation for targetFeature")
+
+    def __init__(self, *, targetFeature=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if targetFeature is not None:
+            self.targetFeature = targetFeature
+
+    def sourceTargetFeature(self):
+        """<p>Return the first <code>ownedFeature</code> of the first owned input <code>parameter</code> of this <code>FeatureChainExpression</code> (if any).</p>"""
+        raise NotImplementedError(
+            "operation sourceTargetFeature(...) not yet implemented"
+        )
+
+
+class AssociationStructure(Association, Structure):
+    """<p>An <code>AssociationStructure</code> is an <code>Association</code> that is also a <code>Structure</code>, classifying link objects that are both links and objects. As objects, link objects can be created and destroyed, and their non-end <code>Features</code> can change over time. However, the values of the end <code>Features</code> of a link object are fixed and cannot change over its lifetime.</p>
+    specializesFromLibrary("Objects::ObjectLink")
+    endFeature->size() = 2 implies
+        specializesFromLibrary("Objects::BinaryLinkObject")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class Interaction(Association, Behavior):
+    """<p>An <code>Interaction</code> is a <code>Behavior</code> that is also an <code>Association</code>, providing a context for multiple objects that have behaviors that impact one another.</p>"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class SuccessionItemFlow(ItemFlow, Succession):
+    """<p>A <code>SuccessionItemFlow</code> is an <code>ItemFlow</code> that also provides temporal ordering. It classifies <code><em>Transfers</em></code> that cannot start until the source <code><em>Occurrence</em></code> has completed and that must complete before the target <code><em>Occurrence</em></code> can start.</p>
+    specializesFromLibrary("Transfers::flowTransfersBefore")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)

--- a/gaphor/SysMLv2/__init__.py
+++ b/gaphor/SysMLv2/__init__.py
@@ -1,0 +1,402 @@
+from gaphor.SysMLv2.sysmlv2 import (
+    InterfaceUsage,
+    ConnectionUsage,
+    ConnectorAsUsage,
+    Usage,
+    Feature,
+    FeatureMembership,
+    Definition,
+    Classifier,
+    DataType,
+    EnumerationDefinition,
+    OccurrenceUsage,
+    Class,
+    OccurrenceDefinition,
+    PortionKind,
+    ItemUsage,
+    Structure,
+    PartUsage,
+    PartDefinition,
+    PortDefinition,
+    ConjugatedPortDefinition,
+    FlowConnectionUsage,
+    ItemFlow,
+    Connector,
+    Association,
+    Step,
+    Behavior,
+    Interaction,
+    ActionUsage,
+    Expression,
+    Function,
+    AllocationUsage,
+    AllocationDefinition,
+    ConnectionDefinition,
+    AssociationStructure,
+    StateUsage,
+    TransitionUsage,
+    AcceptActionUsage,
+    Succession,
+    CalculationUsage,
+    ConstraintUsage,
+    BooleanExpression,
+    Predicate,
+    RequirementUsage,
+    RequirementDefinition,
+    ConcernUsage,
+    ConcernDefinition,
+    CaseUsage,
+    CaseDefinition,
+    CalculationDefinition,
+    ActionDefinition,
+    AnalysisCaseUsage,
+    AnalysisCaseDefinition,
+    VerificationCaseUsage,
+    VerificationCaseDefinition,
+    UseCaseUsage,
+    UseCaseDefinition,
+    ViewUsage,
+    ViewDefinition,
+    ViewpointUsage,
+    ViewpointDefinition,
+    RenderingUsage,
+    RenderingDefinition,
+    MetadataUsage,
+    MetadataFeature,
+    Metaclass,
+    InterfaceDefinition,
+    EventOccurrenceUsage,
+    RequirementVerificationMembership,
+    RequirementConstraintMembership,
+    RequirementConstraintKind,
+    FramedConcernMembership,
+    SubjectMembership,
+    ParameterMembership,
+    ActorMembership,
+    StakeholderMembership,
+    SatisfyRequirementUsage,
+    AssertConstraintUsage,
+    ForLoopActionUsage,
+    LoopActionUsage,
+    InvocationExpression,
+    TriggerKind,
+    AssignmentActionUsage,
+    IfActionUsage,
+    SendActionUsage,
+    PerformActionUsage,
+    WhileLoopActionUsage,
+    StateDefinition,
+    StateSubactionKind,
+    ExhibitStateUsage,
+    TransitionFeatureKind,
+    IncludeUseCaseUsage,
+    OperatorExpression,
+    FeatureChainExpression,
+)
+
+from gaphor.SysMLv2 import sysmlv2
+
+__all__ = [
+    "InterfaceUsage",
+    "ConnectionUsage",
+    "ConnectorAsUsage",
+    "Usage",
+    "Feature",
+    "FeatureMembership",
+    "Definition",
+    "Classifier",
+    "DataType",
+    "EnumerationDefinition",
+    "OccurrenceUsage",
+    "Class",
+    "OccurrenceDefinition",
+    "PortionKind",
+    "ItemUsage",
+    "Structure",
+    "PartUsage",
+    "PartDefinition",
+    "PortDefinition",
+    "ConjugatedPortDefinition",
+    "FlowConnectionUsage",
+    "ItemFlow",
+    "Connector",
+    "Association",
+    "Step",
+    "Behavior",
+    "Interaction",
+    "ActionUsage",
+    "Expression",
+    "Function",
+    "AllocationUsage",
+    "AllocationDefinition",
+    "ConnectionDefinition",
+    "AssociationStructure",
+    "StateUsage",
+    "TransitionUsage",
+    "AcceptActionUsage",
+    "Succession",
+    "CalculationUsage",
+    "ConstraintUsage",
+    "BooleanExpression",
+    "Predicate",
+    "RequirementUsage",
+    "RequirementDefinition",
+    "ConcernUsage",
+    "ConcernDefinition",
+    "CaseUsage",
+    "CaseDefinition",
+    "CalculationDefinition",
+    "ActionDefinition",
+    "AnalysisCaseUsage",
+    "AnalysisCaseDefinition",
+    "VerificationCaseUsage",
+    "VerificationCaseDefinition",
+    "UseCaseUsage",
+    "UseCaseDefinition",
+    "ViewUsage",
+    "ViewDefinition",
+    "ViewpointUsage",
+    "ViewpointDefinition",
+    "RenderingUsage",
+    "RenderingDefinition",
+    "MetadataUsage",
+    "MetadataFeature",
+    "Metaclass",
+    "InterfaceDefinition",
+    "EventOccurrenceUsage",
+    "RequirementVerificationMembership",
+    "RequirementConstraintMembership",
+    "RequirementConstraintKind",
+    "FramedConcernMembership",
+    "SubjectMembership",
+    "ParameterMembership",
+    "ActorMembership",
+    "StakeholderMembership",
+    "SatisfyRequirementUsage",
+    "AssertConstraintUsage",
+    "ForLoopActionUsage",
+    "LoopActionUsage",
+    "InvocationExpression",
+    "TriggerKind",
+    "AssignmentActionUsage",
+    "IfActionUsage",
+    "SendActionUsage",
+    "PerformActionUsage",
+    "WhileLoopActionUsage",
+    "StateDefinition",
+    "StateSubactionKind",
+    "ExhibitStateUsage",
+    "TransitionFeatureKind",
+    "IncludeUseCaseUsage",
+    "OperatorExpression",
+    "FeatureChainExpression",
+]
+
+InterfaceUsage.interfaceDefinition.eType = InterfaceDefinition
+ConnectionUsage.connectionDefinition.eType = AssociationStructure
+Usage.variant.eType = Usage
+Usage.definition.eType = Classifier
+Usage.usage.eType = Usage
+Usage.directedUsage.eType = Usage
+Usage.nestedOccurrence.eType = OccurrenceUsage
+Usage.nestedItem.eType = ItemUsage
+Usage.nestedPart.eType = PartUsage
+Usage.nestedConnection.eType = ConnectorAsUsage
+Usage.nestedFlow.eType = FlowConnectionUsage
+Usage.nestedInterface.eType = InterfaceUsage
+Usage.nestedAllocation.eType = AllocationUsage
+Usage.nestedAction.eType = ActionUsage
+Usage.nestedState.eType = StateUsage
+Usage.nestedTransition.eType = TransitionUsage
+Usage.nestedCalculation.eType = CalculationUsage
+Usage.nestedConstraint.eType = ConstraintUsage
+Usage.nestedRequirement.eType = RequirementUsage
+Usage.nestedConcern.eType = ConcernUsage
+Usage.nestedCase.eType = CaseUsage
+Usage.nestedAnalysisCase.eType = AnalysisCaseUsage
+Usage.nestedVerificationCase.eType = VerificationCaseUsage
+Usage.nestedUseCase.eType = UseCaseUsage
+Usage.nestedView.eType = ViewUsage
+Usage.nestedViewpoint.eType = ViewpointUsage
+Usage.nestedRendering.eType = RenderingUsage
+Usage.nestedMetadata.eType = MetadataUsage
+Feature.chainingFeature.eType = Feature
+Definition.variant.eType = Usage
+Definition.usage.eType = Usage
+Definition.directedUsage.eType = Usage
+Definition.ownedOccurrence.eType = OccurrenceUsage
+Definition.ownedItem.eType = ItemUsage
+Definition.ownedPart.eType = PartUsage
+Definition.ownedConnection.eType = ConnectorAsUsage
+Definition.ownedFlow.eType = FlowConnectionUsage
+Definition.ownedInterface.eType = InterfaceUsage
+Definition.ownedAllocation.eType = AllocationUsage
+Definition.ownedAction.eType = ActionUsage
+Definition.ownedState.eType = StateUsage
+Definition.ownedTransition.eType = TransitionUsage
+Definition.ownedCalculation.eType = CalculationUsage
+Definition.ownedConstraint.eType = ConstraintUsage
+Definition.ownedRequirement.eType = RequirementUsage
+Definition.ownedConcern.eType = ConcernUsage
+Definition.ownedCase.eType = CaseUsage
+Definition.ownedAnalysisCase.eType = AnalysisCaseUsage
+Definition.ownedVerificationCase.eType = VerificationCaseUsage
+Definition.ownedUseCase.eType = UseCaseUsage
+Definition.ownedView.eType = ViewUsage
+Definition.ownedViewpoint.eType = ViewpointUsage
+Definition.ownedRendering.eType = RenderingUsage
+Definition.ownedMetadata.eType = MetadataUsage
+OccurrenceUsage.occurrenceDefinition.eType = Class
+OccurrenceUsage._individualDefinition.eType = OccurrenceDefinition
+ItemUsage.itemDefinition.eType = Structure
+PartUsage.partDefinition.eType = PartDefinition
+FlowConnectionUsage.flowConnectionDefinition.eType = Interaction
+ItemFlow.itemType.eType = Classifier
+ItemFlow._targetInputFeature.eType = Feature
+ItemFlow._sourceOutputFeature.eType = Feature
+ItemFlow.interaction.eType = Interaction
+Connector.relatedFeature.eType = Feature
+Connector.association.eType = Association
+Connector.connectorEnd.eType = Feature
+Connector._sourceFeature.eType = Feature
+Connector.targetFeature.eType = Feature
+Association.associationEnd.eType = Feature
+Step.behavior.eType = Behavior
+Step.parameter.eType = Feature
+Behavior.step.eType = Step
+Behavior.parameter.eType = Feature
+ActionUsage.actionDefinition.eType = Behavior
+Expression._function.eType = Function
+Expression._result.eType = Feature
+Function.expression.eType = Expression
+Function._result.eType = Feature
+AllocationUsage.allocationDefinition.eType = AllocationDefinition
+AllocationDefinition.allocation.eType = AllocationUsage
+ConnectionDefinition.connectionEnd.eType = Usage
+StateUsage.stateDefinition.eType = Behavior
+StateUsage._entryAction.eType = ActionUsage
+StateUsage._doAction.eType = ActionUsage
+StateUsage._exitAction.eType = ActionUsage
+TransitionUsage._source.eType = ActionUsage
+TransitionUsage._target.eType = ActionUsage
+TransitionUsage.triggerAction.eType = AcceptActionUsage
+TransitionUsage.guardExpression.eType = Expression
+TransitionUsage.effectAction.eType = ActionUsage
+TransitionUsage._succession.eType = Succession
+AcceptActionUsage._receiverArgument.eType = Expression
+AcceptActionUsage._payloadArgument.eType = Expression
+Succession._transitionStep.eType = Step
+Succession.triggerStep.eType = Step
+Succession.effectStep.eType = Step
+Succession.guardExpression.eType = Expression
+CalculationUsage._calculationDefinition.eType = Function
+ConstraintUsage._constraintDefinition.eType = Predicate
+BooleanExpression._predicate.eType = Predicate
+RequirementUsage._requirementDefinition.eType = RequirementDefinition
+RequirementUsage.requiredConstraint.eType = ConstraintUsage
+RequirementUsage.assumedConstraint.eType = ConstraintUsage
+RequirementUsage._subjectParameter.eType = Usage
+RequirementUsage.framedConcern.eType = ConcernUsage
+RequirementUsage.actorParameter.eType = PartUsage
+RequirementUsage.stakeholderParameter.eType = PartUsage
+RequirementDefinition._subjectParameter.eType = Usage
+RequirementDefinition.actorParameter.eType = PartUsage
+RequirementDefinition.stakeholderParameter.eType = PartUsage
+RequirementDefinition.assumedConstraint.eType = ConstraintUsage
+RequirementDefinition.requiredConstraint.eType = ConstraintUsage
+RequirementDefinition.framedConcern.eType = ConcernUsage
+ConcernUsage._concernDefinition.eType = ConcernDefinition
+CaseUsage._objectiveRequirement.eType = RequirementUsage
+CaseUsage._caseDefinition.eType = CaseDefinition
+CaseUsage._subjectParameter.eType = Usage
+CaseUsage.actorParameter.eType = PartUsage
+CaseDefinition._objectiveRequirement.eType = RequirementUsage
+CaseDefinition._subjectParameter.eType = Usage
+CaseDefinition.actorParameter.eType = PartUsage
+CalculationDefinition.calculation.eType = CalculationUsage
+ActionDefinition.action.eType = ActionUsage
+AnalysisCaseUsage.analysisAction.eType = ActionUsage
+AnalysisCaseUsage._analysisCaseDefinition.eType = AnalysisCaseDefinition
+AnalysisCaseUsage._resultExpression.eType = Expression
+AnalysisCaseDefinition.analysisAction.eType = ActionUsage
+AnalysisCaseDefinition._resultExpression.eType = Expression
+VerificationCaseUsage._verificationCaseDefinition.eType = VerificationCaseDefinition
+VerificationCaseUsage.verifiedRequirement.eType = RequirementUsage
+VerificationCaseDefinition.verifiedRequirement.eType = RequirementUsage
+UseCaseUsage._useCaseDefinition.eType = UseCaseDefinition
+UseCaseUsage.includedUseCase.eType = UseCaseUsage
+UseCaseDefinition.includedUseCase.eType = UseCaseUsage
+ViewUsage._viewDefinition.eType = ViewDefinition
+ViewUsage.satisfiedViewpoint.eType = ViewpointUsage
+ViewUsage._viewRendering.eType = RenderingUsage
+ViewUsage.viewCondition.eType = Expression
+ViewDefinition.view.eType = ViewUsage
+ViewDefinition.satisfiedViewpoint.eType = ViewpointUsage
+ViewDefinition._viewRendering.eType = RenderingUsage
+ViewDefinition.viewCondition.eType = Expression
+ViewpointUsage._viewpointDefinition.eType = ViewpointDefinition
+ViewpointUsage.viewpointStakeholder.eType = PartUsage
+ViewpointDefinition.viewpointStakeholder.eType = PartUsage
+RenderingUsage._renderingDefinition.eType = RenderingDefinition
+RenderingDefinition.rendering.eType = RenderingUsage
+MetadataUsage._metadataDefinition.eType = Metaclass
+MetadataFeature._metaclass.eType = Metaclass
+EventOccurrenceUsage._eventOccurrence.eType = OccurrenceUsage
+RequirementVerificationMembership._ownedRequirement.eType = RequirementUsage
+RequirementVerificationMembership._verifiedRequirement.eType = RequirementUsage
+RequirementConstraintMembership._ownedConstraint.eType = ConstraintUsage
+RequirementConstraintMembership._referencedConstraint.eType = ConstraintUsage
+FramedConcernMembership._ownedConcern.eType = ConcernUsage
+FramedConcernMembership._referencedConcern.eType = ConcernUsage
+SubjectMembership._ownedSubjectParameter.eType = Usage
+ParameterMembership._ownedMemberParameter.eType = Feature
+ActorMembership._ownedActorParameter.eType = PartUsage
+StakeholderMembership._ownedStakeholderParameter.eType = PartUsage
+SatisfyRequirementUsage._satisfiedRequirement.eType = RequirementUsage
+SatisfyRequirementUsage._satisfyingFeature.eType = Feature
+AssertConstraintUsage._assertedConstraint.eType = ConstraintUsage
+ForLoopActionUsage._seqArgument.eType = Expression
+LoopActionUsage._bodyAction.eType = ActionUsage
+InvocationExpression.argument.eType = Expression
+AssignmentActionUsage._targetArgument.eType = Expression
+AssignmentActionUsage._valueExpression.eType = Expression
+AssignmentActionUsage._referent.eType = Feature
+IfActionUsage._elseAction.eType = ActionUsage
+IfActionUsage._thenAction.eType = ActionUsage
+IfActionUsage._ifArgument.eType = Expression
+SendActionUsage._receiverArgument.eType = Expression
+SendActionUsage._payloadArgument.eType = Expression
+SendActionUsage._senderArgument.eType = Expression
+PerformActionUsage._performedAction.eType = ActionUsage
+WhileLoopActionUsage._whileArgument.eType = Expression
+WhileLoopActionUsage._untilArgument.eType = Expression
+StateDefinition.state.eType = StateUsage
+StateDefinition._entryAction.eType = ActionUsage
+StateDefinition._doAction.eType = ActionUsage
+StateDefinition._exitAction.eType = ActionUsage
+ExhibitStateUsage._exhibitedState.eType = StateUsage
+IncludeUseCaseUsage._useCaseIncluded.eType = UseCaseUsage
+OperatorExpression.operand.eType = Expression
+FeatureChainExpression._targetFeature.eType = Feature
+Usage._owningDefinition.eType = Definition
+Usage._owningUsage.eType = Usage
+Usage.nestedUsage.eType = Usage
+Usage.nestedUsage.eOpposite = Usage._owningUsage
+Feature._owningFeatureMembership.eType = FeatureMembership
+FeatureMembership._ownedMemberFeature.eType = Feature
+FeatureMembership._ownedMemberFeature.eOpposite = Feature._owningFeatureMembership
+Definition.ownedUsage.eType = Usage
+Definition.ownedUsage.eOpposite = Usage._owningDefinition
+PortDefinition._conjugatedPortDefinition.eType = ConjugatedPortDefinition
+ConjugatedPortDefinition._originalPortDefinition.eType = PortDefinition
+ConjugatedPortDefinition._originalPortDefinition.eOpposite = (
+    PortDefinition._conjugatedPortDefinition
+)
+
+otherClassifiers = [
+    PortionKind,
+    RequirementConstraintKind,
+    TriggerKind,
+    StateSubactionKind,
+    TransitionFeatureKind,
+]

--- a/gaphor/SysMLv2/__init__.py
+++ b/gaphor/SysMLv2/__init__.py
@@ -92,6 +92,7 @@ from gaphor.SysMLv2.sysmlv2 import (
     IncludeUseCaseUsage,
     OperatorExpression,
     FeatureChainExpression,
+    PortUsage,
 )
 
 from gaphor.SysMLv2 import sysmlv2
@@ -116,6 +117,7 @@ __all__ = [
     "PartUsage",
     "PartDefinition",
     "PortDefinition",
+    "PortUsage",
     "ConjugatedPortDefinition",
     "FlowConnectionUsage",
     "ItemFlow",
@@ -201,6 +203,7 @@ Usage.directedUsage.eType = Usage
 Usage.nestedOccurrence.eType = OccurrenceUsage
 Usage.nestedItem.eType = ItemUsage
 Usage.nestedPart.eType = PartUsage
+Usage.nestedPort.eType = PortUsage
 Usage.nestedConnection.eType = ConnectorAsUsage
 Usage.nestedFlow.eType = FlowConnectionUsage
 Usage.nestedInterface.eType = InterfaceUsage

--- a/gaphor/SysMLv2/sysmlv2.py
+++ b/gaphor/SysMLv2/sysmlv2.py
@@ -2560,6 +2560,46 @@ class DerivedPartdefinition(EDerivedCollection):
     pass
 
 
+class DerivedPortdefinition(EDerivedCollection):
+    pass
+
+
+class PortUsage(OccurrenceUsage):
+    """<p>A <code>PortUsage</code> is a usage of a <code>PortDefinition</code>. A <code>PortUsage<code> itself as well as all its <code>nestedUsages</code> must be referential (non-composite).</p>
+    nestedUsage->
+        reject(oclIsKindOf(PortUsage))->
+        forAll(not isComposite)
+    specializesFromLibrary('Ports::ports')
+    isComposite and owningType <> null and
+    (owningType.oclIsKindOf(PortDefinition) or
+     owningType.oclIsKindOf(PortUsage)) implies
+        specializesFromLibrary('Ports::Port::subports')
+    owningType = null or
+    not owningType.oclIsKindOf(PortDefinition) and
+    not owningType.oclIsKindOf(PortUsage) implies
+        isReference"""
+
+    portDefinition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedPortdefinition,
+    )
+
+    def __init__(self, *, portDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if portDefinition:
+            self.portDefinition.extend(portDefinition)
+
+
+class DerivedExpression(EDerivedCollection):
+    pass
+
+
 class PartUsage(ItemUsage):
     """<p>A <code>PartUsage</code> is a usage of a <code>PartDefinition</code> to represent a system or a part of a system. At least one of the <code>itemDefinitions</code> of the <code>PartUsage</code> must be a <code>PartDefinition</code>.</p>
 

--- a/gaphor/SysMLv2/sysmlv2.py
+++ b/gaphor/SysMLv2/sysmlv2.py
@@ -1,0 +1,5236 @@
+"""Definition of meta model for SysML v2."""
+# ruff: noqa: C901
+from pyecore.ecore import (
+    EReference,
+    EDerivedCollection,
+    EAttribute,
+    abstract,
+    EEnum,
+)
+
+from gaphor.UML import DataType
+from gaphor.UMLTypes.uml_types import Boolean, String, Integer, Real
+from gaphor.KerML.kerml import (
+    ParameterMembership,
+    BooleanExpression,
+    InvocationExpression,
+    Behavior,
+    Structure,
+    Association,
+    LiteralExpression,
+    Connector,
+    Feature,
+    Classifier,
+    Class,
+    Step,
+    Function,
+    FeatureMembership,
+    Expression,
+    MetadataFeature,
+    BindingConnector,
+    ItemFlow,
+    Succession,
+    Metaclass,
+)
+
+name = "sysmlv2"
+nsURI = "https://www.omg.org/spec/SysML/20230201"
+nsPrefix = "sysml"
+PortionKind = EEnum("PortionKind", literals=["timeslice", "snapshot"])
+
+RequirementConstraintKind = EEnum(
+    "RequirementConstraintKind", literals=["assumption", "requirement"]
+)
+
+TriggerKind = EEnum("TriggerKind", literals=["when", "at", "after"])
+
+StateSubactionKind = EEnum("StateSubactionKind", literals=["entry", "do", "exit"])
+
+TransitionFeatureKind = EEnum(
+    "TransitionFeatureKind", literals=["trigger", "guard", "effect"]
+)
+
+
+class DerivedVariant(EDerivedCollection):
+    pass
+
+
+class DerivedVariantmembership(EDerivedCollection):
+    pass
+
+
+class DerivedNestedusage(EDerivedCollection):
+    pass
+
+
+class DerivedDefinition(EDerivedCollection):
+    pass
+
+
+class DerivedUsage(EDerivedCollection):
+    pass
+
+
+class DerivedDirectedusage(EDerivedCollection):
+    pass
+
+
+class DerivedNestedreference(EDerivedCollection):
+    pass
+
+
+class DerivedNestedattribute(EDerivedCollection):
+    pass
+
+
+class DerivedNestedenumeration(EDerivedCollection):
+    pass
+
+
+class DerivedNestedoccurrence(EDerivedCollection):
+    pass
+
+
+class DerivedNesteditem(EDerivedCollection):
+    pass
+
+
+class DerivedNestedpart(EDerivedCollection):
+    pass
+
+
+class DerivedNestedport(EDerivedCollection):
+    pass
+
+
+class DerivedNestedconnection(EDerivedCollection):
+    pass
+
+
+class DerivedNestedflow(EDerivedCollection):
+    pass
+
+
+class DerivedNestedinterface(EDerivedCollection):
+    pass
+
+
+class DerivedNestedallocation(EDerivedCollection):
+    pass
+
+
+class DerivedNestedaction(EDerivedCollection):
+    pass
+
+
+class DerivedNestedstate(EDerivedCollection):
+    pass
+
+
+class DerivedNestedtransition(EDerivedCollection):
+    pass
+
+
+class DerivedNestedcalculation(EDerivedCollection):
+    pass
+
+
+class DerivedNestedconstraint(EDerivedCollection):
+    pass
+
+
+class DerivedNestedrequirement(EDerivedCollection):
+    pass
+
+
+class DerivedNestedconcern(EDerivedCollection):
+    pass
+
+
+class DerivedNestedcase(EDerivedCollection):
+    pass
+
+
+class DerivedNestedanalysiscase(EDerivedCollection):
+    pass
+
+
+class DerivedNestedverificationcase(EDerivedCollection):
+    pass
+
+
+class DerivedNestedusecase(EDerivedCollection):
+    pass
+
+
+class DerivedNestedview(EDerivedCollection):
+    pass
+
+
+class DerivedNestedviewpoint(EDerivedCollection):
+    pass
+
+
+class DerivedNestedrendering(EDerivedCollection):
+    pass
+
+
+class DerivedNestedmetadata(EDerivedCollection):
+    pass
+
+
+class Usage(Feature):
+    """<p>A <code>Usage</code> is a usage of a <code>Definition</code>. A <code>Usage</code> may only be an <code>ownedFeature</code> of a <code>Definition</code> or another <code>Usage</code>.</p>
+
+    <p>A <code>Usage</code> may have <code>nestedUsages</code> that model <code>features</code> that apply in the context of the <code>owningUsage</code>. A <code>Usage</code> may also have <code>Definitions</code> nested in it, but this has no semantic significance, other than the nested scoping resulting from the <code>Usage</code> being considered as a <code>Namespace</code> for any nested <code>Definitions</code>.</p>
+
+    <p>However, if a <code>Usage</code> has <code>isVariation = true</code>, then it represents a <em>variation point</em> <code>Usage</code>. In this case, all of its <code>members</code> must be <code>variant</code> <code>Usages</code>, related to the <code>Usage</code> by <code>VariantMembership</code> <code>Relationships</code>. Rather than being <code>features</code> of the <code>Usage</code>, <code>variant</code> <code>Usages</code> model different concrete alternatives that can be chosen to fill in for the variation point <code>Usage</code>.</p>
+    variant = variantMembership.ownedVariantUsage
+    variantMembership = ownedMembership->selectByKind(VariantMembership)
+    not isVariation implies variantMembership->isEmpty()
+    isVariation implies variantMembership = ownedMembership
+    isReference = not isComposite
+    owningVariationUsage <> null implies
+        specializes(owningVariationUsage)
+    isVariation implies
+        not ownedSpecialization.specific->exists(isVariation)
+    owningVariationDefinition <> null implies
+        specializes(owningVariationDefinition)
+    directedUsage = directedFeature->selectByKind(Usage)
+    nestedAction = nestedUsage->selectByKind(ActionUsage)
+    nestedAllocation = nestedUsage->selectByKind(AllocationUsage)
+    nestedAnalysisCase = nestedUsage->selectByKind(AnalysisCaseUsage)
+    nestedAttribute = nestedUsage->selectByKind(AttributeUsage)
+    nestedCalculation = nestedUsage->selectByKind(CalculationUsage)
+    nestedCase = nestedUsage->selectByKind(CaseUsage)
+    nestedConcern = nestedUsage->selectByKind(ConcernUsage)
+    nestedConnection = nestedUsage->selectByKind(ConnectorAsUsage)
+    nestedConstraint = nestedUsage->selectByKind(ConstraintUsage)
+    ownedNested = nestedUsage->selectByKind(EnumerationUsage)
+    nestedFlow = nestedUsage->selectByKind(FlowUsage)
+    nestedInterface = nestedUsage->selectByKind(ReferenceUsage)
+    nestedItem = nestedUsage->selectByKind(ItemUsage)
+    nestedMetadata = nestedUsage->selectByKind(MetadataUsage)
+    nestedOccurrence = nestedUsage->selectByKind(OccurrenceUsage)
+    nestedPart = nestedUsage->selectByKind(PartUsage)
+    nestedPort = nestedUsage->selectByKind(PortUsage)
+    nestedReference = nestedUsage->selectByKind(ReferenceUsage)
+    nestedRendering = nestedUsage->selectByKind(RenderingUsage)
+    nestedRequirement = nestedUsage->selectByKind(RequirementUsage)
+    nestedState = nestedUsage->selectByKind(StateUsage)
+    nestedTransition = nestedUsage->selectByKind(TransitionUsage)
+    nestedUsage = ownedFeature->selectByKind(Usage)
+    nestedUseCase = nestedUsage->selectByKind(UseCaseUsage)
+    nestedVerificationCase = nestedUsage->selectByKind(VerificationCaseUsage)
+    nestedView = nestedUsage->selectByKind(ViewUsage)
+    nestedViewpoint = nestedUsage->selectByKind(ViewpointUsage)
+    usage = feature->selectByKind(Usage)
+    owningType <> null implies
+        (owningType.oclIsKindOf(Definition) or
+         ownigType.oclIsKindOf(Usage))"""
+
+    _isReference = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=True,
+        changeable=True,
+        name="isReference",
+        transient=True,
+    )
+    isVariation = EAttribute(eType=Boolean, unique=True, derived=False, changeable=True)
+    variant = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedVariant,
+    )
+    variantMembership = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedVariantmembership,
+    )
+    _owningDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningDefinition",
+        transient=True,
+    )
+    _owningUsage = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="owningUsage",
+        transient=True,
+    )
+    nestedUsage = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedusage,
+    )
+    definition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedDefinition,
+    )
+    usage = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedUsage,
+    )
+    directedUsage = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedDirectedusage,
+    )
+    nestedReference = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedreference,
+    )
+    nestedAttribute = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedattribute,
+    )
+    nestedEnumeration = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedenumeration,
+    )
+    nestedOccurrence = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedoccurrence,
+    )
+    nestedItem = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNesteditem,
+    )
+    nestedPart = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedpart,
+    )
+    nestedPort = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedport,
+    )
+    nestedConnection = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedconnection,
+    )
+    nestedFlow = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedflow,
+    )
+    nestedInterface = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedinterface,
+    )
+    nestedAllocation = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedallocation,
+    )
+    nestedAction = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedaction,
+    )
+    nestedState = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedstate,
+    )
+    nestedTransition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedtransition,
+    )
+    nestedCalculation = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedcalculation,
+    )
+    nestedConstraint = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedconstraint,
+    )
+    nestedRequirement = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedrequirement,
+    )
+    nestedConcern = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedconcern,
+    )
+    nestedCase = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedcase,
+    )
+    nestedAnalysisCase = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedanalysiscase,
+    )
+    nestedVerificationCase = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedverificationcase,
+    )
+    nestedUseCase = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedusecase,
+    )
+    nestedView = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedview,
+    )
+    nestedViewpoint = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedviewpoint,
+    )
+    nestedRendering = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedrendering,
+    )
+    nestedMetadata = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedNestedmetadata,
+    )
+
+    @property
+    def isReference(self):
+        raise NotImplementedError("Missing implementation for isReference")
+
+    @isReference.setter
+    def isReference(self, value):
+        raise NotImplementedError("Missing implementation for isReference")
+
+    @property
+    def owningDefinition(self):
+        raise NotImplementedError("Missing implementation for owningDefinition")
+
+    @owningDefinition.setter
+    def owningDefinition(self, value):
+        raise NotImplementedError("Missing implementation for owningDefinition")
+
+    @property
+    def owningUsage(self):
+        raise NotImplementedError("Missing implementation for owningUsage")
+
+    @owningUsage.setter
+    def owningUsage(self, value):
+        raise NotImplementedError("Missing implementation for owningUsage")
+
+    def __init__(
+        self,
+        *,
+        isReference=None,
+        isVariation=None,
+        variant=None,
+        variantMembership=None,
+        owningDefinition=None,
+        owningUsage=None,
+        nestedUsage=None,
+        definition=None,
+        usage=None,
+        directedUsage=None,
+        nestedReference=None,
+        nestedAttribute=None,
+        nestedEnumeration=None,
+        nestedOccurrence=None,
+        nestedItem=None,
+        nestedPart=None,
+        nestedPort=None,
+        nestedConnection=None,
+        nestedFlow=None,
+        nestedInterface=None,
+        nestedAllocation=None,
+        nestedAction=None,
+        nestedState=None,
+        nestedTransition=None,
+        nestedCalculation=None,
+        nestedConstraint=None,
+        nestedRequirement=None,
+        nestedConcern=None,
+        nestedCase=None,
+        nestedAnalysisCase=None,
+        nestedVerificationCase=None,
+        nestedUseCase=None,
+        nestedView=None,
+        nestedViewpoint=None,
+        nestedRendering=None,
+        nestedMetadata=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isReference is not None:
+            self.isReference = isReference
+
+        if isVariation is not None:
+            self.isVariation = isVariation
+
+        if variant:
+            self.variant.extend(variant)
+
+        if variantMembership:
+            self.variantMembership.extend(variantMembership)
+
+        if owningDefinition is not None:
+            self.owningDefinition = owningDefinition
+
+        if owningUsage is not None:
+            self.owningUsage = owningUsage
+
+        if nestedUsage:
+            self.nestedUsage.extend(nestedUsage)
+
+        if definition:
+            self.definition.extend(definition)
+
+        if usage:
+            self.usage.extend(usage)
+
+        if directedUsage:
+            self.directedUsage.extend(directedUsage)
+
+        if nestedReference:
+            self.nestedReference.extend(nestedReference)
+
+        if nestedAttribute:
+            self.nestedAttribute.extend(nestedAttribute)
+
+        if nestedEnumeration:
+            self.nestedEnumeration.extend(nestedEnumeration)
+
+        if nestedOccurrence:
+            self.nestedOccurrence.extend(nestedOccurrence)
+
+        if nestedItem:
+            self.nestedItem.extend(nestedItem)
+
+        if nestedPart:
+            self.nestedPart.extend(nestedPart)
+
+        if nestedPort:
+            self.nestedPort.extend(nestedPort)
+
+        if nestedConnection:
+            self.nestedConnection.extend(nestedConnection)
+
+        if nestedFlow:
+            self.nestedFlow.extend(nestedFlow)
+
+        if nestedInterface:
+            self.nestedInterface.extend(nestedInterface)
+
+        if nestedAllocation:
+            self.nestedAllocation.extend(nestedAllocation)
+
+        if nestedAction:
+            self.nestedAction.extend(nestedAction)
+
+        if nestedState:
+            self.nestedState.extend(nestedState)
+
+        if nestedTransition:
+            self.nestedTransition.extend(nestedTransition)
+
+        if nestedCalculation:
+            self.nestedCalculation.extend(nestedCalculation)
+
+        if nestedConstraint:
+            self.nestedConstraint.extend(nestedConstraint)
+
+        if nestedRequirement:
+            self.nestedRequirement.extend(nestedRequirement)
+
+        if nestedConcern:
+            self.nestedConcern.extend(nestedConcern)
+
+        if nestedCase:
+            self.nestedCase.extend(nestedCase)
+
+        if nestedAnalysisCase:
+            self.nestedAnalysisCase.extend(nestedAnalysisCase)
+
+        if nestedVerificationCase:
+            self.nestedVerificationCase.extend(nestedVerificationCase)
+
+        if nestedUseCase:
+            self.nestedUseCase.extend(nestedUseCase)
+
+        if nestedView:
+            self.nestedView.extend(nestedView)
+
+        if nestedViewpoint:
+            self.nestedViewpoint.extend(nestedViewpoint)
+
+        if nestedRendering:
+            self.nestedRendering.extend(nestedRendering)
+
+        if nestedMetadata:
+            self.nestedMetadata.extend(nestedMetadata)
+
+
+class DerivedEnumeratedvalue(EDerivedCollection):
+    pass
+
+
+@abstract
+class ConnectorAsUsage(Usage, Connector):
+    """<p>A <code>ConnectorAsUsage</code> is both a <code>Connector</code> and a <code>Usage</code>. <code>ConnectorAsUsage</code> cannot itself be instantiated in a SysML model, but it is the base class for the concrete classes <code>BindingConnectorAsUsage</code>, <code>SuccessionAsUsage</code> and <code>ConnectionUsage</code>.</p>"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class DerivedOwnedreference(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedattribute(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedenumeration(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedoccurrence(EDerivedCollection):
+    pass
+
+
+class DerivedOwneditem(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedpart(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedport(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedconnection(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedflow(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedinterface(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedallocation(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedaction(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedstate(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedtransition(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedcalculation(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedconstraint(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedrequirement(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedconcern(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedcase(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedanalysiscase(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedverificationcase(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedusecase(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedview(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedviewpoint(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedrendering(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedmetadata(EDerivedCollection):
+    pass
+
+
+class DerivedOwnedusage(EDerivedCollection):
+    pass
+
+
+class Definition(Classifier):
+    """<p>A <code>Definition</code> is a <code>Classifier</code> of <code>Usages</code>. The actual kinds of <code>Definition</code> that may appear in a model are given by the subclasses of <code>Definition</code> (possibly as extended with user-defined <em><code>SemanticMetadata</code></em>).</p>
+
+    <p>Normally, a <code>Definition</code> has owned Usages that model <code>features</code> of the thing being defined. A <code>Definition</code> may also have other <code>Definitions</code> nested in it, but this has no semantic significance, other than the nested scoping resulting from the <code>Definition</code> being considered as a <code>Namespace</code> for any nested <code>Definitions</code>.</p>
+
+    <p>However, if a <code>Definition</code> has <code>isVariation</code> = <code>true</code>, then it represents a <em>variation point</em> <code>Definition</code>. In this case, all of its <code>members</code> must be <code>variant</code> <code>Usages</code>, related to the <code>Definition</code> by <code>VariantMembership</code> <code>Relationships</code>. Rather than being <code>features</code> of the <code>Definition</code>, <code>variant</code> <code>Usages</code> model different concrete alternatives that can be chosen to fill in for an abstract <code>Usage</code> of the variation point <code>Definition</code>.</p>
+
+    isVariation implies variantMembership = ownedMembership
+    variant = variantMembership.ownedVariantUsage
+    variantMembership = ownedMembership->selectByKind(VariantMembership)
+    not isVariation implies variantMembership->isEmpty()
+    isVariation implies
+        not ownedSpecialization.specific->exists(isVariation)
+    usage = feature->selectByKind(Usage)
+    directedUsage = directedFeature->selectByKind(Usage)
+    ownedUsage = ownedFeature->selectByKind(Usage)
+    ownedAttribute = ownedUsage->selectByKind(AttributeUsage)
+    ownedReference = ownedUsage->selectByKind(ReferenceUsage)
+    ownedEnumeration = ownedUsage->selectByKind(EnumerationUsage)
+    ownedOccurrence = ownedUsage->selectByKind(OccurrenceUsage)
+    ownedItem = ownedUsage->selectByKind(ItemUsage)
+    ownedPart = ownedUsage->selectByKind(PartUsage)
+    ownedPort = ownedUsage->selectByKind(PortUsage)
+    ownedConnection = ownedUsage->selectByKind(ConnectorAsUsage)
+    ownedFlow = ownedUsage->selectByKind(FlowUsage)
+    ownedInterface = ownedUsage->selectByKind(ReferenceUsage)
+    ownedAllocation = ownedUsage->selectByKind(AllocationUsage)
+    ownedAction = ownedUsage->selectByKind(ActionUsage)
+    ownedState = ownedUsage->selectByKind(StateUsage)
+    ownedTransition = ownedUsage->selectByKind(TransitionUsage)
+    ownedCalculation = ownedUsage->selectByKind(CalculationUsage)
+    ownedConstraint = ownedUsage->selectByKind(ConstraintUsage)
+    ownedRequirement = ownedUsage->selectByKind(RequirementUsage)
+    ownedConcern = ownedUsage->selectByKind(ConcernUsage)
+    ownedCase = ownedUsage->selectByKind(CaseUsage)
+    ownedAnalysisCase = ownedUsage->selectByKind(AnalysisCaseUsage)
+    ownedVerificationCase = ownedUsage->selectByKind(VerificationCaseUsage)
+    ownedUseCase = ownedUsage->selectByKind(UseCaseUsage)
+    ownedView = ownedUsage->selectByKind(ViewUsage)
+    ownedViewpoint = ownedUsage->selectByKind(ViewpointUsage)
+    ownedRendering = ownedUsage->selectByKind(RenderingUsage)
+    ownedMetadata = ownedUsage->selectByKind(MetadataUsage)"""
+
+    isVariation = EAttribute(eType=Boolean, unique=True, derived=False, changeable=True)
+    variant = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedVariant,
+    )
+    variantMembership = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedVariantmembership,
+    )
+    usage = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedUsage,
+    )
+    directedUsage = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedDirectedusage,
+    )
+    ownedReference = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedreference,
+    )
+    ownedAttribute = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedattribute,
+    )
+    ownedEnumeration = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedenumeration,
+    )
+    ownedOccurrence = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedoccurrence,
+    )
+    ownedItem = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwneditem,
+    )
+    ownedPart = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedpart,
+    )
+    ownedPort = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedport,
+    )
+    ownedConnection = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedconnection,
+    )
+    ownedFlow = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedflow,
+    )
+    ownedInterface = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedinterface,
+    )
+    ownedAllocation = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedallocation,
+    )
+    ownedAction = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedaction,
+    )
+    ownedState = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedstate,
+    )
+    ownedTransition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedtransition,
+    )
+    ownedCalculation = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedcalculation,
+    )
+    ownedConstraint = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedconstraint,
+    )
+    ownedRequirement = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedrequirement,
+    )
+    ownedConcern = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedconcern,
+    )
+    ownedCase = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedcase,
+    )
+    ownedAnalysisCase = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedanalysiscase,
+    )
+    ownedVerificationCase = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedverificationcase,
+    )
+    ownedUseCase = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedusecase,
+    )
+    ownedView = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedview,
+    )
+    ownedViewpoint = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedviewpoint,
+    )
+    ownedRendering = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedrendering,
+    )
+    ownedMetadata = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedmetadata,
+    )
+    ownedUsage = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOwnedusage,
+    )
+
+    def __init__(
+        self,
+        *,
+        isVariation=None,
+        variant=None,
+        variantMembership=None,
+        usage=None,
+        directedUsage=None,
+        ownedReference=None,
+        ownedAttribute=None,
+        ownedEnumeration=None,
+        ownedOccurrence=None,
+        ownedItem=None,
+        ownedPart=None,
+        ownedPort=None,
+        ownedConnection=None,
+        ownedFlow=None,
+        ownedInterface=None,
+        ownedAllocation=None,
+        ownedAction=None,
+        ownedState=None,
+        ownedTransition=None,
+        ownedCalculation=None,
+        ownedConstraint=None,
+        ownedRequirement=None,
+        ownedConcern=None,
+        ownedCase=None,
+        ownedAnalysisCase=None,
+        ownedVerificationCase=None,
+        ownedUseCase=None,
+        ownedView=None,
+        ownedViewpoint=None,
+        ownedRendering=None,
+        ownedMetadata=None,
+        ownedUsage=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isVariation is not None:
+            self.isVariation = isVariation
+
+        if variant:
+            self.variant.extend(variant)
+
+        if variantMembership:
+            self.variantMembership.extend(variantMembership)
+
+        if usage:
+            self.usage.extend(usage)
+
+        if directedUsage:
+            self.directedUsage.extend(directedUsage)
+
+        if ownedReference:
+            self.ownedReference.extend(ownedReference)
+
+        if ownedAttribute:
+            self.ownedAttribute.extend(ownedAttribute)
+
+        if ownedEnumeration:
+            self.ownedEnumeration.extend(ownedEnumeration)
+
+        if ownedOccurrence:
+            self.ownedOccurrence.extend(ownedOccurrence)
+
+        if ownedItem:
+            self.ownedItem.extend(ownedItem)
+
+        if ownedPart:
+            self.ownedPart.extend(ownedPart)
+
+        if ownedPort:
+            self.ownedPort.extend(ownedPort)
+
+        if ownedConnection:
+            self.ownedConnection.extend(ownedConnection)
+
+        if ownedFlow:
+            self.ownedFlow.extend(ownedFlow)
+
+        if ownedInterface:
+            self.ownedInterface.extend(ownedInterface)
+
+        if ownedAllocation:
+            self.ownedAllocation.extend(ownedAllocation)
+
+        if ownedAction:
+            self.ownedAction.extend(ownedAction)
+
+        if ownedState:
+            self.ownedState.extend(ownedState)
+
+        if ownedTransition:
+            self.ownedTransition.extend(ownedTransition)
+
+        if ownedCalculation:
+            self.ownedCalculation.extend(ownedCalculation)
+
+        if ownedConstraint:
+            self.ownedConstraint.extend(ownedConstraint)
+
+        if ownedRequirement:
+            self.ownedRequirement.extend(ownedRequirement)
+
+        if ownedConcern:
+            self.ownedConcern.extend(ownedConcern)
+
+        if ownedCase:
+            self.ownedCase.extend(ownedCase)
+
+        if ownedAnalysisCase:
+            self.ownedAnalysisCase.extend(ownedAnalysisCase)
+
+        if ownedVerificationCase:
+            self.ownedVerificationCase.extend(ownedVerificationCase)
+
+        if ownedUseCase:
+            self.ownedUseCase.extend(ownedUseCase)
+
+        if ownedView:
+            self.ownedView.extend(ownedView)
+
+        if ownedViewpoint:
+            self.ownedViewpoint.extend(ownedViewpoint)
+
+        if ownedRendering:
+            self.ownedRendering.extend(ownedRendering)
+
+        if ownedMetadata:
+            self.ownedMetadata.extend(ownedMetadata)
+
+        if ownedUsage:
+            self.ownedUsage.extend(ownedUsage)
+
+
+class AttributeDefinition(Definition, DataType):  # type: ignore
+    """<p>An <code>AttributeDefinition</code> is a <code>Definition</code> and a <code>DataType</code> of information about a quality or characteristic of a system or part of a system that has no independent identity other than its value. All <code>features</code> of an <code>AttributeDefinition</code> must be referential (non-composite).</p>
+
+    <p>As a <code>DataType</code>, an <code>AttributeDefinition</code> must specialize, directly or indirectly, the base <code>DataType</code> <code><em>Base::DataValue</em></code> from the Kernel Semantic Library.</p>
+    feature->forAll(not isComposite)"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class OccurrenceDefinition(Definition, Class):
+    """<p>An <code>OccurrenceDefinition</code> is a <code>Definition</code> of a <code>Class</code> of individuals that have an independent life over time and potentially an extent over space. This includes both structural things and behaviors that act on such structures.</p>
+
+    <p>If <code>isIndividual</code> is true, then the <code>OccurrenceDefinition</code> is constrained to represent an individual thing. The instances of such an <code>OccurrenceDefinition</code> include all spatial and temporal portions of the individual being represented, but only one of these can be the complete <code>Life</code> of the individual. All other instances must be portions of the &quot;maximal portion&quot; that is single <code>Life</code> instance, capturing the conception that all of the instances represent one individual with a single &quot;identity&quot;.</p>
+
+    <p>An <code>OccurrenceDefinition</code> must specialize, directly or indirectly, the base <code>Class</code> <code><em>Occurrence</em></code> from the Kernel Semantic Library.</p>
+
+    let n : Integer = ownedMember->selectByKind(LifeClass) in
+    if isIndividual then n = 1 else n = 0 endif
+    lifeClass =
+        let lifeClasses: OrderedSet(LifeClass) =
+            ownedMember->selectByKind(LifeClass) in
+        if lifeClasses->isEmpty() then null
+        else lifeClasses->first()
+        endif"""
+
+    isIndividual = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    _lifeClass = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="lifeClass",
+        transient=True,
+    )
+
+    @property
+    def lifeClass(self):
+        raise NotImplementedError("Missing implementation for lifeClass")
+
+    @lifeClass.setter
+    def lifeClass(self, value):
+        raise NotImplementedError("Missing implementation for lifeClass")
+
+    def __init__(self, *, lifeClass=None, isIndividual=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if isIndividual is not None:
+            self.isIndividual = isIndividual
+
+        if lifeClass is not None:
+            self.lifeClass = lifeClass
+
+
+class EnumerationDefinition(AttributeDefinition):
+    """<p>An <code>EnumerationDefinition</code> is an <code>AttributeDefinition</code> all of whose instances are given by an explicit list of <code>enumeratedValues</code>. This is realized by requiring that the <code>EnumerationDefinition</code> have <code>isVariation = true</code>, with the <code>enumeratedValues</code> being its <code>variants</code>.</p>
+    isVariation"""
+
+    enumeratedValue = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedEnumeratedvalue,
+    )
+
+    def __init__(self, *, enumeratedValue=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if enumeratedValue:
+            self.enumeratedValue.extend(enumeratedValue)
+
+
+class DerivedActiondefinition(EDerivedCollection):
+    pass
+
+
+class DerivedOccurrencedefinition(EDerivedCollection):
+    pass
+
+
+class OccurrenceUsage(Usage):
+    """<p>An <code>OccurrenceUsage</code> is a <code>Usage</code> whose <code>types</code> are all <code>Classes</code>. Nominally, if a <code>type</code> is an <code>OccurrenceDefinition</code>, an <code>OccurrenceUsage</code> is a <code>Usage</code> of that <code>OccurrenceDefinition</code> within a system. However, other types of Kernel <code>Classes</code> are also allowed, to permit use of <code>Classes</code> from the Kernel Model Libraries.</p>
+
+    individualDefinition =
+        let individualDefinitions : OrderedSet(OccurrenceDefinition) =
+            occurrenceDefinition->
+                selectByKind(OccurrenceDefinition)->
+                select(isIndividual) in
+        if individualDefinitions->isEmpty() then null
+        else individualDefinitions->first() endif
+    isIndividual implies individualDefinition <> null
+    specializesFromLibrary("Occurrences::occurrences")
+    isComposite and
+    owningType <> null and
+    (owningType.oclIsKindOf(Class) or
+     owningType.oclIsKindOf(OccurrenceUsage) or
+     owningType.oclIsKindOf(Feature) and
+        owningType.oclAsType(Feature).type->
+            exists(oclIsKind(Class))) implies
+        specializesFromLibrary("Occurrences::Occurrence::suboccurrences")
+    occurrenceDefinition->select(isIndividual).size() <= 1
+    portionKind <> null implies
+        occurrenceDefinition->forAll(occ |
+            featuringType->exists(specializes(occ)))"""
+
+    isIndividual = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    portionKind = EAttribute(
+        eType=PortionKind, unique=True, derived=False, changeable=True
+    )
+    occurrenceDefinition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOccurrencedefinition,
+    )
+    _individualDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="individualDefinition",
+        transient=True,
+    )
+
+    @property
+    def individualDefinition(self):
+        raise NotImplementedError("Missing implementation for individualDefinition")
+
+    @individualDefinition.setter
+    def individualDefinition(self, value):
+        raise NotImplementedError("Missing implementation for individualDefinition")
+
+    def __init__(
+        self,
+        *,
+        occurrenceDefinition=None,
+        individualDefinition=None,
+        isIndividual=None,
+        portionKind=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isIndividual is not None:
+            self.isIndividual = isIndividual
+
+        if portionKind is not None:
+            self.portionKind = portionKind
+
+        if occurrenceDefinition:
+            self.occurrenceDefinition.extend(occurrenceDefinition)
+
+        if individualDefinition is not None:
+            self.individualDefinition = individualDefinition
+
+
+class ActionUsage(OccurrenceUsage, Step):
+    """<p>An <code>ActionUsage</code> is a <code>Usage</code> that is also a <code>Step</code>, and, so, is typed by a <code>Behavior</code>. Nominally, if the type is an <code>ActionDefinition</code>, an <code>ActionUsage</code> is a <code>Usage</code> of that <code>ActionDefinition</code> within a system. However, other kinds of kernel <code>Behaviors</code> are also allowed, to permit use of <code>Behaviors</code> from the Kernel Model Libraries.</p>
+
+    isSubactionUsage() implies
+        specializesFromLibrary('Actions::Action::subactions')
+    specializesFromLibrary('Actions::actions')
+    isComposite and owningType <> null and
+    (owningType.oclIsKindOf(PartDefinition) or
+     owningType.oclIsKindOf(PartUsage)) implies
+        specializesFromLibrary('Parts::Part::ownedActions')
+    owningFeatureMembership <> null and
+    owningFeatureMembership.oclIsKindOf(StateSubactionMembership) implies
+        let kind : StateSubactionKind =
+            owningFeatureMembership.oclAsType(StateSubactionMembership).kind in
+        if kind = StateSubactionKind::entry then
+            redefinesFromLibrary('States::StateAction::entryAction')
+        else if kind = StateSubactionKind::do then
+            redefinesFromLibrary('States::StateAction::doAction')
+        else
+            redefinesFromLibrary('States::StateAction::exitAction')
+        endif endif
+    owningType <> null and
+        (owningType.oclIsKindOf(AnalysisCaseDefinition) and
+            owningType.oclAsType(AnalysisCaseDefinition).analysisAction->
+                includes(self) or
+         owningType.oclIsKindOf(AnalysisCaseUsage) and
+            owningType.oclAsType(AnalysisCaseUsage).analysisAction->
+                includes(self)) implies
+        specializesFromLibrary('AnalysisCases::AnalysisCase::analysisSteps')"""
+
+    actionDefinition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedActiondefinition,
+    )
+
+    def __init__(self, *, actionDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if actionDefinition:
+            self.actionDefinition.extend(actionDefinition)
+
+    def inputParameters(self):
+        """<p>Return the owned input <code>parameters</code> of this <code>ActionUsage</code>.</p>
+        input->select(f | f.owner = self)"""
+        raise NotImplementedError("operation inputParameters(...) not yet implemented")
+
+    def inputParameter(self, i=None):
+        """<p>Return the <code>i<code>-th owned input <code>parameter</code> of the <code>ActionUsage</code>. Return null if the <code>ActionUsage</code> has less than <code>i<code> owned input <code>parameters</code>.</p>
+        if inputParameters()->size() < i then null
+        else inputParameters()->at(i)
+        endif"""
+        raise NotImplementedError("operation inputParameter(...) not yet implemented")
+
+    def argument(self, i=None):
+        """<p>Return the <code>i<code>-th argument <code>Expression</code> of an <code>ActionUsage</code>, defined as the <code>value</code> <code>Expression</code> of the <code>FeatureValue</code> of the <code>i<code>-th owned input <code>parameter</code> of the <code>ActionUsage</code>. Return null if the <code>ActionUsage</code> has less than <code>i<code> owned input <code>parameters</code> or the <code>i<code>-th owned input <code>parameter</code> has no <code>FeatureValue</code>.</code>
+        if inputParameter(i) = null then null
+        else
+            let featureValue : Sequence(FeatureValue) = inputParameter(i).
+                ownedMembership->select(oclIsKindOf(FeatureValue)) in
+            if featureValue->isEmpty() then null
+            else featureValue->at(1).value
+            endif
+        endif"""
+        raise NotImplementedError("operation argument(...) not yet implemented")
+
+    def isSubactionUsage(self):
+        """<p>Check if this <code>ActionUsage</code> is composite and has an <code>owningType</code> that is an <code>ActionDefinition</code> or <code>ActionUsage</code> but is <em>not</em> the <code>entryAction</code> or <code>exitAction</em></code> of a <code>StateDefinition</code> or <code>StateUsage</code>. If so, then it represents an <code><em>Action</em></code> that is a <code><em>subaction</em></code> of another <code><em>Action</em></code>.</p>
+        isComposite and owningType <> null and
+        (owningType.oclIsKindOf(ActionDefinition) or
+         owningType.oclIsKindOf(ActionUsage)) and
+        (owningFeatureMembership.oclIsKindOf(StateSubactionMembership) implies
+         owningFeatureMembership.oclAsType(StateSubactionMembership).kind =
+            StateSubactionKind::do)"""
+        raise NotImplementedError("operation isSubactionUsage(...) not yet implemented")
+
+
+class Predicate(Function):
+    """<p>A <code>Predicate</code> is a <code>Function</code> whose <code>result</code> <code>parameter</code> has type <code><em>Boolean</em></code> and multiplicity <code>1..1</code>.</p>
+
+    specializesFromLibrary("Performances::BooleanEvaluation")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class RequirementConstraintMembership(FeatureMembership):
+    """<p>A <code>RequirementConstraintMembership</code> is a <code>FeatureMembership</code> for an assumed or required <code>ConstraintUsage</code> of a <code>RequirementDefinition</code> or <code>RequirementUsage<code>.</p>
+    referencedConstraint =
+        let reference : ReferenceSubsetting =
+            ownedConstraint.ownedReferenceSubsetting in
+        if reference = null then ownedConstraint
+        else if not reference.referencedFeature.oclIsKindOf(ConstraintUsage) then null
+        else reference.referencedFeature.oclAsType(ConstraintUsage)
+        endif endif
+    owningType.oclIsKindOf(RequirementDefinition) or
+    owningType.oclIsKindOf(RequirementUsage)
+    ownedConstraint.isComposite"""
+
+    kind = EAttribute(
+        eType=RequirementConstraintKind, unique=True, derived=False, changeable=True
+    )
+    _ownedConstraint = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedConstraint",
+        transient=True,
+    )
+    _referencedConstraint = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="referencedConstraint",
+        transient=True,
+    )
+
+    @property
+    def ownedConstraint(self):
+        raise NotImplementedError("Missing implementation for ownedConstraint")
+
+    @ownedConstraint.setter
+    def ownedConstraint(self, value):
+        raise NotImplementedError("Missing implementation for ownedConstraint")
+
+    @property
+    def referencedConstraint(self):
+        raise NotImplementedError("Missing implementation for referencedConstraint")
+
+    @referencedConstraint.setter
+    def referencedConstraint(self, value):
+        raise NotImplementedError("Missing implementation for referencedConstraint")
+
+    def __init__(
+        self, *, kind=None, ownedConstraint=None, referencedConstraint=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if kind is not None:
+            self.kind = kind
+
+        if ownedConstraint is not None:
+            self.ownedConstraint = ownedConstraint
+
+        if referencedConstraint is not None:
+            self.referencedConstraint = referencedConstraint
+
+
+class RequirementVerificationMembership(RequirementConstraintMembership):
+    """<p>A <code>RequirementVerificationMembership</code> is a <code>RequirementConstraintMembership </code> used in the objective of a <code>VerificationCase</code> to identify a <code>RequirementUsage</code> that is verified by the <code>VerificationCase</code>.</p>
+    kind = RequirementConstraintKind::requirement
+    owningType.oclIsKindOf(RequirementUsage) and
+    owningType.owningFeatureMembership <> null and
+    owningType.owningFeatureMembership.oclIsKindOf(ObjectiveMembership)"""
+
+    _ownedRequirement = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedRequirement",
+        transient=True,
+    )
+    _verifiedRequirement = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="verifiedRequirement",
+        transient=True,
+    )
+
+    @property
+    def ownedRequirement(self):
+        raise NotImplementedError("Missing implementation for ownedRequirement")
+
+    @ownedRequirement.setter
+    def ownedRequirement(self, value):
+        raise NotImplementedError("Missing implementation for ownedRequirement")
+
+    @property
+    def verifiedRequirement(self):
+        raise NotImplementedError("Missing implementation for verifiedRequirement")
+
+    @verifiedRequirement.setter
+    def verifiedRequirement(self, value):
+        raise NotImplementedError("Missing implementation for verifiedRequirement")
+
+    def __init__(self, *, ownedRequirement=None, verifiedRequirement=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if ownedRequirement is not None:
+            self.ownedRequirement = ownedRequirement
+
+        if verifiedRequirement is not None:
+            self.verifiedRequirement = verifiedRequirement
+
+
+class FramedConcernMembership(RequirementConstraintMembership):
+    """<p>A <code>FramedConcernMembership</code> is a <code>RequirementConstraintMembership</code> for a framed <code>ConcernUsage</code> of a <code>RequirementDefinition</code> or <code>RequirementUsage</code>.</p>
+    kind = RequirementConstraintKind::requirement"""
+
+    _ownedConcern = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedConcern",
+        transient=True,
+    )
+    _referencedConcern = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="referencedConcern",
+        transient=True,
+    )
+
+    @property
+    def ownedConcern(self):
+        raise NotImplementedError("Missing implementation for ownedConcern")
+
+    @ownedConcern.setter
+    def ownedConcern(self, value):
+        raise NotImplementedError("Missing implementation for ownedConcern")
+
+    @property
+    def referencedConcern(self):
+        raise NotImplementedError("Missing implementation for referencedConcern")
+
+    @referencedConcern.setter
+    def referencedConcern(self, value):
+        raise NotImplementedError("Missing implementation for referencedConcern")
+
+    def __init__(self, *, ownedConcern=None, referencedConcern=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if ownedConcern is not None:
+            self.ownedConcern = ownedConcern
+
+        if referencedConcern is not None:
+            self.referencedConcern = referencedConcern
+
+
+class SubjectMembership(ParameterMembership):
+    """<p>A <code>SubjectMembership</code> is a <code>ParameterMembership</code> that indicates that its <code>ownedSubjectParameter</code> is the subject of its <code>owningType</code>. The <code>owningType</code> of a <code>SubjectMembership</code> must be a <code>RequirementDefinition</code>, <code>RequirementUsage</code>, <code>CaseDefinition</code>, or <code>CaseUsage</code>.</p>
+    owningType.oclIsType(RequirementDefinition) or
+    owningType.oclIsType(RequiremenCaseRequirementDefinition) or
+    owningType.oclIsType(CaseDefinition) or
+    owningType.oclIsType(CaseUsage)"""
+
+    _ownedSubjectParameter = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedSubjectParameter",
+        transient=True,
+    )
+
+    @property
+    def ownedSubjectParameter(self):
+        raise NotImplementedError("Missing implementation for ownedSubjectParameter")
+
+    @ownedSubjectParameter.setter
+    def ownedSubjectParameter(self, value):
+        raise NotImplementedError("Missing implementation for ownedSubjectParameter")
+
+    def __init__(self, *, ownedSubjectParameter=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if ownedSubjectParameter is not None:
+            self.ownedSubjectParameter = ownedSubjectParameter
+
+
+class ActorMembership(ParameterMembership):
+    """<p>An <code>ActorMembership</code> is a <code>ParameterMembership</code> that identifies a <code>PartUsage</code> as an <em>actor</em> <code>parameter</code>, which specifies a role played by an external entity in interaction with the <code>owningType</code> of the <code>ActorMembership</code>.</p>
+    owningType.oclIsKindOf(RequirementUsage) or
+    owningType.oclIsKindOf(RequirementDefinition) or
+    owningType.oclIsKindOf(CaseDefinition) or
+    owningType.oclIsKindOf(CaseUsage)"""
+
+    _ownedActorParameter = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedActorParameter",
+        transient=True,
+    )
+
+    @property
+    def ownedActorParameter(self):
+        raise NotImplementedError("Missing implementation for ownedActorParameter")
+
+    @ownedActorParameter.setter
+    def ownedActorParameter(self, value):
+        raise NotImplementedError("Missing implementation for ownedActorParameter")
+
+    def __init__(self, *, ownedActorParameter=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if ownedActorParameter is not None:
+            self.ownedActorParameter = ownedActorParameter
+
+
+class StakeholderMembership(ParameterMembership):
+    """<p>A <code>StakeholderMembership</code> is a <code>ParameterMembership</code> that identifies a <code>PartUsage</code> as a <code>stakeholderParameter</code> of a <code>RequirementDefinition</code> or <code>RequirementUsage</code>, which specifies a role played by an entity with concerns framed by the <code>owningType</code>.</p>
+    owningType.oclIsKindOf(RequirementUsage) or
+    owningType.oclIsKindOf(RequirementDefinition)"""
+
+    _ownedStakeholderParameter = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedStakeholderParameter",
+        transient=True,
+    )
+
+    @property
+    def ownedStakeholderParameter(self):
+        raise NotImplementedError(
+            "Missing implementation for ownedStakeholderParameter"
+        )
+
+    @ownedStakeholderParameter.setter
+    def ownedStakeholderParameter(self, value):
+        raise NotImplementedError(
+            "Missing implementation for ownedStakeholderParameter"
+        )
+
+    def __init__(self, *, ownedStakeholderParameter=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if ownedStakeholderParameter is not None:
+            self.ownedStakeholderParameter = ownedStakeholderParameter
+
+
+class Invariant(BooleanExpression):
+    """<p>An <code>Invariant</code> is a <code>BooleanExpression</code> that is asserted to have a specific <code><em>Boolean</em></code> result value. If <code>isNegated = false</code>, then the result is asserted to be true. If <code>isNegated = true</code>, then the result is asserted to be false.</p>
+
+    if isNegated then
+        specializesFromLibrary("Performances::falseEvaluations")
+    else
+        specializesFromLibrary("Performances::trueEvaluations")
+    endif"""
+
+    isNegated = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+
+    def __init__(self, *, isNegated=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if isNegated is not None:
+            self.isNegated = isNegated
+
+
+class TriggerInvocationExpression(InvocationExpression):
+    """<p>A <code>TriggerInvocationExpression<code> is an <code>InvocationExpression</code> that invokes one of the trigger <code>Functions</code> from the Kernel Semantic Library <code><em>Triggers<em></code> package, as indicated by its <code>kind</code>.</p>
+    specializesFromLibrary(
+        if kind = TriggerKind::when then
+            'Triggers::TriggerWhen'
+        else if kind = TriggerKind::at then
+            'Triggers::TriggerAt'
+        else
+            'Triggers::TriggerAfter'
+        endif endif
+    )"""
+
+    kind = EAttribute(eType=TriggerKind, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, kind=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if kind is not None:
+            self.kind = kind
+
+
+class ReturnParameterMembership(ParameterMembership):
+    """<p>A <code>ReturnParameterMembership</code> is a <code>ParameterMembership</code> that indicates that the <code>ownedMemberParameter</code> is the <code>result</code> <code>parameter</code> of a <code>Function</code> or <code>Expression</code>. The <code>direction</code> of the <code>ownedMemberParameter</code> must be <code>out</code>.</p>
+
+    owningType.oclIsKindOf(Function) or owningType.oclIsKindOf(Expression)
+    ownedMemberParameter.direction = ParameterDirectionKind::out"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class DerivedOperand(EDerivedCollection):
+    pass
+
+
+class OperatorExpression(InvocationExpression):
+    """<p>An <code>OperatorExpression</code> is an <code>InvocationExpression</code> whose <code>function</code> is determined by resolving its <code>operator</code> in the context of one of the standard packages from the Kernel Function Library.</p>
+    let libFunctions : Sequence(Element) =
+        Sequence{"BaseFunctions", "DataFunctions", "ControlFunctions"}->
+        collect(ns | resolveGlobal(ns + "::'" + operator + "'")) in
+    libFunctions->includes(function)
+    """
+
+    operator = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+    operand = EReference(
+        ordered=True,
+        unique=True,
+        containment=True,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedOperand,
+    )
+
+    def __init__(self, *, operator=None, operand=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if operator is not None:
+            self.operator = operator
+
+        if operand:
+            self.operand.extend(operand)
+
+
+class LiteralBoolean(LiteralExpression):
+    """<p><code>LiteralBoolean</code> is a <code>LiteralExpression</code> that provides a <code><em>Boolean</em></code> value as a result. Its <code>result</code> <code>parameter</code> must have type <code><em>Boolean</em></code>.</p>"""
+
+    value = EAttribute(eType=Boolean, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, value=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if value is not None:
+            self.value = value
+
+
+class LiteralInteger(LiteralExpression):
+    """<p>A <code>LiteralInteger</code> is a <code>LiteralExpression</code> that provides an <code><em>Integer</em></code> value as a result. Its <code>result</code> <code>parameter</code> must have the type <code><em>Integer</em></code>.</p>"""
+
+    value = EAttribute(eType=Integer, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, value=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if value is not None:
+            self.value = value
+
+
+class LiteralRational(LiteralExpression):
+    """<p>A <code>LiteralRational</code> is a <code>LiteralExpression</code> that provides a <code><em>Rational</em></code> value as a result. Its <code>result</code> <code>parameter</code> must have the type <code><em>Rational</em></code>.</p>"""
+
+    value = EAttribute(eType=Real, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, value=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if value is not None:
+            self.value = value
+
+
+class LiteralInfinity(LiteralExpression):
+    """<p>A <code>LiteralInfinity</code> is a <code>LiteralExpression</code> that provides the positive infinity value (<code>*</code>). It's <code>result</code> must have the type <code><em>Positive</em></code>.</p>"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class LiteralString(LiteralExpression):
+    """<p>A <code>LiteralString</code> is a <code>LiteralExpression</code> that provides a <code><em>String</em></code> value as a result. Its <code>result</code> <code>parameter</code> must have the type <code><em>String</em></code>.</p>"""
+
+    value = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, value=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if value is not None:
+            self.value = value
+
+
+class ItemDefinition(OccurrenceDefinition, Structure):
+    """<p>An <code>ItemDefinition</code> is an <code>OccurrenceDefinition</code> of the <code>Structure</code> of things that may themselves be systems or parts of systems, but may also be things that are acted on by a system or parts of a system, but which do not necessarily perform actions themselves. This includes items that can be exchanged between parts of a system, such as water or electrical signals.</p>
+
+    specializesFromLibrary("Items::Item")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class PortDefinition(OccurrenceDefinition, Structure):
+    """<p>A <code>PortDefinition</code> defines a point at which external entities can connect to and interact with a system or part of a system. Any <code>ownedUsages</code> of a <code>PortDefinition</code>, other than <code>PortUsages</code>, must not be composite.</p>
+
+
+
+    conjugatedPortDefinition =
+    let conjugatedPortDefinitions : OrderedSet(ConjugatedPortDefinition) =
+        ownedMember->selectByKind(ConjugatedPortDefinition) in
+    if conjugatedPortDefinitions->isEmpty() then null
+    else conjugatedPortDefinitions->first()
+    endif
+    ownedUsage->
+        reject(oclIsKindOf(PortUsage))->
+        forAll(not isComposite)
+    not oclIsKindOf(ConjugatedPortDefinition) implies
+        ownedMember->
+            selectByKind(ConjugatedPortDefinition)->
+            size() = 1
+    specializeFromLibrary('Ports::Port')"""
+
+    _conjugatedPortDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="conjugatedPortDefinition",
+        transient=True,
+    )
+
+    @property
+    def conjugatedPortDefinition(self):
+        raise NotImplementedError("Missing implementation for conjugatedPortDefinition")
+
+    @conjugatedPortDefinition.setter
+    def conjugatedPortDefinition(self, value):
+        raise NotImplementedError("Missing implementation for conjugatedPortDefinition")
+
+    def __init__(self, *, conjugatedPortDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if conjugatedPortDefinition is not None:
+            self.conjugatedPortDefinition = conjugatedPortDefinition
+
+
+class Interaction(Association, Behavior):
+    """<p>An <code>Interaction</code> is a <code>Behavior</code> that is also an <code>Association</code>, providing a context for multiple objects that have behaviors that impact one another.</p>"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class AssociationStructure(Association, Structure):
+    """<p>An <code>AssociationStructure</code> is an <code>Association</code> that is also a <code>Structure</code>, classifying link objects that are both links and objects. As objects, link objects can be created and destroyed, and their non-end <code>Features</code> can change over time. However, the values of the end <code>Features</code> of a link object are fixed and cannot change over its lifetime.</p>
+    specializesFromLibrary("Objects::ObjectLink")
+    endFeature->size() = 2 implies
+        specializesFromLibrary("Objects::BinaryLinkObject")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class DerivedStatedefinition(EDerivedCollection):
+    pass
+
+
+class StateUsage(ActionUsage):
+    """<p>A <code>StateUsage</code> is an <code>ActionUsage</code> that is nominally the <code>Usage</code> of a <code>StateDefinition</code>. However, other kinds of kernel <code>Behaviors</code> are also allowed as <code>types</code>, to permit use of <code>Behaviors</code from the Kernel Model Libraries.</p>
+
+    <p>A <code>StateUsage</code> may be related to up to three of its <code>ownedFeatures</code> by <code>StateSubactionMembership</code> <code>Relationships<code>, all of different <code>kinds</code>, corresponding to the entry, do and exit actions of the <code>StateUsage</code>.</p>
+
+    let general : Sequence(Type) = ownedGeneralization.general in
+    general->selectByKind(StateDefinition)->
+        forAll(g | g.isParallel = isParallel) and
+    general->selectByKind(StateUsage)->
+        forAll(g | g.parallel = isParallel)
+    doAction =
+        let doMemberships : Sequence(StateSubactionMembership) =
+            ownedMembership->
+                selectByKind(StateSubactionMembership)->
+                select(kind = StateSubactionKind::do) in
+        if doMemberships->isEmpty() then null
+        else doMemberships->at(1)
+        endif
+    entryAction =
+        let entryMemberships : Sequence(StateSubactionMembership) =
+            ownedMembership->
+                selectByKind(StateSubactionMembership)->
+                select(kind = StateSubactionKind::entry) in
+        if entryMemberships->isEmpty() then null
+        else entryMemberships->at(1)
+        endif
+    isParallel implies
+        nestedAction.incomingTransition->isEmpty() and
+        nestedAction.outgoingTransition->isEmpty()
+    isSubstateUsage(true) implies
+        specializesFromLibrary('States::State::substates')
+    exitAction =
+        let exitMemberships : Sequence(StateSubactionMembership) =
+            ownedMembership->
+                selectByKind(StateSubactionMembership)->
+                select(kind = StateSubactionKind::exit) in
+        if exitMemberships->isEmpty() then null
+        else exitMemberships->at(1)
+        endif
+    specializesFromLibrary('States::StateAction')
+    ownedMembership->
+        selectByKind(StateSubactionMembership)->
+        isUnique(kind)
+    isSubstateUsage(false) implies
+        specializesFromLibrary('States::State::substates')"""
+
+    isParallel = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    stateDefinition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedStatedefinition,
+    )
+    _entryAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="entryAction",
+        transient=True,
+    )
+    _doAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="doAction",
+        transient=True,
+    )
+    _exitAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="exitAction",
+        transient=True,
+    )
+
+    @property
+    def entryAction(self):
+        raise NotImplementedError("Missing implementation for entryAction")
+
+    @entryAction.setter
+    def entryAction(self, value):
+        raise NotImplementedError("Missing implementation for entryAction")
+
+    @property
+    def doAction(self):
+        raise NotImplementedError("Missing implementation for doAction")
+
+    @doAction.setter
+    def doAction(self, value):
+        raise NotImplementedError("Missing implementation for doAction")
+
+    @property
+    def exitAction(self):
+        raise NotImplementedError("Missing implementation for exitAction")
+
+    @exitAction.setter
+    def exitAction(self, value):
+        raise NotImplementedError("Missing implementation for exitAction")
+
+    def __init__(
+        self,
+        *,
+        stateDefinition=None,
+        entryAction=None,
+        doAction=None,
+        exitAction=None,
+        isParallel=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isParallel is not None:
+            self.isParallel = isParallel
+
+        if stateDefinition:
+            self.stateDefinition.extend(stateDefinition)
+
+        if entryAction is not None:
+            self.entryAction = entryAction
+
+        if doAction is not None:
+            self.doAction = doAction
+
+        if exitAction is not None:
+            self.exitAction = exitAction
+
+    def isSubstateUsage(self, isParallel=None):
+        """<p>Check if this <code>StateUsage</code> is composite and has an <code>owningType</code> that is an <code>StateDefinition</code> or <code>StateUsage</code> with the given value of <code>isParallel</code>, but is <em>not</em> an <code>entryAction</code> or <code>exitAction</code>. If so, then it represents a <code><em>StateAction</em></code> that is a <code><em>substate</em></code> or <code><em>exclusiveState</em></code> (for <code>isParallel = false</code>) of another <code><em>StateAction</em></code>.</p>
+        owningType <> null and
+        (owningType.oclIsKindOf(StateDefinition) and
+            owningType.oclAsType(StateDefinition).isParallel = isParallel or
+         owningType.oclIsKindOf(StateUsage) and
+            owningType.oclAsType(StateUsage).isParallel = isParallel) and
+        not owningFeatureMembership.oclIsKindOf(StateSubactionMembership)"""
+        raise NotImplementedError("operation isSubstateUsage(...) not yet implemented")
+
+
+class DerivedTriggeraction(EDerivedCollection):
+    pass
+
+
+class DerivedGuardexpression(EDerivedCollection):
+    pass
+
+
+class DerivedEffectaction(EDerivedCollection):
+    pass
+
+
+class TransitionUsage(ActionUsage):
+    """<p>A <code>TransitionUsage</code> is an <code>ActionUsage<code> representing a triggered transition between <code>ActionUsages</code> or <code>StateUsages</code>. When triggered by a <code>triggerAction</code>, when its <code>guardExpression</code> is true, the <code>TransitionUsage</code> asserts that its <code>source</code> is exited, then its <code>effectAction</code> (if any) is performed, and then its <code>target</code> is entered.</p>
+
+    <p>A <code>TransitionUsage<code> can be related to some of its <code>ownedFeatures</code> using <code>TransitionFeatureMembership</code> <code>Relationships</code>, corresponding to the <code>triggerAction</code>, <code>guardExpression</code> and <code>effectAction</code> of the <code>TransitionUsage</code>.</p>
+    isComposite and owningType <> null and
+    (owningType.oclIsKindOf(ActionDefinition) or
+     owningType.oclIsKindOf(ActionUsage)) and
+    not (owningType.oclIsKindOf(StateDefinition) or
+         owningType.oclIsKindOf(StateUsage)) implies
+        specializesFromLibrary("Actions::Action::decisionTransitionActions")
+    isComposite and owningType <> null and
+    (owningType.oclIsKindOf(StateDefinition) or
+     owningType.oclIsKindOf(StateUsage)) implies
+        specializesFromLibrary("States::State::stateTransitions")
+    specializesFromLibrary("Actions::actions::transitionActions")
+    source =
+        if ownedMembership->isEmpty() then null
+        else
+            let member : Element =
+                ownedMembership->at(1).memberElement in
+            if not member.oclIsKindOf(ActionUsage) then null
+            else member.oclAsKindOf(ActionUsage)
+            endif
+        endif
+    target =
+        if succession.targetFeature->isEmpty() then null
+        else
+            let targetFeature : Feature =
+                succession.targetFeature->at(1) in
+            if not targetFeature.oclIsKindOf(ActionUsage) then null
+            else targetFeature.oclAsType(ActionUsage)
+            endif
+        endif
+    triggerAction = ownedFeatureMembership->
+        selectByKind(TransitionFeatureMembership)->
+        select(kind = TransitionFeatureKind::trigger).transitionFeature->
+        selectByKind(AcceptActionUsage)
+    let successions : Sequence(Successions) =
+        ownedMember->selectByKind(Succession) in
+    successions->notEmpty() and
+    successions->at(1).targetFeature->
+        forAll(oclIsKindOf(ActionUsage))
+    guardExpression = ownedFeatureMembership->
+        selectByKind(TransitionFeatureMembership)->
+        select(kind = TransitionFeatureKind::trigger).transitionFeature->
+        selectByKind(Expression)
+    triggerAction->forAll(specializesFromLibrary('Actions::TransitionAction::accepter') and
+    guardExpression->forAll(specializesFromLibrary('Actions::TransitionAction::guard') and
+    effectAction->forAll(specializesFromLibrary('Actions::TransitionAction::effect'))
+    triggerAction = ownedFeatureMembership->
+        selectByKind(TransitionFeatureMembership)->
+        select(kind = TransitionFeatureKind::trigger).transitionFeatures->
+        selectByKind(AcceptActionUsage)
+    succession.sourceFeature = source
+    ownedMember->selectByKind(BindingConnector)->exists(b |
+        b.relatedFeatures->includes(source) and
+        b.relatedFeatures->includes(inputParameter(2)))
+    triggerAction->notEmpty() implies
+        let payloadParameter : Feature = inputParameter(2) in
+        payloadParameter <> null and
+        payloadParameter.subsetsChain(triggerAction->at(1), triggerPayloadParameter())
+    ownedMember->selectByKind(BindingConnector)->exists(b |
+        b.relatedFeatures->includes(succession) and
+        b.relatedFeatures->includes(resolveGlobal(
+            'TransitionPerformances::TransitionPerformance::transitionLink')))
+    if triggerAction->isEmpty() then
+        inputParameters()->size() >= 1
+    else
+        inputParameters()->size() >= 2
+    endif
+
+    succession = ownedMember->selectByKind(Succession)->at(1)"""
+
+    _source = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="source",
+        transient=True,
+    )
+    _target = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="target",
+        transient=True,
+    )
+    triggerAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedTriggeraction,
+    )
+    guardExpression = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedGuardexpression,
+    )
+    effectAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedEffectaction,
+    )
+    _succession = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="succession",
+        transient=True,
+    )
+
+    @property
+    def source(self):
+        raise NotImplementedError("Missing implementation for source")
+
+    @source.setter
+    def source(self, value):
+        raise NotImplementedError("Missing implementation for source")
+
+    @property
+    def target(self):
+        raise NotImplementedError("Missing implementation for target")
+
+    @target.setter
+    def target(self, value):
+        raise NotImplementedError("Missing implementation for target")
+
+    @property
+    def succession(self):
+        raise NotImplementedError("Missing implementation for succession")
+
+    @succession.setter
+    def succession(self, value):
+        raise NotImplementedError("Missing implementation for succession")
+
+    def __init__(
+        self,
+        *,
+        source=None,
+        target=None,
+        triggerAction=None,
+        guardExpression=None,
+        effectAction=None,
+        succession=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if source is not None:
+            self.source = source
+
+        if target is not None:
+            self.target = target
+
+        if triggerAction:
+            self.triggerAction.extend(triggerAction)
+
+        if guardExpression:
+            self.guardExpression.extend(guardExpression)
+
+        if effectAction:
+            self.effectAction.extend(effectAction)
+
+        if succession is not None:
+            self.succession = succession
+
+    def triggerPayloadParameter(self):
+        """<p>Return the <code>payloadParameter</code> of the <code>triggerAction</code> of this <code>TransitionUsage</code>, if it has one.</p>
+        if triggerAction->isEmpty() then null
+        else triggerAction->first().payloadParameter
+        endif"""
+        raise NotImplementedError(
+            "operation triggerPayloadParameter(...) not yet implemented"
+        )
+
+
+class AcceptActionUsage(ActionUsage):
+    """<p>An <code>AcceptActionUsage</code> is an <code>ActionUsage</code> that specifies the acceptance of an <em><code>incomingTransfer</code></em> from the <code><em>Occurrence</em></code> given by the result of its <code>receiverArgument</code> Expression. (If no <code>receiverArgument</code> is provided, the default is the <em><code>this</code></em> context of the AcceptActionUsage.) The payload of the accepted <em><code>Transfer</em></code> is output on its <code>payloadParameter</code>. Which <em><code>Transfers</em></code> may be accepted is determined by conformance to the typing and (potentially) binding of the <code>payloadParameter</code>.</p>
+
+    inputParameters()->size() >= 2
+    receiverArgument = argument(2)
+    payloadArgument = argument(1)
+    payloadParameter =
+     if parameter->isEmpty() then null
+     else parameter->first() endif
+    not isTriggerAction() implies
+        specializesFromLibrary('Actions::acceptActions')
+    isSubactionUsage() and not isTriggerAction() implies
+        specializesFromLibrary('Actions::Action::acceptSubactions')
+    isTriggerAction() implies
+        specializesFromLibrary('Actions::TransitionAction::accepter')
+    payloadArgument <> null and
+    payloadArgument.oclIsKindOf(TriggerInvocationExpression) implies
+        let invocation : Expression =
+            payloadArgument.oclAsType(Expression) in
+        parameter->size() >= 2 and
+        invocation.parameter->size() >= 2 and
+        ownedFeature->selectByKind(BindingConnector)->exists(b |
+            b.relatedFeatures->includes(parameter->at(2)) and
+            b.relatedFeatures->includes(invocation.parameter->at(2)))"""
+
+    _receiverArgument = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="receiverArgument",
+        transient=True,
+    )
+    _payloadParameter = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="payloadParameter",
+        transient=True,
+    )
+    _payloadArgument = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="payloadArgument",
+        transient=True,
+    )
+
+    @property
+    def receiverArgument(self):
+        raise NotImplementedError("Missing implementation for receiverArgument")
+
+    @receiverArgument.setter
+    def receiverArgument(self, value):
+        raise NotImplementedError("Missing implementation for receiverArgument")
+
+    @property
+    def payloadParameter(self):
+        raise NotImplementedError("Missing implementation for payloadParameter")
+
+    @payloadParameter.setter
+    def payloadParameter(self, value):
+        raise NotImplementedError("Missing implementation for payloadParameter")
+
+    @property
+    def payloadArgument(self):
+        raise NotImplementedError("Missing implementation for payloadArgument")
+
+    @payloadArgument.setter
+    def payloadArgument(self, value):
+        raise NotImplementedError("Missing implementation for payloadArgument")
+
+    def __init__(
+        self,
+        *,
+        receiverArgument=None,
+        payloadParameter=None,
+        payloadArgument=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if receiverArgument is not None:
+            self.receiverArgument = receiverArgument
+
+        if payloadParameter is not None:
+            self.payloadParameter = payloadParameter
+
+        if payloadArgument is not None:
+            self.payloadArgument = payloadArgument
+
+    def isTriggerAction(self):
+        """<p>Check if this <code>AcceptActionUsage</code> is the <code>triggerAction</code> of a <code>TransitionUsage</code>.</p>
+        owningType <> null and
+        owningType.oclIsKindOf(TransitionUsage) and
+        owningType.oclAsType(TransitionUsage).triggerAction->includes(self)"""
+        raise NotImplementedError("operation isTriggerAction(...) not yet implemented")
+
+
+class DerivedAction(EDerivedCollection):
+    pass
+
+
+class ActionDefinition(OccurrenceDefinition, Behavior):
+    """<p>An <code>ActionDefinition</code> is a <code>Definition</code> that is also a <code>Behavior</code> that defines an <em><code>Action</code></em> performed by a system or part of a system.</p>
+    specializesFromLibrary('Actions::Action')
+    action = usage->selectByKind(ActionUsage)"""
+
+    action = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedAction,
+    )
+
+    def __init__(self, *, action=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if action:
+            self.action.extend(action)
+
+
+class DerivedSatisfiedviewpoint(EDerivedCollection):
+    pass
+
+
+class DerivedExposedelement(EDerivedCollection):
+    pass
+
+
+class DerivedViewcondition(EDerivedCollection):
+    pass
+
+
+class DerivedItemdefinition(EDerivedCollection):
+    pass
+
+
+class ItemUsage(OccurrenceUsage):
+    """<p>An <code>ItemUsage</code> is a <code>ItemUsage</code> whose <code>definition</code> is a <code>Structure</code>. Nominally, if the <code>definition</code> is an <code>ItemDefinition</code>, an <code>ItemUsage</code> is a <code>ItemUsage</code> of that <code>ItemDefinition</code> within a system. However, other kinds of Kernel <code>Structures</code> are also allowed, to permit use of <code>Structures</code> from the Kernel Model Libraries.</p>
+    itemDefinition = occurrenceDefinition->selectByKind(ItemDefinition)
+    specializesFromLibrary("Items::items")
+    isComposite and owningType <> null and
+    (owningType.oclIsKindOf(ItemDefinition) or
+     owningType.oclIsKindOf(ItemUsage)) implies
+        specializesFromLibrary("Items::Item::subitem")"""
+
+    itemDefinition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedItemdefinition,
+    )
+
+    def __init__(self, *, itemDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if itemDefinition:
+            self.itemDefinition.extend(itemDefinition)
+
+
+class DerivedPartdefinition(EDerivedCollection):
+    pass
+
+
+class PartUsage(ItemUsage):
+    """<p>A <code>PartUsage</code> is a usage of a <code>PartDefinition</code> to represent a system or a part of a system. At least one of the <code>itemDefinitions</code> of the <code>PartUsage</code> must be a <code>PartDefinition</code>.</p>
+
+    <p>A <code>PartUsage</code> must subset, directly or indirectly, the base <code>PartUsage</code> <em><code>parts</code></em> from the Systems Model Library.</p>
+    itemDefinition->selectByKind(PartDefinition)
+    partDefinition->notEmpty()
+    specializesFromLibrary("Parts::parts")
+    isComposite and owningType <> null and
+    (owningType.oclIsKindOf(ItemDefinition) or
+     owningType.oclIsKindOf(ItemUsage)) implies
+        specializesFromLibrary("Items::Item::subparts")
+    owningFeatureMembership <> null and
+    owningFeatureMembership.oclIsKindOf(ActorMembership) implies
+        if owningType.oclIsKindOf(RequirementDefinition) or
+           owningType.oclIsKindOf(RequirementUsage)
+        then specializesFromLibrary('Requirements::RequirementCheck::actors')
+        else specializesFromLibrary('Cases::Case::actors')
+    owningFeatureMembership <> null and
+    owningFeatureMembership.oclIsKindOf(StakeholderMembership) implies
+        specializesFromLibrary('Requirements::RequirementCheck::stakeholders')"""
+
+    partDefinition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedPartdefinition,
+    )
+
+    def __init__(self, *, partDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if partDefinition:
+            self.partDefinition.extend(partDefinition)
+
+
+class ViewUsage(PartUsage):
+    """<p>A <code>ViewUsage</code> is a usage of a <code>ViewDefinition</code> to specify the generation of a view of the <code>members</code> of a collection of <code>exposedNamespaces</code>. The <code>ViewUsage</code> can satisfy more <code>viewpoints</code> than its definition, and it can specialize the <code>viewRendering</code> specified by its definition.<p>
+    exposedElement = ownedImport->selectByKind(Expose).
+        importedMemberships(Set{}).memberElement->
+        select(elm | includeAsExposed(elm))->
+        asOrderedSet()
+    satisfiedViewpoint = ownedRequirement->
+        selectByKind(ViewpointUsage)->
+        select(isComposite)
+    viewCondition = featureMembership->
+        selectByKind(ElementFilterMembership).
+        condition
+    viewRendering =
+        let renderings: OrderedSet(ViewRenderingMembership) =
+            featureMembership->selectByKind(ViewRenderingMembership) in
+        if renderings->isEmpty() then null
+        else renderings->first().referencedRendering
+        endif
+    featureMembership->
+        selectByKind(ViewRenderingMembership)->
+        size() <= 1
+    specializesFromLibrary('Views::views')
+    owningType <> null and
+    (owningType.oclIsKindOf(ViewDefinition) or
+     owningType.oclIsKindOf(ViewUsage)) implies
+        specializesFromLibrary('Views::View::subviews')"""
+
+    _viewDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="viewDefinition",
+        transient=True,
+    )
+    satisfiedViewpoint = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedSatisfiedviewpoint,
+    )
+    exposedElement = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedExposedelement,
+    )
+    _viewRendering = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="viewRendering",
+        transient=True,
+    )
+    viewCondition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedViewcondition,
+    )
+
+    @property
+    def viewDefinition(self):
+        raise NotImplementedError("Missing implementation for viewDefinition")
+
+    @viewDefinition.setter
+    def viewDefinition(self, value):
+        raise NotImplementedError("Missing implementation for viewDefinition")
+
+    @property
+    def viewRendering(self):
+        raise NotImplementedError("Missing implementation for viewRendering")
+
+    @viewRendering.setter
+    def viewRendering(self, value):
+        raise NotImplementedError("Missing implementation for viewRendering")
+
+    def __init__(
+        self,
+        *,
+        viewDefinition=None,
+        satisfiedViewpoint=None,
+        exposedElement=None,
+        viewRendering=None,
+        viewCondition=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if viewDefinition is not None:
+            self.viewDefinition = viewDefinition
+
+        if satisfiedViewpoint:
+            self.satisfiedViewpoint.extend(satisfiedViewpoint)
+
+        if exposedElement:
+            self.exposedElement.extend(exposedElement)
+
+        if viewRendering is not None:
+            self.viewRendering = viewRendering
+
+        if viewCondition:
+            self.viewCondition.extend(viewCondition)
+
+    def includeAsExposed(self, element=None):
+        """<p>Determine whether the given <code>element</code> meets all the owned and inherited <code>viewConditions</code>.</p>
+        let metadataFeatures: Sequence(AnnotatingElement) =
+            element.ownedAnnotation.annotatingElement->
+                select(oclIsKindOf(MetadataFeature)) in
+        self.membership->selectByKind(ElementFilterMembership).
+            condition->forAll(cond |
+                metadataFeatures->exists(elem |
+                    cond.checkCondition(elem)))"""
+        raise NotImplementedError("operation includeAsExposed(...) not yet implemented")
+
+
+class RenderingUsage(PartUsage):
+    """<p>A <code>RenderingUsage</code> is the usage of a <code>RenderingDefinition</code> to specify the rendering of a specific model view to produce a physical view artifact.</p>
+
+
+    specializeFromLibrary('Views::renderings')
+    owningType <> null and
+    (owningType.oclIsKindOf(RenderingDefinition) or
+     owningType.oclIsKindOf(RenderingUsage)) implies
+        specializesFromLibrary('Views::Rendering::subrenderings')
+    owningFeatureMembership <> null and
+    owningFeatureMembership.oclIsKindOf(ViewRenderingMembership) implies
+        redefinesFromLibrary('Views::View::viewRendering')"""
+
+    _renderingDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="renderingDefinition",
+        transient=True,
+    )
+
+    @property
+    def renderingDefinition(self):
+        raise NotImplementedError("Missing implementation for renderingDefinition")
+
+    @renderingDefinition.setter
+    def renderingDefinition(self, value):
+        raise NotImplementedError("Missing implementation for renderingDefinition")
+
+    def __init__(self, *, renderingDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if renderingDefinition is not None:
+            self.renderingDefinition = renderingDefinition
+
+
+@abstract
+class ControlNode(ActionUsage):
+    """<p>A <code>ControlNode</code> is an <code>ActionUsage</code> that does not have any inherent behavior but provides constraints on incoming and outgoing <code>Successions</code> that are used to control other <code>Actions</code>. A <code>ControlNode</code> must be a composite owned <code>usage</code> of an <code>ActionDefinition</code> or <code>ActionUsage</code>.</p>
+
+    sourceConnector->selectByKind(Succession)->
+        collect(connectorEnd->at(1).multiplicity)->
+        forAll(sourceMult |
+            multiplicityHasBounds(sourceMult, 1, 1))
+    owningType <> null and
+    (owningType.oclIsKindOf(ActionDefinition) or
+     owningType.oclIsKindOf(ActionUsage))
+    targetConnector->selectByKind(Succession)->
+        collect(connectorEnd->at(2).multiplicity)->
+        forAll(targetMult |
+            multiplicityHasBounds(targetMult, 1, 1))
+    specializesFromLibrary('Action::Action::controls')"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def multiplicityHasBounds(self, mult=None, lower=None, upper=None):
+        """<p>Check that the given <code>Multiplicity</code> has <code>lowerBound</code> and <code>upperBound</code> expressions that are model-level evaluable to the given <code>lower</code> and <code>upper</code> values.</p>
+        mult <> null and
+        if mult.oclIsKindOf(MultiplicityRange) then
+            mult.oclAsType(MultiplicityRange).hasBounds(lower, upper)
+        else
+            mult.allSuperTypes()->exists(
+                oclisKindOf(MultiplicityRange) and
+                oclAsType(MultiplicityRange).hasBounds(lower, upper)
+        endif"""
+        raise NotImplementedError(
+            "operation multiplicityHasBounds(...) not yet implemented"
+        )
+
+
+@abstract
+class LoopActionUsage(ActionUsage):
+    """<p>A <code>LoopActionUsage</code> is an <code>ActionUsage</code> that specifies that its <code>bodyAction</code> should be performed repeatedly. Its subclasses <code>WhileLoopActionUsage</code> and <code>ForLoopActionUsage</code> provide different ways to determine how many times the <code>bodyAction</code> should be performed.</p>
+    bodyAction =
+        let parameter : Feature = inputParameter(2) in
+        if parameter <> null and parameter.oclIsKindOf(Action) then
+            parameter.oclAsType(Action)
+        else
+            null
+        endif"""
+
+    _bodyAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="bodyAction",
+        transient=True,
+    )
+
+    @property
+    def bodyAction(self):
+        raise NotImplementedError("Missing implementation for bodyAction")
+
+    @bodyAction.setter
+    def bodyAction(self, value):
+        raise NotImplementedError("Missing implementation for bodyAction")
+
+    def __init__(self, *, bodyAction=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if bodyAction is not None:
+            self.bodyAction = bodyAction
+
+
+class AssignmentActionUsage(ActionUsage):
+    """<p>An <code>AssignmentActionUsage</code> is an <code>ActionUsage</code> that is defined, directly or indirectly, by the <code>ActionDefinition</code> <em><code>AssignmentAction</code></em> from the Systems Model Library. It specifies that the value of the <code>referent</code> <code>Feature</code>, relative to the target given by the result of the <code>targetArgument</code> <code>Expression</code>, should be set to the result of the <code>valueExpression</code>.</p>
+
+    specializesFromLibrary('Actions::assignmentActions')
+    let targetParameter : Feature = inputParameter(1) in
+    targetParameter <> null and
+    targetParameter.ownedFeature->notEmpty() and
+    targetParameter.ownedFeature->first().
+        redefines('AssignmentAction::target::startingAt')
+    valueExpression = argument(2)
+    targetArgument = argument(1)
+    isSubactionUsage() implies
+        specializesFromLibrary('Actions::Action::assignments')
+    let targetParameter : Feature = inputParameter(1) in
+    targetParameter <> null and
+    targetParameter.ownedFeature->notEmpty() and
+    targetParameter->first().ownedFeature->notEmpty() and
+    targetParameter->first().ownedFeature->first().
+        redefines('AssigmentAction::target::startingAt::accessedFeature')
+    let targetParameter : Feature = inputParameter(1) in
+    targetParameter <> null and
+    targetParameter.ownedFeature->notEmpty() and
+    targetParameter->first().ownedFeature->notEmpty() and
+    targetParameter->first().ownedFeature->first().redefines(referent)
+    referent =
+        let unownedFeatures : Sequence(Feature) = ownedMembership->
+            reject(oclIsKindOf(OwningMembership)).memberElement->
+            selectByKind(Feature) in
+        if unownedFeatures->isEmpty() then null
+        else unownedFeatures->first().oclAsType(Feature)
+        endif"""
+
+    _targetArgument = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="targetArgument",
+        transient=True,
+    )
+    _valueExpression = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="valueExpression",
+        transient=True,
+    )
+    _referent = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="referent",
+        transient=True,
+    )
+
+    @property
+    def targetArgument(self):
+        raise NotImplementedError("Missing implementation for targetArgument")
+
+    @targetArgument.setter
+    def targetArgument(self, value):
+        raise NotImplementedError("Missing implementation for targetArgument")
+
+    @property
+    def valueExpression(self):
+        raise NotImplementedError("Missing implementation for valueExpression")
+
+    @valueExpression.setter
+    def valueExpression(self, value):
+        raise NotImplementedError("Missing implementation for valueExpression")
+
+    @property
+    def referent(self):
+        raise NotImplementedError("Missing implementation for referent")
+
+    @referent.setter
+    def referent(self, value):
+        raise NotImplementedError("Missing implementation for referent")
+
+    def __init__(
+        self, *, targetArgument=None, valueExpression=None, referent=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if targetArgument is not None:
+            self.targetArgument = targetArgument
+
+        if valueExpression is not None:
+            self.valueExpression = valueExpression
+
+        if referent is not None:
+            self.referent = referent
+
+
+class IfActionUsage(ActionUsage):
+    """<p>An <code>IfActionUsage</code> is an <code>ActionUsage</code> that specifies that the <code>thenAction</code> <code>ActionUsage</code> should be performed if the result of the <code>ifArgument</code> <code>Expression</code> is true. It may also optionally specify an <code>elseAction</code> <code>ActionUsage</code> that is performed if the result of the <code>ifArgument</code> is false.</p>
+    thenAction =
+        let parameter : Feature = inputParameter(2) in
+        if parameter <> null and parameter.oclIsKindOf(ActionUsage) then
+            parameter.oclAsType(ActionUsage)
+        else
+            null
+        endif
+    isSubactionUsage() implies
+        specializesFromLibrary('Actions::Action::ifSubactions')
+    if elseAction = null then
+        specifiesFromLibrary('Actions::ifThenActions')
+    else
+        specifiesFromLibrary('Actions::ifThenElseActions')
+    endif
+    ifArgument =
+        let parameter : Feature = inputParameter(1) in
+        if parameter <> null and parameter.oclIsKindOf(Expression) then
+            parameter.oclAsType(Expression)
+        else
+            null
+        endif
+    elseAction =
+        let parameter : Feature = inputParameter(3) in
+        if parameter <> null and parameter.oclIsKindOf(ActionUsage) then
+            parameter.oclAsType(ActionUsage)
+        else
+            null
+        endif"""
+
+    _elseAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="elseAction",
+        transient=True,
+    )
+    _thenAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="thenAction",
+        transient=True,
+    )
+    _ifArgument = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ifArgument",
+        transient=True,
+    )
+
+    @property
+    def elseAction(self):
+        raise NotImplementedError("Missing implementation for elseAction")
+
+    @elseAction.setter
+    def elseAction(self, value):
+        raise NotImplementedError("Missing implementation for elseAction")
+
+    @property
+    def thenAction(self):
+        raise NotImplementedError("Missing implementation for thenAction")
+
+    @thenAction.setter
+    def thenAction(self, value):
+        raise NotImplementedError("Missing implementation for thenAction")
+
+    @property
+    def ifArgument(self):
+        raise NotImplementedError("Missing implementation for ifArgument")
+
+    @ifArgument.setter
+    def ifArgument(self, value):
+        raise NotImplementedError("Missing implementation for ifArgument")
+
+    def __init__(self, *, elseAction=None, thenAction=None, ifArgument=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if elseAction is not None:
+            self.elseAction = elseAction
+
+        if thenAction is not None:
+            self.thenAction = thenAction
+
+        if ifArgument is not None:
+            self.ifArgument = ifArgument
+
+
+class SendActionUsage(ActionUsage):
+    """<p>A <code>SendActionUsage</code> is an <code>ActionUsage</code> that specifies the sending of a payload given by the result of its <code>payloadArgument</code> <code>Expression</code> via a <em><code>MessageTransfer</code></em> whose <em><code>source</code></em> is given by the result of the <code>senderArgument</code> <code>Expression</code> and whose <code>target</code> is given by the result of the <code>receiverArgument</code> <code>Expression</code>. If no <code>senderArgument</code> is provided, the default is the <em><code>this</code></em> context for the action. If no <code>receiverArgument</code> is given, then the receiver is to be determined by, e.g., outgoing <em><code>Connections</code></em> from the sender.</p>
+
+    senderArgument = argument(2)
+    payloadArgument = argument(1)
+    inputParameters()->size() >= 3
+    receiverArgument = argument(3)
+    isSubactionUsage() implies
+        specializesFromLibrary('Actions::Action::acceptSubactions')
+    specializesFromLibrary("Actions::sendActions")"""
+
+    _receiverArgument = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="receiverArgument",
+        transient=True,
+    )
+    _payloadArgument = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="payloadArgument",
+        transient=True,
+    )
+    _senderArgument = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="senderArgument",
+        transient=True,
+    )
+
+    @property
+    def receiverArgument(self):
+        raise NotImplementedError("Missing implementation for receiverArgument")
+
+    @receiverArgument.setter
+    def receiverArgument(self, value):
+        raise NotImplementedError("Missing implementation for receiverArgument")
+
+    @property
+    def payloadArgument(self):
+        raise NotImplementedError("Missing implementation for payloadArgument")
+
+    @payloadArgument.setter
+    def payloadArgument(self, value):
+        raise NotImplementedError("Missing implementation for payloadArgument")
+
+    @property
+    def senderArgument(self):
+        raise NotImplementedError("Missing implementation for senderArgument")
+
+    @senderArgument.setter
+    def senderArgument(self, value):
+        raise NotImplementedError("Missing implementation for senderArgument")
+
+    def __init__(
+        self,
+        *,
+        receiverArgument=None,
+        payloadArgument=None,
+        senderArgument=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if receiverArgument is not None:
+            self.receiverArgument = receiverArgument
+
+        if payloadArgument is not None:
+            self.payloadArgument = payloadArgument
+
+        if senderArgument is not None:
+            self.senderArgument = senderArgument
+
+
+class SelectExpression(OperatorExpression):
+    """<p>A <code>SelectExpression</code> is an <code>OperatorExpression</code> whose operator is <code>"select"</code>, which resolves to the <code>Function</code> <em><code>ControlFunctions::select</code></em> from the Kernel Functions Library.</p>"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class CollectExpression(OperatorExpression):
+    """<p>A <code>CollectExpression</code> is an <code>OperatorExpression</code> whose <code>operator</code> is <code>"collect"</code>, which resolves to the <code>Function</code> <em><code>ControlFunctions::collect</code></em> from the Kernel Functions Library.</p>
+    operator = 'collect'"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class FeatureChainExpression(OperatorExpression):
+    """<p>A <code>FeatureChainExpression</code> is an <code>OperatorExpression</code> whose operator is <code>"."</code>, which resolves to the <code>Function</code> <em><code>ControlFunctions::'.'</code></em> from the Kernel Functions Library. It evaluates to the result of chaining the <code>result</code> <code>Feature</code> of its single <code>argument</code> <code>Expression</code> with its <code>targetFeature</code>.</p>
+    let sourceParameter : Feature = sourceTargetFeature() in
+    sourceTargetFeature <> null and
+    sourceTargetFeature.redefinesFromLibrary("ControlFunctions::'.'::source::target")
+    let sourceParameter : Feature = sourceTargetFeature() in
+    sourceTargetFeature <> null and
+    sourceTargetFeature.redefines(targetFeature)
+    targetFeature =
+        let nonParameterMemberships : Sequence(Membership) = ownedMembership->
+            reject(oclIsKindOf(ParameterMembership)) in
+        if nonParameterMemberships->isEmpty() or
+           not nonParameterMemberships->first().memberElement.oclIsKindOf(Feature)
+        then null
+        else nonParameterMemberships->first().memberElement.oclAsType(Feature)
+        endif"""
+
+    _targetFeature = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="targetFeature",
+        transient=True,
+    )
+
+    @property
+    def targetFeature(self):
+        raise NotImplementedError("Missing implementation for targetFeature")
+
+    @targetFeature.setter
+    def targetFeature(self, value):
+        raise NotImplementedError("Missing implementation for targetFeature")
+
+    def __init__(self, *, targetFeature=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if targetFeature is not None:
+            self.targetFeature = targetFeature
+
+    def sourceTargetFeature(self):
+        """<p>Return the first <code>ownedFeature</code> of the first owned input <code>parameter</code> of this <code>FeatureChainExpression</code> (if any).</p>
+        let inputParameters : Feature = ownedFeatures->
+            select(direction = _'in') in
+        if inputParameters->isEmpty() or
+           inputParameters->first().ownedFeature->isEmpty()
+        then null
+        else inputParameters->first().ownedFeature->first()
+        endif"""
+        raise NotImplementedError(
+            "operation sourceTargetFeature(...) not yet implemented"
+        )
+
+
+class PartDefinition(ItemDefinition):
+    """<p>A <code>PartDefinition</code> is an <code>ItemDefinition</code> of a <code>Class</code> of systems or parts of systems. Note that all parts may be considered items for certain purposes, but not all items are parts that can perform actions within a system.</p>
+
+    specializesFromLibrary("Parts::Part")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class ConjugatedPortDefinition(PortDefinition):
+    """<p>A <code>ConjugatedPortDefinition</code> is a <code>PortDefinition</code> that is a <code>PortDefinition</code> of its original <code>PortDefinition</code>. That is, a <code>ConjugatedPortDefinition</code> inherits all the <code>features</code> of the original <code>PortDefinition</code>, but input <code>flows</code> of the original <code>PortDefinition</code> become outputs on the <code>ConjugatedPortDefinition</code> and output <code>flows</code> of the original <code>PortDefinition</code> become inputs on the <code>ConjugatedPortDefinition</code>. Every <code>PortDefinition</code> (that is not itself a <code><code>ConjugatedPortDefinition</code></code>) has exactly one corresponding <code>ConjugatedPortDefinition</code>, whose effective name is the name of the <code>originalPortDefinition</code>, with the character <code>~</code> prepended.</p>
+    ownedPortConjugator.originalPortDefinition = originalPortDefinition
+    conjugatedPortDefinition = null"""
+
+    _ownedPortConjugator = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="ownedPortConjugator",
+        transient=True,
+    )
+    _originalPortDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="originalPortDefinition",
+        transient=True,
+    )
+
+    @property
+    def ownedPortConjugator(self):
+        raise NotImplementedError("Missing implementation for ownedPortConjugator")
+
+    @ownedPortConjugator.setter
+    def ownedPortConjugator(self, value):
+        raise NotImplementedError("Missing implementation for ownedPortConjugator")
+
+    @property
+    def originalPortDefinition(self):
+        raise NotImplementedError("Missing implementation for originalPortDefinition")
+
+    @originalPortDefinition.setter
+    def originalPortDefinition(self, value):
+        raise NotImplementedError("Missing implementation for originalPortDefinition")
+
+    def __init__(
+        self, *, ownedPortConjugator=None, originalPortDefinition=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if ownedPortConjugator is not None:
+            self.ownedPortConjugator = ownedPortConjugator
+
+        if originalPortDefinition is not None:
+            self.originalPortDefinition = originalPortDefinition
+
+
+class CalculationUsage(ActionUsage, Expression):
+    """<p>A <code>CalculationUsage</code> is an <code>ActionUsage<code> that is also an <code>Expression</code>, and, so, is typed by a <code>Function</code>. Nominally, if the <code>type</code> is a <code>CalculationDefinition</code>, a <code>CalculationUsage</code> is a <code>Usage</code> of that <code>CalculationDefinition</code> within a system. However, other kinds of kernel <code>Functions</code> are also allowed, to permit use of <code>Functions</code> from the Kernel Model Libraries.</p>
+    specializesFromLibrary('Calculations::calculations')
+    owningType <> null and
+    (owningType.oclIsKindOf(CalculationDefinition) or
+     owningType.oclIsKindOf(CalculationUsage)) implies
+        specializesFromLibrary('Calculations::Calculation::subcalculations')"""
+
+    _calculationDefinition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="calculationDefinition",
+        transient=True,
+    )
+
+    @property
+    def calculationDefinition(self):
+        raise NotImplementedError("Missing implementation for calculationDefinition")
+
+    @calculationDefinition.setter
+    def calculationDefinition(self, value):
+        raise NotImplementedError("Missing implementation for calculationDefinition")
+
+    def __init__(self, *, calculationDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if calculationDefinition is not None:
+            self.calculationDefinition = calculationDefinition
+
+
+class ConstraintUsage(OccurrenceUsage, BooleanExpression):
+    """<p>A <code>ConstraintUsage</code> is an <code>OccurrenceUsage</code> that is also a <code>BooleanExpression<code>, and, so, is typed by a <code>Predicate</code>. Nominally, if the type is a <code>ConstraintDefinition<code>, a <code>ConstraintUsage</code> is a <code>Usage</code> of that <code>ConstraintDefinition<code>. However, other kinds of kernel <code>Predicates</code> are also allowed, to permit use of <code>Predicates</code> from the Kernel Model Libraries.</p>
+    owningFeatureMembership <> null and
+    owningFeatureMembership.oclIsKindOf(RequirementConstraintMembership) implies
+        if owningFeatureMembership.oclAsType(RequirementConstraintMembership).kind =
+            RequirementConstraintKind::assumption then
+            specializesFromLibrary('Requirements::RequirementCheck::assumptions')
+        else
+            specializesFromLibrary('Requirements::RequirementCheck::constraints')
+        endif
+    specializesFromLibrary('Constraints::constraintChecks')
+    owningType <> null and
+    (owningType.oclIsKindOf(ItemDefinition) or
+     owningType.oclIsKindOf(ItemUsage)) implies
+        specializesFromLibrary('Items::Item::checkedConstraints')"""
+
+    _constraintDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="constraintDefinition",
+        transient=True,
+    )
+
+    @property
+    def constraintDefinition(self):
+        raise NotImplementedError("Missing implementation for constraintDefinition")
+
+    @constraintDefinition.setter
+    def constraintDefinition(self, value):
+        raise NotImplementedError("Missing implementation for constraintDefinition")
+
+    def __init__(self, *, constraintDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if constraintDefinition is not None:
+            self.constraintDefinition = constraintDefinition
+
+
+class MetadataUsage(ItemUsage, MetadataFeature):
+    """<p>A  <code>MetadataUsage</code> is a <code>Usage</code> and a <code>MetadataFeature</code>, used to annotate other <code>Elements</code> in a system model with metadata. As a <code>MetadataFeature</code>, its type must be a <code>Metaclass</code>, which will nominally be a <code>MetadataDefinition</code>. However, any kernel <code>Metaclass</code> is also allowed, to permit use of <code>Metaclasses</code> from the Kernel Model Libraries.</p>
+    specializesFromLibrary('Metadata::metadataItems')"""
+
+    _metadataDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="metadataDefinition",
+        transient=True,
+    )
+
+    @property
+    def metadataDefinition(self):
+        raise NotImplementedError("Missing implementation for metadataDefinition")
+
+    @metadataDefinition.setter
+    def metadataDefinition(self, value):
+        raise NotImplementedError("Missing implementation for metadataDefinition")
+
+    def __init__(self, *, metadataDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if metadataDefinition is not None:
+            self.metadataDefinition = metadataDefinition
+
+
+class BindingConnectorAsUsage(ConnectorAsUsage, BindingConnector):
+    """<p>A <code>BindingConnectorAsUsage</code> is both a <code>BindingConnector</code> and a <code>ConnectorAsUsage</code>.</p>"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class SuccessionItemFlow(ItemFlow, Succession):
+    """<p>A <code>SuccessionItemFlow</code> is an <code>ItemFlow</code> that also provides temporal ordering. It classifies <code><em>Transfers</em></code> that cannot start until the source <code><em>Occurrence</em></code> has completed and that must complete before the target <code><em>Occurrence</em></code> can start.</p>
+    specializesFromLibrary("Transfers::flowTransfersBefore")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class SuccessionAsUsage(ConnectorAsUsage, Succession):
+    """<p>A <code>SuccessionAsUsage</code> is both a <code>ConnectorAsUsage</code> and a <code>Succession</code>.<p>"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class JoinNode(ControlNode):
+    """<p>A <code>JoinNode</code> is a <code>ControlNode</code> that waits for the completion of all the predecessor <code>Actions</code> given by incoming <code>Successions</code>.</p>
+    sourceConnector->selectByKind(Succession)->size() <= 1
+    specializesFromLibrary("Actions::Action::join")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class ForkNode(ControlNode):
+    """<p>A <code>ForkNode</code> is a <code>ControlNode</code> that must be followed by successor <code>Actions</code> as given by all its outgoing <code>Successions</code>.</p>
+    targetConnector->selectByKind(Succession)->size() <= 1
+    specializesFromLibrary("Actions::Action::forks")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MergeNode(ControlNode):
+    """<p>A <code>MergeNode</code> is a <code>ControlNode</code> that asserts the merging of its incoming <code>Successions</code>. A <code>MergeNode</code> may have at most one outgoing <code>Successions</code>.</p>
+    sourceConnector->selectAsKind(Succession)->size() <= 1
+    targetConnector->selectByKind(Succession)->
+        collect(connectorEnd->at(1))->
+        forAll(sourceMult |
+            multiplicityHasBounds(sourceMult, 0, 1))
+    targetConnector->selectByKind(Succession)->
+        forAll(subsetsChain(this,
+            resolveGlobal("ControlPerformances::MergePerformance::incomingHBLink")))
+    specializesFromLibrary("Actions::Action::merges")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class ForLoopActionUsage(LoopActionUsage):
+    """<p>A <code>ForLoopActionUsage</code> is a <code>LoopActionUsage</code> that specifies that its <code>bodyClause</code> <code>ActionUsage</code> should be performed once for each value, in order, from the sequence of values obtained as the result of the <code>seqArgument</code> <code>Expression</code>, with the <code>loopVariable</code> set to the value for each iteration.</p>
+    seqArgument =
+        let parameter : Feature = inputParameter(1) in
+        if parameter <> null and parameter.oclIsKindOf(Expression) then
+            parameter.oclAsType(Expression)
+        else
+            null
+        endif
+
+    isSubactionUsage() implies
+        specializesFromLibrary('Actions::Action::forLoops')
+    loopVariable <> null and
+    loopVariable.redefinesFromLibrary('Actions::ForLoopAction::var')
+    specializesFromLibrary('Actions::forLoopActions')
+    loopVariable =
+        if ownedFeature->isEmpty() or
+            not ownedFeature->first().oclIsKindOf(ReferenceUsage) then
+            null
+        else
+            ownedFeature->first().oclAsType(ReferenceUsage)
+        endif"""
+
+    _seqArgument = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="seqArgument",
+        transient=True,
+    )
+    _loopVariable = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="loopVariable",
+        transient=True,
+    )
+
+    @property
+    def seqArgument(self):
+        raise NotImplementedError("Missing implementation for seqArgument")
+
+    @seqArgument.setter
+    def seqArgument(self, value):
+        raise NotImplementedError("Missing implementation for seqArgument")
+
+    @property
+    def loopVariable(self):
+        raise NotImplementedError("Missing implementation for loopVariable")
+
+    @loopVariable.setter
+    def loopVariable(self, value):
+        raise NotImplementedError("Missing implementation for loopVariable")
+
+    def __init__(self, *, seqArgument=None, loopVariable=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if seqArgument is not None:
+            self.seqArgument = seqArgument
+
+        if loopVariable is not None:
+            self.loopVariable = loopVariable
+
+
+class EventOccurrenceUsage(OccurrenceUsage):
+    """<p>An <code>EventOccurrenceUsage</code> is an <code>OccurrenceUsage</code> that represents another <code>OccurrenceUsage<code> occurring as a <code><em>suboccurrence<em></code> of the containing occurrence of the <code>EventOccurrenceUsage</code>. Unless it is the <code>EventOccurrenceUsage</code> itself, the referenced <code>OccurrenceUsage</code> is related to the <code>EventOccurrenceUsage<code> by a <code>ReferenceSubsetting</code> <code>Relationship</code>.</p>
+
+    <p>If the <code>EventOccurrenceUsage</code> is owned by an <code>OccurrenceDefinition</code> or <code>OccurrenceUsage</code>, then it also subsets the <em><code>timeEnclosedOccurrences</code></em> property of the <code>Class</code> <em><code>Occurrence</code></em> from the Kernel Semantic Library model <em><code>Occurrences</code></em>.</p>
+    eventOccurrence =
+        if ownedReferenceSubsetting = null then self
+        else if ownedReferenceSubsetting.referencedFeature.oclIsKindOf(OccurrenceUsage) then
+            ownedReferenceSubsetting.referencedFeature.oclAsType(OccurrenceUsage)
+        else null
+        endif endif
+    ownedReferenceSubsetting <> null implies
+        ownedReferenceSubsetting.referencedFeature.oclIsKindOf(OccurrenceUsage)
+    owningType <> null and
+    (owningType.oclIsKindOf(OccurrenceDefinition) or
+     owningType.oclIsKindOf(OccurrenceUsage)) implies
+        specializesFromLibrary("Occurrences::Occurrence::timeEnclosedOccurrences")
+    isReference"""
+
+    _eventOccurrence = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="eventOccurrence",
+        transient=True,
+    )
+
+    @property
+    def eventOccurrence(self):
+        raise NotImplementedError("Missing implementation for eventOccurrence")
+
+    @eventOccurrence.setter
+    def eventOccurrence(self, value):
+        raise NotImplementedError("Missing implementation for eventOccurrence")
+
+    def __init__(self, *, eventOccurrence=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if eventOccurrence is not None:
+            self.eventOccurrence = eventOccurrence
+
+
+class PerformActionUsage(ActionUsage, EventOccurrenceUsage):
+    """<p>A <code>PerformActionUsage</code> is an <code>ActionUsage</code> that represents the performance of an <code>ActionUsage</code>. Unless it is the <code>PerformActionUsage</code> itself, the <code>ActionUsage</code> to be performed is related to the <code>PerformActionUsage</code> by a <code>ReferenceSubsetting</code> relationship. A <code>PerformActionUsage</code> is also an <code>EventOccurrenceUsage</code>, with its <code>performedAction</code> as the <code>eventOccurrence</code>.</p>
+    ownedReferenceSubsetting <> null implies
+        ownedReferenceSubsetting.referencedFeature.oclIsKindOf(ActionUsage)
+    owningType <> null and
+    (owningType.oclIsKindOf(PartDefinition) or
+     owningType.oclIsKindOf(PartUsage)) implies
+        specializesFromLibrary('Parts::Part::performedActions')"""
+
+    _performedAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="performedAction",
+        transient=True,
+    )
+
+    @property
+    def performedAction(self):
+        raise NotImplementedError("Missing implementation for performedAction")
+
+    @performedAction.setter
+    def performedAction(self, value):
+        raise NotImplementedError("Missing implementation for performedAction")
+
+    def __init__(self, *, performedAction=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if performedAction is not None:
+            self.performedAction = performedAction
+
+
+class DecisionNode(ControlNode):
+    """<p>A <code>DecisionNode</code> is a <code>ControlNode</code> that makes a selection from its outgoing <code>Successions</code>.</p>
+    targetConnector->selectByKind(Succession)->size() <= 1
+    sourceConnector->selectAsKind(Succession)->
+        collect(connectorEnd->at(2))->
+        forAll(targetMult |
+            multiplicityHasBounds(targetMult, 0, 1))
+    specializesFromLibrary("Actions::Action::decisions")
+    sourceConnector->selectByKind(Succession)->
+        forAll(subsetsChain(this,
+            resolveGlobal("ControlPerformances::MergePerformance::outgoingHBLink")))"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class WhileLoopActionUsage(LoopActionUsage):
+    """<p>A <code>WhileLoopActionUsage</code> is a <code>LoopActionUsage</code> that specifies that the <code>bodyClause</code> <code>ActionUsage</code> should be performed repeatedly while the result of the <code>whileArgument</code> <code>Expression</code> is true or until the result of the <code>untilArgument</code> <code>Expression</code> (if provided) is true. The <code>whileArgument</code> <code>Expression</code> is evaluated before each (possible) performance of the <code>bodyClause</code>, and the <code>untilArgument</code> <code>Expression</code> is evaluated after each performance of the <code>bodyClause</code>.</p>
+    isSubactionUsage() implies
+        specializesFromLibrary('Actions::Action::whileLoops')
+    untilArgument =
+        let parameter : Feature = inputParameter(3) in
+        if parameter <> null and parameter.oclIsKindOf(Expression) then
+            parameter.oclAsType(Expression)
+        else
+            null
+        endif
+
+    specializesFromLibrary('Actions::whileLoopActions')
+    whileArgument =
+        let parameter : Feature = inputParameter(1) in
+        if parameter <> null and parameter.oclIsKindOf(Expression) then
+            parameter.oclAsType(Expression)
+        else
+            null
+        endif"""
+
+    _whileArgument = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="whileArgument",
+        transient=True,
+    )
+    _untilArgument = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="untilArgument",
+        transient=True,
+    )
+
+    @property
+    def whileArgument(self):
+        raise NotImplementedError("Missing implementation for whileArgument")
+
+    @whileArgument.setter
+    def whileArgument(self, value):
+        raise NotImplementedError("Missing implementation for whileArgument")
+
+    @property
+    def untilArgument(self):
+        raise NotImplementedError("Missing implementation for untilArgument")
+
+    @untilArgument.setter
+    def untilArgument(self, value):
+        raise NotImplementedError("Missing implementation for untilArgument")
+
+    def __init__(self, *, whileArgument=None, untilArgument=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if whileArgument is not None:
+            self.whileArgument = whileArgument
+
+        if untilArgument is not None:
+            self.untilArgument = untilArgument
+
+
+class DerivedState(EDerivedCollection):
+    pass
+
+
+class StateDefinition(ActionDefinition):
+    """<p>A <code>StateDefinition</code> is the <code>Definition</code> of the </code>Behavior</code> of a system or part of a system in a certain state condition.</p>
+
+    <p>A <code>StateDefinition</code> may be related to up to three of its <code>ownedFeatures</code> by <code>StateBehaviorMembership</cod> <code>Relationships</code>, all of different <code>kinds</code>, corresponding to the entry, do and exit actions of the <code>StateDefinition</code>.</p>
+    ownedGeneralization.general->selectByKind(StateDefinition)->
+        forAll(g | g.isParallel = isParallel)
+    specializesFromLibrary('States::StateAction')
+    ownedMembership->
+        selectByKind(StateSubactionMembership)->
+        isUnique(kind)
+    state = action->selectByKind(StateUsage)
+    doAction =
+        let doMemberships : Sequence(StateSubactionMembership) =
+            ownedMembership->
+                selectByKind(StateSubactionMembership)->
+                select(kind = StateSubactionKind::do) in
+        if doMemberships->isEmpty() then null
+        else doMemberships->at(1)
+        endif
+    entryAction =
+        let entryMemberships : Sequence(StateSubactionMembership) =
+            ownedMembership->
+                selectByKind(StateSubactionMembership)->
+                select(kind = StateSubactionKind::entry) in
+        if entryMemberships->isEmpty() then null
+        else entryMemberships->at(1)
+        endif
+    isParallel implies
+        ownedAction.incomingTransition->isEmpty() and
+        ownedAction.outgoingTransition->isEmpty()
+    exitAction =
+        let exitMemberships : Sequence(StateSubactionMembership) =
+            ownedMembership->
+                selectByKind(StateSubactionMembership)->
+                select(kind = StateSubactionKind::exit) in
+        if exitMemberships->isEmpty() then null
+        else exitMemberships->at(1)
+        endif"""
+
+    isParallel = EAttribute(
+        eType=Boolean,
+        unique=True,
+        derived=False,
+        changeable=True,
+        default_value="false",
+    )
+    state = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedState,
+    )
+    _entryAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="entryAction",
+        transient=True,
+    )
+    _doAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="doAction",
+        transient=True,
+    )
+    _exitAction = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="exitAction",
+        transient=True,
+    )
+
+    @property
+    def entryAction(self):
+        raise NotImplementedError("Missing implementation for entryAction")
+
+    @entryAction.setter
+    def entryAction(self, value):
+        raise NotImplementedError("Missing implementation for entryAction")
+
+    @property
+    def doAction(self):
+        raise NotImplementedError("Missing implementation for doAction")
+
+    @doAction.setter
+    def doAction(self, value):
+        raise NotImplementedError("Missing implementation for doAction")
+
+    @property
+    def exitAction(self):
+        raise NotImplementedError("Missing implementation for exitAction")
+
+    @exitAction.setter
+    def exitAction(self, value):
+        raise NotImplementedError("Missing implementation for exitAction")
+
+    def __init__(
+        self,
+        *,
+        state=None,
+        entryAction=None,
+        doAction=None,
+        exitAction=None,
+        isParallel=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if isParallel is not None:
+            self.isParallel = isParallel
+
+        if state:
+            self.state.extend(state)
+
+        if entryAction is not None:
+            self.entryAction = entryAction
+
+        if doAction is not None:
+            self.doAction = doAction
+
+        if exitAction is not None:
+            self.exitAction = exitAction
+
+
+class DerivedText(EDerivedCollection):
+    pass
+
+
+class DerivedRequiredconstraint(EDerivedCollection):
+    pass
+
+
+class DerivedAssumedconstraint(EDerivedCollection):
+    pass
+
+
+class DerivedFramedconcern(EDerivedCollection):
+    pass
+
+
+class DerivedActorparameter(EDerivedCollection):
+    pass
+
+
+class DerivedStakeholderparameter(EDerivedCollection):
+    pass
+
+
+class RequirementUsage(ConstraintUsage):
+    """<p>A <code>RequirementUsage</code> is a <code>Usage</code> of a <code>RequirementDefinition</code>.</p>
+    actorParameter = featureMembership->
+        selectByKind(ActorMembership).
+        ownedActorParameter
+    assumedConstraint = ownedFeatureMembership->
+        selectByKind(RequirementConstraintMembership)->
+        select(kind = RequirementConstraintKind::assumption).
+        ownedConstraint
+    framedConcern = featureMembership->
+        selectByKind(FramedConcernMembership).
+        ownedConcern
+    requiredConstraint = ownedFeatureMembership->
+        selectByKind(RequirementConstraintMembership)->
+        select(kind = RequirementConstraintKind::requirement).
+        ownedConstraint
+    stakeholderParameter = featureMembership->
+        selectByKind(AStakholderMembership).
+        ownedStakeholderParameter
+    subjectParameter =
+        let subjects : OrderedSet(SubjectMembership) =
+            featureMembership->selectByKind(SubjectMembership) in
+        if subjects->isEmpty() then null
+        else subjects->first().ownedSubjectParameter
+        endif
+    text = documentation.body
+    featureMembership->
+        selectByKind(SubjectMembership)->
+        size() <= 1
+    input->notEmpty() and input->first() = subjectParameter
+    specializesFromLibrary('Requirements::requirementChecks')
+    isComposite and owningType <> null and
+        (owningType.oclIsKindOf(RequirementDefinition) or
+         owningType.oclIsKindOf(RequirementUsage)) implies
+        specializesFromLibrary('Requirements::RequirementCheck::subrequirements')
+    owningfeatureMembership <> null and
+    owningfeatureMembership.oclIsKindOf(ObjectiveMembership) implies
+        owningType.ownedSpecialization.general->forAll(gen |
+            (gen.oclIsKindOf(CaseDefinition) implies
+                redefines(gen.oclAsType(CaseDefinition).objectiveRequirement)) and
+            (gen.oclIsKindOf(CaseUsage) implies
+                redefines(gen.oclAsType(CaseUsage).objectiveRequirement))
+    owningFeatureMembership <> null and
+    owningFeatureMembership.oclIsKindOf(RequirementVerificationMembership) implies
+        specializesFromLibrary('VerificationCases::VerificationCase::obj::requirementVerifications')
+    """
+
+    reqId = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+    text = EAttribute(
+        eType=String,
+        unique=True,
+        derived=True,
+        changeable=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedText,
+    )
+    _requirementDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="requirementDefinition",
+        transient=True,
+    )
+    requiredConstraint = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedRequiredconstraint,
+    )
+    assumedConstraint = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedAssumedconstraint,
+    )
+    _subjectParameter = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="subjectParameter",
+        transient=True,
+    )
+    framedConcern = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedFramedconcern,
+    )
+    actorParameter = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedActorparameter,
+    )
+    stakeholderParameter = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedStakeholderparameter,
+    )
+
+    @property
+    def requirementDefinition(self):
+        raise NotImplementedError("Missing implementation for requirementDefinition")
+
+    @requirementDefinition.setter
+    def requirementDefinition(self, value):
+        raise NotImplementedError("Missing implementation for requirementDefinition")
+
+    @property
+    def subjectParameter(self):
+        raise NotImplementedError("Missing implementation for subjectParameter")
+
+    @subjectParameter.setter
+    def subjectParameter(self, value):
+        raise NotImplementedError("Missing implementation for subjectParameter")
+
+    def __init__(
+        self,
+        *,
+        requirementDefinition=None,
+        reqId=None,
+        text=None,
+        requiredConstraint=None,
+        assumedConstraint=None,
+        subjectParameter=None,
+        framedConcern=None,
+        actorParameter=None,
+        stakeholderParameter=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if reqId is not None:
+            self.reqId = reqId
+
+        if text:
+            self.text.extend(text)
+
+        if requirementDefinition is not None:
+            self.requirementDefinition = requirementDefinition
+
+        if requiredConstraint:
+            self.requiredConstraint.extend(requiredConstraint)
+
+        if assumedConstraint:
+            self.assumedConstraint.extend(assumedConstraint)
+
+        if subjectParameter is not None:
+            self.subjectParameter = subjectParameter
+
+        if framedConcern:
+            self.framedConcern.extend(framedConcern)
+
+        if actorParameter:
+            self.actorParameter.extend(actorParameter)
+
+        if stakeholderParameter:
+            self.stakeholderParameter.extend(stakeholderParameter)
+
+
+class ConstraintDefinition(OccurrenceDefinition, Predicate):
+    """<p>A <code>ConstraintDefinition</code> is an <code>OccurrenceDefinition</code> that is also a <code>Predicate</code> that defines a constraint that may be asserted to hold on a system or part of a system.</p>
+
+
+    specializesFromLibrary('Constraints::ConstraintCheck')"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class CaseUsage(CalculationUsage):
+    """<p>A <code>CaseUsage</code> is a <code>Usage</code> of a <code>CaseDefinition</code>.</p>
+    objectiveRequirement =
+        let objectives: OrderedSet(RequirementUsage) =
+            featureMembership->
+                selectByKind(ObjectiveMembership).
+                ownedRequirement in
+        if objectives->isEmpty() then null
+        else objectives->first().ownedObjectiveRequirement
+        endif
+    featureMembership->
+        selectByKind(ObjectiveMembership)->
+        size() <= 1
+    featureMembership->
+            selectByKind(SubjectMembership)->
+            size() <= 1
+    actorParameter = featureMembership->
+        selectByKind(ActorMembership).
+        ownedActorParameter
+    subjectParameter =
+        let subjects : OrderedSet(SubjectMembership) =
+            featureMembership->selectByKind(SubjectMembership) in
+        if subjects->isEmpty() then null
+        else subjects->first().ownedSubjectParameter
+        endif
+    input->notEmpty() and input->first() = subjectParameter
+    specializeFromLibrary('Cases::cases')
+    isComposite and owningType <> null and
+        (owningType.oclIsKindOf(CaseDefinition) or
+         owningType.oclIsKindOf(CaseUsage)) implies
+        specializesFromLibrary('Cases::Case::subcases')"""
+
+    _objectiveRequirement = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="objectiveRequirement",
+        transient=True,
+    )
+    _caseDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="caseDefinition",
+        transient=True,
+    )
+    _subjectParameter = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="subjectParameter",
+        transient=True,
+    )
+    actorParameter = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedActorparameter,
+    )
+
+    @property
+    def objectiveRequirement(self):
+        raise NotImplementedError("Missing implementation for objectiveRequirement")
+
+    @objectiveRequirement.setter
+    def objectiveRequirement(self, value):
+        raise NotImplementedError("Missing implementation for objectiveRequirement")
+
+    @property
+    def caseDefinition(self):
+        raise NotImplementedError("Missing implementation for caseDefinition")
+
+    @caseDefinition.setter
+    def caseDefinition(self, value):
+        raise NotImplementedError("Missing implementation for caseDefinition")
+
+    @property
+    def subjectParameter(self):
+        raise NotImplementedError("Missing implementation for subjectParameter")
+
+    @subjectParameter.setter
+    def subjectParameter(self, value):
+        raise NotImplementedError("Missing implementation for subjectParameter")
+
+    def __init__(
+        self,
+        *,
+        objectiveRequirement=None,
+        caseDefinition=None,
+        subjectParameter=None,
+        actorParameter=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if objectiveRequirement is not None:
+            self.objectiveRequirement = objectiveRequirement
+
+        if caseDefinition is not None:
+            self.caseDefinition = caseDefinition
+
+        if subjectParameter is not None:
+            self.subjectParameter = subjectParameter
+
+        if actorParameter:
+            self.actorParameter.extend(actorParameter)
+
+
+class DerivedCalculation(EDerivedCollection):
+    pass
+
+
+class CalculationDefinition(ActionDefinition, Function):
+    """<p>A <code>CalculationDefinition</code> is an <coed>ActionDefinition</code> that also defines a <code>Function</code> producing a <code>result</code>.</p>
+    specializesFromLibrary('Calculations::Calculation')
+    calculation = action->selectByKind(CalculationUsage)"""
+
+    calculation = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedCalculation,
+    )
+
+    def __init__(self, *, calculation=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if calculation:
+            self.calculation.extend(calculation)
+
+
+class DerivedView(EDerivedCollection):
+    pass
+
+
+class ViewDefinition(PartDefinition):
+    """<p>A <code>ViewDefinition</code> is a <code>PartDefinition</code> that specifies how a view artifact is constructed to satisfy a <code>viewpoint</code>. It specifies a <code>viewConditions</code> to define the model content to be presented and a <code>viewRendering</code> to define how the model content is presented.</p>
+    view = usage->selectByKind(ViewUsage)
+    satisfiedViewpoint = ownedRequirement->
+        selectByKind(ViewpointUsage)->
+        select(isComposite)
+    viewRendering =
+        let renderings: OrderedSet(ViewRenderingMembership) =
+            featureMembership->selectByKind(ViewRenderingMembership) in
+        if renderings->isEmpty() then null
+        else renderings->first().referencedRendering
+        endif
+    viewCondition = featureMembership->
+        selectByKind(ElementFilterMembership).
+        condition
+    featureMembership->
+        selectByKind(ViewRenderingMembership)->
+        size() <= 1
+    specializesFromLibrary('Views::View')"""
+
+    view = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedView,
+    )
+    satisfiedViewpoint = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedSatisfiedviewpoint,
+    )
+    _viewRendering = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="viewRendering",
+        transient=True,
+    )
+    viewCondition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedViewcondition,
+    )
+
+    @property
+    def viewRendering(self):
+        raise NotImplementedError("Missing implementation for viewRendering")
+
+    @viewRendering.setter
+    def viewRendering(self, value):
+        raise NotImplementedError("Missing implementation for viewRendering")
+
+    def __init__(
+        self,
+        *,
+        view=None,
+        satisfiedViewpoint=None,
+        viewRendering=None,
+        viewCondition=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if view:
+            self.view.extend(view)
+
+        if satisfiedViewpoint:
+            self.satisfiedViewpoint.extend(satisfiedViewpoint)
+
+        if viewRendering is not None:
+            self.viewRendering = viewRendering
+
+        if viewCondition:
+            self.viewCondition.extend(viewCondition)
+
+
+class DerivedRendering(EDerivedCollection):
+    pass
+
+
+class RenderingDefinition(PartDefinition):
+    """<p>A <code>RenderingDefinition</code> is a <code>PartDefinition</code> that defines a specific rendering of the content of a model view (e.g., symbols, style, layout, etc.).</p>
+    rendering = usages->selectByKind(RenderingUsage)
+    specializesFromLibrary('Views::Rendering')"""
+
+    rendering = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedRendering,
+    )
+
+    def __init__(self, *, rendering=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if rendering:
+            self.rendering.extend(rendering)
+
+
+class MetadataDefinition(ItemDefinition, Metaclass):
+    """<p>A <code>MetadataDefinition</code> is an <code>ItemDefinition</code> that is also a <code>Metaclass</code>.</p>
+    specializesFromLibrary('Metadata::MetadataItem')"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class DerivedConnectiondefinition(EDerivedCollection):
+    pass
+
+
+class ConnectionUsage(ConnectorAsUsage, PartUsage):
+    """<p>A <code>ConnectionUsage</code> is a <code>ConnectorAsUsage</code> that is also a <code>PartUsage</code>. Nominally, if its type is a <code>ConnectionDefinition</code>, then a <code>ConnectionUsage</code> is a Usage of that <code>ConnectionDefinition</code>, representing a connection between parts of a system. However, other kinds of kernel <code>AssociationStructures</code> are also allowed, to permit use of <code>AssociationStructures</code> from the Kernel Model Libraries.</p>
+    specializesFromLibrary("Connections::connections")
+    ownedEndFeature->size() = 2 implies
+        specializesFromLibrary("Connections::binaryConnections")"""
+
+    connectionDefinition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedConnectiondefinition,
+    )
+
+    def __init__(self, *, connectionDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if connectionDefinition:
+            self.connectionDefinition.extend(connectionDefinition)
+
+
+class RequirementDefinition(ConstraintDefinition):
+    """<p>A <code>RequirementDefinition</code> is a <code>ConstraintDefinition</code> that defines a requirement used in the context of a specification as a constraint that a valid solution must satisfy. The specification is relative to a specified subject, possibly in collaboration with one or more external actors.</p>
+    text = documentation.body
+    assumedConstraint = ownedFeatureMembership->
+        selectByKind(RequirementConstraintMembership)->
+        select(kind = RequirementConstraintKind::assumption).
+        ownedConstraint
+    requiredConstraint = ownedFeatureMembership->
+        selectByKind(RequirementConstraintMembership)->
+        select(kind = RequirementConstraintKind::requirement).
+        ownedConstraint
+    subjectParameter =
+        let subjects : OrderedSet(SubjectMembership) =
+            featureMembership->selectByKind(SubjectMembership) in
+        if subjects->isEmpty() then null
+        else subjects->first().ownedSubjectParameter
+        endif
+    framedConcern = featureMembership->
+        selectByKind(FramedConcernMembership).
+        ownedConcern
+    actorParameter = featureMembership->
+        selectByKind(ActorMembership).
+        ownedActorParameter
+    stakeholderParameter = featureMembership->
+        selectByKind(StakholderMembership).
+        ownedStakeholderParameter
+    featureMembership->
+        selectByKind(SubjectMembership)->
+        size() <= 1
+    input->notEmpty() and input->first() = subjectParameter
+    specializesFromLibrary('Requirements::RequirementCheck')"""
+
+    reqId = EAttribute(eType=String, unique=True, derived=False, changeable=True)
+    text = EAttribute(
+        eType=String,
+        unique=True,
+        derived=True,
+        changeable=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedText,
+    )
+    _subjectParameter = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="subjectParameter",
+        transient=True,
+    )
+    actorParameter = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedActorparameter,
+    )
+    stakeholderParameter = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedStakeholderparameter,
+    )
+    assumedConstraint = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedAssumedconstraint,
+    )
+    requiredConstraint = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedRequiredconstraint,
+    )
+    framedConcern = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedFramedconcern,
+    )
+
+    @property
+    def subjectParameter(self):
+        raise NotImplementedError("Missing implementation for subjectParameter")
+
+    @subjectParameter.setter
+    def subjectParameter(self, value):
+        raise NotImplementedError("Missing implementation for subjectParameter")
+
+    def __init__(
+        self,
+        *,
+        reqId=None,
+        text=None,
+        subjectParameter=None,
+        actorParameter=None,
+        stakeholderParameter=None,
+        assumedConstraint=None,
+        requiredConstraint=None,
+        framedConcern=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if reqId is not None:
+            self.reqId = reqId
+
+        if text:
+            self.text.extend(text)
+
+        if subjectParameter is not None:
+            self.subjectParameter = subjectParameter
+
+        if actorParameter:
+            self.actorParameter.extend(actorParameter)
+
+        if stakeholderParameter:
+            self.stakeholderParameter.extend(stakeholderParameter)
+
+        if assumedConstraint:
+            self.assumedConstraint.extend(assumedConstraint)
+
+        if requiredConstraint:
+            self.requiredConstraint.extend(requiredConstraint)
+
+        if framedConcern:
+            self.framedConcern.extend(framedConcern)
+
+
+class ConcernUsage(RequirementUsage):
+    """<p>A <code>ConcernUsage</code> is a <code>Usage</code> of a <code>ConcernDefinition</code>.</p>
+
+     The <code>ownedStakeholder</code> features of the ConcernUsage shall all subset the <em><code>ConcernCheck::concernedStakeholders</code> </em>feature. If the ConcernUsage is an <code>ownedFeature</code> of a StakeholderDefinition or StakeholderUsage, then the ConcernUsage shall have an <code>ownedStakeholder</code> feature that is bound to the <em><code>self</code></em> feature of its owner.</p>
+
+    specializesFromLibrary('Requirements::concernChecks')
+    owningFeatureMembership <> null and
+    owningFeatureMembership.oclIsKindOf(FramedConcernMembership) implies
+        specializesFromLibrary('Requirements::RequirementCheck::concerns')"""
+
+    _concernDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="concernDefinition",
+        transient=True,
+    )
+
+    @property
+    def concernDefinition(self):
+        raise NotImplementedError("Missing implementation for concernDefinition")
+
+    @concernDefinition.setter
+    def concernDefinition(self, value):
+        raise NotImplementedError("Missing implementation for concernDefinition")
+
+    def __init__(self, *, concernDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if concernDefinition is not None:
+            self.concernDefinition = concernDefinition
+
+
+class CaseDefinition(CalculationDefinition):
+    """<p>A <code>CaseDefinition</code> is a <code>CalculationDefinition</code> for a process, often involving collecting evidence or data, relative to a subject, possibly involving the collaboration of one or more other actors, producing a result that meets an objective.</p>
+    objectiveRequirement =
+        let objectives: OrderedSet(RequirementUsage) =
+            featureMembership->
+                selectByKind(ObjectiveMembership).
+                ownedRequirement in
+        if objectives->isEmpty() then null
+        else objectives->first().ownedObjectiveRequirement
+        endif
+    featureMembership->
+        selectByKind(ObjectiveMembership)->
+        size() <= 1
+    subjectParameter =
+        let subjectMems : OrderedSet(SubjectMembership) =
+            featureMembership->selectByKind(SubjectMembership) in
+        if subjectMems->isEmpty() then null
+        else subjectMems->first().ownedSubjectParameter
+        endif
+    actorParameter = featureMembership->
+        selectByKind(ActorMembership).
+        ownedActorParameter
+    featureMembership->selectByKind(SubjectMembership)->size() <= 1
+    input->notEmpty() and input->first() = subjectParameter
+    specializesFromLibrary('Cases::Case')"""
+
+    _objectiveRequirement = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="objectiveRequirement",
+        transient=True,
+    )
+    _subjectParameter = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="subjectParameter",
+        transient=True,
+    )
+    actorParameter = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedActorparameter,
+    )
+
+    @property
+    def objectiveRequirement(self):
+        raise NotImplementedError("Missing implementation for objectiveRequirement")
+
+    @objectiveRequirement.setter
+    def objectiveRequirement(self, value):
+        raise NotImplementedError("Missing implementation for objectiveRequirement")
+
+    @property
+    def subjectParameter(self):
+        raise NotImplementedError("Missing implementation for subjectParameter")
+
+    @subjectParameter.setter
+    def subjectParameter(self, value):
+        raise NotImplementedError("Missing implementation for subjectParameter")
+
+    def __init__(
+        self,
+        *,
+        objectiveRequirement=None,
+        subjectParameter=None,
+        actorParameter=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if objectiveRequirement is not None:
+            self.objectiveRequirement = objectiveRequirement
+
+        if subjectParameter is not None:
+            self.subjectParameter = subjectParameter
+
+        if actorParameter:
+            self.actorParameter.extend(actorParameter)
+
+
+class DerivedAnalysisaction(EDerivedCollection):
+    pass
+
+
+class AnalysisCaseUsage(CaseUsage):
+    """<p>An <code>AnalysisCaseUsage</code> is a <code>Usage</code> of an <code>AnalysisCaseDefinition</code>.</p>
+    analysisAction = usage->select(
+        isComposite and
+        specializes('AnalysisCases::AnalysisAction'))
+    resultExpression =
+        let results : OrderedSet(ResultExpressionMembership) =
+            featureMembersip->
+                selectByKind(ResultExpressionMembership) in
+        if results->isEmpty() then null
+        else results->first().ownedResultExpression
+        endif
+    specializesFromLibrary('AnalysisCases::analysisCases')
+    isComposite and owningType <> null and
+        (owningType.oclIsKindOf(AnalysisCaseDefinition) or
+         owningType.oclIsKindOf(AnalysisCaseUsage)) implies
+        specializesFromLibrary('AnalysisCases::AnalysisCase::subAnalysisCases')"""
+
+    analysisAction = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedAnalysisaction,
+    )
+    _analysisCaseDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="analysisCaseDefinition",
+        transient=True,
+    )
+    _resultExpression = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="resultExpression",
+        transient=True,
+    )
+
+    @property
+    def analysisCaseDefinition(self):
+        raise NotImplementedError("Missing implementation for analysisCaseDefinition")
+
+    @analysisCaseDefinition.setter
+    def analysisCaseDefinition(self, value):
+        raise NotImplementedError("Missing implementation for analysisCaseDefinition")
+
+    @property
+    def resultExpression(self):
+        raise NotImplementedError("Missing implementation for resultExpression")
+
+    @resultExpression.setter
+    def resultExpression(self, value):
+        raise NotImplementedError("Missing implementation for resultExpression")
+
+    def __init__(
+        self,
+        *,
+        analysisAction=None,
+        analysisCaseDefinition=None,
+        resultExpression=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if analysisAction:
+            self.analysisAction.extend(analysisAction)
+
+        if analysisCaseDefinition is not None:
+            self.analysisCaseDefinition = analysisCaseDefinition
+
+        if resultExpression is not None:
+            self.resultExpression = resultExpression
+
+
+class DerivedVerifiedrequirement(EDerivedCollection):
+    pass
+
+
+class VerificationCaseUsage(CaseUsage):
+    """<p>A <code>VerificationCaseUsage</code> is a </code>Usage</code> of a <code>VerificationCaseDefinition</code>.</p>
+    verifiedRequirement =
+        if objectiveRequirement = null then OrderedSet{}
+        else
+            objectiveRequirement.featureMembership->
+                selectByKind(RequirementVerificationMembership).
+                verifiedRequirement->asOrderedSet()
+        endif
+    specializesFromLibrary('VerificationCases::verificationCases')
+    isComposite and owningType <> null and
+        (owningType.oclIsKindOf(VerificationCaseDefinition) or
+         owningType.oclIsKindOf(VerificationCaseUsage))"""
+
+    _verificationCaseDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="verificationCaseDefinition",
+        transient=True,
+    )
+    verifiedRequirement = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedVerifiedrequirement,
+    )
+
+    @property
+    def verificationCaseDefinition(self):
+        raise NotImplementedError(
+            "Missing implementation for verificationCaseDefinition"
+        )
+
+    @verificationCaseDefinition.setter
+    def verificationCaseDefinition(self, value):
+        raise NotImplementedError(
+            "Missing implementation for verificationCaseDefinition"
+        )
+
+    def __init__(
+        self, *, verificationCaseDefinition=None, verifiedRequirement=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if verificationCaseDefinition is not None:
+            self.verificationCaseDefinition = verificationCaseDefinition
+
+        if verifiedRequirement:
+            self.verifiedRequirement.extend(verifiedRequirement)
+
+
+class DerivedIncludedusecase(EDerivedCollection):
+    pass
+
+
+class UseCaseUsage(CaseUsage):
+    """<p>A <code>UseCaseUsage</code> is a <code>Usage</code> of a <code>UseCaseDefinition</code>.</p>
+    includedUseCase = ownedUseCase->
+        selectByKind(IncludeUseCaseUsage).
+        useCaseIncluded
+    specializesFromLibrary('UseCases::useCases')
+    isComposite and owningType <> null and
+    (owningType.oclIsKindOf(UseCaseDefinition) or
+     owningType.oclIsKindOf(UseCaseUsage)) implies
+        specializesFromLibrary('UseCases::UseCase::subUseCases')"""
+
+    _useCaseDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="useCaseDefinition",
+        transient=True,
+    )
+    includedUseCase = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedIncludedusecase,
+    )
+
+    @property
+    def useCaseDefinition(self):
+        raise NotImplementedError("Missing implementation for useCaseDefinition")
+
+    @useCaseDefinition.setter
+    def useCaseDefinition(self, value):
+        raise NotImplementedError("Missing implementation for useCaseDefinition")
+
+    def __init__(self, *, useCaseDefinition=None, includedUseCase=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if useCaseDefinition is not None:
+            self.useCaseDefinition = useCaseDefinition
+
+        if includedUseCase:
+            self.includedUseCase.extend(includedUseCase)
+
+
+class DerivedViewpointstakeholder(EDerivedCollection):
+    pass
+
+
+class ViewpointUsage(RequirementUsage):
+    """<p>A <code>ViewpointUsage<code> is a <code>Usage</code> of a <code>ViewpointDefinition</code>.</p>
+
+
+    viewpointStakeholder = framedConcern.featureMemberhsip->
+        selectByKind(StakeholderMembership).
+        ownedStakeholderParameter
+    specializesFromLibrary('Views::viewpoints')
+    isComposite and owningType <> null and
+    (owningType.oclIsKindOf(ViewDefinition) or
+     owningType.oclIsKindOf(ViewUsage)) implies
+        specializesFromLibrary('Views::View::viewpointSatisfactions')"""
+
+    _viewpointDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="viewpointDefinition",
+        transient=True,
+    )
+    viewpointStakeholder = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedViewpointstakeholder,
+    )
+
+    @property
+    def viewpointDefinition(self):
+        raise NotImplementedError("Missing implementation for viewpointDefinition")
+
+    @viewpointDefinition.setter
+    def viewpointDefinition(self, value):
+        raise NotImplementedError("Missing implementation for viewpointDefinition")
+
+    def __init__(
+        self, *, viewpointDefinition=None, viewpointStakeholder=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if viewpointDefinition is not None:
+            self.viewpointDefinition = viewpointDefinition
+
+        if viewpointStakeholder:
+            self.viewpointStakeholder.extend(viewpointStakeholder)
+
+
+class AssertConstraintUsage(ConstraintUsage, Invariant):
+    """<p>An <code>AssertConstraintUsage</code> is a <code>ConstraintUsage</code> that is also an <code>Invariant</code> and, so, is asserted to be true (by default). Unless it is the <code>AssertConstraintUsage</code> itself, the asserted <code>ConstraintUsage</code> is related to the <code>AssertConstraintUsage</code> by a ReferenceSubsetting <code>Relationship</code>.</p>
+    assertedConstraint =
+        if ownedReferenceSubsetting = null then self
+        else ownedReferenceSubsetting.referencedFeature.oclAsType(ConstraintUsage)
+        endif
+    if isNegated then
+        specializesFromLibrary('Constraints::negatedConstraints')
+    else
+        specializesFromLibrary('Constraints::assertedConstraints')
+    endif"""
+
+    _assertedConstraint = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="assertedConstraint",
+        transient=True,
+    )
+
+    @property
+    def assertedConstraint(self):
+        raise NotImplementedError("Missing implementation for assertedConstraint")
+
+    @assertedConstraint.setter
+    def assertedConstraint(self, value):
+        raise NotImplementedError("Missing implementation for assertedConstraint")
+
+    def __init__(self, *, assertedConstraint=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if assertedConstraint is not None:
+            self.assertedConstraint = assertedConstraint
+
+
+class ExhibitStateUsage(StateUsage, PerformActionUsage):
+    """<p>An <code>ExhibitStateUsage</code> is a <code>StateUsage</code> that represents the exhibiting of a <code>StateUsage</code>. Unless it is the <code>StateUsage</code> itself, the <code>StateUsage</code> to be exhibited is related to the <code>ExhibitStateUsage</code> by a <code>ReferenceSubsetting</code> <code>Relationship</code>. An <code>ExhibitStateUsage</code> is also a <code>PerformActionUsage</code>, with its <code>exhibitedState</code> as the <code>performedAction</code>.</p>
+
+    owningType <> null and
+    (owningType.oclIsKindOf(PartDefinition) or
+     owningType.oclIsKindOf(PartUsage)) implies
+        specializesFromLibrary('Parts::Part::exhibitedStates')"""
+
+    _exhibitedState = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="exhibitedState",
+        transient=True,
+    )
+
+    @property
+    def exhibitedState(self):
+        raise NotImplementedError("Missing implementation for exhibitedState")
+
+    @exhibitedState.setter
+    def exhibitedState(self, value):
+        raise NotImplementedError("Missing implementation for exhibitedState")
+
+    def __init__(self, *, exhibitedState=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if exhibitedState is not None:
+            self.exhibitedState = exhibitedState
+
+
+class DerivedInterfacedefinition(EDerivedCollection):
+    pass
+
+
+class InterfaceUsage(ConnectionUsage):
+    """<p>An <code>InterfaceUsage</code> is a Usage of an <code>InterfaceDefinition</code> to represent an interface connecting parts of a system through specific ports.</p>
+    ownedEndFeature->size() = 2 implies
+        specializesFromLibrary("Interfaces::binaryInterfaces")
+    specializesFromLibrary("Interfaces::interfaces")"""
+
+    interfaceDefinition = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedInterfacedefinition,
+    )
+
+    def __init__(self, *, interfaceDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if interfaceDefinition:
+            self.interfaceDefinition.extend(interfaceDefinition)
+
+
+class DerivedAllocationdefinition(EDerivedCollection):
+    pass
+
+
+class AllocationUsage(ConnectionUsage):
+    """<p>An <code>AllocationUsage</code> is a usage of an <code>AllocationDefinition</code> asserting the allocation of the <code>source</code> feature to the <code>target</code> feature.</p>
+    specializesFromLibrary("Allocations::allocations")"""
+
+    allocationDefinition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedAllocationdefinition,
+    )
+
+    def __init__(self, *, allocationDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if allocationDefinition:
+            self.allocationDefinition.extend(allocationDefinition)
+
+
+class ConcernDefinition(RequirementDefinition):
+    """<p>A <code>ConcernDefinition</code> is a <code>RequirementDefinition</code> that one or more stakeholders may be interested in having addressed. These stakeholders are identified by the <code>ownedStakeholders</code>of the <code>ConcernDefinition</code>.</p>
+
+    specializesFromLibrary('Requirements::ConcernCheck')"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class AnalysisCaseDefinition(CaseDefinition):
+    """<p>An <code>AnalysisCaseDefinition</code> is a <code>CaseDefinition</code> for the case of carrying out an analysis.</p>
+    analysisAction = action->select(
+        isComposite and
+        specializes('AnalysisCases::AnalysisAction'))
+    resultExpression =
+        let results : OrderedSet(ResultExpressionMembership) =
+            featureMembersip->
+                selectByKind(ResultExpressionMembership) in
+        if results->isEmpty() then null
+        else results->first().ownedResultExpression
+        endif
+    specializesFromLibrary('AnalysisCases::AnalysisCase')"""
+
+    analysisAction = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedAnalysisaction,
+    )
+    _resultExpression = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="resultExpression",
+        transient=True,
+    )
+
+    @property
+    def resultExpression(self):
+        raise NotImplementedError("Missing implementation for resultExpression")
+
+    @resultExpression.setter
+    def resultExpression(self, value):
+        raise NotImplementedError("Missing implementation for resultExpression")
+
+    def __init__(self, *, analysisAction=None, resultExpression=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if analysisAction:
+            self.analysisAction.extend(analysisAction)
+
+        if resultExpression is not None:
+            self.resultExpression = resultExpression
+
+
+class VerificationCaseDefinition(CaseDefinition):
+    """<p>A <code>VerificationCaseDefinition</code> is a <code>CaseDefinition</code> for the purpose of verification of the subject of the case against its requirements.</p>
+    verifiedRequirement =
+        if objectiveRequirement = null then OrderedSet{}
+        else
+            objectiveRequirement.featureMembership->
+                selectByKind(RequirementVerificationMembership).
+                verifiedRequirement->asOrderedSet()
+        endif
+    specializesFromLibrary('VerificationCases::VerificationCase')"""
+
+    verifiedRequirement = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedVerifiedrequirement,
+    )
+
+    def __init__(self, *, verifiedRequirement=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if verifiedRequirement:
+            self.verifiedRequirement.extend(verifiedRequirement)
+
+
+class UseCaseDefinition(CaseDefinition):
+    """<p>A <code>UseCaseDefinition</code> is a <code>CaseDefinition</code> that specifies a set of actions performed by its subject, in interaction with one or more actors external to the subject. The objective is to yield an observable result that is of value to one or more of the actors.</p>
+
+    includedUseCase = ownedUseCase->
+        selectByKind(IncludeUseCaseUsage).
+        useCaseIncluded
+    specializesFromLibrary('UseCases::UseCase')"""
+
+    includedUseCase = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedIncludedusecase,
+    )
+
+    def __init__(self, *, includedUseCase=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if includedUseCase:
+            self.includedUseCase.extend(includedUseCase)
+
+
+class ViewpointDefinition(RequirementDefinition):
+    """<p>A <code>ViewpointDefinition</code> is a <code>RequirementDefinition</code> that specifies one or more stakeholder concerns that are to be satisfied by creating a view of a model.</p>
+    viewpointStakeholder = framedConcern.featureMemberhsip->
+        selectByKind(StakeholderMembership).
+        ownedStakeholderParameter
+    specializesFromLibrary('Views::Viewpoint')"""
+
+    viewpointStakeholder = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedViewpointstakeholder,
+    )
+
+    def __init__(self, *, viewpointStakeholder=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if viewpointStakeholder:
+            self.viewpointStakeholder.extend(viewpointStakeholder)
+
+
+class DerivedConnectionend(EDerivedCollection):
+    pass
+
+
+class ConnectionDefinition(PartDefinition, AssociationStructure):
+    """<p>A <code>ConnectionDefinition</code> is a <code>PartDefinition</code> that is also an <code>AssociationStructure</code>. The end <code>Features</code> of a <code>ConnectionDefinition</code> must be <code>Usages</code>.</p>
+    specializesFromLibrary("Connections::Connection")
+    ownedEndFeature->size() = 2 implies
+        specializesFromLibrary("Connections::BinaryConnections")"""
+
+    connectionEnd = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedConnectionend,
+    )
+
+    def __init__(self, *, connectionEnd=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if connectionEnd:
+            self.connectionEnd.extend(connectionEnd)
+
+
+class SatisfyRequirementUsage(RequirementUsage, AssertConstraintUsage):
+    """<p>A <code>SatisfyRequirementUsage</code> is an <code>AssertConstraintUsage</code> that asserts, by default, that a satisfied <code>RequirementUsage</code> is true for a specific <code>satisfyingFeature</code>, or, if <code>isNegated = true</code>, that the <code>RequirementUsage</code> is false. The satisfied <code>RequirementUsage</code> is related to the <code>SatisfyRequirementUsage</code> by a <code>ReferenceSubsetting</code> <code>Relationship</code>.</p>
+    satisfyingFeature =
+        let bindings: BindingConnector = ownedMember->
+            selectByKind(BindingConnector)->
+            select(b | b.relatedElement->includes(subjectParameter)) in
+        if bindings->isEmpty() or
+           bindings->first().relatedElement->exits(r | r <> subjectParameter)
+        then null
+        else bindings->first().relatedElement->any(r | r <> subjectParameter)
+        endif
+    ownedMember->selectByKind(BindingConnector)->
+        select(b |
+            b.relatedElement->includes(subjectParameter) and
+            b.relatedElement->exists(r | r <> subjectParameter))->
+        size() = 1"""
+
+    _satisfiedRequirement = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="satisfiedRequirement",
+        transient=True,
+    )
+    _satisfyingFeature = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="satisfyingFeature",
+        transient=True,
+    )
+
+    @property
+    def satisfiedRequirement(self):
+        raise NotImplementedError("Missing implementation for satisfiedRequirement")
+
+    @satisfiedRequirement.setter
+    def satisfiedRequirement(self, value):
+        raise NotImplementedError("Missing implementation for satisfiedRequirement")
+
+    @property
+    def satisfyingFeature(self):
+        raise NotImplementedError("Missing implementation for satisfyingFeature")
+
+    @satisfyingFeature.setter
+    def satisfyingFeature(self, value):
+        raise NotImplementedError("Missing implementation for satisfyingFeature")
+
+    def __init__(self, *, satisfiedRequirement=None, satisfyingFeature=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if satisfiedRequirement is not None:
+            self.satisfiedRequirement = satisfiedRequirement
+
+        if satisfyingFeature is not None:
+            self.satisfyingFeature = satisfyingFeature
+
+
+class DerivedAllocation(EDerivedCollection):
+    pass
+
+
+class AllocationDefinition(ConnectionDefinition):
+    """<p>An <code>AllocationDefinition</code> is a <code>ConnectionDefinition</code> that specifies that some or all of the responsibility to realize the intent of the <code>source</code> is allocated to the <code>target</code> instances. Such allocations define mappings across the various structures and hierarchies of a system model, perhaps as a precursor to more rigorous specifications and implementations. An <code>AllocationDefinition</code> can itself be refined using nested <code>allocations</code> that give a finer-grained decomposition of the containing allocation mapping.</p>
+    allocation = usage->selectAsKind(AllocationUsage)
+    specializesFromLibrary("Allocations::Allocation")"""
+
+    allocation = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedAllocation,
+    )
+
+    def __init__(self, *, allocation=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if allocation:
+            self.allocation.extend(allocation)
+
+
+class DerivedInterfaceend(EDerivedCollection):
+    pass
+
+
+class InterfaceDefinition(ConnectionDefinition):
+    """<p>An <code>InterfaceDefinition</code> is a <code>ConnectionDefinition</code> all of whose ends are <code>PortUsages</code>, defining an interface between elements that interact through such ports.</p>
+    specializesFromLibrary("Interfaces::Interface")
+    ownedEndFeature->size() = 2 implies
+        specializesFromLibrary("Interfaces::BinaryInterface")"""
+
+    interfaceEnd = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedInterfaceend,
+    )
+
+    def __init__(self, *, interfaceEnd=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if interfaceEnd:
+            self.interfaceEnd.extend(interfaceEnd)
+
+
+class IncludeUseCaseUsage(UseCaseUsage, PerformActionUsage):
+    """<p>An <code>IncludeUseCaseUsage</code> is a <code>UseCaseUsage</code> that represents the inclusion of a <code>UseCaseUsage</code> by a <code>UseCaseDefinition</code> or <code>UseCaseUsage</code>. Unless it is the <code>IncludeUseCaseUsage</code> itself, the <code>UseCaseUsage</code> to be included is related to the <code>includedUseCase</code> by a <code>ReferenceSubsetting</code> <code>Relationship</code>. An <code>IncludeUseCaseUsage</code> is also a PerformActionUsage, with its <code>useCaseIncluded</code> as the <code>performedAction</code>.</p>
+
+    owningType <> null and
+    (owningType.oclIsKindOf(UseCaseDefinition) or
+     owningType.oclIsKindOf(UseCaseUsage) implies
+        specializesFromLibrary('UseCases::UseCase::includedUseCases')"""
+
+    _useCaseIncluded = EReference(
+        ordered=False,
+        unique=True,
+        containment=False,
+        derived=True,
+        name="useCaseIncluded",
+        transient=True,
+    )
+
+    @property
+    def useCaseIncluded(self):
+        raise NotImplementedError("Missing implementation for useCaseIncluded")
+
+    @useCaseIncluded.setter
+    def useCaseIncluded(self, value):
+        raise NotImplementedError("Missing implementation for useCaseIncluded")
+
+    def __init__(self, *, useCaseIncluded=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if useCaseIncluded is not None:
+            self.useCaseIncluded = useCaseIncluded
+
+
+class DerivedFlowconnectiondefinition(EDerivedCollection):
+    pass
+
+
+class FlowConnectionUsage(ConnectionUsage, ActionUsage, ItemFlow):
+    """<p>A <code>FlowConnectionUsage</code> is a <code>ConnectionUsage</code> that is also an <code>ItemFlow</code>.</p>
+    if itemFlowEnds->isEmpty() then
+        specializesFromLibrary("Connections::messageConnections")
+    else
+        specializesFromLibrary("Connections::flowConnections"
+    endif"""
+
+    flowConnectionDefinition = EReference(
+        ordered=True,
+        unique=True,
+        containment=False,
+        derived=True,
+        upper=-1,
+        transient=True,
+        derived_class=DerivedFlowconnectiondefinition,
+    )
+
+    def __init__(self, *, flowConnectionDefinition=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if flowConnectionDefinition:
+            self.flowConnectionDefinition.extend(flowConnectionDefinition)
+
+
+class FlowConnectionDefinition(ConnectionDefinition, ActionDefinition, Interaction):
+    """<p>A <code>FlowConnectionDefinition</code> is a <code>ConnectionDefinition</code> and <code>ActionDefinition</code> that is also an <code>Interaction</code> representing flows between <code>Usages</code>.</p>
+    specializesFromLibrary("Connections::MessageConnection")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class SuccessionFlowConnectionUsage(FlowConnectionUsage, SuccessionItemFlow):
+    """<p>A <code>SuccessionFlowConnectionUsage</code> is a <code>FlowConnectionUsage</code> that is also a <code>SuccessionItemFlow</code>.</p>
+    specializesFromLibrary("Connections::successionFlowConnections")"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)

--- a/gaphor/UMLTypes/__init__.py
+++ b/gaphor/UMLTypes/__init__.py
@@ -1,0 +1,16 @@
+from gaphor.UMLTypes.uml_types import eClassifiers
+from gaphor.UMLTypes.uml_types import eClass
+from gaphor.UMLTypes.uml_types import Integer, Real, String, UnlimitedNatural, Boolean
+
+from gaphor.UMLTypes import uml_types
+
+__all__ = ["Integer", "Real", "String", "UnlimitedNatural", "Boolean"]
+
+otherClassifiers = [Integer, Real, String, UnlimitedNatural, Boolean]
+
+for classif in otherClassifiers:
+    eClassifiers[classif.name] = classif
+    classif.ePackage = eClass
+
+for classif in eClassifiers.values():
+    eClass.eClassifiers.append(classif.eClass)

--- a/gaphor/UMLTypes/uml_types.py
+++ b/gaphor/UMLTypes/uml_types.py
@@ -14,11 +14,28 @@ eClassifiers = {}  # type: ignore
 getEClassifier = partial(Ecore.getEClassifier, searchspace=eClassifiers)
 
 Integer = EDataType("Integer", instanceClassName="int")
+Integer.from_string = lambda x: int(x)
 
 Real = EDataType("Real", instanceClassName="double")
+Real.from_string = lambda x: float(x)
 
 String = EDataType("String", instanceClassName="java.lang.String")
 
 UnlimitedNatural = EDataType("UnlimitedNatural", instanceClassName="int")
 
+
+def unlimited_from_string(x):
+    if x == "*":
+        return -1
+    value = int(x)
+    if value >= 0:
+        return value
+    raise ValueError("UnlimitedNatural must be a >= 0 value")
+
+
+UnlimitedNatural.from_string = unlimited_from_string
+UnlimitedNatural.to_string = lambda x: "*" if x < 0 else str(x)
+
 Boolean = EDataType("Boolean", instanceClassName="boolean")
+Boolean.to_string = lambda x: str(x).lower()
+Boolean.from_string = lambda x: x in ["True", "true"]

--- a/gaphor/UMLTypes/uml_types.py
+++ b/gaphor/UMLTypes/uml_types.py
@@ -1,0 +1,24 @@
+"""Definition of meta model 'uml_types'."""
+from functools import partial
+import pyecore.ecore as Ecore
+from pyecore.ecore import EDataType, EPackage
+
+
+name = "uml_types"
+nsURI = "https://www.omg.org/spec/UML/20161101/PrimitiveTypes"
+nsPrefix = "primitives"
+
+eClass = EPackage(name=name, nsURI=nsURI, nsPrefix=nsPrefix)
+
+eClassifiers = {}  # type: ignore
+getEClassifier = partial(Ecore.getEClassifier, searchspace=eClassifiers)
+
+Integer = EDataType("Integer", instanceClassName="int")
+
+Real = EDataType("Real", instanceClassName="double")
+
+String = EDataType("String", instanceClassName="java.lang.String")
+
+UnlimitedNatural = EDataType("UnlimitedNatural", instanceClassName="int")
+
+Boolean = EDataType("Boolean", instanceClassName="boolean")

--- a/gaphor/codegen/kerml.ecore
+++ b/gaphor/codegen/kerml.ecore
@@ -1,0 +1,2568 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="kerml" nsURI="https://www.omg.org/spec/KerML/20230201" nsPrefix="kerml">
+  <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
+    <details key="settingDelegates" value="http://www.omg.org/spec/SysML"/>
+  </eAnnotations>
+  <eClassifiers xsi:type="ecore:EClass" name="Dependency" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Dependency&lt;/code> is a &lt;code>Relationship&lt;/code> that indicates that one or more &lt;code>client&lt;/code> &lt;code>Elements&lt;/code> require one more &lt;code>supplier&lt;/code> &lt;code>Elements&lt;/code> for their complete specification. In general, this means that a change to one of the &lt;code>supplier&lt;/code> &lt;code>Elements&lt;/code> may necessitate a change to, or re-specification of, the &lt;code>client&lt;/code> &lt;code>Elements&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>Note that a &lt;code>Dependency&lt;/code> is entirely a model-level &lt;code>Relationship&lt;/code>, without instance-level semantics.&lt;/p>"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="client" lowerBound="1"
+        upperBound="-1" eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="clientDependency"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> or &lt;code>Elements&lt;/code> dependent on the &lt;code>supplier&lt;/code> &lt;code>Elements&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="supplier" lowerBound="1"
+        upperBound="-1" eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="supplierDependency"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> or &lt;code>Elements&lt;/code> on which the &lt;code>client&lt;/code> &lt;code>Elements&lt;/code> depend in some respect.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Relationship" abstract="true" eSuperTypes="#//Element">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Relationship&lt;/code> is an &lt;code>Element&lt;/code> that relates other &lt;code>Element&lt;/code>. Some of its &lt;code>relatedElements&lt;/code> may be owned, in which case those &lt;code>ownedRelatedElements&lt;/code> will be deleted from a model if their &lt;code>owningRelationship&lt;/code> is. A &lt;code>Relationship&lt;/code> may also be owned by another &lt;code>Element&lt;/code>, in which case the &lt;code>ownedRelatedElements&lt;/code> of the &lt;code>Relationship&lt;/code> are also considered to be transitively owned by the &lt;code>owningRelatedElement&lt;/code> of the &lt;code>Relationship&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The &lt;code>relatedElements&lt;/code> of a &lt;code>Relationship&lt;/code> are divided into &lt;code>source&lt;/code> and &lt;code>target&lt;/code> &lt;code>Elements&lt;/code>. The &lt;code>Relationship&lt;/code> is considered to be directed from the &lt;code>source&lt;/code> to the &lt;code>target&lt;/code> &lt;code>Elements&lt;/code>. An undirected &lt;code>Relationship&lt;/code> may have either all &lt;code>source&lt;/code> or all &lt;code>target&lt;/code> &lt;code>Elements&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>A &amp;quot;relationship &lt;code>Element&lt;/code>&amp;quot; in the abstract syntax is generically any &lt;code>Element&lt;/code> that is an instance of either &lt;code>Relationship&lt;/code> or a direct or indirect specialization of &lt;code>Relationship&lt;/code>. Any other kind of &lt;code>Element&lt;/code> is a &amp;quot;non-relationship &lt;code>Element&lt;/code>&amp;quot;. It is a convention of that non-relationship &lt;code>Elements&lt;/code> are &lt;em>only&lt;/em> related via reified relationship &lt;code>Elements&lt;/code>. Any meta-associations directly between non-relationship &lt;code>Elements&lt;/code> must be derived from underlying reified &lt;code>Relationship&lt;/code>.&lt;/p>&#xA;&#xA;relatedElement = source->union(target)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedRelatedElement" upperBound="-1"
+        eType="#//Element" containment="true" eOpposite="#//Element/owningRelationship">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;tt>relatedElements&lt;/tt> of this Relationship that are owned by the Relationship.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningRelatedElement" ordered="false"
+        eType="#//Element" eOpposite="#//Element/ownedRelationship">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;tt>relatedElement&lt;/tt> of this Relationship that owns the Relationship, if any.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="relatedElement" unique="false"
+        upperBound="-1" eType="#//Element" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="relationship"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Elements that are related by this Relationship, derived as the union of the &lt;code>source&lt;/code> and &lt;code>target&lt;/code> Elements of the Relationship.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="target" upperBound="-1"
+        eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="targetRelationship"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>relatedElements&lt;/code> to which this Relationship is considered to be directed.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="source" upperBound="-1"
+        eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="sourceRelationship"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>relatedElements&lt;/c ode> from which this Relationship is considered to be directed.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isImplied" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this Relationship was generated by tooling to meet semantic rules, rather than being directly created by a modeler.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Element" abstract="true">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Element&lt;/code> is a constituent of a model that is uniquely identified relative to all other &lt;code>Elements&lt;/code>. It can have &lt;code>Relationships&lt;/code> with other &lt;code>Elements&lt;/code>. Some of these &lt;code>Relationships&lt;/code> might imply ownership of other &lt;code>Elements&lt;/code>, which means that if an &lt;code>Element&lt;/code> is deleted from a model, then so are all the &lt;code>Elements&lt;/code> that it owns.&lt;/p>&#xA;&#xA;ownedElement = ownedRelationship.ownedRelatedElement&#xA;owner = owningRelationship.owningRelatedElement&#xA;qualifiedName =&#xA;    if owningNamespace = null then null&#xA;    else if owningNamespace.owner = null then escapedName()&#xA;    else if owningNamespace.qualifiedName = null or &#xA;            escapedName() = null then null&#xA;    else owningNamespace.qualifiedName + '::' + escapedName()&#xA;    endif endif endif&#xA;documentation = ownedElement->selectByKind(Documentation)&#xA;ownedAnnotation = ownedRelationship->&#xA;    selectByKind(Annotation)->&#xA;    select(a | a.annotatedElement = self)&#xA;name = effectiveName()&#xA;ownedRelationship->exists(isImplied) implies isImpliedIncluded&#xA;isLibraryElement = libraryNamespace() &lt;>null&#xA;&#xA;shortName = effectiveShortName()&#xA;owningNamespace =&#xA;    if owningMembership = null then null&#xA;    else owningMembership.membershipOwningNamespace&#xA;    endif&#xA;textualRepresentation = ownedElement->selectByKind(TextualRepresentation)"/>
+    </eAnnotations>
+    <eOperations name="escapedName" ordered="false" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return &lt;code>name&lt;/code>, if that is not null, otherwise the &lt;code>shortName&lt;/code>, if that is not null, otherwise null. If the returned value is non-null, it is returned as-is if it has the form of a basic name, or, otherwise, represented as a restricted name according to the lexical structure of the KerML textual notation (i.e., surrounded by single quote characters and with special characters escaped).&lt;/p>"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="effectiveShortName" ordered="false" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return an effective &lt;code>shortName&lt;/code> for this &lt;code>Element&lt;/code>. By default this is the same as its &lt;code>declaredShortName&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="declaredShortName"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="effectiveName" ordered="false" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return an effective &lt;code>name&lt;/code> for this &lt;code>Element&lt;/code>. By default this is the same as its &lt;code>declaredName&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="declaredName"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="libraryNamespace" ordered="false" eType="#//Namespace">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>By default, return the library Namespace of the &lt;code>owningRelationship&lt;/code> of this Element, if it has one.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="if owningRelationship &lt;> null then owningRelationship.libraryNamespace()&#xA;else null endif"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningMembership" ordered="false"
+        eType="#//OwningMembership" volatile="true" transient="true" derived="true"
+        eOpposite="#//OwningMembership/ownedMemberElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>owningRelationship&lt;/code> of this &lt;code>Element&lt;/code>, if that &lt;code>Relationship&lt;/code> is a &lt;code>Membership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/owningRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningNamespace" ordered="false"
+        eType="#//Namespace" volatile="true" transient="true" derived="true" eOpposite="#//Namespace/ownedMember">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Namespace&lt;/code> that owns this &lt;code>Element&lt;/code>, which is the &lt;code>membershipOwningNamespace&lt;/code> of the &lt;code>owningMembership&lt;/code> of this &lt;code>Element&lt;/code>, if any.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningRelationship" ordered="false"
+        eType="#//Relationship" eOpposite="#//Relationship/ownedRelatedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Relationship for which this Element is an &lt;tt>ownedRelatedElement&lt;/tt>, if any.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="elementId" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String" iD="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The globally unique identifier for this Element. This is intended to be set by tooling, and it must not change during the lifetime of the Element.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedRelationship" upperBound="-1"
+        eType="#//Relationship" containment="true" eOpposite="#//Relationship/owningRelatedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Relationships for which this Element is the &lt;tt>owningRelatedElement&lt;/tt>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owner" ordered="false"
+        eType="#//Element" volatile="true" transient="true" derived="true" eOpposite="#//Element/ownedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owner of this Element, derived as the &lt;code>owningRelatedElement&lt;/code> of the &lt;code>owningRelationship&lt;/code> of this Element, if any.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedElement" upperBound="-1"
+        eType="#//Element" volatile="true" transient="true" derived="true" eOpposite="#//Element/owner">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Elements owned by this Element, derived as the &lt;tt>ownedRelatedElements&lt;/tt> of the &lt;tt>ownedRelationships&lt;/tt> of this Element.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="documentation" upperBound="-1"
+        eType="#//Documentation" volatile="true" transient="true" derived="true" eOpposite="#//Documentation/documentedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Documentation owned by this Element.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedAnnotation" upperBound="-1"
+        eType="#//Annotation" volatile="true" transient="true" derived="true" eOpposite="#//Annotation/owningAnnotatedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Element&lt;/code> that are &lt;code>Annotations&lt;/code>, for which this &lt;code>Element&lt;/code> is the &lt;code>annotatedElement&lt;/code>.&lt;/code>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="textualRepresentation"
+        upperBound="-1" eType="#//TextualRepresentation" volatile="true" transient="true"
+        derived="true" eOpposite="#//TextualRepresentation/representedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>TextualRepresentations&lt;/code> that annotate this &lt;code>Element&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="aliasIds" upperBound="-1"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Various alternative identifiers for this Element. Generally, these will be set by tools.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="declaredShortName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An optional alternative name for the &lt;code>Element&lt;/code> that is intended to be shorter or in some way more succinct than its primary &lt;code>name&lt;/code>. It may act as a modeler-specified identifier for the &lt;code>Element&lt;/code>, though it is then the responsibility of the modeler to maintain the uniqueness of this identifier within a model or relative to some other context.&lt;/p> &#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="declaredName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The declared name of this &lt;code>Element&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="shortName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The short name to be used for this &lt;code>Element&lt;/code> during name resolution within its &lt;code>owningNamespace&lt;/code>. This is derived using the &lt;code>effectiveShortName()&lt;/code> operation. By default, it is the same as the &lt;code>declaredShortName&lt;/code>, but this is overridden for certain kinds of &lt;code>Elements&lt;/code> to compute a &lt;code>shortName&lt;/code> even when the &lt;code>declaredName&lt;/code> is null.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" ordered="false" eType="ecore:EDataType uml_types.ecore#//String"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The name to be used for this &lt;code>Element&lt;/code> during name resolution within its &lt;code>owningNamespace&lt;/code>. This is derived using the &lt;code>effectiveName()&lt;/code> operation. By default, it is the same as the &lt;code>declaredName&lt;/code>, but this is overridden for certain kinds of &lt;code>Elements&lt;/code> to compute a &lt;code>name&lt;/code> even when the &lt;code>declaredName&lt;/code> is null.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="qualifiedName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The full ownership-qualified name of this &lt;code>Element&lt;/code>, represented in a form that is valid according to the KerML textual concrete syntax for qualified names (including use of unrestricted name notation and escaped characters, as necessary). The &lt;code>qualifiedName&lt;/code> is null if this &lt;code>Element&lt;/code> has no &lt;code>owningNamespace&lt;/code> or if there is not a complete ownership chain of named &lt;code>Namespaces&lt;/code> from a root &lt;code>Namespace&lt;/code> to this &lt;code>Element&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isImpliedIncluded" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether all necessary implied Relationships have been included in the &lt;code>ownedRelationships&lt;/code> of this Element. This property may be true, even if there are not actually any &lt;code>ownedRelationships&lt;/code> with &lt;code>isImplied = true&lt;/code>, meaning that no such Relationships are actually implied for this Element. However, if it is false, then &lt;code>ownedRelationships&lt;/code> may &lt;em>not&lt;/em> contain any implied Relationships. That is, either &lt;em>all&lt;/em> required implied Relationships must be included, or none of them.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isLibraryElement" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" volatile="true"
+        transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this Element is contained in the ownership tree of a library model.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="OwningMembership" eSuperTypes="#//Membership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>OwningMembership&lt;/code> is a &lt;code>Membership&lt;/code> that owns its &lt;code>memberElement&lt;/code> as a &lt;code>ownedRelatedElement&lt;/code>. The &lt;code>ownedMemberElementM&lt;/code> becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>&#xA;&#xA;ownedMemberName = ownedMemberElement.name&#xA;ownedMemberShortName = ownedMemberElement.shortName"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="ownedMemberElementId" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String" volatile="true"
+        transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>elementId&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Membership/memberElementId"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="ownedMemberShortName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>shortName&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Membership/memberShortName"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="ownedMemberName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>name&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Membership/memberName"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMemberElement" ordered="false"
+        lowerBound="1" eType="#//Element" volatile="true" transient="true" derived="true"
+        eOpposite="#//Element/owningMembership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> that becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> due to this &lt;code>OwningMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Membership/memberElement"/>
+      <eAnnotations source="subsets" references="#//Relationship/ownedRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Membership" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Membership&lt;/code> is a &lt;code>Relationship&lt;/code> between a &lt;code>Namespace&lt;/code> and an &lt;code>Element&lt;/code> that indicates the &lt;code>Element&lt;/code> is a &lt;code>member&lt;/code> of (i.e., is contained in) the Namespace. Any &lt;code>memberNames&lt;/code> specify how the &lt;code>memberElement&lt;/code> is identified in the &lt;code>Namespace&lt;/code> and the &lt;code>visibility&lt;/code> specifies whether or not the &lt;code>memberElement&lt;/code> is publicly visible from outside the &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>If a &lt;code>Membership&lt;/code> is an &lt;code>OwningMembership&lt;/code>, then it owns its &lt;code>memberElement&lt;/code>, which becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code>. Otherwise, the &lt;code>memberNames&lt;/code> of a &lt;code>Membership&lt;/code> are effectively aliases within the &lt;code>membershipOwningNamespace&lt;/code> for an &lt;code>Element&lt;/code> with a separate &lt;code>OwningMembership&lt;/code> in the same or a different &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>&amp;nbsp;&lt;/p>&#xA;&#xA;memberElementId = memberElement.elementId"/>
+    </eAnnotations>
+    <eOperations name="isDistinguishableFrom" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>Membership&lt;/code> is distinguishable from a given &lt;code>other&lt;/code> &lt;code>Membership&lt;/code>. By default, this is true if this &lt;code>Membership&lt;/code> has no &lt;code>memberShortName&lt;/code> or &lt;code>memberName&lt;/code>; or each of the &lt;code>memberShortName&lt;/code> and &lt;code>memberName&lt;/code> are different than both of those of the &lt;code>other&lt;/code> &lt;code>Membership&lt;/code>; or neither of the metaclasses of the &lt;code>memberElement&lt;/code> of this &lt;code>Membership&lt;/code> and the &lt;code>memberElement&lt;/code> of the &lt;code>other&lt;/code> &lt;code>Membership&lt;/code> conform to the other. But this may be overridden in specializations of &lt;code>Membership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="not (memberElement.oclKindOf(other.memberElement.oclType()) or&#xA;     other.memberElement.oclKindOf(memberElement.oclType())) or&#xA;(shortMemberName = null or&#xA;    (shortMemberName &lt;> other.shortMemberName and&#xA;     shortMemberName &lt;> other.memberName)) and&#xA;(memberName = null or&#xA;    (memberName &lt;> other.shortMemberName and&#xA;     memberName &lt;> other.memberName)))&#xA;"/>
+      </eAnnotations>
+      <eParameters name="other" ordered="false" lowerBound="1" eType="#//Membership"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="memberElementId" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String" volatile="true"
+        transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>elementId&lt;/code> of the &lt;code>memberElement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="membershipOwningNamespace"
+        ordered="false" lowerBound="1" eType="#//Namespace" volatile="true" transient="true"
+        derived="true" eOpposite="#//Namespace/ownedMembership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Namespace&lt;/code> of which the &lt;code>memberElement&lt;/code> becomes a &lt;cpde>member due to this &lt;code>Membership&lt;/code>.&lt;/cpde>&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="memberShortName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The short name of the &lt;code>memberElement&lt;/code> relative to the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="memberElement" ordered="false"
+        lowerBound="1" eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="membership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> that becomes a &lt;code>member&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> due to this &lt;code>Membership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="memberName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The name of the &lt;code>memberElement&lt;/code> relative to the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="visibility" ordered="false"
+        lowerBound="1" eType="#//VisibilityKind" defaultValueLiteral="public">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether or not the &lt;code>Membership&lt;/code> of the &lt;code>memberElement&lt;/code> in the &lt;code>membershipOwningNamespace&lt;/code> is publicly visible outside that &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Namespace" eSuperTypes="#//Element">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Namespace&lt;/code> is an &lt;code>Element&lt;/code> that contains other &lt;code>Element&lt;/code>, known as its &lt;code>members&lt;/code>, via &lt;code>Membership&lt;/code> &lt;code>Relationships&lt;/code> with those &lt;code>Elements&lt;/code>. The &lt;code>members&lt;/code> of a &lt;code>Namespace&lt;/code> may be owned by the &lt;code>Namespace&lt;/code>, aliased in the &lt;code>Namespace&lt;/code>, or imported into the &lt;code>Namespace&lt;/code> via &lt;code>Import&lt;/code> &lt;code>Relationships&lt;/code> with other &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>A &lt;code>Namespace&lt;/code> can provide names for its &lt;code>members&lt;/code> via the &lt;code>memberNames&lt;/code> and &lt;code>memberShortNames&lt;/code> specified by the &lt;code>Memberships&lt;/code> in the &lt;code>Namespace&lt;/code>. If a &lt;code>Membership&lt;/code> specifies a &lt;code>memberName&lt;/code> and/or &lt;code>memberShortName&lt;/code>, then that those are names of the corresponding &lt;code>memberElement&lt;/code> relative to the &lt;code>Namespace&lt;/code>. For an &lt;code>OwningMembership&lt;/code>, the &lt;code>owningMemberName&lt;/code> and &lt;code>owningMemberShortName&lt;/code> are given by the &lt;code>Element&lt;/code> &lt;code>name&lt;/code> and &lt;code>shortName&lt;/code>. Note that the same &lt;code>Element&lt;/code> may be the &lt;code>memberElement&lt;/code> of multiple &lt;code>Memberships&lt;/code> in a &lt;code>Namespace&lt;/code> (though it may be owned at most once), each of which may define a separate alias for the &lt;code>Element&lt;/code> relative to the &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;membership->forAll(m1 | &#xA;    membership->forAll(m2 | &#xA;        m1 &lt;> m2 implies m1.isDistinguishableFrom(m2)))&#xA;member = membership.memberElement&#xA;ownedMember = ownedMembership->selectByKind(OwningMembership).ownedMemberElement&#xA;importedMembership = importedMemberships(Set{})&#xA;ownedImport = ownedRelationship->selectByKind(Import)&#xA;ownedMembership = ownedRelationship->selectByKind(Membership)"/>
+    </eAnnotations>
+    <eOperations name="namesOf" ordered="false" upperBound="-1" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the names of the given &lt;code>element&lt;/code> as it is known in this &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="let elementMemberships : Sequence(Membership) = &#xA;    memberships->select(memberElement = element) in&#xA;memberships.memberShortName->&#xA;    union(memberships.memberName)->&#xA;    asSet()"/>
+      </eAnnotations>
+      <eParameters name="element" ordered="false" lowerBound="1" eType="#//Element"/>
+    </eOperations>
+    <eOperations name="visibilityOf" ordered="false" lowerBound="1" eType="#//VisibilityKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Returns this visibility of &lt;code>mem&lt;/code> relative to this &lt;code>Namespace&lt;/code>. If &lt;code>mem&lt;/code> is an &lt;code>importedMembership&lt;/code>, this is the &lt;code>visibility&lt;/code> of its Import. Otherwise it is the &lt;code>visibility&lt;/code> of the &lt;code>Membership&lt;/code> itself.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="if importedMembership->includes(mem) then&#xA;    ownedImport->&#xA;        select(importedMemberships(Set{})->includes(mem)).&#xA;        first().visibility&#xA;else if memberships->includes(mem) then&#xA;    mem.visibility&#xA;else&#xA;    VisibilityKind::private&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="mem" ordered="false" lowerBound="1" eType="#//Membership"/>
+    </eOperations>
+    <eOperations name="visibleMemberships" upperBound="-1" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>If &lt;code>includeAll = true&lt;/code>, then return all the &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code>. Otherwise, return only the publicly visible &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code> (which includes those &lt;code>ownedMemberships&lt;/code> that have a &lt;code>visibility&lt;/code> of &lt;code>public&lt;/code> and those &lt;code>importedMemberships&lt;/code> imported with a &lt;code>visibility&lt;/code> of &lt;code>public&lt;/code>). If &lt;code>isRecursive = true&lt;/code>, also recursively include all visible &lt;code>Memberships&lt;/code> of any visible owned &lt;code>Namespaces&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="let visibleMemberships : Sequence(Membership) =&#xA;    if includeAll then memberships&#xA;    else ownedMembership->&#xA;        select(visibility = VisibilityKind::public)->&#xA;        union(ownedImport->&#xA;            select(visibility = VisibilityKind::public).&#xA;            importedMemberships(excluded->including(self)))&#xA;    endif in&#xA;if not isRecursive then visibleMemberships&#xA;else visibleMemberships->union(visibleMemberships->&#xA;        selectAsKind(Namespace).&#xA;        visibleMemberships(excluded->including(self), true, includeAll))&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="excluded" ordered="false" upperBound="-1" eType="#//Namespace"/>
+      <eParameters name="isRecursive" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean"/>
+      <eParameters name="includeAll" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean"/>
+    </eOperations>
+    <eOperations name="importedMemberships" upperBound="-1" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Derive the imported &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code> as the &lt;code>importedMembership&lt;/code> of all &lt;code>ownedImports&lt;/code>, excluding those Imports whose &lt;code>importOwningNamespace&lt;/code> is in the &lt;code>excluded&lt;/code> set, and excluding &lt;code>Memberships&lt;/code> that have distinguisibility collisions with each other or with any &lt;code>ownedMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="ownedImport.importedMemberships(excluded->including(self))"/>
+      </eAnnotations>
+      <eParameters name="excluded" ordered="false" upperBound="-1" eType="#//Namespace"/>
+    </eOperations>
+    <eOperations name="resolve" ordered="false" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Resolve the given qualified name to the named &lt;code>Membership&lt;/code> (if any), starting with this &lt;code>Namespace&lt;/code> as the local scope. The qualified name string must conform to the concrete syntax of the KerML textual notation. According to the KerML name resolution rules every qualified name will resolve to either a single &lt;code>Membership&lt;/code>, or to none.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="let qualification : String = qualificationOf(qualifiedName) in&#xA;let name : String = unqualifiedNameOf(qualifiedName) in&#xA;if qualification = null then resolveLocal(name)&#xA;else &#xA;    let namespace : Element = resolve(qualification) in&#xA;    if namespace = null or not namespace.oclIsKindOf(Namespace) then null&#xA;    else namespace.oclAsType(Namespace).resolveVisible(name) endif&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="qualifiedName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="resolveGlobal" ordered="false" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Resolve the given qualified name to the named &lt;code>Membership&lt;/code> (if any) in the effective global &lt;code>Namespace&lt;/code> that is the outermost naming scope. The qualified name string must conform to the concrete syntax of the KerML textual notation.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="No OCL"/>
+      </eAnnotations>
+      <eParameters name="qualifiedName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="resolveLocal" ordered="false" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Resolve a simple &lt;code>name&lt;/code> starting with this &lt;code>Namespace&lt;/code> as the local scope, and continuing with containing outer scopes as necessary. However, if this &lt;code>Namespace&lt;/code> is a root &lt;code>Namespace&lt;/code>, then the resolution is done directly in global scope.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="if owningNamespace = null then resolveGlobal(name)&#xA;else&#xA;    let memberships : Membership = membership->&#xA;        select(memberShortName = name or memberName = name) in&#xA;    if memberships->notEmpty() then memberships->first()&#xA;    else owningNamspace.resolveLocal(name)&#xA;    endif&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="name" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="resolveVisible" ordered="false" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Resolve a simple name from the visible &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="let memberships : Sequence(Membership) =&#xA;    visibleMemberships(Set{}, false, false)->&#xA;    select(memberShortName = name or memberName = name) in&#xA;if memberships->isEmpty() then null&#xA;else memberships->first()&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="name" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="qualificationOf" ordered="false" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return a string with valid KerML syntax representing the qualification part of a given &lt;code>qualifiedName&lt;/code>, that is, a qualified name with all the segment names of the given name except the last. If the given &lt;code>qualifiedName&lt;/code> has only one segment, then return null.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="No OCL"/>
+      </eAnnotations>
+      <eParameters name="qualifiedName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="unqualifiedNameOf" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the simple name that is the last segment name of the given &lt;code>qualifiedName&lt;/code>. If this segment name has the form of a KerML unrestricted name, then &quot;unescape&quot; it by removing the surrounding single quotes and replacing all escape sequences with the specified character.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="No OCL"/>
+      </eAnnotations>
+      <eParameters name="qualifiedName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="membership" upperBound="-1"
+        eType="#//Membership" changeable="false" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="membershipNamespace"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>Memberships&lt;/code> in this &lt;code>Namespace&lt;/code>, including (at least) the union of &lt;code>ownedMemberships&lt;/code> and &lt;code>importedMemberships&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="union"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedImport" upperBound="-1"
+        eType="#//Import" volatile="true" transient="true" derived="true" eOpposite="#//Import/importOwningNamespace">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Namespace&lt;/code> that are &lt;code>Imports&lt;/code>, for which the &lt;code>Namespace&lt;/code> is the &lt;code>importOwningNamespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="member" upperBound="-1"
+        eType="#//Element" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="namespace"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The set of all member &lt;code>Elements&lt;/code> of this &lt;code>Namespace&lt;/code>, which are the &lt;code>memberElements&lt;/code> of all &lt;code>memberships&lt;/code> of the &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMember" upperBound="-1"
+        eType="#//Element" volatile="true" transient="true" derived="true" eOpposite="#//Element/owningNamespace">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owned &lt;code>members&lt;/code> of this &lt;code>Namespace&lt;/code>, which are the &lt;cpde>&lt;code>ownedMemberElements&lt;/code> of the &lt;code>ownedMemberships&lt;/code> of the .&lt;/cpde>&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/member"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importedMembership" upperBound="-1"
+        eType="#//Membership" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="importingNamespace"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Memberships&lt;/code> in this &lt;code>Namespace&lt;/code> that result from the &lt;code>ownedImports&lt;/code> of this &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/membership"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMembership" upperBound="-1"
+        eType="#//Membership" volatile="true" transient="true" derived="true" eOpposite="#//Membership/membershipOwningNamespace">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Namespace&lt;/code> that are &lt;code>Memberships&lt;/code>, for which the &lt;code>Namespace&lt;/code> is the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/membership #//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Import" abstract="true" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Import&lt;/code> is an &lt;code>Relationship&lt;/code> between its &lt;code>importOwningNamespace&lt;/code> and either a &lt;code>Membership&lt;/code> (for a &lt;code>MembershipImport&lt;/code>) or another &lt;code>Namespace&lt;/code> (for a &lt;code>NamespaceImport&lt;/code>), which determines a set of &lt;code>Memberships&lt;/code> that become &lt;code>importedMemberships&lt;/code> of the &lt;code>importOwningNamespace&lt;/code>. If &lt;code>isImportAll = false&lt;/code> (the default), then only public &lt;code>Memberships&lt;/code> are considered &amp;quot;visible&amp;quot;. If &lt;code>isImportAll = true&lt;/code>, then all &lt;code>Memberships&lt;/code> are considered &amp;quot;visible&amp;quot;, regardless of their declared &lt;code>visibility&lt;/code>. If &lt;code>isRecursive = true&lt;/code>, then visible &lt;code>Memberships&lt;/code> are also recursively imported from owned sub-&lt;code>Namespaces&lt;/code>.&lt;/p>&#xA;&#xA;"/>
+    </eAnnotations>
+    <eOperations name="importedMemberships" upperBound="-1" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Returns Memberships that are to become &lt;code>importedMemberships&lt;/code> of the &lt;code>importOwningNamespace&lt;/code>. (The &lt;code>excluded&lt;/code> parameter is used to handle the possibility of circular Import Relationships.)&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eParameters name="excluded" ordered="false" upperBound="-1" eType="#//Namespace"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="visibility" ordered="false"
+        lowerBound="1" eType="#//VisibilityKind" defaultValueLiteral="public">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The visibility level of the imported &lt;code>members&lt;/code> from this Import relative to the &lt;code>importOwningNamespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isRecursive" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether to recursively import Memberships from visible, owned sub-Namespaces.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isImportAll" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether to import memberships without regard to declared visibility.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importedElement" ordered="false"
+        lowerBound="1" eType="#//Element" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="membershipImport"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The effectively imported &lt;code>Element&lt;/code> for this &lt;/code>Import&lt;/code>. For a &lt;code>MembershipImport&lt;/code>, this is the &lt;code>memberElement&lt;/code> of the &lt;code>importedMembership&lt;/code>. For a &lt;code>NamespaceImport&lt;/code>, it is the &lt;code>importedNamespace&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importOwningNamespace"
+        ordered="false" lowerBound="1" eType="#//Namespace" volatile="true" transient="true"
+        derived="true" eOpposite="#//Namespace/ownedImport">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Namespace into which Memberships are imported by this Import, which must be the &lt;code>owningRelatedElement&lt;/code> of the Import.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="VisibilityKind">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>VisibilityKind&lt;/code> is an enumeration whose literals specify the visibility of a &lt;code>Membership&lt;/code> of an &lt;code>Element&lt;/code> in a &lt;code>Namespace&lt;/code> outside of that &lt;code>Namespace&lt;/code>. Note that &amp;quot;visibility&amp;quot; specifically restricts whether an &lt;code>Element&lt;/code> in a &lt;code>Namespace&lt;/code> may be referenced by name from outside the &lt;code>Namespace&lt;/code> and only otherwise restricts access to an &lt;code>Element&lt;/code> as provided by specific constraints in the abstract syntax (e.g., preventing the import or inheritance of private &lt;code>Elements&lt;/code>).&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eLiterals name="private">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates a &lt;code>Membership&lt;/code> is not visible outside its owning &lt;code>Namespace&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="protected" value="1">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An intermediate level of visibility between &lt;code>public&lt;/code> and &lt;code>private&lt;/code>. By default, it is equivalent to &lt;code>private&lt;/code> for the purposes of normal access to and import of &lt;code>Elements&lt;/code> from a &lt;code>Namespace&lt;/code>. However, other &lt;code>Relationships&lt;/code> may be specified to include &lt;code>Memberships&lt;/code> with &lt;code>protected&lt;/code> visibility in the list of &lt;code>memberships&lt;/code> for a &lt;code>Namespace&lt;/code> (e.g., &lt;code>Specialization&lt;/code>).&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="public" value="2">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates that a &lt;code>Membership&lt;/code> is publicly visible outside its owning &lt;code>Namespace&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Documentation" eSuperTypes="#//Comment">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Documentation&lt;/code> is a &lt;code>Comment&lt;/code> that specifically documents a &lt;code>documentedElement&lt;/code>, which must be its &lt;code>owner&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="documentedElement" ordered="false"
+        lowerBound="1" eType="#//Element" volatile="true" transient="true" derived="true"
+        eOpposite="#//Element/documentation">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> that is documented by this &lt;code>Documentation&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//AnnotatingElement/annotatedElement"/>
+      <eAnnotations source="subsets" references="#//Element/owner"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Comment" eSuperTypes="#//AnnotatingElement">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Comment&lt;/code> is an &lt;code>AnnotatingElement&lt;/code> whose &lt;code>body&lt;/code> in some way describes its &lt;code>annotatedElements&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="locale" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Identification of the language of the &lt;code>body&lt;/code> text and, optionally, the region and/or encoding. The format shall be a POSIX locale conformant to ISO/IEC 15897, with the format &lt;code>[language[_territory][.codeset][@modifier]]&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="body" ordered="false" lowerBound="1"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The annotation text for the &lt;code>Comment&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AnnotatingElement" eSuperTypes="#//Element">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AnnotatingElement&lt;/code> is an &lt;code>Element&lt;/code> that provides additional description of or metadata on some other &lt;code>Element&lt;/code>. An &lt;code>AnnotatingElement&lt;/code> is either attached to its &lt;code>annotatedElements&lt;/code> by &lt;code>Annotation&lt;/code> &lt;code>Relationships&lt;/code>, or it implicitly annotates its &lt;code>owningNamespace&lt;/code>.&lt;/p>&#xA;&#xA;annotatedElement = &#xA; if annotation->notEmpty() then annotation.annotatedElement&#xA; else Sequence{owningNamespace} endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotation" upperBound="-1"
+        eType="#//Annotation" eOpposite="#//Annotation/annotatingElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Annotations&lt;/code> that relate this &lt;code>AnnotatingElement&lt;/code> to its &lt;code>annotatedElements&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotatedElement" lowerBound="1"
+        upperBound="-1" eType="#//Element" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="annotatingElement"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Elements&lt;/code> that are annotated by this &lt;code>AnnotatingElement&lt;/code>. If &lt;code>annotation&lt;/code> is not empty, these are the &lt;code>annotatedElements&lt;/code> of the &lt;code>annotations&lt;/code>. If &lt;code>annotation&lt;/code> is empty, then it is the &lt;code>owningNamespace&lt;/code> of the &lt;code>AnnotatingElement&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Annotation" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Annotation&lt;/code> is a Relationship between an &lt;code>AnnotatingElement&lt;/code> and the &lt;code>Element&lt;/code> that is annotated by that &lt;code>AnnotatingElement&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotatedElement" ordered="false"
+        lowerBound="1" eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="annotation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> that is annotated by the &lt;code>annotatingElement&lt;/code> of this Annotation.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningAnnotatedElement"
+        ordered="false" eType="#//Element" volatile="true" transient="true" derived="true"
+        eOpposite="#//Element/ownedAnnotation">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>annotatedElement&lt;/code> of this &lt;code>Annotation&lt;/code>, when it is also its &lt;code>owningRelatedElement&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Annotation/annotatedElement #//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotatingElement" ordered="false"
+        lowerBound="1" eType="#//AnnotatingElement" eOpposite="#//AnnotatingElement/annotation">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AnnotatingElement&lt;/code> that annotates the &lt;code>annotatedElement&lt;/code> of this &lt;code>Annotation&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TextualRepresentation" eSuperTypes="#//AnnotatingElement">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>TextualRepresentation&lt;/code> is an &lt;code>AnnotatingElement&lt;/code> whose &lt;code>body&lt;/code> represents the &lt;code>representedElement&lt;/code> in a given &lt;code>language&lt;/code>. The &lt;code>representedElement&lt;/code> must be the &lt;code>owner&lt;/code> of the &lt;code>TextualRepresentation&lt;/code>. The named &lt;code>language&lt;/code> can be a natural language, in which case the &lt;code>body&lt;/code> is an informal representation, or an artificial language, in which case the &lt;code>body&lt;/code> is expected to be a formal, machine-parsable representation.&lt;/p>&#xA;&#xA;&lt;p>If the named &lt;code>language&lt;/code> of a &lt;code>TextualRepresentation&lt;/code> is machine-parsable, then the &lt;code>body&lt;/code> text should be legal input text as defined for that &lt;code>language&lt;/code>. The interpretation of the named language string shall be case insensitive. The following &lt;code>language&lt;/code> names are defined to correspond to the given standard languages:&lt;/p>&#xA;&#xA;&lt;table border=&quot;1&quot; cellpadding=&quot;1&quot; cellspacing=&quot;1&quot; width=&quot;498&quot;>&#xA;&#x9;&lt;thead>&#xA;&#x9;&lt;/thead>&#xA;&#x9;&lt;tbody>&#xA;&#x9;&#x9;&lt;tr>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>kerml&lt;/code>&lt;/td>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;width: 332px;&quot;>Kernel Modeling Language&lt;/td>&#xA;&#x9;&#x9;&lt;/tr>&#xA;&#x9;&#x9;&lt;tr>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>ocl&lt;/code>&lt;/td>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;width: 332px;&quot;>Object Constraint Language&lt;/td>&#xA;&#x9;&#x9;&lt;/tr>&#xA;&#x9;&#x9;&lt;tr>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>alf&lt;/code>&lt;/td>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;width: 332px;&quot;>Action Language for fUML&lt;/td>&#xA;&#x9;&#x9;&lt;/tr>&#xA;&#x9;&lt;/tbody>&#xA;&lt;/table>&#xA;&#xA;&lt;p>Other specifications may define specific &lt;code>language&lt;/code> strings, other than those shown above, to be used to indicate the use of languages from those specifications in KerML &lt;code>TextualRepresentation&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>If the &lt;code>language&lt;/code> of a &lt;code>TextualRepresentation&lt;/code> is &amp;quot;&lt;code>kerml&lt;/code>&amp;quot;, then the &lt;code>body&lt;/code> text shall be a legal representation of the &lt;code>representedElement&lt;/code> in the KerML textual concrete syntax. A conforming tool can use such a &lt;code>TextualRepresentation&lt;/code> &lt;code>Annotation&lt;/code> to record the original KerML concrete syntax text from which an &lt;code>Element&lt;/code> was parsed. In this case, it is a tool responsibility to ensure that the &lt;code>body&lt;/code> of the &lt;code>TextualRepresentation&lt;/code> remains correct (or the Annotation is removed) if the annotated &lt;code>Element&lt;/code> changes other than by re-parsing the &lt;code>body&lt;/code> text.&lt;/p>&#xA;&#xA;&lt;p>An &lt;code>Element&lt;/code> with a &lt;code>TextualRepresentation&lt;/code> in a language other than KerML is essentially a semantically &amp;quot;opaque&amp;quot; &lt;code>Element&lt;/code> specified in the other language. However, a conforming KerML tool may interpret such an element consistently with the specification of the named language.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="language" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The natural or artifical language in which the &lt;code>body&lt;/code> text is written.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="body" ordered="false" lowerBound="1"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The textual representation of the &lt;code>representedElement&lt;/code> in the given &lt;code>language&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="representedElement" ordered="false"
+        lowerBound="1" eType="#//Element" volatile="true" transient="true" derived="true"
+        eOpposite="#//Element/textualRepresentation">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> that is represented by this &lt;code>TextualRepresentation&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//AnnotatingElement/annotatedElement"/>
+      <eAnnotations source="subsets" references="#//Element/owner"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="NamespaceImport" eSuperTypes="#//Import">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>NamespaceImport&lt;/code> is an Import that imports &lt;code>Memberships&lt;/code> from its &lt;code>importedNamespace&lt;/code> into the &lt;code>importOwningNamespace&lt;/code>. If &lt;code> isRecursive = false&lt;/code>, then only the visible &lt;code>Memberships&lt;/code> of the &lt;code>importOwningNamespace&lt;/code> are imported. If &lt;code> isRecursive = true&lt;/code>, then, in addition, &lt;code>Memberships&lt;/code> are recursively imported from any &lt;code>ownedMembers&lt;/code> of the &lt;code>importedNamespace&lt;/code> that are &lt;code>Namespaces&lt;/code>.&lt;/p>&#xA;&#xA;importedElement = importedNamespace"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importedNamespace" ordered="false"
+        lowerBound="1" eType="#//Namespace">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="import"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Namespace&lt;/code> whose visible &lt;code>Memberships&lt;/code> are imported by this &lt;code>NamespaceImport&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MembershipImport" eSuperTypes="#//Import">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>MembershipImport&lt;/code> is an &lt;code>Import&lt;/code> that imports its &lt;code>importedMembership&lt;/code> into the &lt;code>importOwningNamespace&lt;/code>. If &lt;code>isRecursive = true&lt;/code> and the &lt;code>memberElement&lt;/code> of the &lt;code>importedMembership&lt;/code> is a &lt;code>Namespace&lt;/code>, then the equivalent of a recursive &lt;code>NamespaceImport&lt;/code> is also performed on that &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;importedElement = importedMembership.memberElement"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importedMembership" ordered="false"
+        lowerBound="1" eType="#//Membership">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="import"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Membership&lt;/code> to be imported.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Subclassification" eSuperTypes="#//Specialization">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Subclassification&lt;/code> is &lt;code>Specialization&lt;/code> in which both the &lt;code>specific&lt;/code> and &lt;code>general&lt;/code> &lt;code>Types&lt;/code> are &lt;code>Classifier&lt;/code>. This means all instances of the specific &lt;code>Classifier&lt;/code> are also instances of the general &lt;code>Classifier&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="superclassifier" ordered="false"
+        lowerBound="1" eType="#//Classifier">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="superclassification"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The more &lt;code>general&lt;/code> Classifier in this &lt;code>Subclassification&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/general"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningClassifier" ordered="false"
+        eType="#//Classifier" volatile="true" transient="true" derived="true" eOpposite="#//Classifier/ownedSubclassification">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Classifier&lt;/code> that owns this &lt;code>Subclassification&lt;/code> relationship, which must also be its &lt;code>subclassifier&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/owningType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subclassifier" ordered="false"
+        lowerBound="1" eType="#//Classifier">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="subclassification"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The more specific &lt;code>Classifier&lt;/code> in this &lt;code>Subclassification&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/specific"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Specialization" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Specialization&lt;/code> is a &lt;code>Relationship&lt;/code> between two &lt;code>Types&lt;/code> that requires all instances of the &lt;code>specific&lt;/code> type to also be instances of the &lt;code>general&lt;/code> Type (i.e., the set of instances of the &lt;code>specific&lt;/code> Type is a &lt;em>subset&lt;/em> of those of the &lt;code>general&lt;/code> Type, which might be the same set).&lt;/p>&#xA;&#xA;not specific.isConjugated"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true" eOpposite="#//Type/ownedSpecialization">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that is the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code> of this &lt;code>Specialization&lt;/code> and owns it as its &lt;code>owningRelatedElement&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Specialization/specific #//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="general" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="generalization"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>Type&lt;/code> with a superset of all instances of the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code>, which might be the same set.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="specific" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="specialization"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>Type&lt;/code> with a subset of all instances of the &lt;code>general&lt;/code> &lt;code>Type&lt;/code>, which might be the same set.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Type" eSuperTypes="#//Namespace">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Type&lt;/code> is a &lt;code>Namespace&lt;/code> that is the most general kind of &lt;code>Element&lt;/code> supporting the semantics of classification. A &lt;code>Type&lt;/code> may be a &lt;code>Classifier&lt;/code> or a &lt;code>Feature&lt;/code>, defining conditions on what is classified by the &lt;code>Type&lt;/code> (see also the description of &lt;code>isSufficient&lt;/code>).&lt;/p>&#xA;&#xA;ownedSpecialization = ownedRelationship->selectByKind(Specialization)->&#xA;    select(s | s.special = self)&#xA;    &#xA;multiplicity = &#xA;    let ownedMultiplicities: Sequence(Multiplicity) =&#xA;        ownedMember->selectByKind(Multiplicity) in&#xA;    if ownedMultiplicities->isEmpty() then null&#xA;    else ownedMultiplicities->first()&#xA;    endif&#xA;ownedFeatureMembership = ownedRelationship->selectByKind(FeatureMembership)&#xA;let ownedConjugators: Sequence(Conjugator) = &#xA;    ownedRelationship->selectByKind(Conjugation) in&#xA;    ownedConjugator = &#xA;        if ownedConjugators->isEmpty() then null &#xA;        else ownedConjugators->at(1) endif&#xA;output =&#xA;    if isConjugated then &#xA;        conjugator.originalType.input&#xA;    else &#xA;        feature->select(direction = out or direction = inout)&#xA;    endif&#xA;input = &#xA;    if isConjugated then &#xA;        conjugator.originalType.output&#xA;    else &#xA;        feature->select(direction = _'in' or direction = inout)&#xA;    endif&#xA;inheritedMembership = inheritedMemberships(Set{})&#xA;specializesFromLibrary('Base::Anything')&#xA;directedFeature = feature->select(f | directionOf(f) &lt;> null)&#xA;feature = featureMembership.ownedMemberFeature&#xA;featureMembership = ownedMembership->union(&#xA;    inheritedMembership->selectByKind(FeatureMembership))&#xA;ownedFeature = ownedFeatureMembership.ownedMemberFeature&#xA;differencingType = ownedDifferencing.differencingType&#xA;intersectingType->excludes(self)&#xA;differencingType->excludes(self)&#xA;unioningType = ownedUnioning.unioningType&#xA;unioningType->excludes(self)&#xA;intersectingType = ownedIntersecting.intersectingType&#xA;ownedRelationship->selectByKind(Conjugator)->size() &lt;= 1&#xA;ownedMember->selectByKind(Multiplicity)->size() &lt;= 1&#xA;endFeature = feature->select(isEnd)&#xA;ownedRelationship->selectByKind(Disjoining)&#xA;ownedRelationship->selectByKind(Unioning)&#xA;ownedRelationship->selectByKind(Intersecting)&#xA;ownedRelationship->selectByKind(Differencing)&#xA;ownedEndFeature = ownedFeature->select(isEnd)&#xA;inheritedFeature = inheritedMemberships->&#xA;    selectByKind(FeatureMembership).memberFeature"/>
+    </eAnnotations>
+    <eOperations name="inheritedMemberships" upperBound="-1" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the inherited &lt;code>Memberships&lt;/code> of this &lt;code>Type&lt;/code>, excluding those supertypes in the &lt;code>excluded&lt;/code> set.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eParameters name="excluded" ordered="false" upperBound="-1" eType="#//Type"/>
+    </eOperations>
+    <eOperations name="directionOf" ordered="false" eType="#//FeatureDirectionKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>If the given &lt;code>feature&lt;/code> is a &lt;code>feature&lt;/code> of this &lt;code>Type&lt;/code>, then return its direction relative to this &lt;code>Type&lt;/code>, taking conjugation into account.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="if input->includes(feature) and output->includes(feature) then &#xA;    FeatureDirectionKind::inout&#xA;else if input->includes(feature) then &#xA;    FeatureDirectionKind::_'in'&#xA;else if output->includes(feature) then &#xA;    FeatureDirectionKind::out&#xA;else &#xA;    null &#xA;endif endif endif"/>
+      </eAnnotations>
+      <eParameters name="feature" ordered="false" lowerBound="1" eType="#//Feature"/>
+    </eOperations>
+    <eOperations name="allSupertypes" ordered="false" upperBound="-1" eType="#//Type">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return all &lt;code>Types&lt;/code> related to this &lt;code>Type&lt;/code> as supertypes directly or transitively by &lt;code>Specialization&lt;/code> &lt;code>Relationships&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="ownedSpecialization->&#xA;    closure(general.ownedSpecialization).general->&#xA;    including(self)"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="specializes" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>Type&lt;/code> is a direct or indirect specialization of the given &lt;code>supertype&lt;code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="if isConjugated then &#xA;    ownedConjugator.originalType.specializes(supertype)&#xA;else&#xA;    allSupertypes()->includes(supertype)&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="supertype" ordered="false" lowerBound="1" eType="#//Type"/>
+    </eOperations>
+    <eOperations name="specializesFromLibrary" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>Type&lt;/code> is a direct or indirect specialization of the named library &lt;code>Type&lt;/code>. &lt;code>libraryTypeName&lt;/code> must conform to the syntax of a KerML qualified name and must resolve to a &lt;code>Type&lt;/code> in global scope.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="let mem : Membership = resolveGlobal(libraryTypeName) in&#xA;mem &lt;> null and mem.memberElement.oclIsKindOf(Type) and&#xA;specializes(mem.memberElement.oclAsType(Type))"/>
+      </eAnnotations>
+      <eParameters name="libraryTypeName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedFeatureMembership"
+        upperBound="-1" eType="#//FeatureMembership" volatile="true" transient="true"
+        derived="true" eOpposite="#//FeatureMembership/owningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedMemberships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>FeatureMemberships&lt;/code>, for which the &lt;code>Type&lt;/code> is the &lt;code>owningType&lt;/code>. Each such &lt;code>FeatureMembership&lt;/code> identifies an &lt;code>ownedFeature&lt;/code> of the &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMembership #//Type/featureMembership"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true" eOpposite="#//Feature/owningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedMemberFeatures&lt;/code> of the &lt;code>ownedFeatureMemberships&lt;/code> of this &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedEndFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true" eOpposite="#//Feature/endOwningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>endFeatures&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>ownedFeatures&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/endFeature #//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="feature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedMemberFeatures&lt;/code> of the &lt;code>featureMemberships&lt;/code> of this &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/member"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="input" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithInput"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>features&lt;/code> related to this &lt;code>Type&lt;/code> by &lt;code>FeatureMemberships&lt;/code> that have &lt;code>direction&lt;/code> &lt;code>in&lt;code> or &lt;code>inout&lt;code>.&lt;/code>&lt;/code>&lt;/code>&lt;/code>&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/directedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="output" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithOutput"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>features&lt;/code> related to this &lt;code>Type&lt;/code> by &lt;code>FeatureMemberships&lt;/code> that have &lt;code>direction&lt;/code> &lt;code>out&lt;code> or &lt;code>inout&lt;code>.&lt;/code>&lt;/code>&lt;/code>&lt;/code>&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/directedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isAbstract" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates whether instances of this &lt;code>Type&lt;/code> must also be instances of at least one of its specialized &lt;code>Types&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="inheritedMembership" upperBound="-1"
+        eType="#//Membership" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="inheritingType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>Memberships&lt;/code> inherited by this &lt;code>Type&lt;/code> via &lt;code>Specialization&lt;/code> or &lt;code>Conjugation&lt;/code>. These are included in the derived union for the &lt;code>memberships&lt;/code> of the &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/membership"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="endFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithEndFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>features&lt;/code> of this &lt;code>Type&lt;/code> with &lt;code>isEnd = true&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isSufficient" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether all things that meet the classification conditions of this &lt;code>Type&lt;/code> must be classified by the &lt;code>Type&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>(A &lt;code>Type&lt;/code>&amp;nbsp;gives conditions that must be met by whatever it classifies, but when &lt;code>isSufficient&lt;/code> is false, things may meet those conditions but still not be classified by the &lt;code>Type&lt;/code>. For example, a Type &lt;code>&lt;em>Car&lt;/em>&lt;/code> that is not sufficient could require everything it classifies to have four wheels, but not all four wheeled things would classify as cars. However, if the &lt;code>Type&lt;/code> &lt;code>&lt;em>Car&lt;/em>&lt;/code> were sufficient, it would classify all four-wheeled things.)&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedConjugator" ordered="false"
+        eType="#//Conjugation" volatile="true" transient="true" derived="true" eOpposite="#//Conjugation/owningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>Conjugation&lt;/code> owned by this &lt;code>Type&lt;/code> for which the &lt;code>Type&lt;/code> is the &lt;code>originalType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isConjugated" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" volatile="true"
+        transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates whether this &lt;code>Type&lt;/code> has an &lt;code>ownedConjugator&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="inheritedFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="inheritingType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All the &lt;code>memberFeatures&lt;/code> of the &lt;code>inheritedMemberships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>FeatureMemberships&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="multiplicity" ordered="false"
+        eType="#//Multiplicity" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithMultiplicity"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An &lt;code>ownedMember&lt;/code> of this &lt;code>Type&lt;/code> that is a &lt;code>Multiplicity&lt;/code>, which constraints the cardinality of the &lt;code>Type&lt;/code>. If there is no such &lt;code>ownedMember&lt;/code>, then the cardinality of this &lt;code>Type&lt;/code> is constrained by all the &lt;code>Multiplicity&lt;/code> constraints applicable to any direct supertypes.&lt;/p>&#xA;&#xA;&lt;p>&amp;nbsp;&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="unioningType" upperBound="-1"
+        eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="unionedType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The interpretations of a &lt;code>Type&lt;/code> with &lt;code>unioningTypes&lt;/code> are asserted to be the same as those of all the &lt;code>unioningTypes&lt;/code> together, which are the &lt;code>Types&lt;/code> derived from the &lt;code>unioningType&lt;/code> of the &lt;code>ownedUnionings&lt;/code> of this &lt;code>Type&lt;/code>. For example, a &lt;code>Classifier&lt;/code> for people might be the union of &lt;code>Classifiers&lt;/code> for all the sexes. Similarly, a feature for people&amp;#39;s children might be the union of features dividing them in the same ways as people in general.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedIntersecting" upperBound="-1"
+        eType="#//Intersecting" volatile="true" transient="true" derived="true" eOpposite="#//Intersecting/typeIntersected">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Intersectings&lt;/code>, have the &lt;code>Type&lt;/code> as their &lt;code>typeIntersected&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="intersectingType" upperBound="-1"
+        eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="intersectedType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The interpretations of a &lt;code>Type&lt;/code> with &lt;code>intersectingTypes&lt;/code> are asserted to be those in common among the &lt;code>intersectingTypes&lt;/code>, which are the &lt;code>Types&lt;/code> derived from the &lt;code>intersectingType&lt;/code> of the &lt;code>ownedIntersectings&lt;/code> of this &lt;code>Type&lt;/code>. For example, a &lt;code>Classifier&lt;/code> might be an intersection of &lt;code>Classifiers&lt;/code> for people of a particular sex and of a particular nationality. Similarly, a feature for people&amp;#39;s children of a particular sex might be the intersection of a &lt;code>Feature&lt;/code> for their children and a &lt;code>Classifier&lt;/code> for people of that sex (because the interpretations of the children &lt;code>Feature&lt;/code> that identify those of that sex are also interpretations of the Classifier for that sex).&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedUnioning" upperBound="-1"
+        eType="#//Unioning" volatile="true" transient="true" derived="true" eOpposite="#//Unioning/typeUnioned">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Unionings&lt;/code>, having the &lt;code>Type&lt;/code> as their &lt;code>typeUnioned&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedDisjoining" ordered="false"
+        upperBound="-1" eType="#//Disjoining" volatile="true" transient="true" derived="true"
+        eOpposite="#//Disjoining/owningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Disjoinings&lt;/code>, for which the &lt;code>Type&lt;/code> is the &lt;code>typeDisjoined&lt;/code> &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featureMembership" upperBound="-1"
+        eType="#//FeatureMembership" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="type"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>FeatureMemberships&lt;/code> for &lt;code>features&lt;/code> of this &lt;code>Type&lt;/code>, which include all &lt;code>ownedFeatureMemberships&lt;/code> and those &lt;code>inheritedMemberships&lt;/code> that are &lt;code>FeatureMemberships&lt;/code> (but does &lt;em>not&lt;/em> include any &lt;code>importedMemberships&lt;/code>).&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="differencingType" upperBound="-1"
+        eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="differencedType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The interpretations of a &lt;code>Type&lt;/code> with &lt;code>differencingTypes&lt;/code> are asserted to be those of the first of those &lt;code>Types&lt;/code>, but not including those of the remaining &lt;code>Types&lt;/code>. For example, a &lt;code>Classifier&lt;/code> might be the difference of a &lt;code>Classifier&lt;/code> for people and another for people of a particular nationality, leaving people who are not of that nationality. Similarly, a feature of people might be the difference between a feature for their children and a &lt;code>Classifier&lt;/code> for people of a particular sex, identifying their children not of that sex (because the interpretations of the children &lt;code>Feature&lt;/code> that identify those of that sex are also interpretations of the &lt;code>Classifier&lt;/code> for that sex).&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedDifferencing" upperBound="-1"
+        eType="#//Differencing" volatile="true" transient="true" derived="true" eOpposite="#//Differencing/typeDifferenced">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Differencings&lt;/code>, having this &lt;code>Type&lt;/code> as their &lt;code>typeDifferenced&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="directedFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithDirectedFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>features&lt;/code> of this &lt;code>Type&lt;/code> that have a non-null &lt;code>direction&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedSpecialization" upperBound="-1"
+        eType="#//Specialization" volatile="true" transient="true" derived="true"
+        eOpposite="#//Specialization/owningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Specializations&lt;/code>, for which the &lt;code>Type&lt;/code> is the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureMembership" eSuperTypes="#//OwningMembership #//Featuring">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FeatureMembership&lt;/code> is an &lt;code>OwningMembership&lt;/code> between a &lt;code>Feature&lt;/code> in an &lt;code>owningType&lt;/code> that is also a &lt;code>Featuring&lt;/code> &lt;code>Relationship&lt;code? between the &lt;code>Feature&lt;/code> and the &lt;code>Type&lt;/code>, in which the &lt;code>featuringType&lt;/code> is the &lt;code>source&lt;/code> and the &lt;code>featureOfType&lt;/code> is the &lt;code>target&lt;/code>. A &lt;code>FeatureMembership&lt;/code> is always owned by its &lt;code>owningType&lt;/code>, which is the &lt;code>featuringType&lt;/code> for the &lt;code>FeatureMembership&lt;/code> considered as a &lt;code>Featuring&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMemberFeature" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true"
+        eOpposite="#//Feature/owningFeatureMembership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that this &lt;code>FeatureMembership&lt;/code> relates to its &lt;code>owningType&lt;/code>, making it an &lt;code>ownedFeature&lt;/code> of the &lt;code>owningType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//OwningMembership/ownedMemberElement #//Featuring/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningType" ordered="false"
+        lowerBound="1" eType="#//Type" volatile="true" transient="true" derived="true"
+        eOpposite="#//Type/ownedFeatureMembership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that owns this &lt;code>FeatureMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Membership/membershipOwningNamespace #//Featuring/type"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Featuring" abstract="true" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Featuring&lt;/code> is a &lt;code>Relationship&lt;/code> between a &lt;code>Type&lt;/code> and a &lt;code>Feature&lt;/code> that is featured by that &lt;code>Type&lt;/code>. It asserts that every instance in the domain of the &lt;code>feature&lt;/code> must be classified by the &lt;code>type&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>&lt;code>Featuring&lt;/code> is abstract and does not commit to which of &lt;code>feature&lt;/code> or &lt;code>type&lt;/code> are the &lt;code>source&lt;/code> or &lt;code>target&lt;/code> of the &lt;code>Relationship&lt;/code>. This commitment is made in the subclasses of &lt;code>Featuring&lt;/code>, &lt;code>TypeFeaturing&lt;/code> and &lt;code>FeatureMembership&lt;/code>, which have opposite directions.&lt;/p>"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringOfType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;code> that features the &lt;code>featureOfType&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="feature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuring"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is featured by the &lt;code>featuringType&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Feature" eSuperTypes="#//Type">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Feature&lt;/code> is a &lt;code>Type&lt;/code> that classifies relations between multiple things (in the universe). The domain of the relation is the intersection of the &lt;code>featuringTypes&lt;/code> of the &lt;code>Feature&lt;/code>. (The domain of a &lt;code>Feature&lt;/code> with no &lt;code>featuringTyps&lt;/code> is implicitly the most general &lt;code>Type&lt;/code> &lt;em>&lt;code>Base::Anything&lt;/code>&lt;/em> from the Kernel Semantic Library.) The co-domain of the relation is the intersection of the &lt;code>types&lt;/code> of the &lt;code>Feature&lt;/code>.&#xA;&#xA;&lt;p>In the simplest cases, the &lt;code>featuringTypes&lt;/code> and &lt;code>types&lt;/code> are &lt;code>Classifiers&lt;/code> and the &lt;code>Feature&lt;/code> relates two things, one from the domain and one from the range. Examples include cars paired with wheels, people paired with other people, and cars paired with numbers representing the car length.&lt;/p>&#xA;&#xA;&lt;p>Since &lt;code>Features&lt;/code> are &lt;code>Types&lt;/code>, their &lt;code>featuringTypes&lt;/code> and &lt;code>types&lt;/code> can be &lt;code>Features&lt;/code>. In this case, the &lt;code>Feature&lt;/code> effectively classifies relations between relations, which can be interpreted as the sequence of things related by the domain &lt;code>Feature&lt;/code> concatenated with the sequence of things related by the co-domain &lt;code>Feature&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The &lt;em>values&lt;/em> of a &lt;code>Feature&lt;/code> for a given instance of its domain are all the instances of its co-domain that are related to that domain instance by the &lt;code>Feature&lt;/code>. The values of a &lt;code>Feature&lt;/code> with &lt;code>chainingFeatures&lt;/code> are the same as values of the last &lt;code>Feature&lt;/code> in the chain, which can be found by starting with values of the first &lt;code>Feature&lt;/code>, then using those values as domain instances to obtain valus of the second &lt;code>Feature&lt;/code>, and so on, to values of the last &lt;code>Feature&lt;/code>.&lt;/p>&#xA;&#xA;ownedRedefinition = ownedSubsetting->selectByKind(Redefinition)&#xA;ownedTypeFeaturing = ownedRelationship->selectByKind(TypeFeaturing)->&#xA;    select(tf | tf.featureOfType = self)&#xA;ownedSubsetting = ownedSpecialization->selectByKind(Subsetting)&#xA;ownedTyping = ownedGeneralization->selectByKind(FeatureTyping)&#xA;type =&#xA;    let types : OrderedSet(Type) = typing.type->&#xA;        union(subsetting.subsettedFeature.type)->&#xA;        asOrderedSet() in&#xA;    if chainingFeature->isEmpty() then types&#xA;    else &#xA;        types->union(chainingFeature->last().type)->&#xA;        asOrderedSet()&#xA;    endif&#xA;multiplicity &lt;> null implies multiplicity.featuringType = featuringType &#xA;specializesFromLibrary(&quot;Base::things&quot;)&#xA;chainingFeatures->excludes(self)&#xA;ownedFeatureChaining = ownedRelationship->selectByKind(FeatureChaining)&#xA;chainingFeature = ownedFeatureChaining.chainingFeature&#xA;chainingFeatures->size() &lt;> 1&#xA;isEnd and owningType &lt;> null implies&#xA;    let i : Integer = &#xA;        owningType.ownedFeature->select(isEnd) in&#xA;    owningType.ownedSpecialization.general->&#xA;        forAll(supertype |&#xA;            let ownedEndFeatures : Sequence(Feature) = &#xA;                supertype.ownedFeature->select(isEnd) in&#xA;            ownedEndFeatures->size() >= i implies&#xA;                redefines(ownedEndFeatures->at(i))&#xA;ownedMembership->&#xA;    selectByKind(FeatureValue)->&#xA;    forAll(fv | specializes(fv.value.result))&#xA;isEnd and owningType &lt;> null and&#xA;owningType.oclIsKindOf(Association) implies&#xA;    specializesFromLibrary(&quot;Links::Link::participants&quot;)&#xA;isComposite and&#xA;ownedTyping.type->includes(oclIsKindOf(Structure)) and&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(Structure) or&#xA; owningType.type->includes(oclIsKindOf(Structure))) implies&#xA;    specializesFromLibrary(&quot;Occurrence::Occurrence::suboccurrences&quot;)&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(LiteralExpression) or&#xA; owningType.oclIsKindOf(FeatureReferenceExpression)) implies&#xA;    if owningType.oclIsKindOf(LiteralString) then&#xA;        specializesFromLibrary(&quot;ScalarValues::String&quot;)&#xA;    else if owningType.oclIsKindOf(LiteralBoolean) then&#xA;        specializesFromLibrary(&quot;ScalarValues::Boolean&quot;)&#xA;    else if owningType.oclIsKindOf(LiteralInteger) then&#xA;        specializesFromLibrary(&quot;ScalarValues::Rational&quot;)&#xA;    else if owningType.oclIsKindOf(LiteralBoolean) then&#xA;        specializesFromLibrary(&quot;ScalarValues::Rational&quot;)&#xA;    else if owningType.oclIsKindOf(LiteralBoolean) then&#xA;        specializesFromLibrary(&quot;ScalarValues::Real&quot;)&#xA;    else specializes(&#xA;        owningType.oclAsType(FeatureReferenceExpression).referent)&#xA;    endif endif endif endif endif&#xA;&#xA;ownedTyping.type->exists(selectByKind(Class)) implies&#xA;    specializesFromLibrary(&quot;Occurrences::occurrences&quot;)&#xA;isComposite and&#xA;ownedTyping.type->includes(oclIsKindOf(Class)) and&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(Class) or&#xA; owningType.oclIsKindOf(Feature) and&#xA;    owningType.oclAsType(Feature).type->&#xA;        exists(oclIsKindOf(Class))) implies&#xA;    specializesFromLibrary(&quot;Occurrence::Occurrence::suboccurrences&quot;)&#xA;ownedTyping.type->exists(selectByKind(DataType)) implies&#xA;    specializesFromLibary(&quot;Base::dataValues&quot;)&#xA;owningType &lt;> null and&#xA;owningType.oclIsKindOf(ItemFlowEnd) and&#xA;owningType.ownedFeature->at(1) = self implies&#xA;    let flowType : Type = owningType.owningType in&#xA;    flowType &lt;> null implies&#xA;        let i : Integer = &#xA;            flowType.ownedFeature.indexOf(owningType) in&#xA;        (i = 1 implies &#xA;            redefinesFromLibrary(&quot;Transfers::Transfer::source::sourceOutput&quot;)) and&#xA;        (i = 2 implies&#xA;            redefinesFromLibrary(&quot;Transfers::Transfer::source::targetInput&quot;))&#xA;                 &#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(Behavior) or&#xA; owningType.oclIsKindOf(Step)) implies&#xA;    let i : Integer = &#xA;        owningType.ownedFeature->select(direction &lt;> null) in&#xA;    owningType.ownedSpecialization.general->&#xA;        forAll(supertype |&#xA;            let ownedParameters : Sequence(Feature) = &#xA;                supertype.ownedFeature->select(direction &lt;> null) in&#xA;            ownedParameters->size() >= i implies&#xA;                redefines(ownedParameters->at(i))&#xA;ownedTyping.type->exists(selectByKind(Structure)) implies&#xA;    specializesFromLibary(&quot;Objects::objects&quot;)&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(Function) and&#xA;    self = owningType.oclAsType(Function).result or&#xA; owningType.oclIsKindOf(Expression) and&#xA;    self = owningType.oclAsType(Expression).result) implies&#xA;    owningType.ownedSpecialization.general->&#xA;        select(oclIsKindOf(Function) or oclIsKindOf(Expression))->&#xA;        forAll(supertype |&#xA;            redefines(&#xA;                if superType.oclIsKindOf(Function) then&#xA;                    superType.oclAsType(Function).result&#xA;                else&#xA;                    superType.oclAsType(Expression).result&#xA;                endif)&#xA;ownedFeatureInverting = ownedRelationship->selectByKind(FeatureInverting)->&#xA;    select(fi | fi.featureInverted = self)&#xA;featuringType =&#xA;    let featuringTypes : OrderedSet(Type) = &#xA;        typeFeaturing.featuringType->asOrderedSet() in&#xA;    if chainingFeature->isEmpty() then featuringTypes&#xA;    else&#xA;        featuringTypes->&#xA;            union(chainingFeature->first().featuringType)->&#xA;            asOrderedSet()&#xA;    endif&#xA;ownedReferenceSubsetting =&#xA;    let referenceSubsettings : OrderedSet(ReferenceSubsetting) =&#xA;        ownedSubsetting->selectByKind(ReferenceSubsetting) in&#xA;    if referenceSubsettings->isEmpty() then null&#xA;    else referenceSubsettings->first() endif&#xA;ownedSubsetting->selectByKind(ReferenceSubsetting)->size() &lt;= 1"/>
+    </eAnnotations>
+    <eOperations name="directionFor" ordered="false" eType="#//FeatureDirectionKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the &lt;code>directionOf&lt;/code> this &lt;code>Feature&lt;/code> relative to the given &lt;code>type&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="type.directionOf(self)"/>
+      </eAnnotations>
+      <eParameters name="type" ordered="false" lowerBound="1" eType="#//Type"/>
+    </eOperations>
+    <eOperations name="isFeaturedWithin" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return whether this Feature has the given &lt;code>type&lt;/code> as a direct or indirect &lt;code>featuringType&lt;/code>. If &lt;code>type&lt;/code> is null, then check if this Feature is implicitly directly or indirectly featured in &lt;em>Base::Anything&lt;/em>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="type = null and feature.featuringType->isEmpty() or&#xA;    type &lt;> null and feature.featuringType->includes(type) or&#xA;    feature.featuringType->exists(t |&#xA;        t.oclIsKindOf(Feature) and&#xA;        t.oclAsType(Feature).isFeaturedWithin(type)) "/>
+      </eAnnotations>
+      <eParameters name="type" ordered="false" eType="#//Type"/>
+    </eOperations>
+    <eOperations name="namingFeature" ordered="false" eType="#//Feature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>By default, the naming &lt;code>Feature&lt;/code> of a &lt;code>Feature&lt;/code> is given by its first &lt;code>redefinedFeature&lt;/code> of its first &lt;code>ownedRedefinition&lt;/code>, if any.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="if ownedRedefinition->isEmpty() then&#xA;    null&#xA;else&#xA;    ownedRedefinition->at(1).redefinedFeature&#xA;endif"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="redefines" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>Feature&lt;/code> &lt;em>directly&lt;/em> redefines the given &lt;code>redefinedFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="ownedRedefinition.redefinedFeature->includes(redefinedFeature)"/>
+      </eAnnotations>
+      <eParameters name="redefinedFeature" ordered="false" lowerBound="1" eType="#//Feature"/>
+    </eOperations>
+    <eOperations name="redefinesFromLibrary" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>Feature&lt;/code> &lt;em>directly&lt;/em> redefines the named library &lt;code>Feature&lt;/code>. &lt;code>libraryFeatureName&lt;/code> must conform to the syntax of a KerML qualified name and must resolve to a &lt;code>Feature&lt;/code> in global scope.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="let mem: Membership = resolveGlobal(libraryFeatureName) in&#xA;mem &lt;> null and mem.memberElement.oclIsKindOf(Feature) and&#xA;redefines(mem.memberElement.oclAsType(Feature))"/>
+      </eAnnotations>
+      <eParameters name="libraryFeatureName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="subsetsChain" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>Feature&lt;/code> directly or indirectly specializes a &lt;code>Feature&lt;/code> whose last two &lt;code>chainingFeatures&lt;/code> are the given &lt;code>Features&lt;/code> &lt;code>first&lt;/code> and &lt;code>second&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="allSuperTypes()->selectAsKind(Feature)->&#xA;    exists(f | let n: Integer = f.chainingFeature->size() in&#xA;        n >= 2 and&#xA;        f.chainingFeature->at(n-1) = first and&#xA;        f.chainingFeature->at(n) = second)"/>
+      </eAnnotations>
+      <eParameters name="first" ordered="false" lowerBound="1" eType="#//Feature"/>
+      <eParameters name="second" ordered="false" lowerBound="1" eType="#//Feature"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true" eOpposite="#//Type/ownedFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that is the &lt;code>owningType&lt;/code> of the &lt;code>owningFeatureMembership&lt;/code> of this &lt;code>Feature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/owningNamespace #//Feature/featuringType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isUnique" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether or not values for this &lt;code>Feature&lt;/code> must have no duplicates or not.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isOrdered" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether an order exists for the values of this &lt;code>Feature&lt;/code> or not.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" upperBound="-1" eType="#//Type"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Types&lt;/code> that restrict the values of this &lt;code>Feature&lt;/code>, such that the values must be instances of all the &lt;code>types&lt;/code>. The types of a &lt;code>Feature&lt;/code> are derived from its &lt;code>typings&lt;/code> and the &lt;code>types&lt;/code> of its &lt;code>subsettings&lt;/code>. If the &lt;code>Feature&lt;/code> is chained, then the &lt;code>types&lt;/code> of the last &lt;code>Feature&lt;/code> in the chain are also &lt;code>types&lt;/code> of the chained &lt;code>Feature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedRedefinition" ordered="false"
+        upperBound="-1" eType="#//Redefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedSubsettings&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>Redefinitions&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>redefiningFeature&lt;/code>.&lt;/p>&#xA;&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Feature/ownedSubsetting"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedSubsetting" ordered="false"
+        upperBound="-1" eType="#//Subsetting" volatile="true" transient="true" derived="true"
+        eOpposite="#//Subsetting/owningFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedSpecializations&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>Subsettings&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>subsettingFeature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedSpecialization"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningFeatureMembership"
+        ordered="false" eType="#//FeatureMembership" volatile="true" transient="true"
+        derived="true" eOpposite="#//FeatureMembership/ownedMemberFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>FeatureMembership&lt;/code> that owns this &lt;code>Feature&lt;/code> as an &lt;code>ownedMemberFeature&lt;/code>, determining its &lt;code>owningType&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/owningMembership"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isComposite" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether the &lt;code>Feature&lt;/code> is a composite &lt;code>feature&lt;/code> of its &lt;code>featuringType&lt;/code>. If so, the values of the &lt;code>Feature&lt;/code> cannot exist after its featuring instance no longer does.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isEnd" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether or not the this &lt;code>Feature&lt;/code> is an end &lt;code>Feature&lt;/code>, requiring a different interpretation of the &lt;code>multiplicity&lt;/code> of the &lt;code>Feature&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>An end &lt;code>Feature&lt;/code> is always considered to map each domain instance to a single co-domain instance, whether or not a &lt;code>Multiplicity&lt;/code> is given for it. If a &lt;code>Multiplicity&lt;/code> is given for an end &lt;code>Feature&lt;/code>, rather than giving the co-domain cardinality for the &lt;code>Feature&lt;/code> as usual, it specifies a cardinality constraint for &lt;em>navigating&lt;/em> across the &lt;code>endFeatures&lt;/code> of the &lt;code>featuringType&lt;/code> of the end &lt;code>Feature&lt;/code>. That is, if a &lt;code>Type&lt;/code> has &lt;em>n&lt;/em> &lt;code>endFeatures&lt;/code>, then the &lt;code>Multiplicity&lt;/code> of any one of those end &lt;code>Features&lt;/code> constrains the cardinality of the set of values of that &lt;code>Feature&lt;/code> when the values of the other &lt;em>n-1&lt;/em> end &lt;code>Features&lt;/code> are held fixed.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="endOwningType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true" eOpposite="#//Type/ownedEndFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that is related to this &lt;code>Feature&lt;/code> by an &lt;code>EndFeatureMembership&lt;/code> in which the &lt;code>Feature&lt;/code> is an &lt;code>ownedMemberFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Feature/owningType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedTyping" upperBound="-1"
+        eType="#//FeatureTyping" volatile="true" transient="true" derived="true" eOpposite="#//FeatureTyping/owningFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedSpecializations&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>FeatureTypings&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>typedFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedSpecialization"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featuringType" upperBound="-1"
+        eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featureOfType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Types&lt;/code> that feature this &lt;code>Feature&lt;/code>, such that any instance in the domain of the &lt;code>Feature&lt;/code> must be classified by all of these &lt;code>Types&lt;/code>, including at least all the &lt;code>featuringTypes&lt;/code> of its &lt;code>typeFeaturings&lt;/code>.  If the &lt;code>Feature&lt;/code> is chained, then the &lt;code>featuringTypes&lt;/code> of the first &lt;code>Feature&lt;/code> in the chain are also &lt;code>featuringTypes&lt;/code> of the chained &lt;code>Feature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedTypeFeaturing" upperBound="-1"
+        eType="#//TypeFeaturing" volatile="true" transient="true" derived="true" eOpposite="#//TypeFeaturing/owningFeatureOfType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>TypeFeaturings&lt;/code> and for which the &lt;code>Feature&lt;/code> is the &lt;code>featureOfType&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isDerived" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether the values of this &lt;code>Feature&lt;/code> can always be computed from the values of other &lt;code>Feature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="chainingFeature" unique="false"
+        upperBound="-1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="chainedFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that are chained together to determine the values of this &lt;code>Feature&lt;/code>, derived from the &lt;code>chainingFeatures&lt;/code> of the &lt;code>ownedFeatureChainings&lt;/code> of this &lt;code>Feature&lt;/code>, in the same order. The values of a &lt;code>Feature&lt;/code> with &lt;code>chainingFeatures&lt;/code> are the same as values of the last &lt;code>Feature&lt;/code> in the chain, which can be found by starting with the values of the first &lt;code>Feature&lt;/code> (for each instance of the domain of the original &lt;code>Feature&lt;/code>), then using each of those as domain instances to find the values of the second &lt;code>Feature&lt;/code> in chainingFeatures, and so on, to values of the last &lt;code>Feature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedFeatureInverting"
+        ordered="false" upperBound="-1" eType="#//FeatureInverting" volatile="true"
+        transient="true" derived="true" eOpposite="#//FeatureInverting/owningFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>FeatureInvertings&lt;/code> and for which the &lt;code>Feature&lt;/code> is the &lt;code>featureInverted&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedFeatureChaining" upperBound="-1"
+        eType="#//FeatureChaining" volatile="true" transient="true" derived="true"
+        eOpposite="#//FeatureChaining/featureChained">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>FeatureChainings&lt;/code>, for which the &lt;code>Feature&lt;/code> will be the &lt;code>featureChained&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isReadOnly" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether the values of this &lt;code>Feature&lt;/code> can change over the lifetime of an instance of the domain.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isPortion" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether the values of this &lt;code>Feature&lt;/code> are contained in the space and time of instances of the domain of the &lt;code>Feature&lt;/code> and represent the same thing as those instances.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="direction" ordered="false"
+        eType="#//FeatureDirectionKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates how values of this &lt;code>Feature&lt;/code> are determined or used (as specified for the &lt;code>FeatureDirectionKind&lt;/code>).&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedReferenceSubsetting"
+        ordered="false" eType="#//ReferenceSubsetting" volatile="true" transient="true"
+        derived="true" eOpposite="#//ReferenceSubsetting/referencingFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The one &lt;code>ownedSubsetting&lt;/code> of this &lt;code>Feature&lt;/code>, if any, that is a &lt;code>ReferenceSubsetting&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>referencingFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Feature/ownedSubsetting"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isNonunique" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" volatile="true"
+        transient="true" defaultValueLiteral="false" derived="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Redefinition" eSuperTypes="#//Subsetting">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Redefinition&lt;/code> is a kind of &lt;code>Subsetting&lt;/code> that requires the &lt;code>redefinedFeature&lt;/code> and the &lt;code>redefiningFeature&lt;/code> to have the same values (on each instance of the domain of the &lt;code>redefiningFeature&lt;/code>). This means any restrictions on the &lt;code>redefiningFeature&lt;/code>, such as &lt;code>type&lt;/code> or &lt;code>multiplicity&lt;/code>, also apply to the &lt;code>redefinedFeature&lt;/code> (on each instance of the domain of the &lt;code>redefiningFeature&lt;/code>), and vice versa. The &lt;code>redefinedFeature&lt;/code> might have values for instances of the domain of the &lt;code>redefiningFeature&lt;/code>, but only as instances of the domain of the &lt;code>redefinedFeature&lt;/code> that happen to also be instances of the domain of the &lt;code>redefiningFeature&lt;/code>. This is supported by the constraints inherited from &lt;code>Subsetting&lt;/code> on the domains of the &lt;code>redefiningFeature&lt;/code> and &lt;code>redefinedFeature&lt;/code>. However, these constraints are narrowed for &lt;code>Redefinition&lt;/code> to require the &lt;code>owningTypes&lt;/code> of the &lt;code>redefiningFeature&lt;/code> and &lt;code>redefinedFeature&lt;/code> to be different and the &lt;code>redefinedFeature&lt;/code> to not be inherited into the &lt;code>owningNamespace&lt;/code> of the &lt;code>redefiningFeature&lt;/code>.This enables the &lt;code>redefiningFeature&lt;/code> to have the same name as the &lt;code>redefinedFeature&lt;/code>, if desired.&lt;/p>&#xA;&#xA;let anythingType: Type =&#xA;    subsettingFeature.resolveGlobal('Base::Anything').oclAsType(Type) in &#xA;-- Including &quot;Anything&quot; accounts for implicit featuringType of Features&#xA;-- with no explicit featuringType.&#xA;let subsettingFeaturingTypes: Set(Type) =&#xA;    subsettingFeature.featuringTypes->asSet()->including(anythingType) in&#xA;let subsettedFeaturingTypes: Set(Type) =&#xA;    subsettedFeature.featuringTypes->asSet()->including(anythingType) in&#xA;subsettingFeaturingTypes &lt;> subsettedFeaturingType"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="redefiningFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="redefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is redefining the &lt;code>redefinedFeature&lt;/code> of this &lt;code>Redefinition&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Subsetting/subsettingFeature"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="redefinedFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="redefining"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is redefined by the &lt;code>redefiningFeature&lt;/code> of this &lt;code>Redefinition&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Subsetting/subsettedFeature"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Subsetting" eSuperTypes="#//Specialization">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Subsetting&lt;/code> is &lt;code>Specialization&lt;/code> in which the &lt;code>specific&lt;/code> and &lt;code>general&lt;/code> &lt;code>Types&lt;/code> are &lt;code>Features&lt;/code>. This means all values of the &lt;code>subsettingFeature&lt;/code> (on instances of its domain, i.e., the intersection of its &lt;code>featuringTypes&lt;/code>) are values of the &lt;code>subsettedFeature&lt;/code> on instances of its domain. To support this the domain of the &lt;code>subsettingFeature&lt;/code> must be the same or specialize (at least indirectly) the domain of the &lt;code>subsettedFeature&lt;/code> (via &lt;code>Specialization&lt;/code>), and the co-domain (intersection of the &lt;code>types&lt;/code>) of the &lt;code>subsettingFeature&lt;/code> must specialize the co-domain of the &lt;code>subsettedFeature&lt;/code>.&lt;/p>&#xA;&#xA;let subsettingFeaturingTypes: OrderedSet(Type) =&#xA;    subsettingFeature.featuringTypes in&#xA;let subsettedFeaturingTypes: OrderedSet(Type) =&#xA;    subsettedFeature.featuringTypes in&#xA;let anythingType: Element =&#xA;    subsettingFeature.resolveGlobal('Base::Anything') in &#xA;subsettedFeaturingTypes->forAll(t |&#xA;    subsettingFeaturingTypes->isEmpty() and t = anythingType or&#xA;    subsettingFeaturingTypes->exists(specializes(t))"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subsettedFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="supersetting"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is subsetted by the &lt;code>subsettingFeature&lt;/code> of this &lt;code>Subsetting&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/general"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subsettingFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="subsetting"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is a subset of the &lt;code>subsettedFeature&lt;/code> of this &lt;code>Subsetting&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/specific"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningFeature" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true"
+        eOpposite="#//Feature/ownedSubsetting">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>subsettingFeature&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>Subsetting&lt;/code>.&lt;/p>&#xA;&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/owningType"/>
+      <eAnnotations source="subsets" references="#//Subsetting/subsettingFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureTyping" eSuperTypes="#//Specialization">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>FeatureTyping&lt;/code> is &lt;code>Specialization&lt;/code> in which the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code> is a &lt;code>Feature&lt;/code>. This means the set of instances of the (specific) &lt;code>typedFeature&lt;/code> is a subset of the set of instances of the (general) &lt;code>type&lt;/code>. In the simplest case, the &lt;code>type&lt;/code> is a &lt;code>Classifier&lt;/code>, whereupon the &lt;code>typedFeature&lt;/code> has values that are instances of the &lt;code>Classifier&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typedFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typing"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that has a &lt;code>type&lt;/code> determined by this &lt;code>FeatureTyping&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/specific"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typingByType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that is being applied by this &lt;code>FeatureTyping&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/general"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningFeature" ordered="false"
+        eType="#//Feature" volatile="true" transient="true" derived="true" eOpposite="#//Feature/ownedTyping">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>typedFeature&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>FeatureTyping&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/owningType"/>
+      <eAnnotations source="subsets" references="#//FeatureTyping/typedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TypeFeaturing" eSuperTypes="#//Featuring">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>TypeFeaturing&lt;/code> is a &lt;code>Featuring&lt;/code> &lt;code>Relationship&lt;/code> in which the &lt;code>featureOfType&lt;/code> is the &lt;code>source&lt;/code> and the &lt;code>featuringType&lt;/code> is the &lt;code>target&lt;/code>.&lt;/p>"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featureOfType" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeFeaturing"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is featured by the &lt;code>featuringType&lt;/code>. It is the &lt;code>source&lt;/code> of the &lt;code>TypeFeaturing&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source #//Featuring/feature"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featuringType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeFeaturingOfType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that features the &lt;code>featureOfType&lt;/code>. It is the &lt;code>target&lt;/code> of the &lt;code>TypeFeaturing&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target #//Featuring/type"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningFeatureOfType" ordered="false"
+        eType="#//Feature" volatile="true" transient="true" derived="true" eOpposite="#//Feature/ownedTypeFeaturing">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>featureOfType&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>TypeFeaturing&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//TypeFeaturing/featureOfType #//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureInverting" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FeatureInverting&lt;/code> is a &lt;code>Relationship&lt;/code> between &lt;code>Features&lt;/code> asserting that their interpretations (sequences) are the reverse of each other, identified as &lt;code>featureInverted&lt;/code> and &lt;code>invertingFeature&lt;/code>. For example, a &lt;code>Feature&lt;/code> identifying each person&amp;#39;s parents is the inverse of a &lt;code>Feature&lt;/code> identifying each person&amp;#39;s children. A person identified as a parent of another will identify that other as one of their children.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featureInverted" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="invertingFeatureInverting"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is an inverse of the &lt;code>invertingFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="invertingFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="invertedFeatureInverting"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is an inverse of the &lt;code>invertedFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningFeature" ordered="false"
+        eType="#//Feature" volatile="true" transient="true" derived="true" eOpposite="#//Feature/ownedFeatureInverting">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>featureInverted&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>FeatureInverting&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement #//FeatureInverting/featureInverted"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureChaining" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>FeatureChaining&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its target &lt;code>Feature&lt;/code> one of the &lt;code>chainingFeatures&lt;/code> of its owning &lt;code>Feature&lt;/code>.&lt;/p>"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="chainingFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="chainedFeatureChaining"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> whose values partly determine values of &lt;code>featureChained&lt;/code>, as described in &lt;code>Feature::chainingFeature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featureChained" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true"
+        eOpposite="#//Feature/ownedFeatureChaining">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> whose values are partly determined by values of the &lt;code>chainingFeature&lt;/code>, as described in &lt;code>Feature::chainingFeature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="FeatureDirectionKind">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>FeatureDirectionKind&lt;/code> enumerates the possible kinds of &lt;code>direction&lt;/code> that a &lt;code>Feature&lt;/code> may be given as a member of a &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eLiterals name="in">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Values&amp;nbsp;of the &lt;code>Feature&lt;/code> on each&amp;nbsp;instance of its domain are&amp;nbsp;determined&amp;nbsp;externally to that instance and&amp;nbsp;used internally.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="inout" value="1">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Values&amp;nbsp;of the &lt;code>Feature&lt;/code> on each&amp;nbsp;instance are&amp;nbsp;determined either as&amp;nbsp;&lt;em>in&lt;/em> or &lt;em>out&lt;/em>&amp;nbsp;directions, or both.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="out" value="2">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Values of the &lt;code>Feature&lt;/code> on each instance of its domain are&amp;nbsp;determined internally to that instance and used externally.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eLiterals>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ReferenceSubsetting" eSuperTypes="#//Subsetting">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>ReferenceSubsetting&lt;/code> is a kind of &lt;code>Subsetting&lt;/code> in which the &lt;code>referencedFeature&lt;/code> is syntactically distinguished from other &lt;code>Features&lt;/code> subsetted by the &lt;code>referencingFeature&lt;/code>. &lt;code>ReferenceSubsetting&lt;/code> has the same semantics as &lt;code>Subsetting&lt;/code>, but the &lt;code>referenceFeature&lt;/code> may have a special purpose relative to the &lt;code>referencingFeature&lt;/code>. For instance, &lt;code>ReferenceSubsetting&lt;/code> is used to identify the &lt;code>relatedFeatures&lt;/code> of a &lt;code>Connector&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>&lt;code>ReferenceSubsetting&lt;/code> is always an &lt;code>ownedRelationship&lt;/code> of its &lt;code>referencingFeature&lt;/code>. A &lt;code>Feature&lt;/code> can have at most one &lt;code>ownedReferenceSubsetting&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referencedFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="referencing"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is referenced by the &lt;code>referencingFeature&lt;/code> of this &lt;code>ReferenceSubsetting&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Subsetting/subsettedFeature"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referencingFeature" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true"
+        eOpposite="#//Feature/ownedReferenceSubsetting">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that owns this &lt;code>ReferenceSubsetting&lt;/code> relationship, which is also its &lt;code>subsettingFeature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Subsetting/subsettingFeature #//Subsetting/owningFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Conjugation" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Conjugation&lt;/code> is a &lt;code>Relationship&lt;/code> between two types in which the &lt;code>conjugatedType&lt;/code> inherits all the &lt;code>Features&lt;/code> of the &lt;code>originalType&lt;/code>, but with all &lt;code>input&lt;/code> and &lt;code>output&lt;/code> &lt;code>Features&lt;/code> reversed. That is, any &lt;code>Features&lt;/code> with a &lt;code>FeatureMembership&lt;/code> with &lt;code>direction&lt;/code> &lt;em>in&lt;/em> relative to the &lt;code>originalType&lt;/code> are considered to have an effective &lt;code>direction&lt;/code> of &lt;em>out&lt;/em> relative to the &lt;code>conjugatedType&lt;/code> and, similarly, &lt;code>Features&lt;/code> with &lt;code>direction&lt;/code> &lt;em>out&lt;/em> in the &lt;code>originalType&lt;/code> are considered to have an effective &lt;code>direction&lt;/code> of &lt;em>in&lt;/em> in the &lt;code>originalType&lt;/code>. &lt;code>Features&lt;/code> with &lt;code>direction&lt;/code> &lt;em>inout&lt;/em>, or with no &lt;code>direction&lt;/code>, in the &lt;code>originalType&lt;/code>, are inherited without change.&lt;/p>&#xA;&#xA;&lt;p>A &lt;code>Type&lt;/code> may participate as a &lt;code>conjugatedType&lt;/code> in at most one &lt;code>Conjugation&lt;/code> relationship, and such a &lt;code>Type&lt;/code> may not also be the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code> in any &lt;code>Specialization&lt;/code> relationship.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="originalType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="conjugation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> to be conjugated.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="conjugatedType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="conjugator"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that is the result of applying &lt;code>Conjugation&lt;/code> to the &lt;code>originalType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true" eOpposite="#//Type/ownedConjugator">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>conjugatedType&lt;/code> of this &lt;code>Conjugation&lt;/code> that is also its &lt;code>owningRelatedElement&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Conjugation/conjugatedType #//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Multiplicity" eSuperTypes="#//Feature">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Multiplicity&lt;/code> is a &lt;code>Feature&lt;/code> whose co-domain is a set of natural numbers giving the allowed cardinalities of each &lt;code>typeWithMultiplicity&lt;/code>. The &lt;em>cardinality&lt;/em> of a &lt;code>Type&lt;/code> is defined as follows, depending on whether the &lt;code>Type&lt;/code> is a &lt;code>Classifier&lt;/code> or &lt;code>Feature&lt;/code>.&#xA;&lt;ul>&#xA;&lt;li>&lt;code>Classifier&lt;/code> – The number of basic instances of the &lt;code>Classifier&lt;/code>, that is, those instances representing things, which are not instances of any subtypes of the &lt;code>Classifier&lt;/code> that are &lt;code>Features&lt;/code>.&#xA;&lt;li>&lt;code>Features&lt;/code> – The number of instances with the same featuring instances. In the case of a &lt;code>Feature&lt;/code> with a &lt;code>Classifier&lt;/code> as its &lt;code>featuringType&lt;/code>, this is the number of values of &lt;code>Feature&lt;/code> for each basic instance of the &lt;code>Classifier&lt;/code>. Note that, for non-unique &lt;code>Features&lt;/code>, all duplicate values are included in this count.&lt;/li>&#xA;&lt;/ul>&#xA;&#xA;&lt;p>&lt;code>Multiplicity&lt;/code> co-domains (in models) can be specified by &lt;code>Expression&lt;/code> that might vary in their results. If the &lt;code>typeWithMultiplicity&lt;/code> is a &lt;code>Classifier&lt;/code>, the domain of the &lt;code>Multiplicity&lt;/code> shall be &lt;em>&lt;code>Base::Anything&lt;/code>&lt;/em>.  If the &lt;code>typeWithMultiplicity&lt;/code> is a &lt;code>Feature&lt;/code>,  the &lt;code>Multiplicity&lt;/code> shall have the same domain as the &lt;code>typeWithMultiplicity&lt;/code>.&lt;/p>&#xA;&#xA;if owningType &lt;> null and owningType.oclIsKindOf(Feature) then&#xA;    featuringType = &#xA;        owningType.oclAsType(Feature).featuringType&#xA;else&#xA;    featuringType->isEmpty()&#xA;endif&#xA;specializesFromLibrary(&quot;Base::naturals&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Intersecting" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Intersecting&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its &lt;code>intersectingType&lt;/code> one of the &lt;code>intersectingTypes&lt;/code> of its &lt;code>typeIntersected&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="intersectingType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="intersectedIntersecting"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> that partly determines interpretations of &lt;code>typeIntersected&lt;/code>, as described in &lt;code>Type::intersectingType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeIntersected" ordered="false"
+        lowerBound="1" eType="#//Type" volatile="true" transient="true" derived="true"
+        eOpposite="#//Type/ownedIntersecting">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> with interpretations partly determined by &lt;code>intersectingType&lt;/code>, as described in &lt;code>Type::intersectingType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Unioning" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Unioning&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its &lt;code>unioningType&lt;/code> one of the &lt;code>unioningTypes&lt;/code> of its &lt;code>typeUnioned&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="unioningType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="unionedUnioning"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> that partly determines interpretations of &lt;code>typeUnioned&lt;/code>, as described in &lt;code>Type::unioningType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeUnioned" ordered="false"
+        lowerBound="1" eType="#//Type" volatile="true" transient="true" derived="true"
+        eOpposite="#//Type/ownedUnioning">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> with interpretations partly determined by &lt;code>unioningType&lt;/code>, as described in &lt;code>Type::unioningType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Disjoining" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Disjoining&lt;/code> is a &lt;code>Relationship&lt;/code> between &lt;code>Types&lt;/code> asserted to have interpretations that are not shared (disjoint) between them, identified as &lt;code>typeDisjoined&lt;/code> and &lt;code>disjoiningType&lt;/code>. For example, a &lt;code>Classifier&lt;/code> for mammals is disjoint from a &lt;code>Classifier&lt;/code> for minerals, and a &lt;code>Feature&lt;/code> for people&amp;#39;s parents is disjoint from a &lt;code>Feature&lt;/code> for their children.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeDisjoined" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="disjoiningTypeDisjoining"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> asserted to be disjoint with the &lt;code>disjoiningType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="disjoiningType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="disjoinedTypeDisjoining"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> asserted to be disjoint with the &lt;code>typeDisjoined&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true" eOpposite="#//Type/ownedDisjoining">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>typeDisjoined&lt;/code> that is also an &lt;code>owningRelatedElement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Disjoining/typeDisjoined #//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Differencing" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Differencing&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its &lt;code>differencingType&lt;/code> one of the &lt;code>differencingTypes&lt;/code> of its &lt;code>typeDifferenced&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="differencingType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="differencedDifferencing"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> that partly determines interpretations of &lt;code>typeDifferenced&lt;/code>, as described in &lt;code>Type::differencingType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeDifferenced" ordered="false"
+        lowerBound="1" eType="#//Type" volatile="true" transient="true" derived="true"
+        eOpposite="#//Type/ownedDifferencing">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> with interpretations partly determined by &lt;code>differencingType&lt;/code>, as described in &lt;code>Type::differencingType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Classifier" eSuperTypes="#//Type">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Classifier&lt;/code> is a &lt;code>Type&lt;/code> that classifies:&lt;/p>&#xA;&#xA;&lt;ul>&#xA;&#x9;&lt;li>Things (in the universe) regardless of how &lt;code>Features&lt;/code> relate them. (These are interpreted semantically as sequences of exactly one thing.)&lt;/li>&#xA;&#x9;&lt;li>How the above things are related by &lt;code>Features.&lt;/code> (These are interpreted semantically as sequences of multiple things, such that the last thing in the sequence is also classified by the &lt;code>Classifier&lt;/code>. Note that his means that a &lt;code>Classifier&lt;/code> modeled as specializing a &lt;code>Feature&lt;/code> cannot classify anything.)&lt;/li>&#xA;&lt;/ul>&#xA;&#xA;&#xA;ownedSubclassification = &#xA;    ownedSpecialization->selectByKind(Superclassification)&#xA;multiplicity &lt;> null implies multiplicity.featuringType->isEmpty()"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedSubclassification"
+        ordered="false" upperBound="-1" eType="#//Subclassification" volatile="true"
+        transient="true" derived="true" eOpposite="#//Subclassification/owningClassifier">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedSpecializations&lt;/code> of this &lt;code>Classifier&lt;/code> that are &lt;code>Subclassifications&lt;/code>, for which this &lt;code>Classifier&lt;/code> is the &lt;code>subclassifier&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedSpecialization"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="EndFeatureMembership" eSuperTypes="#//FeatureMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>EndFeatureMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> that requires its &lt;code>memberFeature&lt;/code> be owned and have &lt;code>isEnd = true&lt;/code>.&lt;/p>&#xA;&#xA;ownedMemberFeature.isEnd"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Structure" eSuperTypes="#//Class">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Structure&lt;/code> is a &lt;code>Class&lt;/code> of objects in the modeled universe that are primarily structural in nature. While such an object is not itself behavioral, it may be involved in and acted on by &lt;code>Behaviors&lt;/code>, and it may be the performer of some of them.&lt;/p>&#xA;&#xA;specializesFromLibrary('Objects::Object')"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Class" eSuperTypes="#//Classifier">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Class&lt;/code> is a &lt;code>Classifier&lt;/code> of things (in the universe) that can be distinguished without regard to how they are related to other things (via &lt;code>Features&lt;/code>). This means multiple things classified by the same &lt;code>Class&lt;/code> can be distinguished, even when they are related other things in exactly the same way.&lt;/p>&#xA;&#xA;specializesFromLibrary('Occurrences::Occurrence')&#xA;ownedSpecialization.general->&#xA;    forAll(not oclIsKindOf(DataType)) and&#xA;not oclIsKindOf(AssociationStructure) implies&#xA;    ownedSpecialization.general->&#xA;        forAll(not oclIsKindOf(Association))"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="DataType" eSuperTypes="#//Classifier">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>DataType&lt;/code> is a &lt;code>Classifier&lt;/code> of things (in the universe) that can only be distinguished by how they are related to other things (via Features). This means multiple things classified by the same &lt;code>DataType&lt;/code>&lt;/p>&#xA;&#xA;&lt;ul>&#xA;&#x9;&lt;li>Cannot be distinguished when they are related to other things in exactly the same way, even when they are intended to be about different things.&lt;/li>&#xA;&#x9;&lt;li>Can be distinguished when they are related to other things in different ways, even when they are intended to be about the same thing.&lt;/li>&#xA;&lt;/ul>&#xA;&#xA;specializesFromLibrary('Base::DataValue')&#xA;ownedSpecialization.general->&#xA;    forAll(not oclIsKindOf(Class) and &#xA;           not oclIsKindOf(Association))"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LibraryPackage" eSuperTypes="#//Package">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LibraryPackage&lt;/code> is a &lt;code>Package&lt;/code> that is the container for a model library. A &lt;code>LibraryPackage&lt;/code> is itself a library &lt;code>Element&lt;/code> as are all &lt;code>Elements&lt;/code> that are directly or indirectly contained in it.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isStandard" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>LibraryPackage&lt;/code> contains a standard library model. This should only be set to true for &lt;code>LibraryPackages&lt;/code> in the standard Kernel Model Libraries or in normative model libraries for a language built on KerML.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Package" eSuperTypes="#//Namespace">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Package&lt;/code> is a &lt;code>Namespace&lt;/code> used to group &lt;code>Elements&lt;/code>, without any instance-level semantics. It may have one or more model-level evaluable &lt;code>filterCondition&lt;/code> &lt;code>Expressions&lt;/code> used to filter its &lt;code>importedMemberships&lt;/code>. Any imported &lt;code>member&lt;/code> must meet all of the &lt;code>filterConditions&lt;/code>.&lt;/p>&#xA;filterCondition = ownedMembership->&#xA;    selectByKind(ElementFilterMembership).condition"/>
+    </eAnnotations>
+    <eOperations name="includeAsMember" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Determine whether the given &lt;code>element&lt;/code> meets all the &lt;code>filterConditions&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="let metadataFeatures: Sequence(AnnotatingElement) = &#xA;    element.ownedAnnotation.annotatingElement->&#xA;        selectByKind(MetadataFeature) in&#xA;    self.filterCondition->forAll(cond | &#xA;        metadataFeatures->exists(elem | &#xA;            cond.checkCondition(elem)))"/>
+      </eAnnotations>
+      <eParameters name="element" ordered="false" lowerBound="1" eType="#//Element"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="filterCondition" upperBound="-1"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="conditionedPackage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The model-level evaluable &lt;code>&lt;em>Boolean&lt;/em>&lt;/code>-valued &lt;code>Expression&lt;/code> used to filter the &lt;code>members&lt;/code> of this &lt;code>Package&lt;/code>, which are owned by the &lt;code>Package&lt;/code> are via &lt;code>ElementFilterMemberships&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Expression" eSuperTypes="#//Step">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Expression&lt;/code> is a &lt;code>Step&lt;/code> that is typed by a &lt;code>Function&lt;/code>. An &lt;code>Expression&lt;/code> that also has a &lt;code>Function&lt;/code> as its &lt;code>featuringType&lt;/code> is a computational step within that &lt;code>Function&lt;/code>. An &lt;code>Expression&lt;/code> always has a single &lt;code>result&lt;/code> parameter, which redefines the &lt;code>result&lt;/code> parameter of its defining &lt;code>function&lt;/code>. This allows &lt;code>Expressions&lt;/code> to be interconnected in tree structures, in which inputs to each &lt;code>Expression&lt;/code> in the tree are determined as the results of other &lt;code>Expression&lt;/code> in the tree.&lt;/p>&#xA;&#xA;isModelLevelEvaluable = modelLevelEvaluable(Set(Element){})&#xA;specializesFromLibrary(&quot;Performances::evaluations&quot;)&#xA;owningMembership &lt;> null and &#xA;owningMembership.oclIsKindOf(FeatureValue) implies&#xA;    let featureWithValue : Feature = &#xA;        owningMembership.oclAsType(FeatureValue).featureWithValue in&#xA;    featuringType = featureWithValue.featuringType&#xA;ownedMembership.selectByKind(ResultExpressionMembership)->&#xA;    forAll(mem | ownedFeature.selectByKind(BindingConnector)->&#xA;        exists(binding |&#xA;            binding.relatedFeature->includes(result) and&#xA;            binding.relatedFeature->includes(mem.ownedResultExpression.result)))&#xA;result =&#xA;    let resultParams : Sequence(Feature) =&#xA;        ownedFeatureMemberships->&#xA;            selectByKind(ReturnParameterMembership).&#xA;            ownedParameterMember in&#xA;    if resultParams->notEmpty() then resultParams->first()&#xA;    else if function &lt;> null then function.result&#xA;    else null&#xA;    endif endif&#xA;ownedFeatureMembership->&#xA;    selectByKind(ReturnParameterMembership)->&#xA;    size() &lt;= 1"/>
+    </eAnnotations>
+    <eOperations name="modelLevelEvaluable" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return whether this &lt;code>Expression&lt;/code> is model-level evaluable. The &lt;code>visited&lt;/code> parameter is used to track possible circular &lt;code>Feature&lt;/code> references. Such circular references are not allowed in model-level evaluable expressions.&lt;/p>&#xA;&#xA;&lt;p>An &lt;code>Expression&lt;/code> that is not otherwise specialized is model-level evaluable if all of it has no &lt;code>ownedSpecialziations&lt;/code> and all its (non-implicit) &lt;code>features&lt;/code> are either &lt;code>in&lt;/code> parameters, the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> or a result &lt;code>Expression&lt;/code> owned via a &lt;code>ResultExpressionMembership&lt;/code>. The &lt;code>parameters&lt;/code>  must not have any &lt;code>ownedFeatures&lt;/code> or a &lt;code>FeatureValue&lt;/code>, and the result &lt;code>Expression&lt;/code> must be model-level evaluable.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="ownedSpecialization->isEmpty() and&#xA;ownedFeature->forAll(f |&#xA;    (f.oclIsKindOf(Relationship) and &#xA;        f.oclAsType(Relationship).isImplicit) or &#xA;    (directionOf(f) = FeatureDirectionKind::_'in' or f = result) and &#xA;        f.ownedFeature->isEmpty() f.valuation = null and  or&#xA;    f.owningFeatureMembership.oclIsKindOf(ResultExpressionMembership) and&#xA;        f.oclAsType(Expression).modelLevelEvaluable(visited)&#xA;    "/>
+      </eAnnotations>
+      <eParameters name="visited" ordered="false" upperBound="-1" eType="#//Feature"/>
+    </eOperations>
+    <eOperations name="evaluate" unique="false" upperBound="-1" eType="#//Element">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>If this &lt;code>Expression&lt;/code> &lt;code>isModelLevelEvaluable&lt;/code>, then evaluate it using the &lt;code>target&lt;/code> as the context &lt;code>Element&lt;/code> for resolving &lt;code>Feature&lt;/code> names and testing classification. The result is a collection of &lt;code>Elements&lt;/code>, which, for a fully evaluable &lt;code>Expression&lt;/code>, will be a &lt;code>LiteralExpression&lt;/code> or a &lt;code>Feature&lt;/code> that is not an &lt;code>Expression&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="let resultExprs : Sequence(Expression) =&#xA;    ownedFeatureMembership->&#xA;        selectByKind(ResultExpressionMembership).&#xA;        ownedResultExpression in&#xA;if resultExpr->isEmpty() then Sequence{}&#xA;else resultExprs->first().evaluate(target)&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="target" ordered="false" lowerBound="1" eType="#//Element"/>
+    </eOperations>
+    <eOperations name="checkCondition" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Model-level evaluate this &lt;code>Expression&lt;/code> with the given &lt;code>target&lt;/code>. If the result is a &lt;code>LiteralBoolean&lt;/code>, return its &lt;code>value&lt;/code>. Otherwise return &lt;code>false&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="let results: Sequence(Element) = evaluate(target) in&#xA;    result->size() = 1 and&#xA;    results->first().oclIsKindOf(LiteralBoolean) and &#xA;    results->first().oclAsType(LiteralBoolean).value"/>
+      </eAnnotations>
+      <eParameters name="target" ordered="false" lowerBound="1" eType="#//Element"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="function" ordered="false"
+        eType="#//Function" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Function&lt;/code> that types this &lt;code>Expression&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>This is the Function that types the Expression.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Step/behavior"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="result" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="computingExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;p>An &lt;code>output&lt;/code> &lt;code>parameter&lt;/code> of the &lt;code>Expression&lt;/code> whose value is the result of the &lt;code>Expression&lt;/code>. The result of an &lt;code>Expression&lt;/code> is either inherited from its &lt;code>function&lt;/code> or it is related to the &lt;code>Expression&lt;/code> via a &lt;code>ReturnParameterMembership&lt;/code>, in which case it redefines the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of its &lt;code>function&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/parameter #//Type/output"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isModelLevelEvaluable"
+        ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>Expression&lt;/code> meets the constraints necessary to be evaluated at &lt;em>model level&lt;/em>, that is, using metadata within the model.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Step" eSuperTypes="#//Feature">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Step&lt;/code> is a &lt;code>Feature&lt;/code> that is typed by one or more &lt;code>Behaviors&lt;/code>. &lt;code>Steps&lt;/code> may be used by one &lt;code>Behavior&lt;/code> to coordinate the performance of other &lt;code>Behaviors&lt;/code>, supporting a steady refinement of behavioral descriptions. &lt;code>Steps&lt;/code> can be ordered in time and can be connected using &lt;code>ItemFlows&lt;/code> to specify things flowing between their &lt;code>parameters&lt;/code>.&lt;/p>&#xA;&#xA;allSupertypes()->includes(resolveGlobal(&quot;Performances::performances&quot;))&#xA;owningType &lt;> null and&#xA;    (owningType.oclIsKindOf(Behavior) or&#xA;     owningType.oclIsKindOf(Step)) implies&#xA;    specializesFromLibrary('Performances::Performance::enclosedPerformance')&#xA;isComposite and owningType &lt;> null and&#xA;(owningType.oclIsKindOf(Structure) or&#xA; owningType.oclIsKindOf(Feature) and&#xA; owningType.oclAsType(Feature).type->&#xA;    exists(oclIsKindOf(Structure)) implies&#xA;    specializesFromLibrary('Objects::Object::ownedPerformance')&#xA;owningType &lt;> null and&#xA;    (owningType.oclIsKindOf(Behavior) or&#xA;     owningType.oclIsKindOf(Step)) and&#xA;    self.isComposite implies&#xA;    specializesFromLibrary('Performances::Performance::subperformance')&#xA;behavior = type->selectByKind(Behavior)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="behavior" upperBound="-1"
+        eType="#//Behavior" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedStep"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Behaviors&lt;/code> that type this &lt;code>Step&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Feature/type"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="parameter" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="parameteredStep"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>Step&lt;/code>, which are defined as its &lt;code>directedFeatures&lt;/code>, whose values are passed into and/or out of a performance of the &lt;code>Step&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Type/directedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Behavior" eSuperTypes="#//Class">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Behavior &lt;/code>coordinates occurrences of other &lt;code>Behaviors&lt;/code>, as well as changes in objects. &lt;code>Behaviors&lt;/code> can be decomposed into &lt;code>Steps&lt;/code> and be characterized by &lt;code>parameters&lt;/code>.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Performances::Performance&quot;)&#xA;step = feature->selectByKind(Step)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="step" ordered="false" upperBound="-1"
+        eType="#//Step" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringBehavior"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Steps&lt;/code> that make up this &lt;code>Behavior&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="parameter" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="parameteredBehavior"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The parameters of this &lt;code>Behavior&lt;/code>, which are defined as its &lt;code>directedFeatures&lt;/code>, whose values are passed into and/or out of a performance of the &lt;code>Behavior&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Type/directedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Function" eSuperTypes="#//Behavior">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Function&lt;/code> is a &lt;code>Behavior&lt;/code> that has an &lt;code>out&lt;/code> &lt;code>parameter&lt;/code> that is identified as its &lt;code>result&lt;/code>. A &lt;code>Function&lt;/code> represents the performance of a calculation that produces the values of its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code>. This calculation may be decomposed into &lt;code>Expressions&lt;/code? that are &lt;code>steps&lt;/code> of the &lt;code>Function&lt;/code>.&lt;/p>&#xA;&#xA;ownedMembership.selectByKind(ResultExpressionMembership)->&#xA;    forAll(mem | ownedFeature.selectByKind(BindingConnector)->&#xA;        exists(binding |&#xA;            binding.relatedFeature->includes(result) and&#xA;            binding.relatedFeature->includes(mem.ownedResultExpression.result)))&#xA;specializesFromLibrary(&quot;Performances::Evaluation&quot;)&#xA;result =&#xA;    let resultParams : Sequence(Feature) =&#xA;        ownedFeatureMemberships->&#xA;            selectByKind(ReturnParameterMembership).&#xA;            ownedParameterMember in&#xA;    if resultParams->notEmpty() then resultParams->first()&#xA;    else null&#xA;    endif&#xA;ownedFeatureMembership->&#xA;    selectByKind(ReturnParameterMembership)->&#xA;    size() &lt;= 1"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        upperBound="-1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="computedFunction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expressions&lt;/code> that are &lt;code>steps&lt;/code> in the calculation of the &lt;code>result&lt;/code> of this &lt;code>Function&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The set of expressions that represent computational steps or parts of a system of equations within the Function.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/step"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="result" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="computingFunction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the &lt;code>Function&lt;/code>, which is owned by the &lt;code>Function&lt;/code> via a &lt;code>ReturnParameterMembership&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The object or value that is the result of evaluating the Function.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/parameter #//Type/output"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isModelLevelEvaluable"
+        ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>Function&lt;/code> can be used as the &lt;code>function&lt;/code> of a model-level evaluable &lt;code>InvocationExpression&lt;/code>. Certain &lt;code>Functions&lt;/code> from the Kernel Functions Library are considered to have &lt;code>isModelLevelEvaluable = true&lt;/code>. For all other &lt;code>Functions&lt;/code> it is &lt;code>false&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>&lt;strong>Note:&lt;/strong> See the specification of the KerML concrete syntax notation for &lt;code>Expressions&lt;/code> for an identification of which library &lt;code>Functions&lt;/code> are model-level evaluable.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ElementFilterMembership" eSuperTypes="#//OwningMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>ElementFilterMembership&lt;/code> is a &lt;code>Membership&lt;/code> between a &lt;code>Namespace&lt;/code> and a model-level evaluable &lt;code>&lt;em>Boolean&lt;/em>&lt;/code>-valued &lt;code>Expression&lt;/code>, asserting that imported &lt;code>members&lt;/code> of the &lt;code>Namespace&lt;/code> should be filtered using the &lt;code>condition&lt;/code> &lt;code>Expression&lt;/code>. A general &lt;code>Namespace&lt;/code> does not define any specific filtering behavior, but such behavior may be defined for various specialized kinds of &lt;code>Namespaces&lt;/code>.&lt;/p>&#xA;&#xA;condition.isModelLevelEvaluable&#xA;condition.result.specializesFromLibrary('ScalarValues::Boolean')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="condition" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningFilter"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The model-level evaluable &lt;code>Boolean&lt;/code>-valued &lt;code>Expression&lt;/code> used to filter the imported &lt;code>members&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> of this &lt;code>ElementFilterMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//OwningMembership/ownedMemberElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralString" eSuperTypes="#//LiteralExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LiteralString&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides a &lt;code>&lt;em>String&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have the type &lt;code>&lt;em>String&lt;/em>&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>&lt;em>String&lt;/em>&lt;/code> value that is the result of evaluating this &lt;code>LiteralString&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The String value that is the result of evaluating this Expression.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LiteralExpression&lt;/code> is an &lt;code>Expression&lt;/code> that provides a basic &lt;code>&lt;em>DataValue&lt;/em>&lt;/code> as a result.&lt;/p>&#xA;&#xA;isModelLevelEvaluable = true&#xA;specializesFromLibrary(&quot;Performances::literalEvaluations&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralRational" eSuperTypes="#//LiteralExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LiteralRational&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides a &lt;code>&lt;em>Rational&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have the type &lt;code>&lt;em>Rational&lt;/em>&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Real">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The value whose rational approximation is the result of evaluating this &lt;code>LiteralRational&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The Real value that is the result of evaluating this Expression.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureReferenceExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FeatureReferenceExpression&lt;/code> is an &lt;code>Expression&lt;/code> whose &lt;code>result&lt;/code> is bound to a &lt;code>referent&lt;/code> &lt;code>Feature&lt;/code>.&lt;/p>&#xA;referent =&#xA;    let nonParameterMemberships : Sequence(Membership) = ownedMembership->&#xA;        reject(oclIsKindOf(ParameterMembership)) in&#xA;    if nonParameterMemberships->isEmpty() or&#xA;       not nonParameterMemberships->first().memberElement.oclIsKindOf(Feature)&#xA;    then null&#xA;    else nonParameterMemberships->first().memberElement.oclAsType(Feature)&#xA;    endif&#xA;ownedMember->selectByKind(BindingConnector)->exists(b |&#xA;    b.relatedFeatures->includes(targetFeature) and&#xA;    b.relatedFeatures->includes(result))"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referent" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="referenceExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is referenced by this &lt;code>FeatureReferenceExpression&lt;/code>, which is its first non-&lt;code>parameter&lt;/code> &lt;code>member&lt;/code>.&lt;p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/member"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralInteger" eSuperTypes="#//LiteralExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LiteralInteger&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides an &lt;code>&lt;em>Integer&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have the type &lt;code>&lt;em>Integer&lt;/em>&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Integer">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>&lt;em>Integer&lt;/em>&lt;/code> value that is the result of evaluating this &lt;code>LiteralInteger&lt;/code>.&lt;/p>&#xA;&lt;p>The Integer value that is the result of evaluating this Expression.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="InvocationExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>InvocationExpression&lt;/code> is an &lt;code>Expression&lt;/code> each of whose input &lt;code>parameters&lt;/code> are bound to the &lt;code>result&lt;/code> of an &lt;code>argument&lt;/code> Expression.&lt;/p>&#xA;&#xA;not ownedTyping->exists(oclIsKindOf(Behavior)) and&#xA;not ownedSubsetting.subsettedFeature.type->exists(oclIsKindOf(Behavior)) implies&#xA;    ownedFeature.selectByKind(BindingConnector)->exists(&#xA;        relatedFeature->includes(self) and&#xA;        relatedFeature->includes(result))&#xA;            &#xA;TBD&#xA;ownedFeature->&#xA;    select(direction = _'in').valuation->&#xA;    select(v | v &lt;> null).value"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="argument" upperBound="-1"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="invocation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>value&lt;/code> &lt;code>Expressions&lt;/code> of the &lt;code>FeatureValues&lt;/code> of the owned input &lt;code>parameters&lt;/code> of the &lt;code>InvocationExpression&lt;/code>."/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SelectExpression" eSuperTypes="#//OperatorExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>SelectExpression&lt;/code> is an &lt;code>OperatorExpression&lt;/code> whose operator is &lt;code>&quot;select&quot;&lt;/code>, which resolves to the &lt;code>Function&lt;/code> &lt;em>&lt;code>ControlFunctions::select&lt;/code>&lt;/em> from the Kernel Functions Library.&lt;/p>"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="OperatorExpression" eSuperTypes="#//InvocationExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>OperatorExpression&lt;/code> is an &lt;code>InvocationExpression&lt;/code> whose &lt;code>function&lt;/code> is determined by resolving its &lt;code>operator&lt;/code> in the context of one of the standard packages from the Kernel Function Library.&lt;/p>&#xA;let libFunctions : Sequence(Element) = &#xA;    Sequence{&quot;BaseFunctions&quot;, &quot;DataFunctions&quot;, &quot;ControlFunctions&quot;}->&#xA;    collect(ns | resolveGlobal(ns + &quot;::'&quot; + operator + &quot;'&quot;)) in&#xA;libFunctions->includes(function)&#xA;    &#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An &lt;code>operator&lt;/code> symbol that names a corresponding &lt;code>Function&lt;/code> from one of the standard packages from the Kernel Function Library .&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="operand" upperBound="-1"
+        eType="#//Expression" volatile="true" transient="true" derived="true" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CollectExpression" eSuperTypes="#//OperatorExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>CollectExpression&lt;/code> is an &lt;code>OperatorExpression&lt;/code> whose &lt;code>operator&lt;/code> is &lt;code>&quot;collect&quot;&lt;/code>, which resolves to the &lt;code>Function&lt;/code> &lt;em>&lt;code>ControlFunctions::collect&lt;/code>&lt;/em> from the Kernel Functions Library.&lt;/p>&#xA;operator = &quot;collect&quot;"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralBoolean" eSuperTypes="#//LiteralExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>LiteralBoolean&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides a &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have type &lt;code>&lt;em>Boolean&lt;/em>&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> value that is the result of evaluating this &lt;code>LiteralBoolean&lt;/code>.&lt;/p>&#xA;&lt;p>The Boolean value that is the result of evaluating this Expression.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="NullExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>NullExpression&lt;/code> is an &lt;code>Expression&lt;/code> that results in a null value.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Performances::nullEvaluations&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralInfinity" eSuperTypes="#//LiteralExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LiteralInfinity&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides the positive infinity value (&lt;code>*&lt;/code>). It's &lt;code>result&lt;/code> must have the type &lt;code>&lt;em>Positive&lt;/em>&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureChainExpression" eSuperTypes="#//OperatorExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FeatureChainExpression&lt;/code> is an &lt;code>OperatorExpression&lt;/code> whose operator is &lt;code>&quot;.&quot;&lt;/code>, which resolves to the &lt;code>Function&lt;/code> &lt;em>&lt;code>ControlFunctions::'.'&lt;/code>&lt;/em> from the Kernel Functions Library. It evaluates to the result of chaining the &lt;code>result&lt;/code> &lt;code>Feature&lt;/code> of its single &lt;code>argument&lt;/code> &lt;code>Expression&lt;/code> with its &lt;code>targetFeature&lt;/code>.&lt;/p>&#xA;let sourceParameter : Feature = sourceTargetFeature() in&#xA;sourceTargetFeature &lt;> null and&#xA;sourceTargetFeature.redefinesFromLibrary(&quot;ControlFunctions::'.'::source::target&quot;)&#xA;let sourceParameter : Feature = sourceTargetFeature() in&#xA;sourceTargetFeature &lt;> null and&#xA;sourceTargetFeature.redefines(targetFeature)&#xA;targetFeature =&#xA;    let nonParameterMemberships : Sequence(Membership) = ownedMembership->&#xA;        reject(oclIsKindOf(ParameterMembership)) in&#xA;    if nonParameterMemberships->isEmpty() or&#xA;       not nonParameterMemberships->first().memberElement.oclIsKindOf(Feature)&#xA;    then null&#xA;    else nonParameterMemberships->first().memberElement.oclAsType(Feature)&#xA;    endif"/>
+    </eAnnotations>
+    <eOperations name="sourceTargetFeature" ordered="false" eType="#//Feature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the first &lt;code>ownedFeature&lt;/code> of the first owned input &lt;code>parameter&lt;/code> of this &lt;code>FeatureChainExpression&lt;/code> (if any).&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="let inputParameters : Feature = ownedFeatures->&#xA;    select(direction = _'in') in&#xA;if inputParameters->isEmpty() or &#xA;   inputParameters->first().ownedFeature->isEmpty()&#xA;then null&#xA;else inputParameters->first().ownedFeature->first()&#xA;endif"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="targetFeature" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="chainExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is accessed by this &lt;code>FeatureChainExpression&lt;code>, which is its first non-&lt;code>parameter&lt;/code> &lt;code>member&lt;/code>.&lt;p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/member"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MetadataAccessExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>MetadataAccessExpression&lt;/code> is an &lt;code>Expression&lt;/code> whose &lt;code>result&lt;/code> is a sequence of instances of &lt;code>Metaclasses&lt;/code> representing all the &lt;code>MetadataFeature&lt;/code> annotations of the &lt;code>referencedElement&lt;/code>. In addition, the sequence includes an instance of the reflective &lt;code>Metaclass&lt;/code> corresponding to the MOF class of the &lt;code>referencedElement&lt;/code>, with values for all the abstract syntax properties of the &lt;code>referencedElement&lt;/code>.&lt;/p>&#xA;specializesFromLibrary(&quot;Performances::metadataAccessEvaluations&quot;)"/>
+    </eAnnotations>
+    <eOperations name="metaclassFeature" ordered="false" lowerBound="1" eType="#//MetadataFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return a &lt;code>MetadataFeature&lt;/code> whose &lt;code>annotatedElement&lt;/code> is the &lt;code>referencedElement&lt;/code>, whose &lt;code>metaclass&lt;/code> is the reflective &lt;code>Metaclass&lt;/code> corresponding to the MOF class of the &lt;code>referencedElement&lt;/code> and whose &lt;code>ownedFeatures&lt;/code> are bound to the MOF properties of the &lt;code>referencedElement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referencedElement" ordered="false"
+        lowerBound="1" eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="accessExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p> The &lt;code>Element&lt;/code> whose metadata is being accessed.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MetadataFeature" eSuperTypes="#//Feature #//AnnotatingElement">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>MetadataFeature&lt;/code> is a &lt;code>Feature&lt;/code> that is an &lt;code>AnnotatingElement&lt;/code> used to annotate another &lt;code>Element&lt;/code> with metadata. It is typed by a &lt;code>Metaclass&lt;/code>. All its &lt;code>ownedFeatures&lt;/code> must redefine &lt;code>features&lt;/code> of its &lt;code>metaclass&lt;/code> and any feature bindings must be model-level evaluable.&lt;/p>&#xA;&#xA;&#xA;specializesFromLibrary(&quot;Metaobjects::metaobjects&quot;)&#xA;isSemantic() implies&#xA;    let annotatedTypes : Sequence(Type) = &#xA;        annotatedElement->selectAsKind(Type) in&#xA;    let baseTypes : Sequence(MetadataFeature) = &#xA;        evaluateFeature(resolveGlobal(&#xA;            'Metaobjects::SemanticMetadata::baseType').&#xA;            oclAsType(Feature))->&#xA;        selectAsKind(MetadataFeature) in&#xA;    annotatedTypes->notEmpty() and &#xA;    baseTypes()->notEmpty() and &#xA;    baseTypes()->first().isSyntactic() implies&#xA;        let annotatedType : Type = annotatedTypes->first() in&#xA;        let baseType : Element = baseTypes->first().syntaxElement() in&#xA;        if annotatedType.oclIsKindOf(Classifier) and &#xA;            baseType.oclIsKindOf(Feature) then&#xA;            baseType.oclAsType(Feature).type->&#xA;                forAll(t | annotatedType.specializes(t))&#xA;        else if baseType.oclIsKindOf(Type) then&#xA;            annotatedType.specializes(baseType.oclAsType(Type))&#xA;        else&#xA;            true&#xA;        endif"/>
+    </eAnnotations>
+    <eOperations name="evaluateFeature" ordered="false" upperBound="-1" eType="#//Element">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>If the given &lt;code>baseFeature&lt;/code> is a &lt;code>feature&lt;/code> of this &lt;code>MetadataFeature&lt;/code>, or is directly or indirectly redefined by a &lt;code>feature&lt;/code>, then return the result of evaluating the appropriate (model-level evaluable) &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> for it (if any), with the MetadataFeature as the target.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="let selectedFeatures : Sequence(Feature) = feature->&#xA;    select(closure(ownedRedefinition.redefinedFeature)->&#xA;           includes(baseFeature)) in&#xA;if selectedFeatures->isEmpty() then null&#xA;else&#xA;    let selectedFeature : Feature = selectedFeatures->first() in&#xA;    let featureValues : FeatureValue = selectedFeature->&#xA;        closure(ownedRedefinition.redefinedFeature).ownedMember->&#xA;        selectAsKind(FeatureValue) in&#xA;    if featureValues->isEmpty() then null&#xA;    else featureValues->first().value.evaluate(self)&#xA;    endif"/>
+      </eAnnotations>
+      <eParameters name="baseFeature" ordered="false" lowerBound="1" eType="#//Feature"/>
+    </eOperations>
+    <eOperations name="isSemantic" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check if this &lt;code>MetadataFeature&lt;/code> has a &lt;code>metaclass&lt;/code> which is a kind of &lt;code>&lt;em>SemanticMetadata&lt;/code>.&lt;p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="specializesFromLibrary('Metaobjects::SemanticMetadata')"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="isSyntactic" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check if this &lt;code>MetadataFeature&lt;/code> has a &lt;code>metaclass&lt;/code> that is a kind of &lt;code>&lt;em>KerML::Element&lt;em>&lt;/code> (that is, it is from the reflective abstract syntax model).&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="specializesFromLibrary('KerML::Element')"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="syntaxElement" ordered="false" eType="#//Element">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>If this &lt;code>MetadataFeature&lt;/code> reflectively represents a model element, then return the corresponding &lt;code>Element&lt;code> instance from the MOF abstract syntax representation of the model.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="No OCL"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="metaclass" ordered="false"
+        eType="#//Metaclass" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedMetadata"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>type&lt;/code> of this &lt;code>MetadataFeature&lt;/code>, which must be a &lt;code>Metaclass&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Feature/type"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Metaclass" eSuperTypes="#//Structure">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Metaclass&lt;/code> is a &lt;code>Structure&lt;/code> used to type &lt;code>MetadataFeatures&lt;/code>.&lt;/p>&#xA;specializesFromLibrary(&quot;Metaobjects::Metaobject&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ParameterMembership" eSuperTypes="#//FeatureMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ParameterMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> that identifies its &lt;code>memberFeature&lt;/code> as a parameter, which is always owned, and must have a &lt;code>direction&lt;/code>. A &lt;code>ParameterMembership&lt;/code> must be owned by a &lt;code>Behavior&lt;/code> or a &lt;code>Step&lt;/code>.&lt;/p>&#xA;ownedMemberParameter.direction &lt;> null&#xA;owningType.oclIsKindOf(Behavior) or owningType.oclIsKindOf(Step)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMemberParameter" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningParameterMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is identified as a &lt;code>parameter&lt;/code> by this &lt;code>ParameterMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//FeatureMembership/ownedMemberFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureValue" eSuperTypes="#//OwningMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FeatureValue&lt;/code> is a &lt;code>Membership&lt;/code> that identifies a particular member &lt;code>Expression&lt;/code> that provides the value of the &lt;code>Feature&lt;/code> that owns the &lt;code>FeatureValue&lt;/code>. The value is specified as either a bound value or an initial value, and as either a concrete or default value. A &lt;code>Feature&lt;/code> can have at most one &lt;code>FeatureValue&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The result of the &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> is bound to the &lt;code>featureWithValue&lt;/code> using a &lt;code>BindingConnector&lt;/code>. If &lt;code>isInitial = false&lt;/code>, then the &lt;code>featuringType&lt;/code> of the &lt;code>BindingConnector&lt;/code> is the same as the &lt;code>featuringType&lt;/code> of the &lt;code>featureWithValue&lt;/code>. If &lt;code>isInitial = true&lt;/code>, then the &lt;code>featuringType&lt;/code> of the &lt;code>BindingConnector&lt;/code> is restricted to its &lt;code>startShot&lt;/code>.&#xA;&#xA;&lt;p>If &lt;code>isDefault = false&lt;/code>, then the above semantics of the &lt;code>FeatureValue&lt;/code> are realized for the given &lt;code>featureWithValue&lt;/code>. Otherwise, the semantics are realized for any individual of the &lt;code>featuringType&lt;/code> of the &lt;code>featureWithValue&lt;/code>, unless another value is explicitly given for the &lt;code>featureWithValue&lt;/code> for that individual.&lt;/p>&#xA;&#xA;not isDefault implies&#xA;    featureWithValue.ownedMember->&#xA;        selectByKind(BindingConnector)->exists(b |&#xA;            b.relatedFeature->includes(featureWithValue) and&#xA;            b.relatedFeature->includes(value.result) and&#xA;            if not isInitial then &#xA;                b.featuringType = featureWithValue.featuringType&#xA;            else &#xA;                b.featuringType->exists(t |&#xA;                    t.oclIsKindOf(Feature) and&#xA;                    t.oclAsType(Feature).chainingFeature =&#xA;                        Sequence{&#xA;                            resolveGlobal(&quot;Base::things::that&quot;),&#xA;                            resolveGlobal(&quot;Occurrences::Occurrence::startShot&quot;)&#xA;                        }&#xA;                )&#xA;            endif)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featureWithValue" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="valuation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> to be provided a value.&lt;/p>&#xA;&#xA;&lt;p>The Feature to be provided a value.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Membership/membershipOwningNamespace"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="value" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="expressedValuation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> that provides the value of the &lt;code>featureWithValue&lt;/code> as its &lt;code>result&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The Expression that provides the value as a result.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//OwningMembership/ownedMemberElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isInitial" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>FeatureValue&lt;/code> specifies a bound value or an initial value for the &lt;code>featureWithValue&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isDefault" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>FeatureValue&lt;/code> is a concrete specification of the bound or initial value of the &lt;code>featureWithValue&lt;/code>, or just a default value that may be overridden.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Association" eSuperTypes="#//Classifier #//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Association&lt;/code> is a &lt;code>Relationship&lt;/code> and a &lt;code>Classifier&lt;/code> to enable classification of links between things (in the universe). The co-domains (&lt;code>types&lt;/code>) of the &lt;code>associationEnd&lt;/code> &lt;code>Features&lt;/code> are the &lt;code>relatedTypes&lt;/code>, as co-domain and participants (linked things) of an &lt;code>Association&lt;/code> identify each other.&lt;/p>&#xA;&#xA;relatedType = associationEnd.type&#xA;specializesFromLibrary(&quot;Links::Link&quot;)&#xA;oclIsKindOf(Structure) = oclIsKindOf(AssociationStructure)&#xA;ownedEndFeature->size() = 2 implies&#xA;    specializesFromLibrary(&quot;Links::BinaryLink)&#xA;not isAbstract implies relatedType->size() >= 2&#xA;associationEnds->size() > 2 implies&#xA;    not specializesFromLibrary(&quot;Links::BinaryLink&quot;)&#xA;sourceType =&#xA;    if relatedType->isEmpty() then null&#xA;    else relatedType->first() endif&#xA;targetType =&#xA;    if relatedType->size() &lt; 2 then OrderedSet{}&#xA;    else &#xA;        relatedType->&#xA;            subSequence(2, relatedType->size())->&#xA;            asOrderedSet() &#xA;    endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="relatedType" unique="false"
+        upperBound="-1" eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="association"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>types&lt;/code> of the &lt;code>associationEnds&lt;/code> of the &lt;code>Association&lt;/code>, which are the &lt;code>relatedElements&lt;/code> of the &lt;code>Association&lt;/code> considered as a &lt;code>Relationship&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/relatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="sourceType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="sourceAssociation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The source &lt;code>relatedType&lt;/code> for this &lt;code>Association&lt;/code>. It is the first &lt;code>relatedType&lt;/code> of the &lt;code>Association&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Association/relatedType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="targetType" ordered="false"
+        upperBound="-1" eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="targetAssociation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The target &lt;code>relatedTypes&lt;/code> for this &lt;code>Association&lt;/code>. This includes all the &lt;code>relatedTypes&lt;/code> other than the &lt;code>sourceType&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+      <eAnnotations source="subsets" references="#//Association/relatedType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="associationEnd" ordered="false"
+        upperBound="-1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="associationWithEnd"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>features&lt;/code> of the &lt;code>Association&lt;/code> that identify the things that can be related by it. A concrete &lt;code>Association&lt;/code> must have at least two &lt;code>associationEnds&lt;/code>. When it has exactly two, the &lt;code>Association&lt;/code> is called a &lt;em>binary&lt;/em> &lt;code>Association&lt;/code>.&lt;/p> &#xA;&#xA;&lt;p>The ends of the Association determine which elements are eligible to be related by instances of the Association.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Type/endFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AssociationStructure" eSuperTypes="#//Association #//Structure">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AssociationStructure&lt;/code> is an &lt;code>Association&lt;/code> that is also a &lt;code>Structure&lt;/code>, classifying link objects that are both links and objects. As objects, link objects can be created and destroyed, and their non-end &lt;code>Features&lt;/code> can change over time. However, the values of the end &lt;code>Features&lt;/code> of a link object are fixed and cannot change over its lifetime.&lt;/p>&#xA;specializesFromLibrary(&quot;Objects::ObjectLink&quot;)&#xA;endFeature->size() = 2 implies&#xA;    specializesFromLibrary(&quot;Objects::BinaryLinkObject&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="BooleanExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>BooleanExpression&lt;/code> is a &lt;em>&lt;code>Boolean&lt;/code>&lt;/em>-valued &lt;code>Expression&lt;/code> whose type is a &lt;code>Predicate&lt;/code>. It represents a logical condition resulting from the evaluation of the &lt;code>Predicate&lt;/code>.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Performances::booleanEvaluations&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="predicate" ordered="false"
+        eType="#//Predicate" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedBooleanExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Predicate&lt;/code> that types this &lt;code>BooleanExpression&lt;/code>.&lt;/p>&#xA;&lt;p>The Predicate that types the Expression.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Expression/function"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Predicate" eSuperTypes="#//Function">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Predicate&lt;/code> is a &lt;code>Function&lt;/code> whose &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> has type &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> and multiplicity &lt;code>1..1&lt;/code>.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Performances::BooleanEvaluation&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ResultExpressionMembership" eSuperTypes="#//FeatureMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ResultExpressionMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> that indicates that the &lt;code>ownedResultExpression&lt;/code> provides the result values for the &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code> that owns it. The owning &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code> must contain a &lt;code>BindingConnector&lt;/code> between the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the &lt;code>ownedResultExpression&lt;/code> and the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the owning &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code>.&lt;/p>&#xA;&#xA;owningType.oclIsKindOf(Function) or owningType.oclIsKindOf(Expression)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedResultExpression"
+        ordered="false" lowerBound="1" eType="#//Expression" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningResultExpressionMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> that provides the result for the owner of the &lt;code>ResultExpressionMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//FeatureMembership/ownedMemberFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Invariant" eSuperTypes="#//BooleanExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Invariant&lt;/code> is a &lt;code>BooleanExpression&lt;/code> that is asserted to have a specific &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> result value. If &lt;code>isNegated = false&lt;/code>, then the result is asserted to be true. If &lt;code>isNegated = true&lt;/code>, then the result is asserted to be false.&lt;/p>&#xA;&#xA;if isNegated then&#xA;    specializesFromLibrary(&quot;Performances::falseEvaluations&quot;)&#xA;else&#xA;    specializesFromLibrary(&quot;Performances::trueEvaluations&quot;)&#xA;endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isNegated" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>Invariant&lt;/code> is asserted to be false rather than true.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ReturnParameterMembership" eSuperTypes="#//ParameterMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ReturnParameterMembership&lt;/code> is a &lt;code>ParameterMembership&lt;/code> that indicates that the &lt;code>ownedMemberParameter&lt;/code> is the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of a &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code>. The &lt;code>direction&lt;/code> of the &lt;code>ownedMemberParameter&lt;/code> must be &lt;code>out&lt;/code>.&lt;/p>&#xA;&#xA;owningType.oclIsKindOf(Function) or owningType.oclIsKindOf(Expression)&#xA;ownedMemberParameter.direction = ParameterDirectionKind::out"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ItemFlow" eSuperTypes="#//Connector #//Step">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ItemFlow&lt;/code> is a &lt;code>Step&lt;/code> that represents the transfer of objects or data values from one &lt;code>Feature&lt;/code> to another. &lt;code>ItemFlows&lt;/code> can take non-zero time to complete.&lt;/p>&#xA;&#xA;if itemFlowEnds->isEmpty() then&#xA;    specializesFromLibrary(&quot;Transfers::transfers&quot;)&#xA;else&#xA;    specializesFromLibrary(&quot;Transfers::flowTransfers&quot;)&#xA;endif&#xA;itemType =&#xA;    if itemFeature = null then Sequence{}&#xA;    else itemFeature.type&#xA;    endif&#xA;sourceOutputFeature =&#xA;    if connectorEnd->isEmpty() or &#xA;        connectorEnd.ownedFeature->isEmpty()&#xA;    then null&#xA;    else connectorEnd.ownedFeature->first()&#xA;    endif&#xA;targetInputFeature =&#xA;    if connectorEnd->size() &lt; 2 or &#xA;        connectorEnd->at(2).ownedFeature->isEmpty()&#xA;    then null&#xA;    else connectorEnd->at(2).ownedFeature->first()&#xA;    endif&#xA;itemFlowEnd = connectorEnd->selectByKind(ItemFlowEnd)&#xA;itemFeature =&#xA;    let itemFeatures : Sequence(ItemFeature) = &#xA;        ownedFeature->selectByKind(ItemFeature) in&#xA;    if itemFeatures->isEmpty() then null&#xA;    else itemFeatures->first()&#xA;    endif&#xA;ownedFeature->selectByKind(ItemFeature)->size() &lt;= 1"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="itemType" unique="false"
+        upperBound="-1" eType="#//Classifier" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="itemFlowForType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The type of values transferred, which is the &lt;code>type&lt;/code> of the &lt;code>itemFeature&lt;/code> of the &lt;code>ItemFlow&lt;/code>.&lt;/p>&#xA;&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="targetInputFeature" unique="false"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="itemFlowToInput"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that receives the values carried by the &lt;code>ItemFlow&lt;/code>. It must be an owned &lt;code>output&lt;/code> of the target participant of the &lt;code>ItemFlow&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="sourceOutputFeature" unique="false"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="itemFlowFromOutput"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that provides the items carried by the &lt;code>ItemFlow&lt;/code>. It must be an owned &lt;code>output&lt;/code> of the &lt;code>source&lt;/code> of the &lt;code>ItemFlow&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="itemFlowEnd" upperBound="2"
+        eType="#//ItemFlowEnd" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>connectorEnds&lt;/code> of this &lt;code>ItemFlow&lt;/code> that are &lt;code>ItemFlowEnds&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Connector/connectorEnd"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="itemFeature" ordered="false"
+        eType="#//ItemFeature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedFeature&lt;/code> of the &lt;code>ItemFlow&lt;/code> that is an &lt;code>ItemFeature&lt;/code> (if any).&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="interaction" upperBound="-1"
+        eType="#//Interaction" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Interactions&lt;/code> that type this &lt;code>ItemFlow&lt;/code>. &lt;code>Interactions&lt;/code> are both &lt;code>Associations&lt;/code> and &lt;code>Behaviors&lt;/code>, which can type &lt;code>Connectors&lt;/code> and &lt;code>Steps&lt;/code>, respectively.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Connector/association #//Step/behavior"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Connector" eSuperTypes="#//Feature #//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Connector&lt;/code> is a usage of &lt;code>Associations&lt;/code>, with links restricted according to instances of the &lt;code>Type&lt;/code> in which they are used (domain of the &lt;code>Connector&lt;/code>). The &lt;code>associations&lt;/code> of the &lt;code>Connector&lt;/code> restrict what kinds of things might be linked. The &lt;code>Connector&lt;/code> further restricts these links to be between values of &lt;code>Features&lt;/code> on instances of its domain.&lt;/p>&#xA;&#xA;relatedFeature = connectorEnd.ownedReferenceSubsetting->&#xA;    select(s | s &lt;> null).subsettedFeature&#xA;relatedFeature->forAll(f | &#xA;    if featuringType->isEmpty() then f.isFeaturedWithin(null)&#xA;    else featuringType->exists(t | f.isFeaturedWithin(t))&#xA;    endif)&#xA;sourceFeature = &#xA;    if relatedFeature->isEmpty() then null &#xA;    else relatedFeature->first() &#xA;    endif&#xA;targetFeature =&#xA;    if relatedFeature->size() &lt; 2 then OrderedSet{}&#xA;    else &#xA;        relatedFeature->&#xA;            subSequence(2, relatedFeature->size())->&#xA;            asOrderedSet()&#xA;    endif&#xA;not isAbstract implies relatedFeature->size() >= 2&#xA;specializesFromLibrary(&quot;Links::links&quot;)&#xA;association->exists(oclIsKindOf(AssociationStructure)) implies&#xA;    specializesFromLibrary(&quot;Objects::linkObjects&quot;)&#xA;connectorEnds->size() = 2 and&#xA;association->exists(oclIsKindOf(AssocationStructure)) implies&#xA;    specializesFromLibrary(&quot;Objects::binaryLinkObjects&quot;)&#xA;connectorEnd->size() = 2 implies&#xA;    specializesFromLibrary(&quot;Links::binaryLinks&quot;)&#xA;connectorEnds->size() > 2 implies&#xA;    not specializesFromLibrary(&quot;Links::BinaryLink&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="relatedFeature" unique="false"
+        upperBound="-1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="connector"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Features&lt;/code> that are related by this &lt;code>Connector&lt;/code> considered as a &lt;code>Relationship&lt;/code> and that restrict the links it identifies, given by the referenced &lt;code>Features&lt;/code> of the &lt;code>connectorEnds&lt;/code> of the &lt;code>Connector&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/relatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="association" upperBound="-1"
+        eType="#//Association" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedConnector"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Associations&lt;/code> that type the &lt;code>Connector&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Feature/type"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isDirected" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>For a binary &lt;code>Connector&lt;/code>, whether or not the &lt;code>Connector&lt;/code> should be considered to have a direction from &lt;code>sourceFeature&lt;/code> to &lt;code>targetFeature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="connectorEnd" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringConnector"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>endFeatures&lt;/code> of a &lt;code>Connector&lt;/code>, which redefine the &lt;code>endFeatures&lt;/code> of the &lt;code>associations&lt;/code> of the &lt;code>Connector&lt;/code>. The &lt;code>connectorEnds&lt;/code> determine via &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationships&lt;/code> which &lt;code>Features&lt;/code> are related by the &lt;code>Connector&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Type/endFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="sourceFeature" eType="#//Feature"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="sourceConnector"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The source &lt;code>relatedFeature&lt;/code> for this &lt;code>Connector&lt;/code>. It is the first &lt;code>relatedFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Connector/relatedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="targetFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="targetConnector"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="p>The target &lt;code>relatedFeatures&lt;/code> for this &lt;code>Connector&lt;/code>. This includes all the &lt;code>relatedFeatures&lt;/code> other than the &lt;code>sourceFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+      <eAnnotations source="subsets" references="#//Connector/relatedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ItemFlowEnd" eSuperTypes="#//Feature">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ItemFlowEnd&lt;/code> is a &lt;code>Feature&lt;/code> that is one of the &lt;code>connectorEnds&lt;/code> giving the &lt;code>&lt;em>source&lt;/em>&lt;/code> or &lt;code>&lt;em>target&lt;/em>&lt;/code> of an &lt;code>ItemFlow&lt;/code>. For &lt;code>ItemFlows&lt;/code> typed by &lt;code>&lt;em>FlowTransfer&lt;/em>&lt;/code> or its specializations, &lt;code>ItemFlowEnds&lt;/code> must have exactly one &lt;code>ownedFeature&lt;/code>, which redefines &lt;code>&lt;em>Transfer::source::sourceOutput&lt;/em>&lt;/code> or &lt;code>&lt;em>Transfer::target::targetInput&lt;/em>&lt;/code> and redefines the corresponding feature of the &lt;code>relatedElement&lt;/code> for its end.&lt;/p>&#xA;isEnd&#xA;ownedFeature->size() = 1&#xA;owningType &lt;> null and owningType.oclIsKindOf(ItemFlow)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ItemFeature" eSuperTypes="#//Feature">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ItemFeature&lt;/code> is the &lt;code>ownedFeature&lt;/code> of an &lt;code>ItemFlow&lt;/code> that identifies the things carried by the kinds of transfers that are instances of the &lt;code>ItemFlow&lt;/code>.&lt;/p>&#xA;ownedRedefinition.redefinedFeature->&#xA;    redefinesFromLibrary(&quot;Transfers::Transfer::item&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Interaction" eSuperTypes="#//Association #//Behavior">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Interaction&lt;/code> is a &lt;code>Behavior&lt;/code> that is also an &lt;code>Association&lt;/code>, providing a context for multiple objects that have behaviors that impact one another.&lt;/p>&#xA;"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SuccessionItemFlow" eSuperTypes="#//ItemFlow #//Succession">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>SuccessionItemFlow&lt;/code> is an &lt;code>ItemFlow&lt;/code> that also provides temporal ordering. It classifies &lt;code>&lt;em>Transfers&lt;/em>&lt;/code> that cannot start until the source &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> has completed and that must complete before the target &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> can start.&lt;/p>&#xA;specializesFromLibrary(&quot;Transfers::flowTransfersBefore&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Succession" eSuperTypes="#//Connector">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Succession&lt;/code> is a binary &lt;code>Connector&lt;/code> that requires its &lt;code>relatedFeatures&lt;/code> to happen separately in time.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Occurences::happensBeforeLinks&quot;)&#xA;transitionStep =&#xA;    if owningNamespace.oclIsKindOf(Step) and &#xA;        owningNamespace.oclAsType(Step).&#xA;            specializesFromLibrary('TransitionPerformances::TransitionPerformance') then&#xA;        owningNamespace.oclAsType(Step)&#xA;    else null&#xA;    endif&#xA;triggerStep =&#xA;    if transitionStep = null or &#xA;       transitionStep.ownedFeature.size() &lt; 2 or&#xA;       not transitionStep.ownedFeature->at(2).oclIsKindOf(Step) &#xA;    then Set{}&#xA;    else Set{transitionStep.ownedFeature->at(2).oclAsType(Step)}&#xA;    endif&#xA;effectStep =&#xA;    if transitionStep = null or &#xA;       transitionStep.ownedFeature.size() &lt; 4 or&#xA;       not transitionStep.ownedFeature->at(4).oclIsKindOf(Step) &#xA;    then Set{}&#xA;    else Set{transitionStep.ownedFeature->at(4).oclAsType(Step)}&#xA;    endif&#xA;guardExpression =&#xA;    if transitionStep = null or &#xA;       transitionStep.ownedFeature.size() &lt; 3 or&#xA;       not transitionStep.ownedFeature->at(3).oclIsKindOf(Expression) &#xA;    then Set{}&#xA;    else Set{transitionStep.ownedFeature->at(3).oclAsType(Expression)}&#xA;    endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="transitionStep" ordered="false"
+        eType="#//Step" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="succession"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>Step&lt;/code> that is typed by the &lt;code>Behavior&lt;/code> &lt;code>&lt;em>TransitionPerformances::TransitionPerformance&lt;/em>&lt;/code> (from the Kernel Semantic Library) that has this &lt;code>Succession&lt;/code> as its &lt;em>&lt;code>transitionLink&lt;/code>&lt;/em>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="triggerStep" ordered="false"
+        upperBound="-1" eType="#//Step" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="succession"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Steps&lt;/code> that map incoming events to the timing of occurrences of the &lt;code>transitionStep&lt;/code>. The values of &lt;code>triggerStep&lt;/code> subset the list of acceptable events to be received by a &lt;code>Behavior&lt;/code> or the object that performs it.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="effectStep" ordered="false"
+        upperBound="-1" eType="#//Step" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="succession"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Steps&lt;/code> that represent occurrences that are side effects of the &lt;code>transitionStep&lt;/code> occurring.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="guardExpression" ordered="false"
+        upperBound="-1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="succession"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Expressions&lt;/code> that must evaluate to true before the &lt;code>transitionStep&lt;/code> can occur.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="BindingConnector" eSuperTypes="#//Connector">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>BindingConnector&lt;/code> is a binary &lt;code>Connector&lt;/code> that requires its &lt;code>relatedFeatures&lt;/code> to identify the same things (have the same values).&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Links::selfLinks&quot;)&#xA;relatedFeature->size() = 2"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MultiplicityRange" eSuperTypes="#//Multiplicity">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>MultiplicityRange&lt;/code> is a &lt;code>Multiplicity&lt;/code> whose value is defined to be the (inclusive) range of natural numbers given by the result of a &lt;code>lowerBound&lt;/code> &lt;code>Expression&lt;/code> and the result of an &lt;code>upperBound&lt;/code> &lt;code>Expression&lt;/code>. The result of these &lt;code>Expressions&lt;/code> shall be of type &lt;code>&lt;em>Natural&lt;/em>&lt;/code>. If the result of the &lt;code>upperBound&lt;/code> &lt;code>Expression&lt;/code> is the unbounded value &lt;code>*&lt;/code>, then the specified range includes all natural numbers greater than or equal to the &lt;code>lowerBound&lt;/code> value. If no &lt;code>lowerBound&lt;/code> &lt;code>Expression&lt;/code>, then the default is that the lower bound has the same value as the upper bound, except if the &lt;code>upperBound&lt;/code> evaluates to &lt;code>*&lt;/code>, in which case the default for the lower bound is 0.&lt;/p>&#xA;&#xA;bound->forAll(b | b.featuringType = self.featuringType)&#xA;bound.result->forAll(specializesFromLibrary('ScalarValues::Natural'))&#xA;lowerBound =&#xA;    let ownedMembers : Sequence(Element) = &#xA;        ownedMembership->selectByKind(OwningMembership).ownedMember in&#xA;    if ownedMembers->size() &lt; 2 or &#xA;        not ownedMembers->first().oclIsKindOf(Expression) then null&#xA;    else ownedMembers->first().oclAsType(Expression)&#xA;    endif&#xA;upperBound =&#xA;    let ownedMembers : Sequence(Element) = &#xA;        ownedMembership->selectByKind(OwningMembership).ownedMember in&#xA;    if ownedMembers->isEmpty() or &#xA;       not ownedMembers->last().oclIsKindOf(Expression) &#xA;    then null&#xA;    else ownedMembers->last().oclAsType(Expression)&#xA;    endif "/>
+    </eAnnotations>
+    <eOperations name="hasBounds" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>MultiplicityRange&lt;/code> represents the range bounded by the given values &lt;code>lower&lt;/code> and &lt;code>upper&lt;/code>, presuming the &lt;code>lowerBound&lt;/code> and &lt;code>upperBound&lt;/code> &lt;code>Expressions&lt;/code> are model-level evaluable.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="valueOf(upperBound) = upper and&#xA;let lowerValue: UnlimitedNatural = valueOf(lowerBound) in&#xA;(lowerValue = lower or&#xA; lowerValue = null and &#xA;    (lower = upper or &#xA;     lower = 0 and upper = *))&#xA; "/>
+      </eAnnotations>
+      <eParameters name="lower" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Integer"/>
+      <eParameters name="upper" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//UnlimitedNatural"/>
+    </eOperations>
+    <eOperations name="valueOf" ordered="false" eType="ecore:EDataType uml_types.ecore#//UnlimitedNatural">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Evaluate the given &lt;code>bound&lt;/code> &lt;code>Expression&lt;/code> (at model level) and return the result represented as a MOF &lt;code>UnlimitedNatural&lt;/code> value.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/uml2/1.1.0/GenModel">
+        <details key="body" value="if bound = null or not bound.isModelLevelEvaluable then &#xA;    null&#xA;else&#xA;    let boundEval: Sequence(Element) = bound.evaluate(owningType) in&#xA;    if boundEval->size() &lt;> 1 then null else&#xA;        let valueEval: Element = boundEval->at(1) in&#xA;        if valueEval.oclIsKindOf(LiteralInfinity) then *&#xA;        else if valueEval.oclIsKindOf(LiteralInteger) then&#xA;            let value : Integer = &#xA;                valueEval.oclAsKindOf(LiteralInteger).value in&#xA;            if value >= 0 then value else null endif&#xA;        else null&#xA;        endif endif&#xA;    endif&#xA;endif "/>
+      </eAnnotations>
+      <eParameters name="bound" ordered="false" eType="#//Expression"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="lowerBound" ordered="false"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="multiplicity"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> whose result provides the lower bound of the &lt;code>MultiplicityRange&lt;/code>. If no &lt;code>lowerBound&lt;/code> &lt;code>Expression&lt;/code> is given, then the lower bound shall have the same value as the upper bound, unless the upper bound is unbounded (&lt;code>*&lt;/code>), in which case the lower bound shall be 0.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//MultiplicityRange/bound"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="upperBound" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="multiplicity"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="The &lt;code>Expression&lt;/code> whose result is the upper bound of the &lt;code>MultiplicityRange&lt;/code>."/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//MultiplicityRange/bound"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="bound" lowerBound="1" upperBound="2"
+        eType="#//Expression" changeable="false" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="multiplicity"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owned &lt;code>Expressions&lt;/code> of the &lt;code>MultiplicityRange&lt;/code> whose results provide its bounds. These must be the only &lt;code>ownedMembers&lt;/code> of the &lt;code>MultiplicityRange&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="union"/>
+      <eAnnotations source="redefines" references="#//Namespace/ownedMember"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+</ecore:EPackage>

--- a/gaphor/codegen/sysmlv2.ecore
+++ b/gaphor/codegen/sysmlv2.ecore
@@ -1,0 +1,5268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="sysmlv2" nsURI="https://www.omg.org/spec/SysML/20230201" nsPrefix="sysml">
+  <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
+    <details key="settingDelegates" value="http://www.omg.org/spec/SysML"/>
+  </eAnnotations>
+  <eClassifiers xsi:type="ecore:EClass" name="InterfaceUsage" eSuperTypes="#//ConnectionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>InterfaceUsage&lt;/code> is a Usage of an &lt;code>InterfaceDefinition&lt;/code> to represent an interface connecting parts of a system through specific ports.&lt;/p>&#xA;ownedEndFeature->size() = 2 implies&#xA;    specializesFromLibrary(&quot;Interfaces::binaryInterfaces&quot;)&#xA;specializesFromLibrary(&quot;Interfaces::interfaces&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="interfaceDefinition" ordered="false"
+        upperBound="-1" eType="#//InterfaceDefinition" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedInterface"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>InterfaceDefinitions&lt;/code> that type this &lt;code>InterfaceUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//ConnectionUsage/connectionDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ConnectionUsage" eSuperTypes="#//ConnectorAsUsage #//PartUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ConnectionUsage&lt;/code> is a &lt;code>ConnectorAsUsage&lt;/code> that is also a &lt;code>PartUsage&lt;/code>. Nominally, if its type is a &lt;code>ConnectionDefinition&lt;/code>, then a &lt;code>ConnectionUsage&lt;/code> is a Usage of that &lt;code>ConnectionDefinition&lt;/code>, representing a connection between parts of a system. However, other kinds of kernel &lt;code>AssociationStructures&lt;/code> are also allowed, to permit use of &lt;code>AssociationStructures&lt;/code> from the Kernel Model Libraries.&lt;/p>&#xA;specializesFromLibrary(&quot;Connections::connections&quot;)&#xA;ownedEndFeature->size() = 2 implies&#xA;    specializesFromLibrary(&quot;Connections::binaryConnections&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="connectionDefinition" upperBound="-1"
+        eType="#//AssociationStructure" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedConnection"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AssociationStructures&lt;/code> that are the types of this &lt;code>ConnectionUsage&lt;/code>. Nominally, these are , but other kinds of Kernel &lt;code>AssociationStructures&lt;/code> are also allowed, to permit use of &lt;code>AssociationStructures&lt;/code> from the Kernel Model Libraries&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Connector/association"/>
+      <eAnnotations source="subsets" references="#//ItemUsage/itemDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ConnectorAsUsage" abstract="true" eSuperTypes="#//Usage #//Connector">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ConnectorAsUsage&lt;/code> is both a &lt;code>Connector&lt;/code> and a &lt;code>Usage&lt;/code>. &lt;code>ConnectorAsUsage&lt;/code> cannot itself be instantiated in a SysML model, but it is the base class for the concrete classes &lt;code>BindingConnectorAsUsage&lt;/code>, &lt;code>SuccessionAsUsage&lt;/code> and &lt;code>ConnectionUsage&lt;/code>.&lt;/p>"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Usage" eSuperTypes="#//Feature">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Usage&lt;/code> is a usage of a &lt;code>Definition&lt;/code>. A &lt;code>Usage&lt;/code> may only be an &lt;code>ownedFeature&lt;/code> of a &lt;code>Definition&lt;/code> or another &lt;code>Usage&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>A &lt;code>Usage&lt;/code> may have &lt;code>nestedUsages&lt;/code> that model &lt;code>features&lt;/code> that apply in the context of the &lt;code>owningUsage&lt;/code>. A &lt;code>Usage&lt;/code> may also have &lt;code>Definitions&lt;/code> nested in it, but this has no semantic significance, other than the nested scoping resulting from the &lt;code>Usage&lt;/code> being considered as a &lt;code>Namespace&lt;/code> for any nested &lt;code>Definitions&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>However, if a &lt;code>Usage&lt;/code> has &lt;code>isVariation = true&lt;/code>, then it represents a &lt;em>variation point&lt;/em> &lt;code>Usage&lt;/code>. In this case, all of its &lt;code>members&lt;/code> must be &lt;code>variant&lt;/code> &lt;code>Usages&lt;/code>, related to the &lt;code>Usage&lt;/code> by &lt;code>VariantMembership&lt;/code> &lt;code>Relationships&lt;/code>. Rather than being &lt;code>features&lt;/code> of the &lt;code>Usage&lt;/code>, &lt;code>variant&lt;/code> &lt;code>Usages&lt;/code> model different concrete alternatives that can be chosen to fill in for the variation point &lt;code>Usage&lt;/code>.&lt;/p>&#xA;variant = variantMembership.ownedVariantUsage&#xA;variantMembership = ownedMembership->selectByKind(VariantMembership)&#xA;not isVariation implies variantMembership->isEmpty()&#xA;isVariation implies variantMembership = ownedMembership&#xA;isReference = not isComposite&#xA;owningVariationUsage &lt;> null implies&#xA;    specializes(owningVariationUsage)&#xA;isVariation implies&#xA;    not ownedSpecialization.specific->exists(isVariation)&#xA;owningVariationDefinition &lt;> null implies&#xA;    specializes(owningVariationDefinition)&#xA;directedUsage = directedFeature->selectByKind(Usage)&#xA;nestedAction = nestedUsage->selectByKind(ActionUsage)&#xA;nestedAllocation = nestedUsage->selectByKind(AllocationUsage)&#xA;nestedAnalysisCase = nestedUsage->selectByKind(AnalysisCaseUsage)&#xA;nestedAttribute = nestedUsage->selectByKind(AttributeUsage)&#xA;nestedCalculation = nestedUsage->selectByKind(CalculationUsage)&#xA;nestedCase = nestedUsage->selectByKind(CaseUsage)&#xA;nestedConcern = nestedUsage->selectByKind(ConcernUsage)&#xA;nestedConnection = nestedUsage->selectByKind(ConnectorAsUsage)&#xA;nestedConstraint = nestedUsage->selectByKind(ConstraintUsage)&#xA;ownedNested = nestedUsage->selectByKind(EnumerationUsage)&#xA;nestedFlow = nestedUsage->selectByKind(FlowUsage)&#xA;nestedInterface = nestedUsage->selectByKind(ReferenceUsage)&#xA;nestedItem = nestedUsage->selectByKind(ItemUsage)&#xA;nestedMetadata = nestedUsage->selectByKind(MetadataUsage)&#xA;nestedOccurrence = nestedUsage->selectByKind(OccurrenceUsage)&#xA;nestedPart = nestedUsage->selectByKind(PartUsage)&#xA;nestedPort = nestedUsage->selectByKind(PortUsage)&#xA;nestedReference = nestedUsage->selectByKind(ReferenceUsage)&#xA;nestedRendering = nestedUsage->selectByKind(RenderingUsage)&#xA;nestedRequirement = nestedUsage->selectByKind(RequirementUsage)&#xA;nestedState = nestedUsage->selectByKind(StateUsage)&#xA;nestedTransition = nestedUsage->selectByKind(TransitionUsage)&#xA;nestedUsage = ownedFeature->selectByKind(Usage)&#xA;nestedUseCase = nestedUsage->selectByKind(UseCaseUsage)&#xA;nestedVerificationCase = nestedUsage->selectByKind(VerificationCaseUsage)&#xA;nestedView = nestedUsage->selectByKind(ViewUsage)&#xA;nestedViewpoint = nestedUsage->selectByKind(ViewpointUsage)&#xA;usage = feature->selectByKind(Usage)&#xA;owningType &lt;> null implies&#xA;    (owningType.oclIsKindOf(Definition) or&#xA;     ownigType.oclIsKindOf(Usage))"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isReference" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" volatile="true"
+        transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>Usage&lt;/code> is a referential &lt;code>Usage&lt;/code>, that is, it has &lt;code>isComposite = false&lt;/code>.&lt;p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isVariation" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>Usage&lt;/code> is for a variation point or not. If true, then all the &lt;code>memberships&lt;/code> of the &lt;code>Usage&lt;/code> must be &lt;code>VariantMemberships&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="variant" ordered="false"
+        upperBound="-1" eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningVariationUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Usages&lt;/code> which represent the variants of this &lt;code>Usage&lt;/code> as a variation point &lt;code>Usage&lt;/code>, if &lt;code>isVariation = true&lt;/code>. If &lt;code>isVariation = false&lt;/code>, then there must be no &lt;code>variants&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="variantMembership" ordered="false"
+        upperBound="-1" eType="#//VariantMembership" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningVariationUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedMemberships&lt;/code> of this &lt;code>Usage&lt;/code> that are &lt;code>VariantMemberships&lt;/code>. If &lt;code>isVariation = true&lt;/code>, then this must be all &lt;code>memberships&lt;/code> of the &lt;code>Usage&lt;/code>. If &lt;code>isVariation = false&lt;/code>, then &lt;code>variantMembership&lt;/code>must be empty.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMembership"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningDefinition" ordered="false"
+        eType="#//Definition" volatile="true" transient="true" derived="true" eOpposite="#//Definition/ownedUsage">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Definition&lt;/code> that owns this &lt;code>Usage&lt;/code> (if any).&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Feature/owningType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningUsage" ordered="false"
+        eType="#//Usage" volatile="true" transient="true" derived="true" eOpposite="#//Usage/nestedUsage">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Usage&lt;/code> in which this &lt;code>Usage&lt;/code> is nested (if any).&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Feature/owningType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedUsage" upperBound="-1"
+        eType="#//Usage" volatile="true" transient="true" derived="true" eOpposite="#//Usage/owningUsage">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Usages&lt;/code> that are &lt;code>ownedFeatures&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature #//Usage/usage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="definition" upperBound="-1"
+        eType="#//Classifier" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Classifiers&lt;/code> that are the types of this &lt;code>Usage&lt;/code>. Nominally, these are &lt;code>Definitions&lt;/code>, but other kinds of Kernel &lt;code>Classifiers&lt;/code> are also allowed, to permit use of &lt;code>Classifiers&lt;/code> from the Kernel Model Libraries.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Feature/type"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="usage" upperBound="-1"
+        eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Usages&lt;/code> that are &lt;code>features&lt;/code> of this &lt;code>Usage&lt;/code> (not necessarily owned).&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="directedUsage" upperBound="-1"
+        eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value=" /usageWithDirectedUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>usages&lt;/code> of this &lt;code>Usage&lt;/code> that are &lt;code>directedFeatures&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/usage #//Type/directedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedReference" upperBound="-1"
+        eType="#//ReferenceUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="referenceOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ReferenceUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedAttribute" upperBound="-1"
+        eType="#//AttributeUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="attributeOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The code>AttributeUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedEnumeration" upperBound="-1"
+        eType="#//EnumerationUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="enumerationOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The code>EnumerationUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedAttribute"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedOccurrence" upperBound="-1"
+        eType="#//OccurrenceUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="occurrenceOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>OccurrenceUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedItem" upperBound="-1"
+        eType="#//ItemUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="itemOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ItemUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedOccurrence"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedPart" upperBound="-1"
+        eType="#//PartUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="partOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>PartUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedItem"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedPort" upperBound="-1"
+        eType="#//PortUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="portOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>PortUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedConnection" upperBound="-1"
+        eType="#//ConnectorAsUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="connectionOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConnectorAsUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>. Note that this list includes &lt;code>BindingConnectorAsUsages&lt;/code> and &lt;code>SuccessionAsUsages&lt;/code>, even though these are &lt;code>ConnectorAsUsages&lt;/code> but not &lt;code>ConnectionUsages&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedPart"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedFlow" ordered="false"
+        upperBound="-1" eType="#//FlowConnectionUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="flowOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The code>FlowConnectionUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedConnection"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedInterface" upperBound="-1"
+        eType="#//InterfaceUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="interfaceOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>InterfaceUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedConnection"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedAllocation" upperBound="-1"
+        eType="#//AllocationUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="allocationOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AllocationUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedConnection"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedAction" upperBound="-1"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="actionOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedOccurrence"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedState" upperBound="-1"
+        eType="#//StateUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="stateOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>StateUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedAction"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedTransition" ordered="false"
+        upperBound="-1" eType="#//TransitionUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="transitionOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>TransitionUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedCalculation" upperBound="-1"
+        eType="#//CalculationUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="calculationOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>CalculationUsage&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedAction"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedConstraint" upperBound="-1"
+        eType="#//ConstraintUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="constraintOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConstraintUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedOccurrence"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedRequirement" upperBound="-1"
+        eType="#//RequirementUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="requirementOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>RequirementUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedConstraint"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedConcern" ordered="false"
+        upperBound="-1" eType="#//ConcernUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="concernOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConcernUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedRequirement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedCase" upperBound="-1"
+        eType="#//CaseUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="caseOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>CaseUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedCalculation"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedAnalysisCase" upperBound="-1"
+        eType="#//AnalysisCaseUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="analysisCaseOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AnalysisCaseUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedCase"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedVerificationCase"
+        upperBound="-1" eType="#//VerificationCaseUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="verificationCaseOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>VerificationCaseUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedCase"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedUseCase" upperBound="-1"
+        eType="#//UseCaseUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="useCaseOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>UseCaseUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedCase"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedView" upperBound="-1"
+        eType="#//ViewUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="viewOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ViewUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedPart"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedViewpoint" upperBound="-1"
+        eType="#//ViewpointUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="viewpointOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ViewpointUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedRequirement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedRendering" upperBound="-1"
+        eType="#//RenderingUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="renderingOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>RenderingUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedPart"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nestedMetadata" upperBound="-1"
+        eType="#//MetadataUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="metadataOwningUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>MetadataUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this of this &lt;code>Usage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedItem"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Feature" eSuperTypes="#//Type">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Feature&lt;/code> is a &lt;code>Type&lt;/code> that classifies relations between multiple things (in the universe). The domain of the relation is the intersection of the &lt;code>featuringTypes&lt;/code> of the &lt;code>Feature&lt;/code>. (The domain of a &lt;code>Feature&lt;/code> with no &lt;code>featuringTyps&lt;/code> is implicitly the most general &lt;code>Type&lt;/code> &lt;em>&lt;code>Base::Anything&lt;/code>&lt;/em> from the Kernel Semantic Library.) The co-domain of the relation is the intersection of the &lt;code>types&lt;/code> of the &lt;code>Feature&lt;/code>.&#xA;&#xA;&lt;p>In the simplest cases, the &lt;code>featuringTypes&lt;/code> and &lt;code>types&lt;/code> are &lt;code>Classifiers&lt;/code> and the &lt;code>Feature&lt;/code> relates two things, one from the domain and one from the range. Examples include cars paired with wheels, people paired with other people, and cars paired with numbers representing the car length.&lt;/p>&#xA;&#xA;&lt;p>Since &lt;code>Features&lt;/code> are &lt;code>Types&lt;/code>, their &lt;code>featuringTypes&lt;/code> and &lt;code>types&lt;/code> can be &lt;code>Features&lt;/code>. In this case, the &lt;code>Feature&lt;/code> effectively classifies relations between relations, which can be interpreted as the sequence of things related by the domain &lt;code>Feature&lt;/code> concatenated with the sequence of things related by the co-domain &lt;code>Feature&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The &lt;em>values&lt;/em> of a &lt;code>Feature&lt;/code> for a given instance of its domain are all the instances of its co-domain that are related to that domain instance by the &lt;code>Feature&lt;/code>. The values of a &lt;code>Feature&lt;/code> with &lt;code>chainingFeatures&lt;/code> are the same as values of the last &lt;code>Feature&lt;/code> in the chain, which can be found by starting with values of the first &lt;code>Feature&lt;/code>, then using those values as domain instances to obtain valus of the second &lt;code>Feature&lt;/code>, and so on, to values of the last &lt;code>Feature&lt;/code>.&lt;/p>&#xA;&#xA;ownedRedefinition = ownedSubsetting->selectByKind(Redefinition)&#xA;ownedTypeFeaturing = ownedRelationship->selectByKind(TypeFeaturing)->&#xA;    select(tf | tf.featureOfType = self)&#xA;ownedSubsetting = ownedSpecialization->selectByKind(Subsetting)&#xA;ownedTyping = ownedGeneralization->selectByKind(FeatureTyping)&#xA;type =&#xA;    let types : OrderedSet(Type) = typing.type->&#xA;        union(subsetting.subsettedFeature.type)->&#xA;        asOrderedSet() in&#xA;    if chainingFeature->isEmpty() then types&#xA;    else &#xA;        types->union(chainingFeature->last().type)->&#xA;        asOrderedSet()&#xA;    endif&#xA;multiplicity &lt;> null implies multiplicity.featuringType = featuringType &#xA;specializesFromLibrary(&quot;Base::things&quot;)&#xA;chainingFeatures->excludes(self)&#xA;ownedFeatureChaining = ownedRelationship->selectByKind(FeatureChaining)&#xA;chainingFeature = ownedFeatureChaining.chainingFeature&#xA;chainingFeatures->size() &lt;> 1&#xA;isEnd and owningType &lt;> null implies&#xA;    let i : Integer = &#xA;        owningType.ownedFeature->select(isEnd) in&#xA;    owningType.ownedSpecialization.general->&#xA;        forAll(supertype |&#xA;            let ownedEndFeatures : Sequence(Feature) = &#xA;                supertype.ownedFeature->select(isEnd) in&#xA;            ownedEndFeatures->size() >= i implies&#xA;                redefines(ownedEndFeatures->at(i))&#xA;ownedMembership->&#xA;    selectByKind(FeatureValue)->&#xA;    forAll(fv | specializes(fv.value.result))&#xA;isEnd and owningType &lt;> null and&#xA;owningType.oclIsKindOf(Association) implies&#xA;    specializesFromLibrary(&quot;Links::Link::participants&quot;)&#xA;isComposite and&#xA;ownedTyping.type->includes(oclIsKindOf(Structure)) and&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(Structure) or&#xA; owningType.type->includes(oclIsKindOf(Structure))) implies&#xA;    specializesFromLibrary(&quot;Occurrence::Occurrence::suboccurrences&quot;)&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(LiteralExpression) or&#xA; owningType.oclIsKindOf(FeatureReferenceExpression)) implies&#xA;    if owningType.oclIsKindOf(LiteralString) then&#xA;        specializesFromLibrary(&quot;ScalarValues::String&quot;)&#xA;    else if owningType.oclIsKindOf(LiteralBoolean) then&#xA;        specializesFromLibrary(&quot;ScalarValues::Boolean&quot;)&#xA;    else if owningType.oclIsKindOf(LiteralInteger) then&#xA;        specializesFromLibrary(&quot;ScalarValues::Rational&quot;)&#xA;    else if owningType.oclIsKindOf(LiteralBoolean) then&#xA;        specializesFromLibrary(&quot;ScalarValues::Rational&quot;)&#xA;    else if owningType.oclIsKindOf(LiteralBoolean) then&#xA;        specializesFromLibrary(&quot;ScalarValues::Real&quot;)&#xA;    else specializes(&#xA;        owningType.oclAsType(FeatureReferenceExpression).referent)&#xA;    endif endif endif endif endif&#xA;&#xA;ownedTyping.type->exists(selectByKind(Class)) implies&#xA;    specializesFromLibrary(&quot;Occurrences::occurrences&quot;)&#xA;isComposite and&#xA;ownedTyping.type->includes(oclIsKindOf(Class)) and&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(Class) or&#xA; owningType.oclIsKindOf(Feature) and&#xA;    owningType.oclAsType(Feature).type->&#xA;        exists(oclIsKindOf(Class))) implies&#xA;    specializesFromLibrary(&quot;Occurrence::Occurrence::suboccurrences&quot;)&#xA;ownedTyping.type->exists(selectByKind(DataType)) implies&#xA;    specializesFromLibary(&quot;Base::dataValues&quot;)&#xA;owningType &lt;> null and&#xA;owningType.oclIsKindOf(ItemFlowEnd) and&#xA;owningType.ownedFeature->at(1) = self implies&#xA;    let flowType : Type = owningType.owningType in&#xA;    flowType &lt;> null implies&#xA;        let i : Integer = &#xA;            flowType.ownedFeature.indexOf(owningType) in&#xA;        (i = 1 implies &#xA;            redefinesFromLibrary(&quot;Transfers::Transfer::source::sourceOutput&quot;)) and&#xA;        (i = 2 implies&#xA;            redefinesFromLibrary(&quot;Transfers::Transfer::source::targetInput&quot;))&#xA;                 &#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(Behavior) or&#xA; owningType.oclIsKindOf(Step)) implies&#xA;    let i : Integer = &#xA;        owningType.ownedFeature->select(direction &lt;> null) in&#xA;    owningType.ownedSpecialization.general->&#xA;        forAll(supertype |&#xA;            let ownedParameters : Sequence(Feature) = &#xA;                supertype.ownedFeature->select(direction &lt;> null) in&#xA;            ownedParameters->size() >= i implies&#xA;                redefines(ownedParameters->at(i))&#xA;ownedTyping.type->exists(selectByKind(Structure)) implies&#xA;    specializesFromLibary(&quot;Objects::objects&quot;)&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(Function) and&#xA;    self = owningType.oclAsType(Function).result or&#xA; owningType.oclIsKindOf(Expression) and&#xA;    self = owningType.oclAsType(Expression).result) implies&#xA;    owningType.ownedSpecialization.general->&#xA;        select(oclIsKindOf(Function) or oclIsKindOf(Expression))->&#xA;        forAll(supertype |&#xA;            redefines(&#xA;                if superType.oclIsKindOf(Function) then&#xA;                    superType.oclAsType(Function).result&#xA;                else&#xA;                    superType.oclAsType(Expression).result&#xA;                endif)&#xA;ownedFeatureInverting = ownedRelationship->selectByKind(FeatureInverting)->&#xA;    select(fi | fi.featureInverted = self)&#xA;featuringType =&#xA;    let featuringTypes : OrderedSet(Type) = &#xA;        typeFeaturing.featuringType->asOrderedSet() in&#xA;    if chainingFeature->isEmpty() then featuringTypes&#xA;    else&#xA;        featuringTypes->&#xA;            union(chainingFeature->first().featuringType)->&#xA;            asOrderedSet()&#xA;    endif&#xA;ownedReferenceSubsetting =&#xA;    let referenceSubsettings : OrderedSet(ReferenceSubsetting) =&#xA;        ownedSubsetting->selectByKind(ReferenceSubsetting) in&#xA;    if referenceSubsettings->isEmpty() then null&#xA;    else referenceSubsettings->first() endif&#xA;ownedSubsetting->selectByKind(ReferenceSubsetting)->size() &lt;= 1"/>
+    </eAnnotations>
+    <eOperations name="directionFor" ordered="false" eType="#//FeatureDirectionKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the &lt;code>directionOf&lt;/code> this &lt;code>Feature&lt;/code> relative to the given &lt;code>type&lt;/code>.&lt;/p>&#xA;type.directionOf(self)"/>
+      </eAnnotations>
+      <eParameters name="type" ordered="false" lowerBound="1" eType="#//Type"/>
+    </eOperations>
+    <eOperations name="isFeaturedWithin" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return whether this Feature has the given &lt;code>type&lt;/code> as a direct or indirect &lt;code>featuringType&lt;/code>. If &lt;code>type&lt;/code> is null, then check if this Feature is implicitly directly or indirectly featured in &lt;em>Base::Anything&lt;/em>.&lt;/p>&#xA;type = null and feature.featuringType->isEmpty() or&#xA;    type &lt;> null and feature.featuringType->includes(type) or&#xA;    feature.featuringType->exists(t |&#xA;        t.oclIsKindOf(Feature) and&#xA;        t.oclAsType(Feature).isFeaturedWithin(type)) "/>
+      </eAnnotations>
+      <eParameters name="type" ordered="false" eType="#//Type"/>
+    </eOperations>
+    <eOperations name="namingFeature" ordered="false" eType="#//Feature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>By default, the naming &lt;code>Feature&lt;/code> of a &lt;code>Feature&lt;/code> is given by its first &lt;code>redefinedFeature&lt;/code> of its first &lt;code>ownedRedefinition&lt;/code>, if any.&lt;/p>&#xA;if ownedRedefinition->isEmpty() then&#xA;    null&#xA;else&#xA;    ownedRedefinition->at(1).redefinedFeature&#xA;endif"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="redefines" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>Feature&lt;/code> &lt;em>directly&lt;/em> redefines the given &lt;code>redefinedFeature&lt;/code>.&lt;/p>&#xA;ownedRedefinition.redefinedFeature->includes(redefinedFeature)"/>
+      </eAnnotations>
+      <eParameters name="redefinedFeature" ordered="false" lowerBound="1" eType="#//Feature"/>
+    </eOperations>
+    <eOperations name="redefinesFromLibrary" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>Feature&lt;/code> &lt;em>directly&lt;/em> redefines the named library &lt;code>Feature&lt;/code>. &lt;code>libraryFeatureName&lt;/code> must conform to the syntax of a KerML qualified name and must resolve to a &lt;code>Feature&lt;/code> in global scope.&lt;/p>&#xA;let mem: Membership = resolveGlobal(libraryFeatureName) in&#xA;mem &lt;> null and mem.memberElement.oclIsKindOf(Feature) and&#xA;redefines(mem.memberElement.oclAsType(Feature))"/>
+      </eAnnotations>
+      <eParameters name="libraryFeatureName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="subsetsChain" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>Feature&lt;/code> directly or indirectly specializes a &lt;code>Feature&lt;/code> whose last two &lt;code>chainingFeatures&lt;/code> are the given &lt;code>Features&lt;/code> &lt;code>first&lt;/code> and &lt;code>second&lt;/code>.&lt;/p>&#xA;allSuperTypes()->selectAsKind(Feature)->&#xA;    exists(f | let n: Integer = f.chainingFeature->size() in&#xA;        n >= 2 and&#xA;        f.chainingFeature->at(n-1) = first and&#xA;        f.chainingFeature->at(n) = second)"/>
+      </eAnnotations>
+      <eParameters name="first" ordered="false" lowerBound="1" eType="#//Feature"/>
+      <eParameters name="second" ordered="false" lowerBound="1" eType="#//Feature"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningFeatureMembership"
+        ordered="false" eType="#//FeatureMembership" volatile="true" transient="true"
+        derived="true" eOpposite="#//FeatureMembership/ownedMemberFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>FeatureMembership&lt;/code> that owns this &lt;code>Feature&lt;/code> as an &lt;code>ownedMemberFeature&lt;/code>, determining its &lt;code>owningType&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/owningMembership"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true" eOpposite="#//Type/ownedFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that is the &lt;code>owningType&lt;/code> of the &lt;code>owningFeatureMembership&lt;/code> of this &lt;code>Feature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/owningNamespace #//Feature/featuringType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="endOwningType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true" eOpposite="#//Type/ownedEndFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that is related to this &lt;code>Feature&lt;/code> by an &lt;code>EndFeatureMembership&lt;/code> in which the &lt;code>Feature&lt;/code> is an &lt;code>ownedMemberFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Feature/owningType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isUnique" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether or not values for this &lt;code>Feature&lt;/code> must have no duplicates or not.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isOrdered" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether an order exists for the values of this &lt;code>Feature&lt;/code> or not.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" upperBound="-1" eType="#//Type"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Types&lt;/code> that restrict the values of this &lt;code>Feature&lt;/code>, such that the values must be instances of all the &lt;code>types&lt;/code>. The types of a &lt;code>Feature&lt;/code> are derived from its &lt;code>typings&lt;/code> and the &lt;code>types&lt;/code> of its &lt;code>subsettings&lt;/code>. If the &lt;code>Feature&lt;/code> is chained, then the &lt;code>types&lt;/code> of the last &lt;code>Feature&lt;/code> in the chain are also &lt;code>types&lt;/code> of the chained &lt;code>Feature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedRedefinition" ordered="false"
+        upperBound="-1" eType="#//Redefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedSubsettings&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>Redefinitions&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>redefiningFeature&lt;/code>.&lt;/p>&#xA;&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Feature/ownedSubsetting"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedSubsetting" ordered="false"
+        upperBound="-1" eType="#//Subsetting" volatile="true" transient="true" derived="true"
+        eOpposite="#//Subsetting/owningFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedSpecializations&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>Subsettings&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>subsettingFeature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedSpecialization"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isComposite" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether the &lt;code>Feature&lt;/code> is a composite &lt;code>feature&lt;/code> of its &lt;code>featuringType&lt;/code>. If so, the values of the &lt;code>Feature&lt;/code> cannot exist after its featuring instance no longer does.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isEnd" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether or not the this &lt;code>Feature&lt;/code> is an end &lt;code>Feature&lt;/code>, requiring a different interpretation of the &lt;code>multiplicity&lt;/code> of the &lt;code>Feature&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>An end &lt;code>Feature&lt;/code> is always considered to map each domain instance to a single co-domain instance, whether or not a &lt;code>Multiplicity&lt;/code> is given for it. If a &lt;code>Multiplicity&lt;/code> is given for an end &lt;code>Feature&lt;/code>, rather than giving the co-domain cardinality for the &lt;code>Feature&lt;/code> as usual, it specifies a cardinality constraint for &lt;em>navigating&lt;/em> across the &lt;code>endFeatures&lt;/code> of the &lt;code>featuringType&lt;/code> of the end &lt;code>Feature&lt;/code>. That is, if a &lt;code>Type&lt;/code> has &lt;em>n&lt;/em> &lt;code>endFeatures&lt;/code>, then the &lt;code>Multiplicity&lt;/code> of any one of those end &lt;code>Features&lt;/code> constrains the cardinality of the set of values of that &lt;code>Feature&lt;/code> when the values of the other &lt;em>n-1&lt;/em> end &lt;code>Features&lt;/code> are held fixed.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedTyping" upperBound="-1"
+        eType="#//FeatureTyping" volatile="true" transient="true" derived="true" eOpposite="#//FeatureTyping/owningFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedSpecializations&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>FeatureTypings&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>typedFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedSpecialization"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featuringType" upperBound="-1"
+        eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featureOfType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Types&lt;/code> that feature this &lt;code>Feature&lt;/code>, such that any instance in the domain of the &lt;code>Feature&lt;/code> must be classified by all of these &lt;code>Types&lt;/code>, including at least all the &lt;code>featuringTypes&lt;/code> of its &lt;code>typeFeaturings&lt;/code>.  If the &lt;code>Feature&lt;/code> is chained, then the &lt;code>featuringTypes&lt;/code> of the first &lt;code>Feature&lt;/code> in the chain are also &lt;code>featuringTypes&lt;/code> of the chained &lt;code>Feature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedTypeFeaturing" upperBound="-1"
+        eType="#//TypeFeaturing" volatile="true" transient="true" derived="true" eOpposite="#//TypeFeaturing/owningFeatureOfType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>TypeFeaturings&lt;/code> and for which the &lt;code>Feature&lt;/code> is the &lt;code>featureOfType&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isDerived" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether the values of this &lt;code>Feature&lt;/code> can always be computed from the values of other &lt;code>Feature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="chainingFeature" unique="false"
+        upperBound="-1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="chainedFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that are chained together to determine the values of this &lt;code>Feature&lt;/code>, derived from the &lt;code>chainingFeatures&lt;/code> of the &lt;code>ownedFeatureChainings&lt;/code> of this &lt;code>Feature&lt;/code>, in the same order. The values of a &lt;code>Feature&lt;/code> with &lt;code>chainingFeatures&lt;/code> are the same as values of the last &lt;code>Feature&lt;/code> in the chain, which can be found by starting with the values of the first &lt;code>Feature&lt;/code> (for each instance of the domain of the original &lt;code>Feature&lt;/code>), then using each of those as domain instances to find the values of the second &lt;code>Feature&lt;/code> in chainingFeatures, and so on, to values of the last &lt;code>Feature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedFeatureInverting"
+        ordered="false" upperBound="-1" eType="#//FeatureInverting" volatile="true"
+        transient="true" derived="true" eOpposite="#//FeatureInverting/owningFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>FeatureInvertings&lt;/code> and for which the &lt;code>Feature&lt;/code> is the &lt;code>featureInverted&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedFeatureChaining" upperBound="-1"
+        eType="#//FeatureChaining" volatile="true" transient="true" derived="true"
+        eOpposite="#//FeatureChaining/featureChained">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>FeatureChainings&lt;/code>, for which the &lt;code>Feature&lt;/code> will be the &lt;code>featureChained&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isReadOnly" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether the values of this &lt;code>Feature&lt;/code> can change over the lifetime of an instance of the domain.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isPortion" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether the values of this &lt;code>Feature&lt;/code> are contained in the space and time of instances of the domain of the &lt;code>Feature&lt;/code> and represent the same thing as those instances.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="direction" ordered="false"
+        eType="#//FeatureDirectionKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates how values of this &lt;code>Feature&lt;/code> are determined or used (as specified for the &lt;code>FeatureDirectionKind&lt;/code>).&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedReferenceSubsetting"
+        ordered="false" eType="#//ReferenceSubsetting" volatile="true" transient="true"
+        derived="true" eOpposite="#//ReferenceSubsetting/referencingFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The one &lt;code>ownedSubsetting&lt;/code> of this &lt;code>Feature&lt;/code>, if any, that is a &lt;code>ReferenceSubsetting&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>referencingFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Feature/ownedSubsetting"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isNonunique" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" volatile="true"
+        transient="true" defaultValueLiteral="false" derived="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Type" eSuperTypes="#//Namespace">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Type&lt;/code> is a &lt;code>Namespace&lt;/code> that is the most general kind of &lt;code>Element&lt;/code> supporting the semantics of classification. A &lt;code>Type&lt;/code> may be a &lt;code>Classifier&lt;/code> or a &lt;code>Feature&lt;/code>, defining conditions on what is classified by the &lt;code>Type&lt;/code> (see also the description of &lt;code>isSufficient&lt;/code>).&lt;/p>&#xA;&#xA;ownedSpecialization = ownedRelationship->selectByKind(Specialization)->&#xA;    select(s | s.special = self)&#xA;    &#xA;multiplicity = &#xA;    let ownedMultiplicities: Sequence(Multiplicity) =&#xA;        ownedMember->selectByKind(Multiplicity) in&#xA;    if ownedMultiplicities->isEmpty() then null&#xA;    else ownedMultiplicities->first()&#xA;    endif&#xA;ownedFeatureMembership = ownedRelationship->selectByKind(FeatureMembership)&#xA;let ownedConjugators: Sequence(Conjugator) = &#xA;    ownedRelationship->selectByKind(Conjugation) in&#xA;    ownedConjugator = &#xA;        if ownedConjugators->isEmpty() then null &#xA;        else ownedConjugators->at(1) endif&#xA;output =&#xA;    if isConjugated then &#xA;        conjugator.originalType.input&#xA;    else &#xA;        feature->select(direction = out or direction = inout)&#xA;    endif&#xA;input = &#xA;    if isConjugated then &#xA;        conjugator.originalType.output&#xA;    else &#xA;        feature->select(direction = _'in' or direction = inout)&#xA;    endif&#xA;inheritedMembership = inheritedMemberships(Set{})&#xA;specializesFromLibrary('Base::Anything')&#xA;directedFeature = feature->select(f | directionOf(f) &lt;> null)&#xA;feature = featureMembership.ownedMemberFeature&#xA;featureMembership = ownedMembership->union(&#xA;    inheritedMembership->selectByKind(FeatureMembership))&#xA;ownedFeature = ownedFeatureMembership.ownedMemberFeature&#xA;differencingType = ownedDifferencing.differencingType&#xA;intersectingType->excludes(self)&#xA;differencingType->excludes(self)&#xA;unioningType = ownedUnioning.unioningType&#xA;unioningType->excludes(self)&#xA;intersectingType = ownedIntersecting.intersectingType&#xA;ownedRelationship->selectByKind(Conjugator)->size() &lt;= 1&#xA;ownedMember->selectByKind(Multiplicity)->size() &lt;= 1&#xA;endFeature = feature->select(isEnd)&#xA;ownedRelationship->selectByKind(Disjoining)&#xA;ownedRelationship->selectByKind(Unioning)&#xA;ownedRelationship->selectByKind(Intersecting)&#xA;ownedRelationship->selectByKind(Differencing)&#xA;ownedEndFeature = ownedFeature->select(isEnd)&#xA;inheritedFeature = inheritedMemberships->&#xA;    selectByKind(FeatureMembership).memberFeature"/>
+    </eAnnotations>
+    <eOperations name="inheritedMemberships" upperBound="-1" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the inherited &lt;code>Memberships&lt;/code> of this &lt;code>Type&lt;/code>, excluding those supertypes in the &lt;code>excluded&lt;/code> set.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eParameters name="excluded" ordered="false" upperBound="-1" eType="#//Type"/>
+    </eOperations>
+    <eOperations name="directionOf" ordered="false" eType="#//FeatureDirectionKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>If the given &lt;code>feature&lt;/code> is a &lt;code>feature&lt;/code> of this &lt;code>Type&lt;/code>, then return its direction relative to this &lt;code>Type&lt;/code>, taking conjugation into account.&lt;/p>&#xA;&#xA;if input->includes(feature) and output->includes(feature) then &#xA;    FeatureDirectionKind::inout&#xA;else if input->includes(feature) then &#xA;    FeatureDirectionKind::_'in'&#xA;else if output->includes(feature) then &#xA;    FeatureDirectionKind::out&#xA;else &#xA;    null &#xA;endif endif endif"/>
+      </eAnnotations>
+      <eParameters name="feature" ordered="false" lowerBound="1" eType="#//Feature"/>
+    </eOperations>
+    <eOperations name="allSupertypes" ordered="false" upperBound="-1" eType="#//Type">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return all &lt;code>Types&lt;/code> related to this &lt;code>Type&lt;/code> as supertypes directly or transitively by &lt;code>Specialization&lt;/code> &lt;code>Relationships&lt;/code>.&lt;/p>&#xA;&#xA;ownedSpecialization->&#xA;    closure(general.ownedSpecialization).general->&#xA;    including(self)"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="specializes" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>Type&lt;/code> is a direct or indirect specialization of the given &lt;code>supertype&lt;code>.&lt;/p>&#xA;if isConjugated then &#xA;    ownedConjugator.originalType.specializes(supertype)&#xA;else&#xA;    allSupertypes()->includes(supertype)&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="supertype" ordered="false" lowerBound="1" eType="#//Type"/>
+    </eOperations>
+    <eOperations name="specializesFromLibrary" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>Type&lt;/code> is a direct or indirect specialization of the named library &lt;code>Type&lt;/code>. &lt;code>libraryTypeName&lt;/code> must conform to the syntax of a KerML qualified name and must resolve to a &lt;code>Type&lt;/code> in global scope.&lt;/p>&#xA;&#xA;let mem : Membership = resolveGlobal(libraryTypeName) in&#xA;mem &lt;> null and mem.memberElement.oclIsKindOf(Type) and&#xA;specializes(mem.memberElement.oclAsType(Type))"/>
+      </eAnnotations>
+      <eParameters name="libraryTypeName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedSpecialization" upperBound="-1"
+        eType="#//Specialization" volatile="true" transient="true" derived="true"
+        eOpposite="#//Specialization/owningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Specializations&lt;/code>, for which the &lt;code>Type&lt;/code> is the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedFeatureMembership"
+        upperBound="-1" eType="#//FeatureMembership" volatile="true" transient="true"
+        derived="true" eOpposite="#//FeatureMembership/owningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedMemberships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>FeatureMemberships&lt;/code>, for which the &lt;code>Type&lt;/code> is the &lt;code>owningType&lt;/code>. Each such &lt;code>FeatureMembership&lt;/code> identifies an &lt;code>ownedFeature&lt;/code> of the &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMembership #//Type/featureMembership"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="feature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedMemberFeatures&lt;/code> of the &lt;code>featureMemberships&lt;/code> of this &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/member"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true" eOpposite="#//Feature/owningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedMemberFeatures&lt;/code> of the &lt;code>ownedFeatureMemberships&lt;/code> of this &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="input" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithInput"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>features&lt;/code> related to this &lt;code>Type&lt;/code> by &lt;code>FeatureMemberships&lt;/code> that have &lt;code>direction&lt;/code> &lt;code>in&lt;code> or &lt;code>inout&lt;code>.&lt;/code>&lt;/code>&lt;/code>&lt;/code>&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/directedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="output" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithOutput"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>features&lt;/code> related to this &lt;code>Type&lt;/code> by &lt;code>FeatureMemberships&lt;/code> that have &lt;code>direction&lt;/code> &lt;code>out&lt;code> or &lt;code>inout&lt;code>.&lt;/code>&lt;/code>&lt;/code>&lt;/code>&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/directedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isAbstract" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates whether instances of this &lt;code>Type&lt;/code> must also be instances of at least one of its specialized &lt;code>Types&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="inheritedMembership" upperBound="-1"
+        eType="#//Membership" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="inheritingType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>Memberships&lt;/code> inherited by this &lt;code>Type&lt;/code> via &lt;code>Specialization&lt;/code> or &lt;code>Conjugation&lt;/code>. These are included in the derived union for the &lt;code>memberships&lt;/code> of the &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/membership"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="endFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithEndFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>features&lt;/code> of this &lt;code>Type&lt;/code> with &lt;code>isEnd = true&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedEndFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true" eOpposite="#//Feature/endOwningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>endFeatures&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>ownedFeatures&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/endFeature #//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isSufficient" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether all things that meet the classification conditions of this &lt;code>Type&lt;/code> must be classified by the &lt;code>Type&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>(A &lt;code>Type&lt;/code>&amp;nbsp;gives conditions that must be met by whatever it classifies, but when &lt;code>isSufficient&lt;/code> is false, things may meet those conditions but still not be classified by the &lt;code>Type&lt;/code>. For example, a Type &lt;code>&lt;em>Car&lt;/em>&lt;/code> that is not sufficient could require everything it classifies to have four wheels, but not all four wheeled things would classify as cars. However, if the &lt;code>Type&lt;/code> &lt;code>&lt;em>Car&lt;/em>&lt;/code> were sufficient, it would classify all four-wheeled things.)&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedConjugator" ordered="false"
+        eType="#//Conjugation" volatile="true" transient="true" derived="true" eOpposite="#//Conjugation/owningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>Conjugation&lt;/code> owned by this &lt;code>Type&lt;/code> for which the &lt;code>Type&lt;/code> is the &lt;code>originalType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isConjugated" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" volatile="true"
+        transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates whether this &lt;code>Type&lt;/code> has an &lt;code>ownedConjugator&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="inheritedFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="inheritingType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All the &lt;code>memberFeatures&lt;/code> of the &lt;code>inheritedMemberships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>FeatureMemberships&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="multiplicity" ordered="false"
+        eType="#//Multiplicity" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithMultiplicity"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An &lt;code>ownedMember&lt;/code> of this &lt;code>Type&lt;/code> that is a &lt;code>Multiplicity&lt;/code>, which constraints the cardinality of the &lt;code>Type&lt;/code>. If there is no such &lt;code>ownedMember&lt;/code>, then the cardinality of this &lt;code>Type&lt;/code> is constrained by all the &lt;code>Multiplicity&lt;/code> constraints applicable to any direct supertypes.&lt;/p>&#xA;&#xA;&lt;p>&amp;nbsp;&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="unioningType" upperBound="-1"
+        eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="unionedType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The interpretations of a &lt;code>Type&lt;/code> with &lt;code>unioningTypes&lt;/code> are asserted to be the same as those of all the &lt;code>unioningTypes&lt;/code> together, which are the &lt;code>Types&lt;/code> derived from the &lt;code>unioningType&lt;/code> of the &lt;code>ownedUnionings&lt;/code> of this &lt;code>Type&lt;/code>. For example, a &lt;code>Classifier&lt;/code> for people might be the union of &lt;code>Classifiers&lt;/code> for all the sexes. Similarly, a feature for people&amp;#39;s children might be the union of features dividing them in the same ways as people in general.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedIntersecting" upperBound="-1"
+        eType="#//Intersecting" volatile="true" transient="true" derived="true" eOpposite="#//Intersecting/typeIntersected">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Intersectings&lt;/code>, have the &lt;code>Type&lt;/code> as their &lt;code>typeIntersected&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="intersectingType" upperBound="-1"
+        eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="intersectedType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The interpretations of a &lt;code>Type&lt;/code> with &lt;code>intersectingTypes&lt;/code> are asserted to be those in common among the &lt;code>intersectingTypes&lt;/code>, which are the &lt;code>Types&lt;/code> derived from the &lt;code>intersectingType&lt;/code> of the &lt;code>ownedIntersectings&lt;/code> of this &lt;code>Type&lt;/code>. For example, a &lt;code>Classifier&lt;/code> might be an intersection of &lt;code>Classifiers&lt;/code> for people of a particular sex and of a particular nationality. Similarly, a feature for people&amp;#39;s children of a particular sex might be the intersection of a &lt;code>Feature&lt;/code> for their children and a &lt;code>Classifier&lt;/code> for people of that sex (because the interpretations of the children &lt;code>Feature&lt;/code> that identify those of that sex are also interpretations of the Classifier for that sex).&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedUnioning" upperBound="-1"
+        eType="#//Unioning" volatile="true" transient="true" derived="true" eOpposite="#//Unioning/typeUnioned">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Unionings&lt;/code>, having the &lt;code>Type&lt;/code> as their &lt;code>typeUnioned&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedDisjoining" ordered="false"
+        upperBound="-1" eType="#//Disjoining" volatile="true" transient="true" derived="true"
+        eOpposite="#//Disjoining/owningType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Disjoinings&lt;/code>, for which the &lt;code>Type&lt;/code> is the &lt;code>typeDisjoined&lt;/code> &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featureMembership" upperBound="-1"
+        eType="#//FeatureMembership" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="type"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>FeatureMemberships&lt;/code> for &lt;code>features&lt;/code> of this &lt;code>Type&lt;/code>, which include all &lt;code>ownedFeatureMemberships&lt;/code> and those &lt;code>inheritedMemberships&lt;/code> that are &lt;code>FeatureMemberships&lt;/code> (but does &lt;em>not&lt;/em> include any &lt;code>importedMemberships&lt;/code>).&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="differencingType" upperBound="-1"
+        eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="differencedType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The interpretations of a &lt;code>Type&lt;/code> with &lt;code>differencingTypes&lt;/code> are asserted to be those of the first of those &lt;code>Types&lt;/code>, but not including those of the remaining &lt;code>Types&lt;/code>. For example, a &lt;code>Classifier&lt;/code> might be the difference of a &lt;code>Classifier&lt;/code> for people and another for people of a particular nationality, leaving people who are not of that nationality. Similarly, a feature of people might be the difference between a feature for their children and a &lt;code>Classifier&lt;/code> for people of a particular sex, identifying their children not of that sex (because the interpretations of the children &lt;code>Feature&lt;/code> that identify those of that sex are also interpretations of the &lt;code>Classifier&lt;/code> for that sex).&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedDifferencing" upperBound="-1"
+        eType="#//Differencing" volatile="true" transient="true" derived="true" eOpposite="#//Differencing/typeDifferenced">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Differencings&lt;/code>, having this &lt;code>Type&lt;/code> as their &lt;code>typeDifferenced&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="directedFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeWithDirectedFeature"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>features&lt;/code> of this &lt;code>Type&lt;/code> that have a non-null &lt;code>direction&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Namespace" eSuperTypes="#//Element">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Namespace&lt;/code> is an &lt;code>Element&lt;/code> that contains other &lt;code>Element&lt;/code>, known as its &lt;code>members&lt;/code>, via &lt;code>Membership&lt;/code> &lt;code>Relationships&lt;/code> with those &lt;code>Elements&lt;/code>. The &lt;code>members&lt;/code> of a &lt;code>Namespace&lt;/code> may be owned by the &lt;code>Namespace&lt;/code>, aliased in the &lt;code>Namespace&lt;/code>, or imported into the &lt;code>Namespace&lt;/code> via &lt;code>Import&lt;/code> &lt;code>Relationships&lt;/code> with other &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>A &lt;code>Namespace&lt;/code> can provide names for its &lt;code>members&lt;/code> via the &lt;code>memberNames&lt;/code> and &lt;code>memberShortNames&lt;/code> specified by the &lt;code>Memberships&lt;/code> in the &lt;code>Namespace&lt;/code>. If a &lt;code>Membership&lt;/code> specifies a &lt;code>memberName&lt;/code> and/or &lt;code>memberShortName&lt;/code>, then that those are names of the corresponding &lt;code>memberElement&lt;/code> relative to the &lt;code>Namespace&lt;/code>. For an &lt;code>OwningMembership&lt;/code>, the &lt;code>owningMemberName&lt;/code> and &lt;code>owningMemberShortName&lt;/code> are given by the &lt;code>Element&lt;/code> &lt;code>name&lt;/code> and &lt;code>shortName&lt;/code>. Note that the same &lt;code>Element&lt;/code> may be the &lt;code>memberElement&lt;/code> of multiple &lt;code>Memberships&lt;/code> in a &lt;code>Namespace&lt;/code> (though it may be owned at most once), each of which may define a separate alias for the &lt;code>Element&lt;/code> relative to the &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;membership->forAll(m1 | &#xA;    membership->forAll(m2 | &#xA;        m1 &lt;> m2 implies m1.isDistinguishableFrom(m2)))&#xA;member = membership.memberElement&#xA;ownedMember = ownedMembership->selectByKind(OwningMembership).ownedMemberElement&#xA;importedMembership = importedMemberships(Set{})&#xA;ownedImport = ownedRelationship->selectByKind(Import)&#xA;ownedMembership = ownedRelationship->selectByKind(Membership)"/>
+    </eAnnotations>
+    <eOperations name="namesOf" ordered="false" upperBound="-1" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the names of the given &lt;code>element&lt;/code> as it is known in this &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;let elementMemberships : Sequence(Membership) = &#xA;    memberships->select(memberElement = element) in&#xA;memberships.memberShortName->&#xA;    union(memberships.memberName)->&#xA;    asSet()"/>
+      </eAnnotations>
+      <eParameters name="element" ordered="false" lowerBound="1" eType="#//Element"/>
+    </eOperations>
+    <eOperations name="visibilityOf" ordered="false" lowerBound="1" eType="#//VisibilityKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Returns this visibility of &lt;code>mem&lt;/code> relative to this &lt;code>Namespace&lt;/code>. If &lt;code>mem&lt;/code> is an &lt;code>importedMembership&lt;/code>, this is the &lt;code>visibility&lt;/code> of its Import. Otherwise it is the &lt;code>visibility&lt;/code> of the &lt;code>Membership&lt;/code> itself.&lt;/p>&#xA;&#xA;if importedMembership->includes(mem) then&#xA;    ownedImport->&#xA;        select(importedMemberships(Set{})->includes(mem)).&#xA;        first().visibility&#xA;else if memberships->includes(mem) then&#xA;    mem.visibility&#xA;else&#xA;    VisibilityKind::private&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="mem" ordered="false" lowerBound="1" eType="#//Membership"/>
+    </eOperations>
+    <eOperations name="visibleMemberships" upperBound="-1" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>If &lt;code>includeAll = true&lt;/code>, then return all the &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code>. Otherwise, return only the publicly visible &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code> (which includes those &lt;code>ownedMemberships&lt;/code> that have a &lt;code>visibility&lt;/code> of &lt;code>public&lt;/code> and those &lt;code>importedMemberships&lt;/code> imported with a &lt;code>visibility&lt;/code> of &lt;code>public&lt;/code>). If &lt;code>isRecursive = true&lt;/code>, also recursively include all visible &lt;code>Memberships&lt;/code> of any visible owned &lt;code>Namespaces&lt;/code>.&lt;/p>&#xA;&#xA;let visibleMemberships : Sequence(Membership) =&#xA;    if includeAll then memberships&#xA;    else ownedMembership->&#xA;        select(visibility = VisibilityKind::public)->&#xA;        union(ownedImport->&#xA;            select(visibility = VisibilityKind::public).&#xA;            importedMemberships(excluded->including(self)))&#xA;    endif in&#xA;if not isRecursive then visibleMemberships&#xA;else visibleMemberships->union(visibleMemberships->&#xA;        selectAsKind(Namespace).&#xA;        visibleMemberships(excluded->including(self), true, includeAll))&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="excluded" ordered="false" upperBound="-1" eType="#//Namespace"/>
+      <eParameters name="isRecursive" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean"/>
+      <eParameters name="includeAll" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean"/>
+    </eOperations>
+    <eOperations name="importedMemberships" upperBound="-1" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Derive the imported &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code> as the &lt;code>importedMembership&lt;/code> of all &lt;code>ownedImports&lt;/code>, excluding those Imports whose &lt;code>importOwningNamespace&lt;/code> is in the &lt;code>excluded&lt;/code> set, and excluding &lt;code>Memberships&lt;/code> that have distinguisibility collisions with each other or with any &lt;code>ownedMembership&lt;/code>.&lt;/p>&#xA;&#xA;ownedImport.importedMemberships(excluded->including(self))"/>
+      </eAnnotations>
+      <eParameters name="excluded" ordered="false" upperBound="-1" eType="#//Namespace"/>
+    </eOperations>
+    <eOperations name="resolve" ordered="false" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Resolve the given qualified name to the named &lt;code>Membership&lt;/code> (if any), starting with this &lt;code>Namespace&lt;/code> as the local scope. The qualified name string must conform to the concrete syntax of the KerML textual notation. According to the KerML name resolution rules every qualified name will resolve to either a single &lt;code>Membership&lt;/code>, or to none.&lt;/p>&#xA;&#xA;let qualification : String = qualificationOf(qualifiedName) in&#xA;let name : String = unqualifiedNameOf(qualifiedName) in&#xA;if qualification = null then resolveLocal(name)&#xA;else &#xA;    let namespace : Element = resolve(qualification) in&#xA;    if namespace = null or not namespace.oclIsKindOf(Namespace) then null&#xA;    else namespace.oclAsType(Namespace).resolveVisible(name) endif&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="qualifiedName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="resolveGlobal" ordered="false" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Resolve the given qualified name to the named &lt;code>Membership&lt;/code> (if any) in the effective global &lt;code>Namespace&lt;/code> that is the outermost naming scope. The qualified name string must conform to the concrete syntax of the KerML textual notation.&lt;/p>&#xA;&#xA;No OCL"/>
+      </eAnnotations>
+      <eParameters name="qualifiedName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="resolveLocal" ordered="false" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Resolve a simple &lt;code>name&lt;/code> starting with this &lt;code>Namespace&lt;/code> as the local scope, and continuing with containing outer scopes as necessary. However, if this &lt;code>Namespace&lt;/code> is a root &lt;code>Namespace&lt;/code>, then the resolution is done directly in global scope.&lt;/p>&#xA;&#xA;if owningNamespace = null then resolveGlobal(name)&#xA;else&#xA;    let memberships : Membership = membership->&#xA;        select(memberShortName = name or memberName = name) in&#xA;    if memberships->notEmpty() then memberships->first()&#xA;    else owningNamspace.resolveLocal(name)&#xA;    endif&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="name" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="resolveVisible" ordered="false" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Resolve a simple name from the visible &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;let memberships : Sequence(Membership) =&#xA;    visibleMemberships(Set{}, false, false)->&#xA;    select(memberShortName = name or memberName = name) in&#xA;if memberships->isEmpty() then null&#xA;else memberships->first()&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="name" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="qualificationOf" ordered="false" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return a string with valid KerML syntax representing the qualification part of a given &lt;code>qualifiedName&lt;/code>, that is, a qualified name with all the segment names of the given name except the last. If the given &lt;code>qualifiedName&lt;/code> has only one segment, then return null.&lt;/p>&#xA;No OCL"/>
+      </eAnnotations>
+      <eParameters name="qualifiedName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eOperations name="unqualifiedNameOf" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the simple name that is the last segment name of the given &lt;code>qualifiedName&lt;/code>. If this segment name has the form of a KerML unrestricted name, then &quot;unescape&quot; it by removing the surrounding single quotes and replacing all escape sequences with the specified character.&lt;/p>&#xA;No OCL"/>
+      </eAnnotations>
+      <eParameters name="qualifiedName" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMembership" upperBound="-1"
+        eType="#//Membership" volatile="true" transient="true" derived="true" eOpposite="#//Membership/membershipOwningNamespace">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Namespace&lt;/code> that are &lt;code>Memberships&lt;/code>, for which the &lt;code>Namespace&lt;/code> is the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/membership #//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMember" upperBound="-1"
+        eType="#//Element" volatile="true" transient="true" derived="true" eOpposite="#//Element/owningNamespace">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owned &lt;code>members&lt;/code> of this &lt;code>Namespace&lt;/code>, which are the &lt;cpde>&lt;code>ownedMemberElements&lt;/code> of the &lt;code>ownedMemberships&lt;/code> of the .&lt;/cpde>&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/member"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="membership" upperBound="-1"
+        eType="#//Membership" changeable="false" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="membershipNamespace"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>All &lt;code>Memberships&lt;/code> in this &lt;code>Namespace&lt;/code>, including (at least) the union of &lt;code>ownedMemberships&lt;/code> and &lt;code>importedMemberships&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="union"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedImport" upperBound="-1"
+        eType="#//Import" volatile="true" transient="true" derived="true" eOpposite="#//Import/importOwningNamespace">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Namespace&lt;/code> that are &lt;code>Imports&lt;/code>, for which the &lt;code>Namespace&lt;/code> is the &lt;code>importOwningNamespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="member" upperBound="-1"
+        eType="#//Element" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="namespace"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The set of all member &lt;code>Elements&lt;/code> of this &lt;code>Namespace&lt;/code>, which are the &lt;code>memberElements&lt;/code> of all &lt;code>memberships&lt;/code> of the &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importedMembership" upperBound="-1"
+        eType="#//Membership" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="importingNamespace"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Memberships&lt;/code> in this &lt;code>Namespace&lt;/code> that result from the &lt;code>ownedImports&lt;/code> of this &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/membership"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Element" abstract="true">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Element&lt;/code> is a constituent of a model that is uniquely identified relative to all other &lt;code>Elements&lt;/code>. It can have &lt;code>Relationships&lt;/code> with other &lt;code>Elements&lt;/code>. Some of these &lt;code>Relationships&lt;/code> might imply ownership of other &lt;code>Elements&lt;/code>, which means that if an &lt;code>Element&lt;/code> is deleted from a model, then so are all the &lt;code>Elements&lt;/code> that it owns.&lt;/p>&#xA;&#xA;ownedElement = ownedRelationship.ownedRelatedElement&#xA;owner = owningRelationship.owningRelatedElement&#xA;qualifiedName =&#xA;    if owningNamespace = null then null&#xA;    else if owningNamespace.owner = null then escapedName()&#xA;    else if owningNamespace.qualifiedName = null or &#xA;            escapedName() = null then null&#xA;    else owningNamespace.qualifiedName + '::' + escapedName()&#xA;    endif endif endif&#xA;documentation = ownedElement->selectByKind(Documentation)&#xA;ownedAnnotation = ownedRelationship->&#xA;    selectByKind(Annotation)->&#xA;    select(a | a.annotatedElement = self)&#xA;name = effectiveName()&#xA;ownedRelationship->exists(isImplied) implies isImpliedIncluded&#xA;isLibraryElement = libraryNamespace() &lt;>null&#xA;&#xA;shortName = effectiveShortName()&#xA;owningNamespace =&#xA;    if owningMembership = null then null&#xA;    else owningMembership.membershipOwningNamespace&#xA;    endif&#xA;textualRepresentation = ownedElement->selectByKind(TextualRepresentation)"/>
+    </eAnnotations>
+    <eOperations name="escapedName" ordered="false" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return &lt;code>name&lt;/code>, if that is not null, otherwise the &lt;code>shortName&lt;/code>, if that is not null, otherwise null. If the returned value is non-null, it is returned as-is if it has the form of a basic name, or, otherwise, represented as a restricted name according to the lexical structure of the KerML textual notation (i.e., surrounded by single quote characters and with special characters escaped).&lt;/p>"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="effectiveShortName" ordered="false" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return an effective &lt;code>shortName&lt;/code> for this &lt;code>Element&lt;/code>. By default this is the same as its &lt;code>declaredShortName&lt;/code>.&lt;/p>&#xA;declaredShortName"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="effectiveName" ordered="false" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return an effective &lt;code>name&lt;/code> for this &lt;code>Element&lt;/code>. By default this is the same as its &lt;code>declaredName&lt;/code>.&lt;/p>&#xA;declaredName"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="libraryNamespace" ordered="false" eType="#//Namespace">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>By default, return the library Namespace of the &lt;code>owningRelationship&lt;/code> of this Element, if it has one.&lt;/p>&#xA;if owningRelationship &lt;> null then owningRelationship.libraryNamespace()&#xA;else null endif"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningMembership" ordered="false"
+        eType="#//OwningMembership" volatile="true" transient="true" derived="true"
+        eOpposite="#//OwningMembership/ownedMemberElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>owningRelationship&lt;/code> of this &lt;code>Element&lt;/code>, if that &lt;code>Relationship&lt;/code> is a &lt;code>Membership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/owningRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedRelationship" upperBound="-1"
+        eType="#//Relationship" containment="true" eOpposite="#//Relationship/owningRelatedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Relationships for which this Element is the &lt;tt>owningRelatedElement&lt;/tt>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningRelationship" ordered="false"
+        eType="#//Relationship" eOpposite="#//Relationship/ownedRelatedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Relationship for which this Element is an &lt;tt>ownedRelatedElement&lt;/tt>, if any.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningNamespace" ordered="false"
+        eType="#//Namespace" volatile="true" transient="true" derived="true" eOpposite="#//Namespace/ownedMember">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Namespace&lt;/code> that owns this &lt;code>Element&lt;/code>, which is the &lt;code>membershipOwningNamespace&lt;/code> of the &lt;code>owningMembership&lt;/code> of this &lt;code>Element&lt;/code>, if any.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="elementId" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String" iD="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The globally unique identifier for this Element. This is intended to be set by tooling, and it must not change during the lifetime of the Element.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owner" ordered="false"
+        eType="#//Element" volatile="true" transient="true" derived="true" eOpposite="#//Element/ownedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owner of this Element, derived as the &lt;code>owningRelatedElement&lt;/code> of the &lt;code>owningRelationship&lt;/code> of this Element, if any.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedElement" upperBound="-1"
+        eType="#//Element" volatile="true" transient="true" derived="true" eOpposite="#//Element/owner">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Elements owned by this Element, derived as the &lt;tt>ownedRelatedElements&lt;/tt> of the &lt;tt>ownedRelationships&lt;/tt> of this Element.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="documentation" upperBound="-1"
+        eType="#//Documentation" volatile="true" transient="true" derived="true" eOpposite="#//Documentation/documentedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Documentation owned by this Element.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedAnnotation" upperBound="-1"
+        eType="#//Annotation" volatile="true" transient="true" derived="true" eOpposite="#//Annotation/owningAnnotatedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Element&lt;/code> that are &lt;code>Annotations&lt;/code>, for which this &lt;code>Element&lt;/code> is the &lt;code>annotatedElement&lt;/code>.&lt;/code>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedRelationship"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="textualRepresentation"
+        upperBound="-1" eType="#//TextualRepresentation" volatile="true" transient="true"
+        derived="true" eOpposite="#//TextualRepresentation/representedElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>TextualRepresentations&lt;/code> that annotate this &lt;code>Element&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Element/ownedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="aliasIds" upperBound="-1"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Various alternative identifiers for this Element. Generally, these will be set by tools.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="declaredShortName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An optional alternative name for the &lt;code>Element&lt;/code> that is intended to be shorter or in some way more succinct than its primary &lt;code>name&lt;/code>. It may act as a modeler-specified identifier for the &lt;code>Element&lt;/code>, though it is then the responsibility of the modeler to maintain the uniqueness of this identifier within a model or relative to some other context.&lt;/p> &#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="declaredName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The declared name of this &lt;code>Element&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="shortName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The short name to be used for this &lt;code>Element&lt;/code> during name resolution within its &lt;code>owningNamespace&lt;/code>. This is derived using the &lt;code>effectiveShortName()&lt;/code> operation. By default, it is the same as the &lt;code>declaredShortName&lt;/code>, but this is overridden for certain kinds of &lt;code>Elements&lt;/code> to compute a &lt;code>shortName&lt;/code> even when the &lt;code>declaredName&lt;/code> is null.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" ordered="false" eType="ecore:EDataType uml_types.ecore#//String"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The name to be used for this &lt;code>Element&lt;/code> during name resolution within its &lt;code>owningNamespace&lt;/code>. This is derived using the &lt;code>effectiveName()&lt;/code> operation. By default, it is the same as the &lt;code>declaredName&lt;/code>, but this is overridden for certain kinds of &lt;code>Elements&lt;/code> to compute a &lt;code>name&lt;/code> even when the &lt;code>declaredName&lt;/code> is null.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="qualifiedName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The full ownership-qualified name of this &lt;code>Element&lt;/code>, represented in a form that is valid according to the KerML textual concrete syntax for qualified names (including use of unrestricted name notation and escaped characters, as necessary). The &lt;code>qualifiedName&lt;/code> is null if this &lt;code>Element&lt;/code> has no &lt;code>owningNamespace&lt;/code> or if there is not a complete ownership chain of named &lt;code>Namespaces&lt;/code> from a root &lt;code>Namespace&lt;/code> to this &lt;code>Element&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isImpliedIncluded" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether all necessary implied Relationships have been included in the &lt;code>ownedRelationships&lt;/code> of this Element. This property may be true, even if there are not actually any &lt;code>ownedRelationships&lt;/code> with &lt;code>isImplied = true&lt;/code>, meaning that no such Relationships are actually implied for this Element. However, if it is false, then &lt;code>ownedRelationships&lt;/code> may &lt;em>not&lt;/em> contain any implied Relationships. That is, either &lt;em>all&lt;/em> required implied Relationships must be included, or none of them.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isLibraryElement" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" volatile="true"
+        transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this Element is contained in the ownership tree of a library model.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="OwningMembership" eSuperTypes="#//Membership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>OwningMembership&lt;/code> is a &lt;code>Membership&lt;/code> that owns its &lt;code>memberElement&lt;/code> as a &lt;code>ownedRelatedElement&lt;/code>. The &lt;code>ownedMemberElementM&lt;/code> becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>&#xA;&#xA;ownedMemberName = ownedMemberElement.name&#xA;ownedMemberShortName = ownedMemberElement.shortName"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="ownedMemberElementId" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String" volatile="true"
+        transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>elementId&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Membership/memberElementId"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="ownedMemberShortName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>shortName&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Membership/memberShortName"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="ownedMemberName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>name&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Membership/memberName"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMemberElement" ordered="false"
+        lowerBound="1" eType="#//Element" volatile="true" transient="true" derived="true"
+        eOpposite="#//Element/owningMembership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> that becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> due to this &lt;code>OwningMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Membership/memberElement"/>
+      <eAnnotations source="subsets" references="#//Relationship/ownedRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Membership" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Membership&lt;/code> is a &lt;code>Relationship&lt;/code> between a &lt;code>Namespace&lt;/code> and an &lt;code>Element&lt;/code> that indicates the &lt;code>Element&lt;/code> is a &lt;code>member&lt;/code> of (i.e., is contained in) the Namespace. Any &lt;code>memberNames&lt;/code> specify how the &lt;code>memberElement&lt;/code> is identified in the &lt;code>Namespace&lt;/code> and the &lt;code>visibility&lt;/code> specifies whether or not the &lt;code>memberElement&lt;/code> is publicly visible from outside the &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>If a &lt;code>Membership&lt;/code> is an &lt;code>OwningMembership&lt;/code>, then it owns its &lt;code>memberElement&lt;/code>, which becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code>. Otherwise, the &lt;code>memberNames&lt;/code> of a &lt;code>Membership&lt;/code> are effectively aliases within the &lt;code>membershipOwningNamespace&lt;/code> for an &lt;code>Element&lt;/code> with a separate &lt;code>OwningMembership&lt;/code> in the same or a different &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>&amp;nbsp;&lt;/p>&#xA;&#xA;memberElementId = memberElement.elementId"/>
+    </eAnnotations>
+    <eOperations name="isDistinguishableFrom" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>Membership&lt;/code> is distinguishable from a given &lt;code>other&lt;/code> &lt;code>Membership&lt;/code>. By default, this is true if this &lt;code>Membership&lt;/code> has no &lt;code>memberShortName&lt;/code> or &lt;code>memberName&lt;/code>; or each of the &lt;code>memberShortName&lt;/code> and &lt;code>memberName&lt;/code> are different than both of those of the &lt;code>other&lt;/code> &lt;code>Membership&lt;/code>; or neither of the metaclasses of the &lt;code>memberElement&lt;/code> of this &lt;code>Membership&lt;/code> and the &lt;code>memberElement&lt;/code> of the &lt;code>other&lt;/code> &lt;code>Membership&lt;/code> conform to the other. But this may be overridden in specializations of &lt;code>Membership&lt;/code>.&lt;/p>&#xA;&#xA;not (memberElement.oclKindOf(other.memberElement.oclType()) or&#xA;     other.memberElement.oclKindOf(memberElement.oclType())) or&#xA;(shortMemberName = null or&#xA;    (shortMemberName &lt;> other.shortMemberName and&#xA;     shortMemberName &lt;> other.memberName)) and&#xA;(memberName = null or&#xA;    (memberName &lt;> other.shortMemberName and&#xA;     memberName &lt;> other.memberName)))&#xA;"/>
+      </eAnnotations>
+      <eParameters name="other" ordered="false" lowerBound="1" eType="#//Membership"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="memberElementId" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String" volatile="true"
+        transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>elementId&lt;/code> of the &lt;code>memberElement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="membershipOwningNamespace"
+        ordered="false" lowerBound="1" eType="#//Namespace" volatile="true" transient="true"
+        derived="true" eOpposite="#//Namespace/ownedMembership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Namespace&lt;/code> of which the &lt;code>memberElement&lt;/code> becomes a &lt;cpde>member due to this &lt;code>Membership&lt;/code>.&lt;/cpde>&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="memberShortName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The short name of the &lt;code>memberElement&lt;/code> relative to the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="memberElement" ordered="false"
+        lowerBound="1" eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="membership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> that becomes a &lt;code>member&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> due to this &lt;code>Membership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="memberName" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The name of the &lt;code>memberElement&lt;/code> relative to the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="visibility" ordered="false"
+        lowerBound="1" eType="#//VisibilityKind" defaultValueLiteral="public">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether or not the &lt;code>Membership&lt;/code> of the &lt;code>memberElement&lt;/code> in the &lt;code>membershipOwningNamespace&lt;/code> is publicly visible outside that &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Relationship" abstract="true" eSuperTypes="#//Element">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Relationship&lt;/code> is an &lt;code>Element&lt;/code> that relates other &lt;code>Element&lt;/code>. Some of its &lt;code>relatedElements&lt;/code> may be owned, in which case those &lt;code>ownedRelatedElements&lt;/code> will be deleted from a model if their &lt;code>owningRelationship&lt;/code> is. A &lt;code>Relationship&lt;/code> may also be owned by another &lt;code>Element&lt;/code>, in which case the &lt;code>ownedRelatedElements&lt;/code> of the &lt;code>Relationship&lt;/code> are also considered to be transitively owned by the &lt;code>owningRelatedElement&lt;/code> of the &lt;code>Relationship&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The &lt;code>relatedElements&lt;/code> of a &lt;code>Relationship&lt;/code> are divided into &lt;code>source&lt;/code> and &lt;code>target&lt;/code> &lt;code>Elements&lt;/code>. The &lt;code>Relationship&lt;/code> is considered to be directed from the &lt;code>source&lt;/code> to the &lt;code>target&lt;/code> &lt;code>Elements&lt;/code>. An undirected &lt;code>Relationship&lt;/code> may have either all &lt;code>source&lt;/code> or all &lt;code>target&lt;/code> &lt;code>Elements&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>A &amp;quot;relationship &lt;code>Element&lt;/code>&amp;quot; in the abstract syntax is generically any &lt;code>Element&lt;/code> that is an instance of either &lt;code>Relationship&lt;/code> or a direct or indirect specialization of &lt;code>Relationship&lt;/code>. Any other kind of &lt;code>Element&lt;/code> is a &amp;quot;non-relationship &lt;code>Element&lt;/code>&amp;quot;. It is a convention of that non-relationship &lt;code>Elements&lt;/code> are &lt;em>only&lt;/em> related via reified relationship &lt;code>Elements&lt;/code>. Any meta-associations directly between non-relationship &lt;code>Elements&lt;/code> must be derived from underlying reified &lt;code>Relationship&lt;/code>.&lt;/p>&#xA;&#xA;relatedElement = source->union(target)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="relatedElement" unique="false"
+        upperBound="-1" eType="#//Element" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="relationship"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Elements that are related by this Relationship, derived as the union of the &lt;code>source&lt;/code> and &lt;code>target&lt;/code> Elements of the Relationship.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="target" upperBound="-1"
+        eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="targetRelationship"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>relatedElements&lt;/code> to which this Relationship is considered to be directed.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="source" upperBound="-1"
+        eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="sourceRelationship"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>relatedElements&lt;/c ode> from which this Relationship is considered to be directed.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningRelatedElement" ordered="false"
+        eType="#//Element" eOpposite="#//Element/ownedRelationship">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;tt>relatedElement&lt;/tt> of this Relationship that owns the Relationship, if any.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedRelatedElement" upperBound="-1"
+        eType="#//Element" containment="true" eOpposite="#//Element/owningRelationship">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;tt>relatedElements&lt;/tt> of this Relationship that are owned by the Relationship.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isImplied" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this Relationship was generated by tooling to meet semantic rules, rather than being directly created by a modeler.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="VisibilityKind">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>VisibilityKind&lt;/code> is an enumeration whose literals specify the visibility of a &lt;code>Membership&lt;/code> of an &lt;code>Element&lt;/code> in a &lt;code>Namespace&lt;/code> outside of that &lt;code>Namespace&lt;/code>. Note that &amp;quot;visibility&amp;quot; specifically restricts whether an &lt;code>Element&lt;/code> in a &lt;code>Namespace&lt;/code> may be referenced by name from outside the &lt;code>Namespace&lt;/code> and only otherwise restricts access to an &lt;code>Element&lt;/code> as provided by specific constraints in the abstract syntax (e.g., preventing the import or inheritance of private &lt;code>Elements&lt;/code>).&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eLiterals name="private">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates a &lt;code>Membership&lt;/code> is not visible outside its owning &lt;code>Namespace&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="protected" value="1">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An intermediate level of visibility between &lt;code>public&lt;/code> and &lt;code>private&lt;/code>. By default, it is equivalent to &lt;code>private&lt;/code> for the purposes of normal access to and import of &lt;code>Elements&lt;/code> from a &lt;code>Namespace&lt;/code>. However, other &lt;code>Relationships&lt;/code> may be specified to include &lt;code>Memberships&lt;/code> with &lt;code>protected&lt;/code> visibility in the list of &lt;code>memberships&lt;/code> for a &lt;code>Namespace&lt;/code> (e.g., &lt;code>Specialization&lt;/code>).&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="public" value="2">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates that a &lt;code>Membership&lt;/code> is publicly visible outside its owning &lt;code>Namespace&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Documentation" eSuperTypes="#//Comment">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Documentation&lt;/code> is a &lt;code>Comment&lt;/code> that specifically documents a &lt;code>documentedElement&lt;/code>, which must be its &lt;code>owner&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="documentedElement" ordered="false"
+        lowerBound="1" eType="#//Element" volatile="true" transient="true" derived="true"
+        eOpposite="#//Element/documentation">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> that is documented by this &lt;code>Documentation&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//AnnotatingElement/annotatedElement"/>
+      <eAnnotations source="subsets" references="#//Element/owner"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Comment" eSuperTypes="#//AnnotatingElement">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Comment&lt;/code> is an &lt;code>AnnotatingElement&lt;/code> whose &lt;code>body&lt;/code> in some way describes its &lt;code>annotatedElements&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="locale" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Identification of the language of the &lt;code>body&lt;/code> text and, optionally, the region and/or encoding. The format shall be a POSIX locale conformant to ISO/IEC 15897, with the format &lt;code>[language[_territory][.codeset][@modifier]]&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="body" ordered="false" lowerBound="1"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The annotation text for the &lt;code>Comment&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AnnotatingElement" eSuperTypes="#//Element">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AnnotatingElement&lt;/code> is an &lt;code>Element&lt;/code> that provides additional description of or metadata on some other &lt;code>Element&lt;/code>. An &lt;code>AnnotatingElement&lt;/code> is either attached to its &lt;code>annotatedElements&lt;/code> by &lt;code>Annotation&lt;/code> &lt;code>Relationships&lt;/code>, or it implicitly annotates its &lt;code>owningNamespace&lt;/code>.&lt;/p>&#xA;&#xA;annotatedElement = &#xA; if annotation->notEmpty() then annotation.annotatedElement&#xA; else Sequence{owningNamespace} endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotation" upperBound="-1"
+        eType="#//Annotation" eOpposite="#//Annotation/annotatingElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Annotations&lt;/code> that relate this &lt;code>AnnotatingElement&lt;/code> to its &lt;code>annotatedElements&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotatedElement" lowerBound="1"
+        upperBound="-1" eType="#//Element" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="annotatingElement"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Elements&lt;/code> that are annotated by this &lt;code>AnnotatingElement&lt;/code>. If &lt;code>annotation&lt;/code> is not empty, these are the &lt;code>annotatedElements&lt;/code> of the &lt;code>annotations&lt;/code>. If &lt;code>annotation&lt;/code> is empty, then it is the &lt;code>owningNamespace&lt;/code> of the &lt;code>AnnotatingElement&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Annotation" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Annotation&lt;/code> is a Relationship between an &lt;code>AnnotatingElement&lt;/code> and the &lt;code>Element&lt;/code> that is annotated by that &lt;code>AnnotatingElement&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotatedElement" ordered="false"
+        lowerBound="1" eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="annotation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> that is annotated by the &lt;code>annotatingElement&lt;/code> of this Annotation.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningAnnotatedElement"
+        ordered="false" eType="#//Element" volatile="true" transient="true" derived="true"
+        eOpposite="#//Element/ownedAnnotation">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>annotatedElement&lt;/code> of this &lt;code>Annotation&lt;/code>, when it is also its &lt;code>owningRelatedElement&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Annotation/annotatedElement #//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotatingElement" ordered="false"
+        lowerBound="1" eType="#//AnnotatingElement" eOpposite="#//AnnotatingElement/annotation">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AnnotatingElement&lt;/code> that annotates the &lt;code>annotatedElement&lt;/code> of this &lt;code>Annotation&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TextualRepresentation" eSuperTypes="#//AnnotatingElement">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>TextualRepresentation&lt;/code> is an &lt;code>AnnotatingElement&lt;/code> whose &lt;code>body&lt;/code> represents the &lt;code>representedElement&lt;/code> in a given &lt;code>language&lt;/code>. The &lt;code>representedElement&lt;/code> must be the &lt;code>owner&lt;/code> of the &lt;code>TextualRepresentation&lt;/code>. The named &lt;code>language&lt;/code> can be a natural language, in which case the &lt;code>body&lt;/code> is an informal representation, or an artificial language, in which case the &lt;code>body&lt;/code> is expected to be a formal, machine-parsable representation.&lt;/p>&#xA;&#xA;&lt;p>If the named &lt;code>language&lt;/code> of a &lt;code>TextualRepresentation&lt;/code> is machine-parsable, then the &lt;code>body&lt;/code> text should be legal input text as defined for that &lt;code>language&lt;/code>. The interpretation of the named language string shall be case insensitive. The following &lt;code>language&lt;/code> names are defined to correspond to the given standard languages:&lt;/p>&#xA;&#xA;&lt;table border=&quot;1&quot; cellpadding=&quot;1&quot; cellspacing=&quot;1&quot; width=&quot;498&quot;>&#xA;&#x9;&lt;thead>&#xA;&#x9;&lt;/thead>&#xA;&#x9;&lt;tbody>&#xA;&#x9;&#x9;&lt;tr>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>kerml&lt;/code>&lt;/td>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;width: 332px;&quot;>Kernel Modeling Language&lt;/td>&#xA;&#x9;&#x9;&lt;/tr>&#xA;&#x9;&#x9;&lt;tr>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>ocl&lt;/code>&lt;/td>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;width: 332px;&quot;>Object Constraint Language&lt;/td>&#xA;&#x9;&#x9;&lt;/tr>&#xA;&#x9;&#x9;&lt;tr>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>alf&lt;/code>&lt;/td>&#xA;&#x9;&#x9;&#x9;&lt;td style=&quot;width: 332px;&quot;>Action Language for fUML&lt;/td>&#xA;&#x9;&#x9;&lt;/tr>&#xA;&#x9;&lt;/tbody>&#xA;&lt;/table>&#xA;&#xA;&lt;p>Other specifications may define specific &lt;code>language&lt;/code> strings, other than those shown above, to be used to indicate the use of languages from those specifications in KerML &lt;code>TextualRepresentation&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>If the &lt;code>language&lt;/code> of a &lt;code>TextualRepresentation&lt;/code> is &amp;quot;&lt;code>kerml&lt;/code>&amp;quot;, then the &lt;code>body&lt;/code> text shall be a legal representation of the &lt;code>representedElement&lt;/code> in the KerML textual concrete syntax. A conforming tool can use such a &lt;code>TextualRepresentation&lt;/code> &lt;code>Annotation&lt;/code> to record the original KerML concrete syntax text from which an &lt;code>Element&lt;/code> was parsed. In this case, it is a tool responsibility to ensure that the &lt;code>body&lt;/code> of the &lt;code>TextualRepresentation&lt;/code> remains correct (or the Annotation is removed) if the annotated &lt;code>Element&lt;/code> changes other than by re-parsing the &lt;code>body&lt;/code> text.&lt;/p>&#xA;&#xA;&lt;p>An &lt;code>Element&lt;/code> with a &lt;code>TextualRepresentation&lt;/code> in a language other than KerML is essentially a semantically &amp;quot;opaque&amp;quot; &lt;code>Element&lt;/code> specified in the other language. However, a conforming KerML tool may interpret such an element consistently with the specification of the named language.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="language" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The natural or artifical language in which the &lt;code>body&lt;/code> text is written.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="body" ordered="false" lowerBound="1"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The textual representation of the &lt;code>representedElement&lt;/code> in the given &lt;code>language&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="representedElement" ordered="false"
+        lowerBound="1" eType="#//Element" volatile="true" transient="true" derived="true"
+        eOpposite="#//Element/textualRepresentation">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> that is represented by this &lt;code>TextualRepresentation&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//AnnotatingElement/annotatedElement"/>
+      <eAnnotations source="subsets" references="#//Element/owner"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Import" abstract="true" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Import&lt;/code> is an &lt;code>Relationship&lt;/code> between its &lt;code>importOwningNamespace&lt;/code> and either a &lt;code>Membership&lt;/code> (for a &lt;code>MembershipImport&lt;/code>) or another &lt;code>Namespace&lt;/code> (for a &lt;code>NamespaceImport&lt;/code>), which determines a set of &lt;code>Memberships&lt;/code> that become &lt;code>importedMemberships&lt;/code> of the &lt;code>importOwningNamespace&lt;/code>. If &lt;code>isImportAll = false&lt;/code> (the default), then only public &lt;code>Memberships&lt;/code> are considered &amp;quot;visible&amp;quot;. If &lt;code>isImportAll = true&lt;/code>, then all &lt;code>Memberships&lt;/code> are considered &amp;quot;visible&amp;quot;, regardless of their declared &lt;code>visibility&lt;/code>. If &lt;code>isRecursive = true&lt;/code>, then visible &lt;code>Memberships&lt;/code> are also recursively imported from owned sub-&lt;code>Namespaces&lt;/code>.&lt;/p>&#xA;&#xA;"/>
+    </eAnnotations>
+    <eOperations name="importedMemberships" upperBound="-1" eType="#//Membership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Returns Memberships that are to become &lt;code>importedMemberships&lt;/code> of the &lt;code>importOwningNamespace&lt;/code>. (The &lt;code>excluded&lt;/code> parameter is used to handle the possibility of circular Import Relationships.)&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eParameters name="excluded" ordered="false" upperBound="-1" eType="#//Namespace"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="visibility" ordered="false"
+        lowerBound="1" eType="#//VisibilityKind" defaultValueLiteral="public">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The visibility level of the imported &lt;code>members&lt;/code> from this Import relative to the &lt;code>importOwningNamespace&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isRecursive" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether to recursively import Memberships from visible, owned sub-Namespaces.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isImportAll" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether to import memberships without regard to declared visibility.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importedElement" ordered="false"
+        lowerBound="1" eType="#//Element" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="membershipImport"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The effectively imported &lt;code>Element&lt;/code> for this &lt;/code>Import&lt;/code>. For a &lt;code>MembershipImport&lt;/code>, this is the &lt;code>memberElement&lt;/code> of the &lt;code>importedMembership&lt;/code>. For a &lt;code>NamespaceImport&lt;/code>, it is the &lt;code>importedNamespace&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importOwningNamespace"
+        ordered="false" lowerBound="1" eType="#//Namespace" volatile="true" transient="true"
+        derived="true" eOpposite="#//Namespace/ownedImport">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Namespace into which Memberships are imported by this Import, which must be the &lt;code>owningRelatedElement&lt;/code> of the Import.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Specialization" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Specialization&lt;/code> is a &lt;code>Relationship&lt;/code> between two &lt;code>Types&lt;/code> that requires all instances of the &lt;code>specific&lt;/code> type to also be instances of the &lt;code>general&lt;/code> Type (i.e., the set of instances of the &lt;code>specific&lt;/code> Type is a &lt;em>subset&lt;/em> of those of the &lt;code>general&lt;/code> Type, which might be the same set).&lt;/p>&#xA;&#xA;not specific.isConjugated"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="general" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="generalization"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>Type&lt;/code> with a superset of all instances of the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code>, which might be the same set.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="specific" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="specialization"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>Type&lt;/code> with a subset of all instances of the &lt;code>general&lt;/code> &lt;code>Type&lt;/code>, which might be the same set.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true" eOpposite="#//Type/ownedSpecialization">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that is the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code> of this &lt;code>Specialization&lt;/code> and owns it as its &lt;code>owningRelatedElement&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Specialization/specific #//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureMembership" eSuperTypes="#//OwningMembership #//Featuring">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FeatureMembership&lt;/code> is an &lt;code>OwningMembership&lt;/code> between a &lt;code>Feature&lt;/code> in an &lt;code>owningType&lt;/code> that is also a &lt;code>Featuring&lt;/code> &lt;code>Relationship&lt;code? between the &lt;code>Feature&lt;/code> and the &lt;code>Type&lt;/code>, in which the &lt;code>featuringType&lt;/code> is the &lt;code>source&lt;/code> and the &lt;code>featureOfType&lt;/code> is the &lt;code>target&lt;/code>. A &lt;code>FeatureMembership&lt;/code> is always owned by its &lt;code>owningType&lt;/code>, which is the &lt;code>featuringType&lt;/code> for the &lt;code>FeatureMembership&lt;/code> considered as a &lt;code>Featuring&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMemberFeature" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true"
+        eOpposite="#//Feature/owningFeatureMembership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that this &lt;code>FeatureMembership&lt;/code> relates to its &lt;code>owningType&lt;/code>, making it an &lt;code>ownedFeature&lt;/code> of the &lt;code>owningType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//OwningMembership/ownedMemberElement #//Featuring/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningType" ordered="false"
+        lowerBound="1" eType="#//Type" volatile="true" transient="true" derived="true"
+        eOpposite="#//Type/ownedFeatureMembership">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that owns this &lt;code>FeatureMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Membership/membershipOwningNamespace #//Featuring/type"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Featuring" abstract="true" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Featuring&lt;/code> is a &lt;code>Relationship&lt;/code> between a &lt;code>Type&lt;/code> and a &lt;code>Feature&lt;/code> that is featured by that &lt;code>Type&lt;/code>. It asserts that every instance in the domain of the &lt;code>feature&lt;/code> must be classified by the &lt;code>type&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>&lt;code>Featuring&lt;/code> is abstract and does not commit to which of &lt;code>feature&lt;/code> or &lt;code>type&lt;/code> are the &lt;code>source&lt;/code> or &lt;code>target&lt;/code> of the &lt;code>Relationship&lt;/code>. This commitment is made in the subclasses of &lt;code>Featuring&lt;/code>, &lt;code>TypeFeaturing&lt;/code> and &lt;code>FeatureMembership&lt;/code>, which have opposite directions.&lt;/p>"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringOfType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;code> that features the &lt;code>featureOfType&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="feature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuring"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is featured by the &lt;code>featuringType&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/relatedElement"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Conjugation" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Conjugation&lt;/code> is a &lt;code>Relationship&lt;/code> between two types in which the &lt;code>conjugatedType&lt;/code> inherits all the &lt;code>Features&lt;/code> of the &lt;code>originalType&lt;/code>, but with all &lt;code>input&lt;/code> and &lt;code>output&lt;/code> &lt;code>Features&lt;/code> reversed. That is, any &lt;code>Features&lt;/code> with a &lt;code>FeatureMembership&lt;/code> with &lt;code>direction&lt;/code> &lt;em>in&lt;/em> relative to the &lt;code>originalType&lt;/code> are considered to have an effective &lt;code>direction&lt;/code> of &lt;em>out&lt;/em> relative to the &lt;code>conjugatedType&lt;/code> and, similarly, &lt;code>Features&lt;/code> with &lt;code>direction&lt;/code> &lt;em>out&lt;/em> in the &lt;code>originalType&lt;/code> are considered to have an effective &lt;code>direction&lt;/code> of &lt;em>in&lt;/em> in the &lt;code>originalType&lt;/code>. &lt;code>Features&lt;/code> with &lt;code>direction&lt;/code> &lt;em>inout&lt;/em>, or with no &lt;code>direction&lt;/code>, in the &lt;code>originalType&lt;/code>, are inherited without change.&lt;/p>&#xA;&#xA;&lt;p>A &lt;code>Type&lt;/code> may participate as a &lt;code>conjugatedType&lt;/code> in at most one &lt;code>Conjugation&lt;/code> relationship, and such a &lt;code>Type&lt;/code> may not also be the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code> in any &lt;code>Specialization&lt;/code> relationship.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="originalType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="conjugation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> to be conjugated.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="conjugatedType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="conjugator"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that is the result of applying &lt;code>Conjugation&lt;/code> to the &lt;code>originalType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true" eOpposite="#//Type/ownedConjugator">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>conjugatedType&lt;/code> of this &lt;code>Conjugation&lt;/code> that is also its &lt;code>owningRelatedElement&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Conjugation/conjugatedType #//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Multiplicity" eSuperTypes="#//Feature">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Multiplicity&lt;/code> is a &lt;code>Feature&lt;/code> whose co-domain is a set of natural numbers giving the allowed cardinalities of each &lt;code>typeWithMultiplicity&lt;/code>. The &lt;em>cardinality&lt;/em> of a &lt;code>Type&lt;/code> is defined as follows, depending on whether the &lt;code>Type&lt;/code> is a &lt;code>Classifier&lt;/code> or &lt;code>Feature&lt;/code>.&#xA;&lt;ul>&#xA;&lt;li>&lt;code>Classifier&lt;/code> – The number of basic instances of the &lt;code>Classifier&lt;/code>, that is, those instances representing things, which are not instances of any subtypes of the &lt;code>Classifier&lt;/code> that are &lt;code>Features&lt;/code>.&#xA;&lt;li>&lt;code>Features&lt;/code> – The number of instances with the same featuring instances. In the case of a &lt;code>Feature&lt;/code> with a &lt;code>Classifier&lt;/code> as its &lt;code>featuringType&lt;/code>, this is the number of values of &lt;code>Feature&lt;/code> for each basic instance of the &lt;code>Classifier&lt;/code>. Note that, for non-unique &lt;code>Features&lt;/code>, all duplicate values are included in this count.&lt;/li>&#xA;&lt;/ul>&#xA;&#xA;&lt;p>&lt;code>Multiplicity&lt;/code> co-domains (in models) can be specified by &lt;code>Expression&lt;/code> that might vary in their results. If the &lt;code>typeWithMultiplicity&lt;/code> is a &lt;code>Classifier&lt;/code>, the domain of the &lt;code>Multiplicity&lt;/code> shall be &lt;em>&lt;code>Base::Anything&lt;/code>&lt;/em>.  If the &lt;code>typeWithMultiplicity&lt;/code> is a &lt;code>Feature&lt;/code>,  the &lt;code>Multiplicity&lt;/code> shall have the same domain as the &lt;code>typeWithMultiplicity&lt;/code>.&lt;/p>&#xA;&#xA;if owningType &lt;> null and owningType.oclIsKindOf(Feature) then&#xA;    featuringType = &#xA;        owningType.oclAsType(Feature).featuringType&#xA;else&#xA;    featuringType->isEmpty()&#xA;endif&#xA;specializesFromLibrary(&quot;Base::naturals&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Intersecting" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Intersecting&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its &lt;code>intersectingType&lt;/code> one of the &lt;code>intersectingTypes&lt;/code> of its &lt;code>typeIntersected&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="intersectingType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="intersectedIntersecting"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> that partly determines interpretations of &lt;code>typeIntersected&lt;/code>, as described in &lt;code>Type::intersectingType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeIntersected" ordered="false"
+        lowerBound="1" eType="#//Type" volatile="true" transient="true" derived="true"
+        eOpposite="#//Type/ownedIntersecting">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> with interpretations partly determined by &lt;code>intersectingType&lt;/code>, as described in &lt;code>Type::intersectingType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Unioning" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Unioning&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its &lt;code>unioningType&lt;/code> one of the &lt;code>unioningTypes&lt;/code> of its &lt;code>typeUnioned&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="unioningType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="unionedUnioning"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> that partly determines interpretations of &lt;code>typeUnioned&lt;/code>, as described in &lt;code>Type::unioningType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeUnioned" ordered="false"
+        lowerBound="1" eType="#//Type" volatile="true" transient="true" derived="true"
+        eOpposite="#//Type/ownedUnioning">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> with interpretations partly determined by &lt;code>unioningType&lt;/code>, as described in &lt;code>Type::unioningType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Disjoining" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Disjoining&lt;/code> is a &lt;code>Relationship&lt;/code> between &lt;code>Types&lt;/code> asserted to have interpretations that are not shared (disjoint) between them, identified as &lt;code>typeDisjoined&lt;/code> and &lt;code>disjoiningType&lt;/code>. For example, a &lt;code>Classifier&lt;/code> for mammals is disjoint from a &lt;code>Classifier&lt;/code> for minerals, and a &lt;code>Feature&lt;/code> for people&amp;#39;s parents is disjoint from a &lt;code>Feature&lt;/code> for their children.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeDisjoined" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="disjoiningTypeDisjoining"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> asserted to be disjoint with the &lt;code>disjoiningType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="disjoiningType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="disjoinedTypeDisjoining"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> asserted to be disjoint with the &lt;code>typeDisjoined&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true" eOpposite="#//Type/ownedDisjoining">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>typeDisjoined&lt;/code> that is also an &lt;code>owningRelatedElement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Disjoining/typeDisjoined #//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Differencing" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Differencing&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its &lt;code>differencingType&lt;/code> one of the &lt;code>differencingTypes&lt;/code> of its &lt;code>typeDifferenced&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="differencingType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="differencedDifferencing"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> that partly determines interpretations of &lt;code>typeDifferenced&lt;/code>, as described in &lt;code>Type::differencingType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeDifferenced" ordered="false"
+        lowerBound="1" eType="#//Type" volatile="true" transient="true" derived="true"
+        eOpposite="#//Type/ownedDifferencing">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Type&lt;/code> with interpretations partly determined by &lt;code>differencingType&lt;/code>, as described in &lt;code>Type::differencingType&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="FeatureDirectionKind">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>FeatureDirectionKind&lt;/code> enumerates the possible kinds of &lt;code>direction&lt;/code> that a &lt;code>Feature&lt;/code> may be given as a member of a &lt;code>Type&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eLiterals name="in">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Values&amp;nbsp;of the &lt;code>Feature&lt;/code> on each&amp;nbsp;instance of its domain are&amp;nbsp;determined&amp;nbsp;externally to that instance and&amp;nbsp;used internally.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="inout" value="1">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Values&amp;nbsp;of the &lt;code>Feature&lt;/code> on each&amp;nbsp;instance are&amp;nbsp;determined either as&amp;nbsp;&lt;em>in&lt;/em> or &lt;em>out&lt;/em>&amp;nbsp;directions, or both.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="out" value="2">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Values of the &lt;code>Feature&lt;/code> on each instance of its domain are&amp;nbsp;determined internally to that instance and used externally.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eLiterals>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Redefinition" eSuperTypes="#//Subsetting">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Redefinition&lt;/code> is a kind of &lt;code>Subsetting&lt;/code> that requires the &lt;code>redefinedFeature&lt;/code> and the &lt;code>redefiningFeature&lt;/code> to have the same values (on each instance of the domain of the &lt;code>redefiningFeature&lt;/code>). This means any restrictions on the &lt;code>redefiningFeature&lt;/code>, such as &lt;code>type&lt;/code> or &lt;code>multiplicity&lt;/code>, also apply to the &lt;code>redefinedFeature&lt;/code> (on each instance of the domain of the &lt;code>redefiningFeature&lt;/code>), and vice versa. The &lt;code>redefinedFeature&lt;/code> might have values for instances of the domain of the &lt;code>redefiningFeature&lt;/code>, but only as instances of the domain of the &lt;code>redefinedFeature&lt;/code> that happen to also be instances of the domain of the &lt;code>redefiningFeature&lt;/code>. This is supported by the constraints inherited from &lt;code>Subsetting&lt;/code> on the domains of the &lt;code>redefiningFeature&lt;/code> and &lt;code>redefinedFeature&lt;/code>. However, these constraints are narrowed for &lt;code>Redefinition&lt;/code> to require the &lt;code>owningTypes&lt;/code> of the &lt;code>redefiningFeature&lt;/code> and &lt;code>redefinedFeature&lt;/code> to be different and the &lt;code>redefinedFeature&lt;/code> to not be inherited into the &lt;code>owningNamespace&lt;/code> of the &lt;code>redefiningFeature&lt;/code>.This enables the &lt;code>redefiningFeature&lt;/code> to have the same name as the &lt;code>redefinedFeature&lt;/code>, if desired.&lt;/p>&#xA;&#xA;let anythingType: Type =&#xA;    subsettingFeature.resolveGlobal('Base::Anything').oclAsType(Type) in &#xA;-- Including &quot;Anything&quot; accounts for implicit featuringType of Features&#xA;-- with no explicit featuringType.&#xA;let subsettingFeaturingTypes: Set(Type) =&#xA;    subsettingFeature.featuringTypes->asSet()->including(anythingType) in&#xA;let subsettedFeaturingTypes: Set(Type) =&#xA;    subsettedFeature.featuringTypes->asSet()->including(anythingType) in&#xA;subsettingFeaturingTypes &lt;> subsettedFeaturingType"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="redefiningFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="redefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is redefining the &lt;code>redefinedFeature&lt;/code> of this &lt;code>Redefinition&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Subsetting/subsettingFeature"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="redefinedFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="redefining"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is redefined by the &lt;code>redefiningFeature&lt;/code> of this &lt;code>Redefinition&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Subsetting/subsettedFeature"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Subsetting" eSuperTypes="#//Specialization">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Subsetting&lt;/code> is &lt;code>Specialization&lt;/code> in which the &lt;code>specific&lt;/code> and &lt;code>general&lt;/code> &lt;code>Types&lt;/code> are &lt;code>Features&lt;/code>. This means all values of the &lt;code>subsettingFeature&lt;/code> (on instances of its domain, i.e., the intersection of its &lt;code>featuringTypes&lt;/code>) are values of the &lt;code>subsettedFeature&lt;/code> on instances of its domain. To support this the domain of the &lt;code>subsettingFeature&lt;/code> must be the same or specialize (at least indirectly) the domain of the &lt;code>subsettedFeature&lt;/code> (via &lt;code>Specialization&lt;/code>), and the co-domain (intersection of the &lt;code>types&lt;/code>) of the &lt;code>subsettingFeature&lt;/code> must specialize the co-domain of the &lt;code>subsettedFeature&lt;/code>.&lt;/p>&#xA;&#xA;let subsettingFeaturingTypes: OrderedSet(Type) =&#xA;    subsettingFeature.featuringTypes in&#xA;let subsettedFeaturingTypes: OrderedSet(Type) =&#xA;    subsettedFeature.featuringTypes in&#xA;let anythingType: Element =&#xA;    subsettingFeature.resolveGlobal('Base::Anything') in &#xA;subsettedFeaturingTypes->forAll(t |&#xA;    subsettingFeaturingTypes->isEmpty() and t = anythingType or&#xA;    subsettingFeaturingTypes->exists(specializes(t))"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subsettedFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="supersetting"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is subsetted by the &lt;code>subsettingFeature&lt;/code> of this &lt;code>Subsetting&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/general"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subsettingFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="subsetting"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is a subset of the &lt;code>subsettedFeature&lt;/code> of this &lt;code>Subsetting&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/specific"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningFeature" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true"
+        eOpposite="#//Feature/ownedSubsetting">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>subsettingFeature&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>Subsetting&lt;/code>.&lt;/p>&#xA;&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/owningType"/>
+      <eAnnotations source="subsets" references="#//Subsetting/subsettingFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureTyping" eSuperTypes="#//Specialization">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>FeatureTyping&lt;/code> is &lt;code>Specialization&lt;/code> in which the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code> is a &lt;code>Feature&lt;/code>. This means the set of instances of the (specific) &lt;code>typedFeature&lt;/code> is a subset of the set of instances of the (general) &lt;code>type&lt;/code>. In the simplest case, the &lt;code>type&lt;/code> is a &lt;code>Classifier&lt;/code>, whereupon the &lt;code>typedFeature&lt;/code> has values that are instances of the &lt;code>Classifier&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typedFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typing"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that has a &lt;code>type&lt;/code> determined by this &lt;code>FeatureTyping&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/specific"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typingByType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that is being applied by this &lt;code>FeatureTyping&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/general"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningFeature" ordered="false"
+        eType="#//Feature" volatile="true" transient="true" derived="true" eOpposite="#//Feature/ownedTyping">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>typedFeature&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>FeatureTyping&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/owningType"/>
+      <eAnnotations source="subsets" references="#//FeatureTyping/typedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TypeFeaturing" eSuperTypes="#//Featuring">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>TypeFeaturing&lt;/code> is a &lt;code>Featuring&lt;/code> &lt;code>Relationship&lt;/code> in which the &lt;code>featureOfType&lt;/code> is the &lt;code>source&lt;/code> and the &lt;code>featuringType&lt;/code> is the &lt;code>target&lt;/code>.&lt;/p>"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featureOfType" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeFeaturing"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is featured by the &lt;code>featuringType&lt;/code>. It is the &lt;code>source&lt;/code> of the &lt;code>TypeFeaturing&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source #//Featuring/feature"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featuringType" ordered="false"
+        lowerBound="1" eType="#//Type">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typeFeaturingOfType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Type&lt;/code> that features the &lt;code>featureOfType&lt;/code>. It is the &lt;code>target&lt;/code> of the &lt;code>TypeFeaturing&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target #//Featuring/type"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningFeatureOfType" ordered="false"
+        eType="#//Feature" volatile="true" transient="true" derived="true" eOpposite="#//Feature/ownedTypeFeaturing">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>featureOfType&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>TypeFeaturing&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//TypeFeaturing/featureOfType #//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureInverting" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FeatureInverting&lt;/code> is a &lt;code>Relationship&lt;/code> between &lt;code>Features&lt;/code> asserting that their interpretations (sequences) are the reverse of each other, identified as &lt;code>featureInverted&lt;/code> and &lt;code>invertingFeature&lt;/code>. For example, a &lt;code>Feature&lt;/code> identifying each person&amp;#39;s parents is the inverse of a &lt;code>Feature&lt;/code> identifying each person&amp;#39;s children. A person identified as a parent of another will identify that other as one of their children.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featureInverted" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="invertingFeatureInverting"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is an inverse of the &lt;code>invertingFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="invertingFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="invertedFeatureInverting"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is an inverse of the &lt;code>invertedFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningFeature" ordered="false"
+        eType="#//Feature" volatile="true" transient="true" derived="true" eOpposite="#//Feature/ownedFeatureInverting">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>featureInverted&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>FeatureInverting&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement #//FeatureInverting/featureInverted"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureChaining" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>FeatureChaining&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its target &lt;code>Feature&lt;/code> one of the &lt;code>chainingFeatures&lt;/code> of its owning &lt;code>Feature&lt;/code>.&lt;/p>"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="chainingFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="chainedFeatureChaining"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> whose values partly determine values of &lt;code>featureChained&lt;/code>, as described in &lt;code>Feature::chainingFeature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featureChained" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true"
+        eOpposite="#//Feature/ownedFeatureChaining">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> whose values are partly determined by values of the &lt;code>chainingFeature&lt;/code>, as described in &lt;code>Feature::chainingFeature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Relationship/owningRelatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ReferenceSubsetting" eSuperTypes="#//Subsetting">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>ReferenceSubsetting&lt;/code> is a kind of &lt;code>Subsetting&lt;/code> in which the &lt;code>referencedFeature&lt;/code> is syntactically distinguished from other &lt;code>Features&lt;/code> subsetted by the &lt;code>referencingFeature&lt;/code>. &lt;code>ReferenceSubsetting&lt;/code> has the same semantics as &lt;code>Subsetting&lt;/code>, but the &lt;code>referenceFeature&lt;/code> may have a special purpose relative to the &lt;code>referencingFeature&lt;/code>. For instance, &lt;code>ReferenceSubsetting&lt;/code> is used to identify the &lt;code>relatedFeatures&lt;/code> of a &lt;code>Connector&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>&lt;code>ReferenceSubsetting&lt;/code> is always an &lt;code>ownedRelationship&lt;/code> of its &lt;code>referencingFeature&lt;/code>. A &lt;code>Feature&lt;/code> can have at most one &lt;code>ownedReferenceSubsetting&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referencedFeature" ordered="false"
+        lowerBound="1" eType="#//Feature">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="referencing"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is referenced by the &lt;code>referencingFeature&lt;/code> of this &lt;code>ReferenceSubsetting&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Subsetting/subsettedFeature"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referencingFeature" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true"
+        eOpposite="#//Feature/ownedReferenceSubsetting">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that owns this &lt;code>ReferenceSubsetting&lt;/code> relationship, which is also its &lt;code>subsettingFeature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Subsetting/subsettingFeature #//Subsetting/owningFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="VariantMembership" eSuperTypes="#//OwningMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>VariantMembership&lt;/code> is a &lt;code>Membership&lt;/code> between a variation point &lt;code>Definition&lt;/code> or &lt;code>Usage&lt;/code> and a &lt;code>Usage&lt;/code> that represents a variant in the context of that variation. The &lt;code>membershipOwningNamespace&lt;/code> for the &lt;code>VariantMembership&lt;/code> must be either a Definition or a &lt;code>Usage&lt;/code> with &lt;code>isVariation = true&lt;/code>.&lt;/p>&#xA;membershipOwningNamespace.oclIsKindOf(Definition) and&#xA;    membershipOwningNamespace.oclAsType(Definition).isVariation or&#xA;membershipOwningNamespace.oclIsKindOf(Usage) and&#xA;    membershipOwningNamespace.oclAsType(Usage).isVariation&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedVariantUsage" ordered="false"
+        lowerBound="1" eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningVariantMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Usage&lt;/code> that represents a variant in the context of the &lt;code>owningVariationDefinition&lt;/code> or &lt;code>owningVariationUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//OwningMembership/ownedMemberElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Definition" eSuperTypes="#//Classifier">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Definition&lt;/code> is a &lt;code>Classifier&lt;/code> of &lt;code>Usages&lt;/code>. The actual kinds of &lt;code>Definition&lt;/code> that may appear in a model are given by the subclasses of &lt;code>Definition&lt;/code> (possibly as extended with user-defined &lt;em>&lt;code>SemanticMetadata&lt;/code>&lt;/em>).&lt;/p>&#xA;&#xA;&lt;p>Normally, a &lt;code>Definition&lt;/code> has owned Usages that model &lt;code>features&lt;/code> of the thing being defined. A &lt;code>Definition&lt;/code> may also have other &lt;code>Definitions&lt;/code> nested in it, but this has no semantic significance, other than the nested scoping resulting from the &lt;code>Definition&lt;/code> being considered as a &lt;code>Namespace&lt;/code> for any nested &lt;code>Definitions&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>However, if a &lt;code>Definition&lt;/code> has &lt;code>isVariation&lt;/code> = &lt;code>true&lt;/code>, then it represents a &lt;em>variation point&lt;/em> &lt;code>Definition&lt;/code>. In this case, all of its &lt;code>members&lt;/code> must be &lt;code>variant&lt;/code> &lt;code>Usages&lt;/code>, related to the &lt;code>Definition&lt;/code> by &lt;code>VariantMembership&lt;/code> &lt;code>Relationships&lt;/code>. Rather than being &lt;code>features&lt;/code> of the &lt;code>Definition&lt;/code>, &lt;code>variant&lt;/code> &lt;code>Usages&lt;/code> model different concrete alternatives that can be chosen to fill in for an abstract &lt;code>Usage&lt;/code> of the variation point &lt;code>Definition&lt;/code>.&lt;/p>&#xA;&#xA;isVariation implies variantMembership = ownedMembership&#xA;variant = variantMembership.ownedVariantUsage&#xA;variantMembership = ownedMembership->selectByKind(VariantMembership)&#xA;not isVariation implies variantMembership->isEmpty()&#xA;isVariation implies&#xA;    not ownedSpecialization.specific->exists(isVariation)&#xA;usage = feature->selectByKind(Usage)&#xA;directedUsage = directedFeature->selectByKind(Usage)&#xA;ownedUsage = ownedFeature->selectByKind(Usage)&#xA;ownedAttribute = ownedUsage->selectByKind(AttributeUsage)&#xA;ownedReference = ownedUsage->selectByKind(ReferenceUsage)&#xA;ownedEnumeration = ownedUsage->selectByKind(EnumerationUsage)&#xA;ownedOccurrence = ownedUsage->selectByKind(OccurrenceUsage)&#xA;ownedItem = ownedUsage->selectByKind(ItemUsage)&#xA;ownedPart = ownedUsage->selectByKind(PartUsage)&#xA;ownedPort = ownedUsage->selectByKind(PortUsage)&#xA;ownedConnection = ownedUsage->selectByKind(ConnectorAsUsage)&#xA;ownedFlow = ownedUsage->selectByKind(FlowUsage)&#xA;ownedInterface = ownedUsage->selectByKind(ReferenceUsage)&#xA;ownedAllocation = ownedUsage->selectByKind(AllocationUsage)&#xA;ownedAction = ownedUsage->selectByKind(ActionUsage)&#xA;ownedState = ownedUsage->selectByKind(StateUsage)&#xA;ownedTransition = ownedUsage->selectByKind(TransitionUsage)&#xA;ownedCalculation = ownedUsage->selectByKind(CalculationUsage)&#xA;ownedConstraint = ownedUsage->selectByKind(ConstraintUsage)&#xA;ownedRequirement = ownedUsage->selectByKind(RequirementUsage)&#xA;ownedConcern = ownedUsage->selectByKind(ConcernUsage)&#xA;ownedCase = ownedUsage->selectByKind(CaseUsage)&#xA;ownedAnalysisCase = ownedUsage->selectByKind(AnalysisCaseUsage)&#xA;ownedVerificationCase = ownedUsage->selectByKind(VerificationCaseUsage)&#xA;ownedUseCase = ownedUsage->selectByKind(UseCaseUsage)&#xA;ownedView = ownedUsage->selectByKind(ViewUsage)&#xA;ownedViewpoint = ownedUsage->selectByKind(ViewpointUsage)&#xA;ownedRendering = ownedUsage->selectByKind(RenderingUsage)&#xA;ownedMetadata = ownedUsage->selectByKind(MetadataUsage)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isVariation" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>Definition&lt;/code> is for a variation point or not. If true, then all the &lt;code>memberships&lt;/code> of the &lt;code>Definition&lt;/code> must be &lt;code>VariantMemberships&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="variant" ordered="false"
+        upperBound="-1" eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningVariationDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Usages&lt;/code> which represent the variants of this &lt;code>Definition&lt;/code> as a variation point &lt;code>Definition&lt;/code>, if &lt;code>isVariation&lt;/code> = true. If &lt;code>isVariation = false&lt;/code>, the there must be no &lt;code>variants&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="variantMembership" ordered="false"
+        upperBound="-1" eType="#//VariantMembership" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningVariationDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedMemberships&lt;/code> of this &lt;code>Definition&lt;/code> that are &lt;code>VariantMemberships&lt;/code>. If &lt;code>isVariation&lt;/code> = true, then this must be all &lt;code>ownedMemberships&lt;/code> of the &lt;code>Definition&lt;/code>. If &lt;code>isVariation&lt;/code> = false, then &lt;code>variantMembership&lt;/code>must be empty.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMembership"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="usage" upperBound="-1"
+        eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Usages&lt;/code> that are &lt;code>features&lt;/code> of this &lt;code>Definition&lt;/code> (not necessarily owned).&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="directedUsage" upperBound="-1"
+        eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definitionWithDirectedUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>usages&lt;/code> of this &lt;code>Definition&lt;/code> that are &lt;code>directedFeatures&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/usage #//Type/directedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedReference" upperBound="-1"
+        eType="#//ReferenceUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="referenceOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ReferenceUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedAttribute" upperBound="-1"
+        eType="#//AttributeUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="attributeOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AttributeUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedEnumeration" upperBound="-1"
+        eType="#//EnumerationUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="enumerationOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>EnumerationUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedAttribute"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedOccurrence" upperBound="-1"
+        eType="#//OccurrenceUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="occurrenceOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>OccurrenceUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedItem" upperBound="-1"
+        eType="#//ItemUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="itemOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ItemUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedOccurrence"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedPart" upperBound="-1"
+        eType="#//PartUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="partOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>PartUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedItem"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedPort" upperBound="-1"
+        eType="#//PortUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="portOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>PortUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedConnection" upperBound="-1"
+        eType="#//ConnectorAsUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="connectionOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConnectorAsUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>. Note that this list includes &lt;code>BindingConnectorAsUsages&lt;/code> and &lt;code>SuccessionAsUsages&lt;/code>, even though these are &lt;code>ConnectorAsUsages&lt;/code> but not &lt;code>ConnectionUsages&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedPart"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedFlow" ordered="false"
+        upperBound="-1" eType="#//FlowConnectionUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="flowOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>FlowConnectionUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedConnection"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedInterface" upperBound="-1"
+        eType="#//InterfaceUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="interfaceOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>InterfaceUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedConnection"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedAllocation" upperBound="-1"
+        eType="#//AllocationUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="allocationOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AllocationUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedConnection"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedAction" upperBound="-1"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="actionOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedOccurrence"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedState" upperBound="-1"
+        eType="#//StateUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="stateOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>StateUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedAction"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedTransition" ordered="false"
+        upperBound="-1" eType="#//TransitionUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="transitionOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>TransitionUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedCalculation" upperBound="-1"
+        eType="#//CalculationUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="calculationOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>CalculationUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedAction"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedConstraint" upperBound="-1"
+        eType="#//ConstraintUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="constraintOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConstraintUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedOccurrence"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedRequirement" upperBound="-1"
+        eType="#//RequirementUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="requirementOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>RequirementUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedConstraint"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedConcern" ordered="false"
+        upperBound="-1" eType="#//ConcernUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="concernOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConcernUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedRequirement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedCase" upperBound="-1"
+        eType="#//CaseUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="caseOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The code>CaseUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedCalculation"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedAnalysisCase" upperBound="-1"
+        eType="#//AnalysisCaseUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="analysisCaseOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AnalysisCaseUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedCase"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedVerificationCase"
+        upperBound="-1" eType="#//VerificationCaseUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="verificationCaseOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>VerificationCaseUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedCase"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedUseCase" upperBound="-1"
+        eType="#//UseCaseUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="useCaseOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>UseCaseUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedCase"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedView" upperBound="-1"
+        eType="#//ViewUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="viewOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ViewUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedPart"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedViewpoint" upperBound="-1"
+        eType="#//ViewpointUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="viewpointOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ViewpointUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedRequirement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedRendering" upperBound="-1"
+        eType="#//RenderingUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="redenderingOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>RenderingUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedPart"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMetadata" upperBound="-1"
+        eType="#//MetadataUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="metadataOwningDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>MetadataUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedItem"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedUsage" upperBound="-1"
+        eType="#//Usage" volatile="true" transient="true" derived="true" eOpposite="#//Usage/owningDefinition">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Usages&lt;/code> that are &lt;code>ownedFeatures&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature #//Definition/usage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Classifier" eSuperTypes="#//Type">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Classifier&lt;/code> is a &lt;code>Type&lt;/code> that classifies:&lt;/p>&#xA;&#xA;&lt;ul>&#xA;&#x9;&lt;li>Things (in the universe) regardless of how &lt;code>Features&lt;/code> relate them. (These are interpreted semantically as sequences of exactly one thing.)&lt;/li>&#xA;&#x9;&lt;li>How the above things are related by &lt;code>Features.&lt;/code> (These are interpreted semantically as sequences of multiple things, such that the last thing in the sequence is also classified by the &lt;code>Classifier&lt;/code>. Note that his means that a &lt;code>Classifier&lt;/code> modeled as specializing a &lt;code>Feature&lt;/code> cannot classify anything.)&lt;/li>&#xA;&lt;/ul>&#xA;&#xA;&#xA;ownedSubclassification = &#xA;    ownedSpecialization->selectByKind(Superclassification)&#xA;multiplicity &lt;> null implies multiplicity.featuringType->isEmpty()"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedSubclassification"
+        ordered="false" upperBound="-1" eType="#//Subclassification" volatile="true"
+        transient="true" derived="true" eOpposite="#//Subclassification/owningClassifier">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedSpecializations&lt;/code> of this &lt;code>Classifier&lt;/code> that are &lt;code>Subclassifications&lt;/code>, for which this &lt;code>Classifier&lt;/code> is the &lt;code>subclassifier&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedSpecialization"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Subclassification" eSuperTypes="#//Specialization">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>Subclassification&lt;/code> is &lt;code>Specialization&lt;/code> in which both the &lt;code>specific&lt;/code> and &lt;code>general&lt;/code> &lt;code>Types&lt;/code> are &lt;code>Classifier&lt;/code>. This means all instances of the specific &lt;code>Classifier&lt;/code> are also instances of the general &lt;code>Classifier&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="superclassifier" ordered="false"
+        lowerBound="1" eType="#//Classifier">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="superclassification"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The more &lt;code>general&lt;/code> Classifier in this &lt;code>Subclassification&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/general"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subclassifier" ordered="false"
+        lowerBound="1" eType="#//Classifier">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="subclassification"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The more specific &lt;code>Classifier&lt;/code> in this &lt;code>Subclassification&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/specific"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="owningClassifier" ordered="false"
+        eType="#//Classifier" volatile="true" transient="true" derived="true" eOpposite="#//Classifier/ownedSubclassification">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Classifier&lt;/code> that owns this &lt;code>Subclassification&lt;/code> relationship, which must also be its &lt;code>subclassifier&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Specialization/owningType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ReferenceUsage" eSuperTypes="#//Usage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ReferenceUsage&lt;/code> is a &lt;code>Usage&lt;/code> that specifies a non-compositional (&lt;code>isComposite = false&lt;/code>) reference to something. The &lt;code>definition&lt;/code> of a &lt;code>ReferenceUsage&lt;/code> can be any kind of &lt;code>Classifier&lt;/code>, with the default being the top-level &lt;code>Classifier&lt;/code> &lt;code>&lt;em>Base::Anything&lt;/em>&lt;/code> from the Kernel Semantic Library. This allows the specification of a generic reference without distinguishing if the thing referenced is an attribute value, item, action, etc.&lt;/p>&#xA;isReference"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AttributeUsage" eSuperTypes="#//Usage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AttributeUsage&lt;code> is a &lt;code>Usage&lt;/code> whose type is a &lt;code>DataType&lt;/code>. Nominally, if the type is an &lt;code>AttributeDefinition&lt;/code>, an &lt;code>AttributeUsage&lt;code> is a usage of a &lt;code>AttributeDefinition&lt;/code> to represent the value of some system quality or characteristic. However, other kinds of kernel &lt;code>DataTypes&lt;/code> are also allowed, to permit use of &lt;code>DataTypes&lt;/code> from the Kernel Model Libraries. An &lt;code>AttributeUsage&lt;code> itself as well as all its nested &lt;code>features&lt;/code> must be referential (non-composite).&lt;/p>&#xA;&#xA;&lt;p>An &lt;code>AttributeUsage&lt;code> must specialize, directly or indirectly, the base &lt;code>Feature&lt;code> &lt;code>&lt;em>Base::dataValues&lt;/code> from the Kernel Semantic Library.&lt;/p>&#xA;isReference&#xA;feature->forAll(not isComposite)&#xA;specializesFromLibrary(&quot;Base::dataValues&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="attributeDefinition" upperBound="-1"
+        eType="#//DataType" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedAttribute"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>DataTypes&lt;/code> that are the types of this &lt;code>AttributeUsage&lt;/code>. Nominally, these are &lt;code>AttributeDefinitions&lt;/code>, but other kinds of kernel &lt;code>DataTypes&lt;/code> are also allowed, to permit use of &lt;code>DataTypes,/code> from the Kernel Model Libraries.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Usage/definition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="DataType" eSuperTypes="#//Classifier">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>DataType&lt;/code> is a &lt;code>Classifier&lt;/code> of things (in the universe) that can only be distinguished by how they are related to other things (via Features). This means multiple things classified by the same &lt;code>DataType&lt;/code>&lt;/p>&#xA;&#xA;&lt;ul>&#xA;&#x9;&lt;li>Cannot be distinguished when they are related to other things in exactly the same way, even when they are intended to be about different things.&lt;/li>&#xA;&#x9;&lt;li>Can be distinguished when they are related to other things in different ways, even when they are intended to be about the same thing.&lt;/li>&#xA;&lt;/ul>&#xA;&#xA;specializesFromLibrary('Base::DataValue')&#xA;ownedSpecialization.general->&#xA;    forAll(not oclIsKindOf(Class) and &#xA;           not oclIsKindOf(Association))"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="EnumerationUsage" eSuperTypes="#//AttributeUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>EnumerationUsage&lt;/code> is an &lt;code>AttributeUsage&lt;/code> whose &lt;code>attributeDefinition&lt;/code> is an &lt;code>EnumerationDefinition&lt;/code>.&lt;/p>"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="enumerationDefinition"
+        ordered="false" lowerBound="1" eType="#//EnumerationDefinition" volatile="true"
+        transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedEnumeration"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The single EnumerationDefinition that is the type of this EnumerationUsage.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//AttributeUsage/attributeDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="EnumerationDefinition" eSuperTypes="#//AttributeDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>EnumerationDefinition&lt;/code> is an &lt;code>AttributeDefinition&lt;/code> all of whose instances are given by an explicit list of &lt;code>enumeratedValues&lt;/code>. This is realized by requiring that the &lt;code>EnumerationDefinition&lt;/code> have &lt;code>isVariation = true&lt;/code>, with the &lt;code>enumeratedValues&lt;/code> being its &lt;code>variants&lt;/code>.&lt;/p> &#xA;isVariation"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="enumeratedValue" upperBound="-1"
+        eType="#//EnumerationUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningEnumerationDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>EnumerationUsages&lt;/code> of this &lt;code>EnumerationDefinition&lt;/code>that have distinct, fixed values. Each &lt;code>enumeratedValue&lt;/code> specifies one of the allowed instances of the &lt;code>EnumerationDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Definition/variant"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AttributeDefinition" eSuperTypes="#//Definition #//DataType">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AttributeDefinition&lt;/code> is a &lt;code>Definition&lt;/code> and a &lt;code>DataType&lt;/code> of information about a quality or characteristic of a system or part of a system that has no independent identity other than its value. All &lt;code>features&lt;/code> of an &lt;code>AttributeDefinition&lt;/code> must be referential (non-composite).&lt;/p>&#xA;&#xA;&lt;p>As a &lt;code>DataType&lt;/code>, an &lt;code>AttributeDefinition&lt;/code> must specialize, directly or indirectly, the base &lt;code>DataType&lt;/code> &lt;code>&lt;em>Base::DataValue&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p>&#xA;feature->forAll(not isComposite)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="OccurrenceUsage" eSuperTypes="#//Usage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>OccurrenceUsage&lt;/code> is a &lt;code>Usage&lt;/code> whose &lt;code>types&lt;/code> are all &lt;code>Classes&lt;/code>. Nominally, if a &lt;code>type&lt;/code> is an &lt;code>OccurrenceDefinition&lt;/code>, an &lt;code>OccurrenceUsage&lt;/code> is a &lt;code>Usage&lt;/code> of that &lt;code>OccurrenceDefinition&lt;/code> within a system. However, other types of Kernel &lt;code>Classes&lt;/code> are also allowed, to permit use of &lt;code>Classes&lt;/code> from the Kernel Model Libraries.&lt;/p>&#xA;&#xA;individualDefinition =&#xA;    let individualDefinitions : OrderedSet(OccurrenceDefinition) = &#xA;        occurrenceDefinition->&#xA;            selectByKind(OccurrenceDefinition)->&#xA;            select(isIndividual) in&#xA;    if individualDefinitions->isEmpty() then null&#xA;    else individualDefinitions->first() endif&#xA;isIndividual implies individualDefinition &lt;> null&#xA;specializesFromLibrary(&quot;Occurrences::occurrences&quot;)&#xA;isComposite and&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(Class) or&#xA; owningType.oclIsKindOf(OccurrenceUsage) or&#xA; owningType.oclIsKindOf(Feature) and&#xA;    owningType.oclAsType(Feature).type->&#xA;        exists(oclIsKind(Class))) implies&#xA;    specializesFromLibrary(&quot;Occurrences::Occurrence::suboccurrences&quot;)&#xA;occurrenceDefinition->select(isIndividual).size() &lt;= 1&#xA;portionKind &lt;> null implies&#xA;    occurrenceDefinition->forAll(occ | &#xA;        featuringType->exists(specializes(occ)))"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="occurrenceDefinition" upperBound="-1"
+        eType="#//Class" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedOccurrence"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Classes&lt;/code> that are the types of this &lt;code>OccurrenceUsage&lt;/code>. Nominally, these are &lt;code>OccurrenceDefinitions&lt;/code>, but other kinds of kernel &lt;code>Classes&lt;/code> are also allowed, to permit use of &lt;code>Classes&lt;/code> from the Kernel Model Libraries.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Usage/definition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="individualDefinition" ordered="false"
+        eType="#//OccurrenceDefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="individualUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The at most one &lt;code>occurrenceDefinition&lt;/code> that has &lt;code>isIndividual = true&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//OccurrenceUsage/occurrenceDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isIndividual" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>OccurrenceUsage&lt;/code> represents the usage of the specific individual (or portion of it) represented by its &lt;code>individualDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="portionKind" ordered="false"
+        eType="#//PortionKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The kind of (temporal) portion of the life of the &lt;code>occurrenceDefinition&lt;/code> represented by this &lt;code>OccurrenceUsage&lt;/code>, if it is so restricted.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Class" eSuperTypes="#//Classifier">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Class&lt;/code> is a &lt;code>Classifier&lt;/code> of things (in the universe) that can be distinguished without regard to how they are related to other things (via &lt;code>Features&lt;/code>). This means multiple things classified by the same &lt;code>Class&lt;/code> can be distinguished, even when they are related other things in exactly the same way.&lt;/p>&#xA;&#xA;specializesFromLibrary('Occurrences::Occurrence')&#xA;ownedSpecialization.general->&#xA;    forAll(not oclIsKindOf(DataType)) and&#xA;not oclIsKindOf(AssociationStructure) implies&#xA;    ownedSpecialization.general->&#xA;        forAll(not oclIsKindOf(Association))"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="OccurrenceDefinition" eSuperTypes="#//Definition #//Class">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>OccurrenceDefinition&lt;/code> is a &lt;code>Definition&lt;/code> of a &lt;code>Class&lt;/code> of individuals that have an independent life over time and potentially an extent over space. This includes both structural things and behaviors that act on such structures.&lt;/p>&#xA;&#xA;&lt;p>If &lt;code>isIndividual&lt;/code> is true, then the &lt;code>OccurrenceDefinition&lt;/code> is constrained to represent an individual thing. The instances of such an &lt;code>OccurrenceDefinition&lt;/code> include all spatial and temporal portions of the individual being represented, but only one of these can be the complete &lt;code>Life&lt;/code> of the individual. All other instances must be portions of the &amp;quot;maximal portion&amp;quot; that is single &lt;code>Life&lt;/code> instance, capturing the conception that all of the instances represent one individual with a single &amp;quot;identity&amp;quot;.&lt;/p>&#xA;&#xA;&lt;p>An &lt;code>OccurrenceDefinition&lt;/code> must specialize, directly or indirectly, the base &lt;code>Class&lt;/code> &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p>&#xA;&#xA;let n : Integer = ownedMember->selectByKind(LifeClass) in&#xA;if isIndividual then n = 1 else n = 0 endif&#xA;lifeClass =&#xA;    let lifeClasses: OrderedSet(LifeClass) = &#xA;        ownedMember->selectByKind(LifeClass) in&#xA;    if lifeClasses->isEmpty() then null&#xA;    else lifeClasses->first()&#xA;    endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="lifeClass" ordered="false"
+        eType="#//LifeClass" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="individualDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>If &lt;code>isIndividual&lt;/code> is true, a &lt;code>LifeClass&lt;/code> that specializes this &lt;code>OccurrenceDefinition&lt;/code>, restricting it to represent an individual.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isIndividual" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this OccurrenceDefinition is constrained to represent single individual.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LifeClass" eSuperTypes="#//Class">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;coed>LifeClass&lt;/code> is a &lt;code>Class&lt;/code> that specializes both the &lt;code>Class&lt;/code> &lt;code>&lt;em>Occurrences::Life&lt;/em>&lt;/code> from the Kernel Semantic Library and a single &lt;code>OccurrenceDefinition&lt;/code>, and has a multiplicity of 0..1. This constrains the &lt;code>OccurrenceDefinition&lt;/code> being specialized to have at most one instance that is a complete &lt;code>Life&lt;/code>.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Occurrences::Life&quot;)&#xA;multiplicity &lt;> null and&#xA;multiplicity.specializesFromLibrary(&quot;Base::zeroOrOne&quot;)&#xA;specializes(individualDefinition)&#xA;isSufficient"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="PortionKind">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>PortionKind&lt;/code> is an enumeration of the specific kinds of &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> portions that can be represented by an &lt;code>OccurrenceUsage&lt;/code>.&lt;/p>"/>
+    </eAnnotations>
+    <eLiterals name="timeslice">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A time slice of an &lt;code>Occurrence&lt;/code> (a portion over time).&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="snapshot" value="1">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A snapshot of an &lt;code>Occurrence&lt;/code> (a time slice with zero duration).&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ItemUsage" eSuperTypes="#//OccurrenceUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ItemUsage&lt;/code> is a &lt;code>ItemUsage&lt;/code> whose &lt;code>definition&lt;/code> is a &lt;code>Structure&lt;/code>. Nominally, if the &lt;code>definition&lt;/code> is an &lt;code>ItemDefinition&lt;/code>, an &lt;code>ItemUsage&lt;/code> is a &lt;code>ItemUsage&lt;/code> of that &lt;code>ItemDefinition&lt;/code> within a system. However, other kinds of Kernel &lt;code>Structures&lt;/code> are also allowed, to permit use of &lt;code>Structures&lt;/code> from the Kernel Model Libraries.&lt;/p>&#xA;itemDefinition = occurrenceDefinition->selectByKind(ItemDefinition)&#xA;specializesFromLibrary(&quot;Items::items&quot;)&#xA;isComposite and owningType &lt;> null and&#xA;(owningType.oclIsKindOf(ItemDefinition) or&#xA; owningType.oclIsKindOf(ItemUsage)) implies&#xA;    specializesFromLibrary(&quot;Items::Item::subitem&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="itemDefinition" upperBound="-1"
+        eType="#//Structure" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedItem"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The Structures that are the &lt;code>definitions&lt;/code> of this ItemUsage. Nominally, these are ItemDefinitions, but other kinds of Kernel Structures are also allowed, to permit use of Structures from the Kernel Library.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//OccurrenceUsage/occurrenceDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Structure" eSuperTypes="#//Class">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Structure&lt;/code> is a &lt;code>Class&lt;/code> of objects in the modeled universe that are primarily structural in nature. While such an object is not itself behavioral, it may be involved in and acted on by &lt;code>Behaviors&lt;/code>, and it may be the performer of some of them.&lt;/p>&#xA;&#xA;specializesFromLibrary('Objects::Object')"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PartUsage" eSuperTypes="#//ItemUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>PartUsage&lt;/code> is a usage of a &lt;code>PartDefinition&lt;/code> to represent a system or a part of a system. At least one of the &lt;code>itemDefinitions&lt;/code> of the &lt;code>PartUsage&lt;/code> must be a &lt;code>PartDefinition&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>A &lt;code>PartUsage&lt;/code> must subset, directly or indirectly, the base &lt;code>PartUsage&lt;/code> &lt;em>&lt;code>parts&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p>&#xA;itemDefinition->selectByKind(PartDefinition)&#xA;partDefinition->notEmpty()&#xA;specializesFromLibrary(&quot;Parts::parts&quot;)&#xA;isComposite and owningType &lt;> null and&#xA;(owningType.oclIsKindOf(ItemDefinition) or&#xA; owningType.oclIsKindOf(ItemUsage)) implies&#xA;    specializesFromLibrary(&quot;Items::Item::subparts&quot;)&#xA;owningFeatureMembership &lt;> null and&#xA;owningFeatureMembership.oclIsKindOf(ActorMembership) implies&#xA;    if owningType.oclIsKindOf(RequirementDefinition) or &#xA;       owningType.oclIsKindOf(RequirementUsage)&#xA;    then specializesFromLibrary('Requirements::RequirementCheck::actors')&#xA;    else specializesFromLibrary('Cases::Case::actors')&#xA;owningFeatureMembership &lt;> null and&#xA;owningFeatureMembership.oclIsKindOf(StakeholderMembership) implies&#xA;    specializesFromLibrary('Requirements::RequirementCheck::stakeholders')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="partDefinition" upperBound="-1"
+        eType="#//PartDefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedPart"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>itemDefinitions&lt;/code> of this PartUsage that are PartDefinitions.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//ItemUsage/itemDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PartDefinition" eSuperTypes="#//ItemDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>PartDefinition&lt;/code> is an &lt;code>ItemDefinition&lt;/code> of a &lt;code>Class&lt;/code> of systems or parts of systems. Note that all parts may be considered items for certain purposes, but not all items are parts that can perform actions within a system.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Parts::Part&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ItemDefinition" eSuperTypes="#//OccurrenceDefinition #//Structure">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ItemDefinition&lt;/code> is an &lt;code>OccurrenceDefinition&lt;/code> of the &lt;code>Structure&lt;/code> of things that may themselves be systems or parts of systems, but may also be things that are acted on by a system or parts of a system, but which do not necessarily perform actions themselves. This includes items that can be exchanged between parts of a system, such as water or electrical signals.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Items::Item&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PortUsage" eSuperTypes="#//OccurrenceUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>PortUsage&lt;/code> is a usage of a &lt;code>PortDefinition&lt;/code>. A &lt;code>PortUsage&lt;code> itself as well as all its &lt;code>nestedUsages&lt;/code> must be referential (non-composite).&lt;/p>&#xA;nestedUsage->&#xA;    reject(oclIsKindOf(PortUsage))->&#xA;    forAll(not isComposite)&#xA;specializesFromLibrary('Ports::ports')&#xA;isComposite and owningType &lt;> null and&#xA;(owningType.oclIsKindOf(PortDefinition) or&#xA; owningType.oclIsKindOf(PortUsage)) implies&#xA;    specializesFromLibrary('Ports::Port::subports')&#xA;owningType = null or&#xA;not owningType.oclIsKindOf(PortDefinition) and&#xA;not owningType.oclIsKindOf(PortUsage) implies&#xA;    isReference"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="portDefinition" upperBound="-1"
+        eType="#//PortDefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedPort"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>occurrenceDefinitions&lt;/code> of this &lt;code>PortUsage&lt;/code>, which must all be &lt;code>PortDefinitions&lt;code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//OccurrenceUsage/occurrenceDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PortDefinition" eSuperTypes="#//OccurrenceDefinition #//Structure">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>PortDefinition&lt;/code> defines a point at which external entities can connect to and interact with a system or part of a system. Any &lt;code>ownedUsages&lt;/code> of a &lt;code>PortDefinition&lt;/code>, other than &lt;code>PortUsages&lt;/code>, must not be composite.&lt;/p>&#xA;&#xA;&#xA;&#xA;conjugatedPortDefinition = &#xA;let conjugatedPortDefinitions : OrderedSet(ConjugatedPortDefinition) =&#xA;    ownedMember->selectByKind(ConjugatedPortDefinition) in&#xA;if conjugatedPortDefinitions->isEmpty() then null&#xA;else conjugatedPortDefinitions->first()&#xA;endif&#xA;ownedUsage->&#xA;    reject(oclIsKindOf(PortUsage))->&#xA;    forAll(not isComposite)&#xA;not oclIsKindOf(ConjugatedPortDefinition) implies&#xA;    ownedMember->&#xA;        selectByKind(ConjugatedPortDefinition)->&#xA;        size() = 1&#xA;specializeFromLibrary('Ports::Port')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="conjugatedPortDefinition"
+        ordered="false" eType="#//ConjugatedPortDefinition" volatile="true" transient="true"
+        derived="true" eOpposite="#//ConjugatedPortDefinition/originalPortDefinition">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;codeConjugatedPortDefinition&lt;/code> that is conjugate to this &lt;code>PortDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ConjugatedPortDefinition" eSuperTypes="#//PortDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ConjugatedPortDefinition&lt;/code> is a &lt;code>PortDefinition&lt;/code> that is a &lt;code>PortDefinition&lt;/code> of its original &lt;code>PortDefinition&lt;/code>. That is, a &lt;code>ConjugatedPortDefinition&lt;/code> inherits all the &lt;code>features&lt;/code> of the original &lt;code>PortDefinition&lt;/code>, but input &lt;code>flows&lt;/code> of the original &lt;code>PortDefinition&lt;/code> become outputs on the &lt;code>ConjugatedPortDefinition&lt;/code> and output &lt;code>flows&lt;/code> of the original &lt;code>PortDefinition&lt;/code> become inputs on the &lt;code>ConjugatedPortDefinition&lt;/code>. Every &lt;code>PortDefinition&lt;/code> (that is not itself a &lt;code>&lt;code>ConjugatedPortDefinition&lt;/code>&lt;/code>) has exactly one corresponding &lt;code>ConjugatedPortDefinition&lt;/code>, whose effective name is the name of the &lt;code>originalPortDefinition&lt;/code>, with the character &lt;code>~&lt;/code> prepended.&lt;/p>&#xA;ownedPortConjugator.originalPortDefinition = originalPortDefinition&#xA;conjugatedPortDefinition = null"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedPortConjugator" ordered="false"
+        lowerBound="1" eType="#//PortConjugation" volatile="true" transient="true"
+        derived="true" eOpposite="#//PortConjugation/conjugatedPortDefinition">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>PortConjugation&lt;/code> that is the &lt;code>ownedConjugator&lt;/code> of this &lt;code>ConjugatedPortDefinition&lt;/code>, linking it to its &lt;code>originalPortDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Type/ownedConjugator"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="originalPortDefinition"
+        ordered="false" lowerBound="1" eType="#//PortDefinition" volatile="true" transient="true"
+        derived="true" eOpposite="#//PortDefinition/conjugatedPortDefinition">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The original &lt;code>PortDefinition&lt;/code> for this &lt;code>ConjugatedPortDefinition&lt;/code>, which is the &lt;code>owningNamespace&lt;/code> of the &lt;code>ConjugatedPortDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Element/owningNamespace"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PortConjugation" eSuperTypes="#//Conjugation">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>PortConjugation&lt;/code> is a &lt;code>Conjugation&lt;/code> &lt;code>Relationship&lt;/code> between a &lt;code>PortDefinition&lt;/code> and its corresponding &lt;code>ConjugatedPortDefinition&lt;/code>. As a result of this &lt;code>Relationship&lt;/code>, the &lt;code>ConjugatedPortDefinition&lt;/code> inherits all the &lt;code>features&lt;/code> of the original &lt;code>PortDefinition&lt;/code>, but input &lt;code>flows&lt;/code> of the original &lt;code>PortDefinition&lt;/code> become outputs on the &lt;code>ConjugatedPortDefinition&lt;/code> and output &lt;code>flows&lt;/code> of the original &lt;code>PortDefinition&lt;/code> become inputs on the &lt;code>ConjugatedPortDefinition&lt;/code>.&lt;/code>&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="originalPortDefinition"
+        ordered="false" lowerBound="1" eType="#//PortDefinition">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="portConjugation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>PortDefinition&lt;/code> being conjugated.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Conjugation/originalType"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="conjugatedPortDefinition"
+        ordered="false" lowerBound="1" eType="#//ConjugatedPortDefinition" volatile="true"
+        transient="true" derived="true" eOpposite="#//ConjugatedPortDefinition/ownedPortConjugator">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConjugatedPortDefinition&lt;/code> that is conjugate to the &lt;code>originalPortDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Conjugation/owningType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FlowConnectionUsage" eSuperTypes="#//ConnectionUsage #//ActionUsage #//ItemFlow">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FlowConnectionUsage&lt;/code> is a &lt;code>ConnectionUsage&lt;/code> that is also an &lt;code>ItemFlow&lt;/code>.&lt;/p>&#xA;if itemFlowEnds->isEmpty() then&#xA;    specializesFromLibrary(&quot;Connections::messageConnections&quot;)&#xA;else&#xA;    specializesFromLibrary(&quot;Connections::flowConnections&quot;&#xA;endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="flowConnectionDefinition"
+        upperBound="-1" eType="#//Interaction" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedFlowConnection"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Interactions&lt;/code> that are the &lt;code>types&lt;/code> of this &lt;code>FlowConnectionUsage&lt;/code>. Nominally, these are &lt;code>FlowConnectionDefinitions&lt;/code>, but other kinds of Kernel &lt;code>Interactions&lt;/code> are also allowed, to permit use of Interactions from the Kernel Model Libraries.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//ActionUsage/actionDefinition #//ConnectionUsage/connectionDefinition #//ItemFlow/interaction"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ItemFlow" eSuperTypes="#//Connector #//Step">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ItemFlow&lt;/code> is a &lt;code>Step&lt;/code> that represents the transfer of objects or data values from one &lt;code>Feature&lt;/code> to another. &lt;code>ItemFlows&lt;/code> can take non-zero time to complete.&lt;/p>&#xA;&#xA;if itemFlowEnds->isEmpty() then&#xA;    specializesFromLibrary(&quot;Transfers::transfers&quot;)&#xA;else&#xA;    specializesFromLibrary(&quot;Transfers::flowTransfers&quot;)&#xA;endif&#xA;itemType =&#xA;    if itemFeature = null then Sequence{}&#xA;    else itemFeature.type&#xA;    endif&#xA;sourceOutputFeature =&#xA;    if connectorEnd->isEmpty() or &#xA;        connectorEnd.ownedFeature->isEmpty()&#xA;    then null&#xA;    else connectorEnd.ownedFeature->first()&#xA;    endif&#xA;targetInputFeature =&#xA;    if connectorEnd->size() &lt; 2 or &#xA;        connectorEnd->at(2).ownedFeature->isEmpty()&#xA;    then null&#xA;    else connectorEnd->at(2).ownedFeature->first()&#xA;    endif&#xA;itemFlowEnd = connectorEnd->selectByKind(ItemFlowEnd)&#xA;itemFeature =&#xA;    let itemFeatures : Sequence(ItemFeature) = &#xA;        ownedFeature->selectByKind(ItemFeature) in&#xA;    if itemFeatures->isEmpty() then null&#xA;    else itemFeatures->first()&#xA;    endif&#xA;ownedFeature->selectByKind(ItemFeature)->size() &lt;= 1"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="itemType" unique="false"
+        upperBound="-1" eType="#//Classifier" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="itemFlowForType"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The type of values transferred, which is the &lt;code>type&lt;/code> of the &lt;code>itemFeature&lt;/code> of the &lt;code>ItemFlow&lt;/code>.&lt;/p>&#xA;&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="targetInputFeature" unique="false"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="itemFlowToInput"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that receives the values carried by the &lt;code>ItemFlow&lt;/code>. It must be an owned &lt;code>output&lt;/code> of the target participant of the &lt;code>ItemFlow&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="sourceOutputFeature" unique="false"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="itemFlowFromOutput"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that provides the items carried by the &lt;code>ItemFlow&lt;/code>. It must be an owned &lt;code>output&lt;/code> of the &lt;code>source&lt;/code> of the &lt;code>ItemFlow&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="itemFlowEnd" upperBound="2"
+        eType="#//ItemFlowEnd" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>connectorEnds&lt;/code> of this &lt;code>ItemFlow&lt;/code> that are &lt;code>ItemFlowEnds&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Connector/connectorEnd"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="itemFeature" ordered="false"
+        eType="#//ItemFeature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedFeature&lt;/code> of the &lt;code>ItemFlow&lt;/code> that is an &lt;code>ItemFeature&lt;/code> (if any).&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="interaction" upperBound="-1"
+        eType="#//Interaction" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Interactions&lt;/code> that type this &lt;code>ItemFlow&lt;/code>. &lt;code>Interactions&lt;/code> are both &lt;code>Associations&lt;/code> and &lt;code>Behaviors&lt;/code>, which can type &lt;code>Connectors&lt;/code> and &lt;code>Steps&lt;/code>, respectively.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Connector/association #//Step/behavior"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Connector" eSuperTypes="#//Feature #//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Connector&lt;/code> is a usage of &lt;code>Associations&lt;/code>, with links restricted according to instances of the &lt;code>Type&lt;/code> in which they are used (domain of the &lt;code>Connector&lt;/code>). The &lt;code>associations&lt;/code> of the &lt;code>Connector&lt;/code> restrict what kinds of things might be linked. The &lt;code>Connector&lt;/code> further restricts these links to be between values of &lt;code>Features&lt;/code> on instances of its domain.&lt;/p>&#xA;&#xA;relatedFeature = connectorEnd.ownedReferenceSubsetting->&#xA;    select(s | s &lt;> null).subsettedFeature&#xA;relatedFeature->forAll(f | &#xA;    if featuringType->isEmpty() then f.isFeaturedWithin(null)&#xA;    else featuringType->exists(t | f.isFeaturedWithin(t))&#xA;    endif)&#xA;sourceFeature = &#xA;    if relatedFeature->isEmpty() then null &#xA;    else relatedFeature->first() &#xA;    endif&#xA;targetFeature =&#xA;    if relatedFeature->size() &lt; 2 then OrderedSet{}&#xA;    else &#xA;        relatedFeature->&#xA;            subSequence(2, relatedFeature->size())->&#xA;            asOrderedSet()&#xA;    endif&#xA;not isAbstract implies relatedFeature->size() >= 2&#xA;specializesFromLibrary(&quot;Links::links&quot;)&#xA;association->exists(oclIsKindOf(AssociationStructure)) implies&#xA;    specializesFromLibrary(&quot;Objects::linkObjects&quot;)&#xA;connectorEnds->size() = 2 and&#xA;association->exists(oclIsKindOf(AssocationStructure)) implies&#xA;    specializesFromLibrary(&quot;Objects::binaryLinkObjects&quot;)&#xA;connectorEnd->size() = 2 implies&#xA;    specializesFromLibrary(&quot;Links::binaryLinks&quot;)&#xA;connectorEnds->size() > 2 implies&#xA;    not specializesFromLibrary(&quot;Links::BinaryLink&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="relatedFeature" unique="false"
+        upperBound="-1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="connector"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Features&lt;/code> that are related by this &lt;code>Connector&lt;/code> considered as a &lt;code>Relationship&lt;/code> and that restrict the links it identifies, given by the referenced &lt;code>Features&lt;/code> of the &lt;code>connectorEnds&lt;/code> of the &lt;code>Connector&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/relatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="association" upperBound="-1"
+        eType="#//Association" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedConnector"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Associations&lt;/code> that type the &lt;code>Connector&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Feature/type"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isDirected" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>For a binary &lt;code>Connector&lt;/code>, whether or not the &lt;code>Connector&lt;/code> should be considered to have a direction from &lt;code>sourceFeature&lt;/code> to &lt;code>targetFeature&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="connectorEnd" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringConnector"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>endFeatures&lt;/code> of a &lt;code>Connector&lt;/code>, which redefine the &lt;code>endFeatures&lt;/code> of the &lt;code>associations&lt;/code> of the &lt;code>Connector&lt;/code>. The &lt;code>connectorEnds&lt;/code> determine via &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationships&lt;/code> which &lt;code>Features&lt;/code> are related by the &lt;code>Connector&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Type/endFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="sourceFeature" eType="#//Feature"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="sourceConnector"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The source &lt;code>relatedFeature&lt;/code> for this &lt;code>Connector&lt;/code>. It is the first &lt;code>relatedFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Connector/relatedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="targetFeature" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="targetConnector"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="p>The target &lt;code>relatedFeatures&lt;/code> for this &lt;code>Connector&lt;/code>. This includes all the &lt;code>relatedFeatures&lt;/code> other than the &lt;code>sourceFeature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+      <eAnnotations source="subsets" references="#//Connector/relatedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Association" eSuperTypes="#//Classifier #//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Association&lt;/code> is a &lt;code>Relationship&lt;/code> and a &lt;code>Classifier&lt;/code> to enable classification of links between things (in the universe). The co-domains (&lt;code>types&lt;/code>) of the &lt;code>associationEnd&lt;/code> &lt;code>Features&lt;/code> are the &lt;code>relatedTypes&lt;/code>, as co-domain and participants (linked things) of an &lt;code>Association&lt;/code> identify each other.&lt;/p>&#xA;&#xA;relatedType = associationEnd.type&#xA;specializesFromLibrary(&quot;Links::Link&quot;)&#xA;oclIsKindOf(Structure) = oclIsKindOf(AssociationStructure)&#xA;ownedEndFeature->size() = 2 implies&#xA;    specializesFromLibrary(&quot;Links::BinaryLink)&#xA;not isAbstract implies relatedType->size() >= 2&#xA;associationEnds->size() > 2 implies&#xA;    not specializesFromLibrary(&quot;Links::BinaryLink&quot;)&#xA;sourceType =&#xA;    if relatedType->isEmpty() then null&#xA;    else relatedType->first() endif&#xA;targetType =&#xA;    if relatedType->size() &lt; 2 then OrderedSet{}&#xA;    else &#xA;        relatedType->&#xA;            subSequence(2, relatedType->size())->&#xA;            asOrderedSet() &#xA;    endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="relatedType" unique="false"
+        upperBound="-1" eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="association"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>types&lt;/code> of the &lt;code>associationEnds&lt;/code> of the &lt;code>Association&lt;/code>, which are the &lt;code>relatedElements&lt;/code> of the &lt;code>Association&lt;/code> considered as a &lt;code>Relationship&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/relatedElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="sourceType" ordered="false"
+        eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="sourceAssociation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The source &lt;code>relatedType&lt;/code> for this &lt;code>Association&lt;/code>. It is the first &lt;code>relatedType&lt;/code> of the &lt;code>Association&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+      <eAnnotations source="subsets" references="#//Association/relatedType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="targetType" ordered="false"
+        upperBound="-1" eType="#//Type" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="targetAssociation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The target &lt;code>relatedTypes&lt;/code> for this &lt;code>Association&lt;/code>. This includes all the &lt;code>relatedTypes&lt;/code> other than the &lt;code>sourceType&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+      <eAnnotations source="subsets" references="#//Association/relatedType"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="associationEnd" ordered="false"
+        upperBound="-1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="associationWithEnd"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>features&lt;/code> of the &lt;code>Association&lt;/code> that identify the things that can be related by it. A concrete &lt;code>Association&lt;/code> must have at least two &lt;code>associationEnds&lt;/code>. When it has exactly two, the &lt;code>Association&lt;/code> is called a &lt;em>binary&lt;/em> &lt;code>Association&lt;/code>.&lt;/p> &#xA;&#xA;&lt;p>The ends of the Association determine which elements are eligible to be related by instances of the Association.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Type/endFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Step" eSuperTypes="#//Feature">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Step&lt;/code> is a &lt;code>Feature&lt;/code> that is typed by one or more &lt;code>Behaviors&lt;/code>. &lt;code>Steps&lt;/code> may be used by one &lt;code>Behavior&lt;/code> to coordinate the performance of other &lt;code>Behaviors&lt;/code>, supporting a steady refinement of behavioral descriptions. &lt;code>Steps&lt;/code> can be ordered in time and can be connected using &lt;code>ItemFlows&lt;/code> to specify things flowing between their &lt;code>parameters&lt;/code>.&lt;/p>&#xA;&#xA;allSupertypes()->includes(resolveGlobal(&quot;Performances::performances&quot;))&#xA;owningType &lt;> null and&#xA;    (owningType.oclIsKindOf(Behavior) or&#xA;     owningType.oclIsKindOf(Step)) implies&#xA;    specializesFromLibrary('Performances::Performance::enclosedPerformance')&#xA;isComposite and owningType &lt;> null and&#xA;(owningType.oclIsKindOf(Structure) or&#xA; owningType.oclIsKindOf(Feature) and&#xA; owningType.oclAsType(Feature).type->&#xA;    exists(oclIsKindOf(Structure)) implies&#xA;    specializesFromLibrary('Objects::Object::ownedPerformance')&#xA;owningType &lt;> null and&#xA;    (owningType.oclIsKindOf(Behavior) or&#xA;     owningType.oclIsKindOf(Step)) and&#xA;    self.isComposite implies&#xA;    specializesFromLibrary('Performances::Performance::subperformance')&#xA;behavior = type->selectByKind(Behavior)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="behavior" upperBound="-1"
+        eType="#//Behavior" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedStep"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Behaviors&lt;/code> that type this &lt;code>Step&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Feature/type"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="parameter" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="parameteredStep"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>Step&lt;/code>, which are defined as its &lt;code>directedFeatures&lt;/code>, whose values are passed into and/or out of a performance of the &lt;code>Step&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Type/directedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Behavior" eSuperTypes="#//Class">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Behavior &lt;/code>coordinates occurrences of other &lt;code>Behaviors&lt;/code>, as well as changes in objects. &lt;code>Behaviors&lt;/code> can be decomposed into &lt;code>Steps&lt;/code> and be characterized by &lt;code>parameters&lt;/code>.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Performances::Performance&quot;)&#xA;step = feature->selectByKind(Step)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="step" ordered="false" upperBound="-1"
+        eType="#//Step" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringBehavior"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Steps&lt;/code> that make up this &lt;code>Behavior&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="parameter" upperBound="-1"
+        eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="parameteredBehavior"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The parameters of this &lt;code>Behavior&lt;/code>, which are defined as its &lt;code>directedFeatures&lt;/code>, whose values are passed into and/or out of a performance of the &lt;code>Behavior&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Type/directedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ItemFlowEnd" eSuperTypes="#//Feature">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ItemFlowEnd&lt;/code> is a &lt;code>Feature&lt;/code> that is one of the &lt;code>connectorEnds&lt;/code> giving the &lt;code>&lt;em>source&lt;/em>&lt;/code> or &lt;code>&lt;em>target&lt;/em>&lt;/code> of an &lt;code>ItemFlow&lt;/code>. For &lt;code>ItemFlows&lt;/code> typed by &lt;code>&lt;em>FlowTransfer&lt;/em>&lt;/code> or its specializations, &lt;code>ItemFlowEnds&lt;/code> must have exactly one &lt;code>ownedFeature&lt;/code>, which redefines &lt;code>&lt;em>Transfer::source::sourceOutput&lt;/em>&lt;/code> or &lt;code>&lt;em>Transfer::target::targetInput&lt;/em>&lt;/code> and redefines the corresponding feature of the &lt;code>relatedElement&lt;/code> for its end.&lt;/p>&#xA;isEnd&#xA;ownedFeature->size() = 1&#xA;owningType &lt;> null and owningType.oclIsKindOf(ItemFlow)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ItemFeature" eSuperTypes="#//Feature">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ItemFeature&lt;/code> is the &lt;code>ownedFeature&lt;/code> of an &lt;code>ItemFlow&lt;/code> that identifies the things carried by the kinds of transfers that are instances of the &lt;code>ItemFlow&lt;/code>.&lt;/p>&#xA;ownedRedefinition.redefinedFeature->&#xA;    redefinesFromLibrary(&quot;Transfers::Transfer::item&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Interaction" eSuperTypes="#//Association #//Behavior">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Interaction&lt;/code> is a &lt;code>Behavior&lt;/code> that is also an &lt;code>Association&lt;/code>, providing a context for multiple objects that have behaviors that impact one another.&lt;/p>&#xA;"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ActionUsage" eSuperTypes="#//OccurrenceUsage #//Step">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ActionUsage&lt;/code> is a &lt;code>Usage&lt;/code> that is also a &lt;code>Step&lt;/code>, and, so, is typed by a &lt;code>Behavior&lt;/code>. Nominally, if the type is an &lt;code>ActionDefinition&lt;/code>, an &lt;code>ActionUsage&lt;/code> is a &lt;code>Usage&lt;/code> of that &lt;code>ActionDefinition&lt;/code> within a system. However, other kinds of kernel &lt;code>Behaviors&lt;/code> are also allowed, to permit use of &lt;code>Behaviors&lt;/code> from the Kernel Model Libraries.&lt;/p>&#xA;&#xA;isSubactionUsage() implies&#xA;    specializesFromLibrary('Actions::Action::subactions')&#xA;specializesFromLibrary('Actions::actions')&#xA;isComposite and owningType &lt;> null and&#xA;(owningType.oclIsKindOf(PartDefinition) or&#xA; owningType.oclIsKindOf(PartUsage)) implies&#xA;    specializesFromLibrary('Parts::Part::ownedActions')&#xA;owningFeatureMembership &lt;> null and&#xA;owningFeatureMembership.oclIsKindOf(StateSubactionMembership) implies&#xA;    let kind : StateSubactionKind = &#xA;        owningFeatureMembership.oclAsType(StateSubactionMembership).kind in&#xA;    if kind = StateSubactionKind::entry then&#xA;        redefinesFromLibrary('States::StateAction::entryAction')&#xA;    else if kind = StateSubactionKind::do then&#xA;        redefinesFromLibrary('States::StateAction::doAction')&#xA;    else&#xA;        redefinesFromLibrary('States::StateAction::exitAction')&#xA;    endif endif&#xA;owningType &lt;> null and&#xA;    (owningType.oclIsKindOf(AnalysisCaseDefinition) and&#xA;        owningType.oclAsType(AnalysisCaseDefinition).analysisAction->&#xA;            includes(self) or&#xA;     owningType.oclIsKindOf(AnalysisCaseUsage) and&#xA;        owningType.oclAsType(AnalysisCaseUsage).analysisAction->&#xA;            includes(self)) implies&#xA;    specializesFromLibrary('AnalysisCases::AnalysisCase::analysisSteps')"/>
+    </eAnnotations>
+    <eOperations name="inputParameters" ordered="false" upperBound="-1" eType="#//Feature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the owned input &lt;code>parameters&lt;/code> of this &lt;code>ActionUsage&lt;/code>.&lt;/p>&#xA;input->select(f | f.owner = self)"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="inputParameter" ordered="false" eType="#//Feature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the &lt;code>i&lt;code>-th owned input &lt;code>parameter&lt;/code> of the &lt;code>ActionUsage&lt;/code>. Return null if the &lt;code>ActionUsage&lt;/code> has less than &lt;code>i&lt;code> owned input &lt;code>parameters&lt;/code>.&lt;/p>&#xA;if inputParameters()->size() &lt; i then null&#xA;else inputParameters()->at(i)&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="i" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Integer"/>
+    </eOperations>
+    <eOperations name="argument" ordered="false" eType="#//Expression">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the &lt;code>i&lt;code>-th argument &lt;code>Expression&lt;/code> of an &lt;code>ActionUsage&lt;/code>, defined as the &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> of the &lt;code>FeatureValue&lt;/code> of the &lt;code>i&lt;code>-th owned input &lt;code>parameter&lt;/code> of the &lt;code>ActionUsage&lt;/code>. Return null if the &lt;code>ActionUsage&lt;/code> has less than &lt;code>i&lt;code> owned input &lt;code>parameters&lt;/code> or the &lt;code>i&lt;code>-th owned input &lt;code>parameter&lt;/code> has no &lt;code>FeatureValue&lt;/code>.&lt;/code>&#xA;if inputParameter(i) = null then null&#xA;else&#xA;    let featureValue : Sequence(FeatureValue) = inputParameter(i).&#xA;        ownedMembership->select(oclIsKindOf(FeatureValue)) in&#xA;    if featureValue->isEmpty() then null&#xA;    else featureValue->at(1).value&#xA;    endif&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="i" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Integer"/>
+    </eOperations>
+    <eOperations name="isSubactionUsage" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check if this &lt;code>ActionUsage&lt;/code> is composite and has an &lt;code>owningType&lt;/code> that is an &lt;code>ActionDefinition&lt;/code> or &lt;code>ActionUsage&lt;/code> but is &lt;em>not&lt;/em> the &lt;code>entryAction&lt;/code> or &lt;code>exitAction&lt;/em>&lt;/code> of a &lt;code>StateDefinition&lt;/code> or &lt;code>StateUsage&lt;/code>. If so, then it represents an &lt;code>&lt;em>Action&lt;/em>&lt;/code> that is a &lt;code>&lt;em>subaction&lt;/em>&lt;/code> of another &lt;code>&lt;em>Action&lt;/em>&lt;/code>.&lt;/p>&#xA;isComposite and owningType &lt;> null and&#xA;(owningType.oclIsKindOf(ActionDefinition) or&#xA; owningType.oclIsKindOf(ActionUsage)) and&#xA;(owningFeatureMembership.oclIsKindOf(StateSubactionMembership) implies&#xA; owningFeatureMembership.oclAsType(StateSubactionMembership).kind = &#xA;    StateSubactionKind::do)"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="actionDefinition" upperBound="-1"
+        eType="#//Behavior" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Behaviors&lt;/code> that are the &lt;code>types&lt;/code> of this &lt;code>ActionUsage&lt;/code>. Nominally, these would be &lt;code>ActionDefinitions&lt;code>, but other kinds of Kernel &lt;code>Behaviors&lt;/code> are also allowed, to permit use of &lt;code>Behaviors&lt;/code> from the Kernel Model Libraries.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Step/behavior #//OccurrenceUsage/occurrenceDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Expression" eSuperTypes="#//Step">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Expression&lt;/code> is a &lt;code>Step&lt;/code> that is typed by a &lt;code>Function&lt;/code>. An &lt;code>Expression&lt;/code> that also has a &lt;code>Function&lt;/code> as its &lt;code>featuringType&lt;/code> is a computational step within that &lt;code>Function&lt;/code>. An &lt;code>Expression&lt;/code> always has a single &lt;code>result&lt;/code> parameter, which redefines the &lt;code>result&lt;/code> parameter of its defining &lt;code>function&lt;/code>. This allows &lt;code>Expressions&lt;/code> to be interconnected in tree structures, in which inputs to each &lt;code>Expression&lt;/code> in the tree are determined as the results of other &lt;code>Expression&lt;/code> in the tree.&lt;/p>&#xA;&#xA;isModelLevelEvaluable = modelLevelEvaluable(Set(Element){})&#xA;specializesFromLibrary(&quot;Performances::evaluations&quot;)&#xA;owningMembership &lt;> null and &#xA;owningMembership.oclIsKindOf(FeatureValue) implies&#xA;    let featureWithValue : Feature = &#xA;        owningMembership.oclAsType(FeatureValue).featureWithValue in&#xA;    featuringType = featureWithValue.featuringType&#xA;ownedMembership.selectByKind(ResultExpressionMembership)->&#xA;    forAll(mem | ownedFeature.selectByKind(BindingConnector)->&#xA;        exists(binding |&#xA;            binding.relatedFeature->includes(result) and&#xA;            binding.relatedFeature->includes(mem.ownedResultExpression.result)))&#xA;result =&#xA;    let resultParams : Sequence(Feature) =&#xA;        ownedFeatureMemberships->&#xA;            selectByKind(ReturnParameterMembership).&#xA;            ownedParameterMember in&#xA;    if resultParams->notEmpty() then resultParams->first()&#xA;    else if function &lt;> null then function.result&#xA;    else null&#xA;    endif endif&#xA;ownedFeatureMembership->&#xA;    selectByKind(ReturnParameterMembership)->&#xA;    size() &lt;= 1"/>
+    </eAnnotations>
+    <eOperations name="modelLevelEvaluable" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return whether this &lt;code>Expression&lt;/code> is model-level evaluable. The &lt;code>visited&lt;/code> parameter is used to track possible circular &lt;code>Feature&lt;/code> references. Such circular references are not allowed in model-level evaluable expressions.&lt;/p>&#xA;&#xA;&lt;p>An &lt;code>Expression&lt;/code> that is not otherwise specialized is model-level evaluable if all of it has no &lt;code>ownedSpecialziations&lt;/code> and all its (non-implicit) &lt;code>features&lt;/code> are either &lt;code>in&lt;/code> parameters, the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> or a result &lt;code>Expression&lt;/code> owned via a &lt;code>ResultExpressionMembership&lt;/code>. The &lt;code>parameters&lt;/code>  must not have any &lt;code>ownedFeatures&lt;/code> or a &lt;code>FeatureValue&lt;/code>, and the result &lt;code>Expression&lt;/code> must be model-level evaluable.&lt;/p>&#xA;ownedSpecialization->isEmpty() and&#xA;ownedFeature->forAll(f |&#xA;    (f.oclIsKindOf(Relationship) and &#xA;        f.oclAsType(Relationship).isImplicit) or &#xA;    (directionOf(f) = FeatureDirectionKind::_'in' or f = result) and &#xA;        f.ownedFeature->isEmpty() f.valuation = null and  or&#xA;    f.owningFeatureMembership.oclIsKindOf(ResultExpressionMembership) and&#xA;        f.oclAsType(Expression).modelLevelEvaluable(visited)&#xA;    "/>
+      </eAnnotations>
+      <eParameters name="visited" ordered="false" upperBound="-1" eType="#//Feature"/>
+    </eOperations>
+    <eOperations name="evaluate" unique="false" upperBound="-1" eType="#//Element">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>If this &lt;code>Expression&lt;/code> &lt;code>isModelLevelEvaluable&lt;/code>, then evaluate it using the &lt;code>target&lt;/code> as the context &lt;code>Element&lt;/code> for resolving &lt;code>Feature&lt;/code> names and testing classification. The result is a collection of &lt;code>Elements&lt;/code>, which, for a fully evaluable &lt;code>Expression&lt;/code>, will be a &lt;code>LiteralExpression&lt;/code> or a &lt;code>Feature&lt;/code> that is not an &lt;code>Expression&lt;/code>.&lt;/p>&#xA;isModelLevelEvaluable&#xA;let resultExprs : Sequence(Expression) =&#xA;    ownedFeatureMembership->&#xA;        selectByKind(ResultExpressionMembership).&#xA;        ownedResultExpression in&#xA;if resultExpr->isEmpty() then Sequence{}&#xA;else resultExprs->first().evaluate(target)&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="target" ordered="false" lowerBound="1" eType="#//Element"/>
+    </eOperations>
+    <eOperations name="checkCondition" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Model-level evaluate this &lt;code>Expression&lt;/code> with the given &lt;code>target&lt;/code>. If the result is a &lt;code>LiteralBoolean&lt;/code>, return its &lt;code>value&lt;/code>. Otherwise return &lt;code>false&lt;/code>.&lt;/p>&#xA;&#xA;let results: Sequence(Element) = evaluate(target) in&#xA;    result->size() = 1 and&#xA;    results->first().oclIsKindOf(LiteralBoolean) and &#xA;    results->first().oclAsType(LiteralBoolean).value"/>
+      </eAnnotations>
+      <eParameters name="target" ordered="false" lowerBound="1" eType="#//Element"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="function" ordered="false"
+        eType="#//Function" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Function&lt;/code> that types this &lt;code>Expression&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>This is the Function that types the Expression.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Step/behavior"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="result" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="computingExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;p>An &lt;code>output&lt;/code> &lt;code>parameter&lt;/code> of the &lt;code>Expression&lt;/code> whose value is the result of the &lt;code>Expression&lt;/code>. The result of an &lt;code>Expression&lt;/code> is either inherited from its &lt;code>function&lt;/code> or it is related to the &lt;code>Expression&lt;/code> via a &lt;code>ReturnParameterMembership&lt;/code>, in which case it redefines the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of its &lt;code>function&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/parameter #//Type/output"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isModelLevelEvaluable"
+        ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>Expression&lt;/code> meets the constraints necessary to be evaluated at &lt;em>model level&lt;/em>, that is, using metadata within the model.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Function" eSuperTypes="#//Behavior">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Function&lt;/code> is a &lt;code>Behavior&lt;/code> that has an &lt;code>out&lt;/code> &lt;code>parameter&lt;/code> that is identified as its &lt;code>result&lt;/code>. A &lt;code>Function&lt;/code> represents the performance of a calculation that produces the values of its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code>. This calculation may be decomposed into &lt;code>Expressions&lt;/code? that are &lt;code>steps&lt;/code> of the &lt;code>Function&lt;/code>.&lt;/p>&#xA;&#xA;ownedMembership.selectByKind(ResultExpressionMembership)->&#xA;    forAll(mem | ownedFeature.selectByKind(BindingConnector)->&#xA;        exists(binding |&#xA;            binding.relatedFeature->includes(result) and&#xA;            binding.relatedFeature->includes(mem.ownedResultExpression.result)))&#xA;specializesFromLibrary(&quot;Performances::Evaluation&quot;)&#xA;result =&#xA;    let resultParams : Sequence(Feature) =&#xA;        ownedFeatureMemberships->&#xA;            selectByKind(ReturnParameterMembership).&#xA;            ownedParameterMember in&#xA;    if resultParams->notEmpty() then resultParams->first()&#xA;    else null&#xA;    endif&#xA;ownedFeatureMembership->&#xA;    selectByKind(ReturnParameterMembership)->&#xA;    size() &lt;= 1"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        upperBound="-1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="computedFunction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expressions&lt;/code> that are &lt;code>steps&lt;/code> in the calculation of the &lt;code>result&lt;/code> of this &lt;code>Function&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The set of expressions that represent computational steps or parts of a system of equations within the Function.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/step"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="result" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="computingFunction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the &lt;code>Function&lt;/code>, which is owned by the &lt;code>Function&lt;/code> via a &lt;code>ReturnParameterMembership&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The object or value that is the result of evaluating the Function.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/parameter #//Type/output"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isModelLevelEvaluable"
+        ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>Function&lt;/code> can be used as the &lt;code>function&lt;/code> of a model-level evaluable &lt;code>InvocationExpression&lt;/code>. Certain &lt;code>Functions&lt;/code> from the Kernel Functions Library are considered to have &lt;code>isModelLevelEvaluable = true&lt;/code>. For all other &lt;code>Functions&lt;/code> it is &lt;code>false&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>&lt;strong>Note:&lt;/strong> See the specification of the KerML concrete syntax notation for &lt;code>Expressions&lt;/code> for an identification of which library &lt;code>Functions&lt;/code> are model-level evaluable.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AllocationUsage" eSuperTypes="#//ConnectionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AllocationUsage&lt;/code> is a usage of an &lt;code>AllocationDefinition&lt;/code> asserting the allocation of the &lt;code>source&lt;/code> feature to the &lt;code>target&lt;/code> feature.&lt;/p>&#xA;specializesFromLibrary(&quot;Allocations::allocations&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="allocationDefinition" upperBound="-1"
+        eType="#//AllocationDefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedAllocation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AllocationDefinitions&lt;/code> that are the types of this &lt;code>AllocationUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//ConnectionUsage/connectionDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AllocationDefinition" eSuperTypes="#//ConnectionDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AllocationDefinition&lt;/code> is a &lt;code>ConnectionDefinition&lt;/code> that specifies that some or all of the responsibility to realize the intent of the &lt;code>source&lt;/code> is allocated to the &lt;code>target&lt;/code> instances. Such allocations define mappings across the various structures and hierarchies of a system model, perhaps as a precursor to more rigorous specifications and implementations. An &lt;code>AllocationDefinition&lt;/code> can itself be refined using nested &lt;code>allocations&lt;/code> that give a finer-grained decomposition of the containing allocation mapping.&lt;/p>&#xA;allocation = usage->selectAsKind(AllocationUsage)&#xA;specializesFromLibrary(&quot;Allocations::Allocation&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="allocation" upperBound="-1"
+        eType="#//AllocationUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringAllocationDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AllocationUsages&lt;/code> that refine the allocation mapping defined by this &lt;code>AllocationDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/usage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ConnectionDefinition" eSuperTypes="#//PartDefinition #//AssociationStructure">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ConnectionDefinition&lt;/code> is a &lt;code>PartDefinition&lt;/code> that is also an &lt;code>AssociationStructure&lt;/code>. The end &lt;code>Features&lt;/code> of a &lt;code>ConnectionDefinition&lt;/code> must be &lt;code>Usages&lt;/code>.&lt;/p>&#xA;specializesFromLibrary(&quot;Connections::Connection&quot;)&#xA;ownedEndFeature->size() = 2 implies&#xA;    specializesFromLibrary(&quot;Connections::BinaryConnections&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="connectionEnd" upperBound="-1"
+        eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="connectionDefinitionWithEnd"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Usages&lt;/code> that define the things related by the &lt;code>ConnectionDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Association/associationEnd"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AssociationStructure" eSuperTypes="#//Association #//Structure">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AssociationStructure&lt;/code> is an &lt;code>Association&lt;/code> that is also a &lt;code>Structure&lt;/code>, classifying link objects that are both links and objects. As objects, link objects can be created and destroyed, and their non-end &lt;code>Features&lt;/code> can change over time. However, the values of the end &lt;code>Features&lt;/code> of a link object are fixed and cannot change over its lifetime.&lt;/p>&#xA;specializesFromLibrary(&quot;Objects::ObjectLink&quot;)&#xA;endFeature->size() = 2 implies&#xA;    specializesFromLibrary(&quot;Objects::BinaryLinkObject&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="StateUsage" eSuperTypes="#//ActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>StateUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that is nominally the &lt;code>Usage&lt;/code> of a &lt;code>StateDefinition&lt;/code>. However, other kinds of kernel &lt;code>Behaviors&lt;/code> are also allowed as &lt;code>types&lt;/code>, to permit use of &lt;code>Behaviors&lt;/code from the Kernel Model Libraries.&lt;/p>&#xA;&#xA;&lt;p>A &lt;code>StateUsage&lt;/code> may be related to up to three of its &lt;code>ownedFeatures&lt;/code> by &lt;code>StateSubactionMembership&lt;/code> &lt;code>Relationships&lt;code>, all of different &lt;code>kinds&lt;/code>, corresponding to the entry, do and exit actions of the &lt;code>StateUsage&lt;/code>.&lt;/p>&#xA;&#xA;let general : Sequence(Type) = ownedGeneralization.general in&#xA;general->selectByKind(StateDefinition)->&#xA;    forAll(g | g.isParallel = isParallel) and&#xA;general->selectByKind(StateUsage)->&#xA;    forAll(g | g.parallel = isParallel)&#xA;doAction =&#xA;    let doMemberships : Sequence(StateSubactionMembership) =&#xA;        ownedMembership->&#xA;            selectByKind(StateSubactionMembership)->&#xA;            select(kind = StateSubactionKind::do) in&#xA;    if doMemberships->isEmpty() then null&#xA;    else doMemberships->at(1)&#xA;    endif&#xA;entryAction =&#xA;    let entryMemberships : Sequence(StateSubactionMembership) =&#xA;        ownedMembership->&#xA;            selectByKind(StateSubactionMembership)->&#xA;            select(kind = StateSubactionKind::entry) in&#xA;    if entryMemberships->isEmpty() then null&#xA;    else entryMemberships->at(1)&#xA;    endif&#xA;isParallel implies&#xA;    nestedAction.incomingTransition->isEmpty() and&#xA;    nestedAction.outgoingTransition->isEmpty()&#xA;isSubstateUsage(true) implies&#xA;    specializesFromLibrary('States::State::substates')&#xA;exitAction =&#xA;    let exitMemberships : Sequence(StateSubactionMembership) =&#xA;        ownedMembership->&#xA;            selectByKind(StateSubactionMembership)->&#xA;            select(kind = StateSubactionKind::exit) in&#xA;    if exitMemberships->isEmpty() then null&#xA;    else exitMemberships->at(1)&#xA;    endif&#xA;specializesFromLibrary('States::StateAction')&#xA;ownedMembership->&#xA;    selectByKind(StateSubactionMembership)->&#xA;    isUnique(kind)&#xA;isSubstateUsage(false) implies&#xA;    specializesFromLibrary('States::State::substates')"/>
+    </eAnnotations>
+    <eOperations name="isSubstateUsage" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check if this &lt;code>StateUsage&lt;/code> is composite and has an &lt;code>owningType&lt;/code> that is an &lt;code>StateDefinition&lt;/code> or &lt;code>StateUsage&lt;/code> with the given value of &lt;code>isParallel&lt;/code>, but is &lt;em>not&lt;/em> an &lt;code>entryAction&lt;/code> or &lt;code>exitAction&lt;/code>. If so, then it represents a &lt;code>&lt;em>StateAction&lt;/em>&lt;/code> that is a &lt;code>&lt;em>substate&lt;/em>&lt;/code> or &lt;code>&lt;em>exclusiveState&lt;/em>&lt;/code> (for &lt;code>isParallel = false&lt;/code>) of another &lt;code>&lt;em>StateAction&lt;/em>&lt;/code>.&lt;/p>&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(StateDefinition) and&#xA;    owningType.oclAsType(StateDefinition).isParallel = isParallel or&#xA; owningType.oclIsKindOf(StateUsage) and&#xA;    owningType.oclAsType(StateUsage).isParallel = isParallel) and&#xA;not owningFeatureMembership.oclIsKindOf(StateSubactionMembership)"/>
+      </eAnnotations>
+      <eParameters name="isParallel" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="stateDefinition" upperBound="-1"
+        eType="#//Behavior" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedState"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Behaviors&lt;code> that are the &lt;code>types&lt;/code> of this &lt;code>StateUsage&lt;code>. Nominally, these would be &lt;code>StateDefinitions&lt;/code>, but kernel &lt;code>Behaviors&lt;/code> are also allowed, to permit use of &lt;code>Behaviors&lt;/code> from the Kernel Model Libraries.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//ActionUsage/actionDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="entryAction" ordered="false"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="enteredState"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateUsage&lt;/code> to be performed on entry to the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateUsage&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = entry&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="doAction" ordered="false"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="activeState"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateUsage&lt;/code> to be performed while in the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateUsage&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = do&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="exitAction" ordered="false"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="exitedState"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateUsage&lt;/code> to be performed on exit to the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateUsage&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = exit&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isParallel" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether the &lt;code>nestedStates&lt;/code> of this &lt;code>StateUsage&lt;/code> are to all be performed in parallel. If true, none of the &lt;code>nestedActions&lt;/code> (which include &lt;code>nestedStates&lt;/code>) may have any incoming or outgoing &lt;code>Transitions&lt;/code>. If false, only one &lt;code>nestedState&lt;/code> may be performed at a time.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TransitionUsage" eSuperTypes="#//ActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>TransitionUsage&lt;/code> is an &lt;code>ActionUsage&lt;code> representing a triggered transition between &lt;code>ActionUsages&lt;/code> or &lt;code>StateUsages&lt;/code>. When triggered by a &lt;code>triggerAction&lt;/code>, when its &lt;code>guardExpression&lt;/code> is true, the &lt;code>TransitionUsage&lt;/code> asserts that its &lt;code>source&lt;/code> is exited, then its &lt;code>effectAction&lt;/code> (if any) is performed, and then its &lt;code>target&lt;/code> is entered.&lt;/p>&#xA;&#xA;&lt;p>A &lt;code>TransitionUsage&lt;code> can be related to some of its &lt;code>ownedFeatures&lt;/code> using &lt;code>TransitionFeatureMembership&lt;/code> &lt;code>Relationships&lt;/code>, corresponding to the &lt;code>triggerAction&lt;/code>, &lt;code>guardExpression&lt;/code> and &lt;code>effectAction&lt;/code> of the &lt;code>TransitionUsage&lt;/code>.&lt;/p>&#xA;isComposite and owningType &lt;> null and&#xA;(owningType.oclIsKindOf(ActionDefinition) or &#xA; owningType.oclIsKindOf(ActionUsage)) and&#xA;not (owningType.oclIsKindOf(StateDefinition) or&#xA;     owningType.oclIsKindOf(StateUsage)) implies&#xA;    specializesFromLibrary(&quot;Actions::Action::decisionTransitionActions&quot;)&#xA;isComposite and owningType &lt;> null and&#xA;(owningType.oclIsKindOf(StateDefinition) or&#xA; owningType.oclIsKindOf(StateUsage)) implies&#xA;    specializesFromLibrary(&quot;States::State::stateTransitions&quot;)&#xA;specializesFromLibrary(&quot;Actions::actions::transitionActions&quot;)&#xA;source =&#xA;    if ownedMembership->isEmpty() then null&#xA;    else&#xA;        let member : Element = &#xA;            ownedMembership->at(1).memberElement in &#xA;        if not member.oclIsKindOf(ActionUsage) then null&#xA;        else member.oclAsKindOf(ActionUsage)&#xA;        endif&#xA;    endif&#xA;target =&#xA;    if succession.targetFeature->isEmpty() then null&#xA;    else&#xA;        let targetFeature : Feature = &#xA;            succession.targetFeature->at(1) in&#xA;        if not targetFeature.oclIsKindOf(ActionUsage) then null&#xA;        else targetFeature.oclAsType(ActionUsage)&#xA;        endif&#xA;    endif&#xA;triggerAction = ownedFeatureMembership->&#xA;    selectByKind(TransitionFeatureMembership)->&#xA;    select(kind = TransitionFeatureKind::trigger).transitionFeature->&#xA;    selectByKind(AcceptActionUsage)&#xA;let successions : Sequence(Successions) = &#xA;    ownedMember->selectByKind(Succession) in&#xA;successions->notEmpty() and&#xA;successions->at(1).targetFeature->&#xA;    forAll(oclIsKindOf(ActionUsage))&#xA;guardExpression = ownedFeatureMembership->&#xA;    selectByKind(TransitionFeatureMembership)->&#xA;    select(kind = TransitionFeatureKind::trigger).transitionFeature->&#xA;    selectByKind(Expression)&#xA;triggerAction->forAll(specializesFromLibrary('Actions::TransitionAction::accepter') and&#xA;guardExpression->forAll(specializesFromLibrary('Actions::TransitionAction::guard') and&#xA;effectAction->forAll(specializesFromLibrary('Actions::TransitionAction::effect'))&#xA;triggerAction = ownedFeatureMembership->&#xA;    selectByKind(TransitionFeatureMembership)->&#xA;    select(kind = TransitionFeatureKind::trigger).transitionFeatures->&#xA;    selectByKind(AcceptActionUsage)&#xA;succession.sourceFeature = source&#xA;ownedMember->selectByKind(BindingConnector)->exists(b |&#xA;    b.relatedFeatures->includes(source) and&#xA;    b.relatedFeatures->includes(inputParameter(2)))&#xA;triggerAction->notEmpty() implies&#xA;    let payloadParameter : Feature = inputParameter(2) in&#xA;    payloadParameter &lt;> null and&#xA;    payloadParameter.subsetsChain(triggerAction->at(1), triggerPayloadParameter())&#xA;ownedMember->selectByKind(BindingConnector)->exists(b |&#xA;    b.relatedFeatures->includes(succession) and&#xA;    b.relatedFeatures->includes(resolveGlobal(&#xA;        'TransitionPerformances::TransitionPerformance::transitionLink')))&#xA;if triggerAction->isEmpty() then&#xA;    inputParameters()->size() >= 1&#xA;else&#xA;    inputParameters()->size() >= 2&#xA;endif&#xA;    &#xA;succession = ownedMember->selectByKind(Succession)->at(1)"/>
+    </eAnnotations>
+    <eOperations name="triggerPayloadParameter" ordered="false" eType="#//ReferenceUsage">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the &lt;code>payloadParameter&lt;/code> of the &lt;code>triggerAction&lt;/code> of this &lt;code>TransitionUsage&lt;/code>, if it has one.&lt;/p>&#xA;if triggerAction->isEmpty() then null&#xA;else triggerAction->first().payloadParameter&#xA;endif"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="source" ordered="false"
+        lowerBound="1" eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="outgoingTransition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The source &lt;code>ActionUsage&lt;/code> of this &lt;code>TransitionUsage&lt;/code>, which becomes the &lt;code>source&lt;/code> of the &lt;code>succession&lt;/code> for the &lt;code>TransitionUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="target" ordered="false"
+        lowerBound="1" eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="incomingTransition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The target &lt;code>ActionUsage&lt;/code> of this &lt;code>TransitionUsage&lt;code>, which is the &lt;code>targetFeature&lt;/code> of the &lt;code>succession&lt;/code> for the &lt;code>TransitionUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="triggerAction" ordered="false"
+        upperBound="-1" eType="#//AcceptActionUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="triggeredTransition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AcceptActionUsages&lt;/code> that define the triggers of this &lt;code>TransitionUsage&lt;/code>, which are the &lt;code>ownedFeatures&lt;/code> of the &lt;code>TransitionUsage&lt;/code> related to it by &lt;code>TransitionFeatureMemberships&lt;/code> with &lt;code>kind = trigger&lt;/code>, which must all be &lt;code>AcceptActionUsages&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="guardExpression" ordered="false"
+        upperBound="-1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="guardedTransition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expressions&lt;/code> that define the guards of this &lt;code>TransitionUsage&lt;/code>, which are the &lt;code>ownedFeatures&lt;/code> of the &lt;code>TransitionUsage&lt;/code> related to it by &lt;code>TransitionFeatureMemberships&lt;/code> with &lt;code>kind = guard&lt;/code>, which must all be &lt;code>Expressions&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="effectAction" ordered="false"
+        upperBound="-1" eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="activeTransition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsages&lt;/code> that define the effects of this &lt;code>TransitionUsage&lt;/code>, which are the &lt;code>ownedFeatures&lt;/code> of the &lt;code>TransitionUsage&lt;/code> related to it by &lt;code>TransitionFeatureMemberships&lt;/code> with &lt;code>kind = effect&lt;/code>, which must all be &lt;code>Expressions&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/feature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="succession" ordered="false"
+        lowerBound="1" eType="#//Succession" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="linkedTransition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Succession&lt;/code> that is the &lt;code>ownedFeature&lt;/code> of this &lt;code>TransitionUsage&lt;/code>, which, if the &lt;code>TransitionUsage&lt;/code> is triggered, asserts the temporal ordering of the &lt;code>source&lt;/code> and &lt;code>target&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AcceptActionUsage" eSuperTypes="#//ActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AcceptActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that specifies the acceptance of an &lt;em>&lt;code>incomingTransfer&lt;/code>&lt;/em> from the &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> given by the result of its &lt;code>receiverArgument&lt;/code> Expression. (If no &lt;code>receiverArgument&lt;/code> is provided, the default is the &lt;em>&lt;code>this&lt;/code>&lt;/em> context of the AcceptActionUsage.) The payload of the accepted &lt;em>&lt;code>Transfer&lt;/em>&lt;/code> is output on its &lt;code>payloadParameter&lt;/code>. Which &lt;em>&lt;code>Transfers&lt;/em>&lt;/code> may be accepted is determined by conformance to the typing and (potentially) binding of the &lt;code>payloadParameter&lt;/code>.&lt;/p>&#xA;&#xA;inputParameters()->size() >= 2&#xA;receiverArgument = argument(2)&#xA;payloadArgument = argument(1)&#xA;payloadParameter = &#xA; if parameter->isEmpty() then null&#xA; else parameter->first() endif&#xA;not isTriggerAction() implies&#xA;    specializesFromLibrary('Actions::acceptActions')&#xA;isSubactionUsage() and not isTriggerAction() implies&#xA;    specializesFromLibrary('Actions::Action::acceptSubactions')&#xA;isTriggerAction() implies&#xA;    specializesFromLibrary('Actions::TransitionAction::accepter')&#xA;payloadArgument &lt;> null and&#xA;payloadArgument.oclIsKindOf(TriggerInvocationExpression) implies&#xA;    let invocation : Expression =&#xA;        payloadArgument.oclAsType(Expression) in&#xA;    parameter->size() >= 2 and&#xA;    invocation.parameter->size() >= 2 and        &#xA;    ownedFeature->selectByKind(BindingConnector)->exists(b |&#xA;        b.relatedFeatures->includes(parameter->at(2)) and&#xA;        b.relatedFeatures->includes(invocation.parameter->at(2)))"/>
+    </eAnnotations>
+    <eOperations name="isTriggerAction" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check if this &lt;code>AcceptActionUsage&lt;/code> is the &lt;code>triggerAction&lt;/code> of a &lt;code>TransitionUsage&lt;/code>.&lt;/p>&#xA;owningType &lt;> null and &#xA;owningType.oclIsKindOf(TransitionUsage) and&#xA;owningType.oclAsType(TransitionUsage).triggerAction->includes(self)"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="receiverArgument" ordered="false"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="acceptActionUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An &lt;code>Expression&lt;code> whose &lt;code>result&lt;/code> is bound to the &lt;em>&lt;code>receiver&lt;/code>&lt;/em> input &lt;code>parameter&lt;/code> of this &lt;code>AcceptActionUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="payloadParameter" ordered="false"
+        lowerBound="1" eType="#//ReferenceUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningAcceptActionUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>nestedReference&lt;/code> of this &lt;code>AcceptActionUsage&lt;/code> that redefines the &lt;code>payload&lt;/code> output &lt;code>parameter&lt;/code> of the base &lt;code>AcceptActionUsage&lt;/code> &lt;em>&lt;code>AcceptAction&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedReference #//Step/parameter"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="payloadArgument" ordered="false"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="acceptingActionUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An &lt;code>Expression&lt;code> whose &lt;code>result&lt;/code> is bound to the &lt;code>&lt;em>payload&lt;/em>&lt;/code> &lt;code>parameter &lt;/code> of this &lt;code>AcceptActionUsage&lt;/code>. If provided, the &lt;code>AcceptActionUsage&lt;/code> will only accept a &lt;code>&lt;em>Transfer&lt;/em>&lt;/code> with exactly this &lt;code>&lt;em>payload&lt;/em>&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Succession" eSuperTypes="#//Connector">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Succession&lt;/code> is a binary &lt;code>Connector&lt;/code> that requires its &lt;code>relatedFeatures&lt;/code> to happen separately in time.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Occurences::happensBeforeLinks&quot;)&#xA;transitionStep =&#xA;    if owningNamespace.oclIsKindOf(Step) and &#xA;        owningNamespace.oclAsType(Step).&#xA;            specializesFromLibrary('TransitionPerformances::TransitionPerformance') then&#xA;        owningNamespace.oclAsType(Step)&#xA;    else null&#xA;    endif&#xA;triggerStep =&#xA;    if transitionStep = null or &#xA;       transitionStep.ownedFeature.size() &lt; 2 or&#xA;       not transitionStep.ownedFeature->at(2).oclIsKindOf(Step) &#xA;    then Set{}&#xA;    else Set{transitionStep.ownedFeature->at(2).oclAsType(Step)}&#xA;    endif&#xA;effectStep =&#xA;    if transitionStep = null or &#xA;       transitionStep.ownedFeature.size() &lt; 4 or&#xA;       not transitionStep.ownedFeature->at(4).oclIsKindOf(Step) &#xA;    then Set{}&#xA;    else Set{transitionStep.ownedFeature->at(4).oclAsType(Step)}&#xA;    endif&#xA;guardExpression =&#xA;    if transitionStep = null or &#xA;       transitionStep.ownedFeature.size() &lt; 3 or&#xA;       not transitionStep.ownedFeature->at(3).oclIsKindOf(Expression) &#xA;    then Set{}&#xA;    else Set{transitionStep.ownedFeature->at(3).oclAsType(Expression)}&#xA;    endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="transitionStep" ordered="false"
+        eType="#//Step" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="succession"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>A &lt;code>Step&lt;/code> that is typed by the &lt;code>Behavior&lt;/code> &lt;code>&lt;em>TransitionPerformances::TransitionPerformance&lt;/em>&lt;/code> (from the Kernel Semantic Library) that has this &lt;code>Succession&lt;/code> as its &lt;em>&lt;code>transitionLink&lt;/code>&lt;/em>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="triggerStep" ordered="false"
+        upperBound="-1" eType="#//Step" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="succession"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Steps&lt;/code> that map incoming events to the timing of occurrences of the &lt;code>transitionStep&lt;/code>. The values of &lt;code>triggerStep&lt;/code> subset the list of acceptable events to be received by a &lt;code>Behavior&lt;/code> or the object that performs it.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="effectStep" ordered="false"
+        upperBound="-1" eType="#//Step" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="succession"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Steps&lt;/code> that represent occurrences that are side effects of the &lt;code>transitionStep&lt;/code> occurring.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="guardExpression" ordered="false"
+        upperBound="-1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="succession"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>&lt;code>Expressions&lt;/code> that must evaluate to true before the &lt;code>transitionStep&lt;/code> can occur.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CalculationUsage" eSuperTypes="#//ActionUsage #//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>CalculationUsage&lt;/code> is an &lt;code>ActionUsage&lt;code> that is also an &lt;code>Expression&lt;/code>, and, so, is typed by a &lt;code>Function&lt;/code>. Nominally, if the &lt;code>type&lt;/code> is a &lt;code>CalculationDefinition&lt;/code>, a &lt;code>CalculationUsage&lt;/code> is a &lt;code>Usage&lt;/code> of that &lt;code>CalculationDefinition&lt;/code> within a system. However, other kinds of kernel &lt;code>Functions&lt;/code> are also allowed, to permit use of &lt;code>Functions&lt;/code> from the Kernel Model Libraries.&lt;/p>&#xA;specializesFromLibrary('Calculations::calculations')&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(CalculationDefinition) or&#xA; owningType.oclIsKindOf(CalculationUsage)) implies&#xA;    specializesFromLibrary('Calculations::Calculation::subcalculations')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="calculationDefinition"
+        eType="#//Function" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedCalculation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;ode>Function&lt;/code> that is the &lt;code>type&lt;/code> of this &lt;code>CalculationUsage&lt;/code>. Nominally, this would be a &lt;code>CalculationDefinition&lt;/code>, but a kernel &lt;code>Function&lt;/code> is also allowed, to permit use of &lt;code>Functions&lt;/code> from the Kernel Model Libraries.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Expression/function #//ActionUsage/actionDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ConstraintUsage" eSuperTypes="#//OccurrenceUsage #//BooleanExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ConstraintUsage&lt;/code> is an &lt;code>OccurrenceUsage&lt;/code> that is also a &lt;code>BooleanExpression&lt;code>, and, so, is typed by a &lt;code>Predicate&lt;/code>. Nominally, if the type is a &lt;code>ConstraintDefinition&lt;code>, a &lt;code>ConstraintUsage&lt;/code> is a &lt;code>Usage&lt;/code> of that &lt;code>ConstraintDefinition&lt;code>. However, other kinds of kernel &lt;code>Predicates&lt;/code> are also allowed, to permit use of &lt;code>Predicates&lt;/code> from the Kernel Model Libraries.&lt;/p>&#xA;owningFeatureMembership &lt;> null and&#xA;owningFeatureMembership.oclIsKindOf(RequirementConstraintMembership) implies&#xA;    if owningFeatureMembership.oclAsType(RequirementConstraintMembership).kind = &#xA;        RequirementConstraintKind::assumption then&#xA;        specializesFromLibrary('Requirements::RequirementCheck::assumptions')&#xA;    else&#xA;        specializesFromLibrary('Requirements::RequirementCheck::constraints')&#xA;    endif&#xA;specializesFromLibrary('Constraints::constraintChecks')&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(ItemDefinition) or&#xA; owningType.oclIsKindOf(ItemUsage)) implies&#xA;    specializesFromLibrary('Items::Item::checkedConstraints')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="constraintDefinition" ordered="false"
+        eType="#//Predicate" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedConstraint"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The (single) &lt;code>Predicate&lt;/code> that is the type of this &lt;code>ConstraintUsage&lt;/code>. Nominally, this will be a &lt;code>ConstraintDefinition&lt;/code>, but other kinds of &lt;code>Predicates&lt;/code> are also allowed, to permit use of &lt;code>Predicates&lt;/code> from the Kernel Model Libraries.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//BooleanExpression/predicate"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="BooleanExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>BooleanExpression&lt;/code> is a &lt;em>&lt;code>Boolean&lt;/code>&lt;/em>-valued &lt;code>Expression&lt;/code> whose type is a &lt;code>Predicate&lt;/code>. It represents a logical condition resulting from the evaluation of the &lt;code>Predicate&lt;/code>.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Performances::booleanEvaluations&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="predicate" ordered="false"
+        eType="#//Predicate" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedBooleanExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Predicate&lt;/code> that types this &lt;code>BooleanExpression&lt;/code>.&lt;/p>&#xA;&lt;p>The Predicate that types the Expression.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Expression/function"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Predicate" eSuperTypes="#//Function">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Predicate&lt;/code> is a &lt;code>Function&lt;/code> whose &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> has type &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> and multiplicity &lt;code>1..1&lt;/code>.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Performances::BooleanEvaluation&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="RequirementUsage" eSuperTypes="#//ConstraintUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>RequirementUsage&lt;/code> is a &lt;code>Usage&lt;/code> of a &lt;code>RequirementDefinition&lt;/code>.&lt;/p>&#xA;actorParameter = featureMembership->&#xA;    selectByKind(ActorMembership).&#xA;    ownedActorParameter&#xA;assumedConstraint = ownedFeatureMembership->&#xA;    selectByKind(RequirementConstraintMembership)->&#xA;    select(kind = RequirementConstraintKind::assumption).&#xA;    ownedConstraint&#xA;framedConcern = featureMembership->&#xA;    selectByKind(FramedConcernMembership).&#xA;    ownedConcern&#xA;requiredConstraint = ownedFeatureMembership->&#xA;    selectByKind(RequirementConstraintMembership)->&#xA;    select(kind = RequirementConstraintKind::requirement).&#xA;    ownedConstraint&#xA;stakeholderParameter = featureMembership->&#xA;    selectByKind(AStakholderMembership).&#xA;    ownedStakeholderParameter&#xA;subjectParameter =&#xA;    let subjects : OrderedSet(SubjectMembership) = &#xA;        featureMembership->selectByKind(SubjectMembership) in&#xA;    if subjects->isEmpty() then null&#xA;    else subjects->first().ownedSubjectParameter&#xA;    endif&#xA;text = documentation.body&#xA;featureMembership->&#xA;    selectByKind(SubjectMembership)->&#xA;    size() &lt;= 1&#xA;input->notEmpty() and input->first() = subjectParameter&#xA;specializesFromLibrary('Requirements::requirementChecks')&#xA;isComposite and owningType &lt;> null and&#xA;    (owningType.oclIsKindOf(RequirementDefinition) or&#xA;     owningType.oclIsKindOf(RequirementUsage)) implies&#xA;    specializesFromLibrary('Requirements::RequirementCheck::subrequirements')&#xA;owningfeatureMembership &lt;> null and&#xA;owningfeatureMembership.oclIsKindOf(ObjectiveMembership) implies&#xA;    owningType.ownedSpecialization.general->forAll(gen |&#xA;        (gen.oclIsKindOf(CaseDefinition) implies&#xA;            redefines(gen.oclAsType(CaseDefinition).objectiveRequirement)) and&#xA;        (gen.oclIsKindOf(CaseUsage) implies&#xA;            redefines(gen.oclAsType(CaseUsage).objectiveRequirement))&#xA;owningFeatureMembership &lt;> null and&#xA;owningFeatureMembership.oclIsKindOf(RequirementVerificationMembership) implies&#xA;    specializesFromLibrary('VerificationCases::VerificationCase::obj::requirementVerifications')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="requirementDefinition"
+        ordered="false" eType="#//RequirementDefinition" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedRequirement"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>RequirementDefinition&lt;/code> that is the single &lt;code>definition&lt;/code> of this &lt;code>RequirementUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//ConstraintUsage/constraintDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="reqId" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An optional modeler-specified identifier for this &lt;code>RequirementUsage&lt;/code> (used, e.g., to link it to an original requirement text in some source document), which is the &lt;code>declaredShortName&lt;/code> for the &lt;code>RequirementUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Element/declaredShortName"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" ordered="false" upperBound="-1"
+        eType="ecore:EDataType uml_types.ecore#//String" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An optional textual statement of the requirement represented by this &lt;code>RequirementUsage&lt;/code>, derived from the &lt;code>bodies&lt;code> of the &lt;code>documentation&lt;/code> of the &lt;code>RequirementUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="requiredConstraint" upperBound="-1"
+        eType="#//ConstraintUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="requiringRequirement"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owned &lt;code>ConstraintUsages&lt;/code> that represent requirements of this &lt;code>RequirementUsage&lt;/code>, which are the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementUsage&lt;/code> with &lt;code>kind&lt;/code> = &lt;code>requirement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="assumedConstraint" upperBound="-1"
+        eType="#//ConstraintUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="assumingRequirement"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owned &lt;code>ConstraintUsages&lt;/code> that represent assumptions of this &lt;code>RequirementUsage&lt;/code>, derived as the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementUsage&lt;/code> with &lt;code>kind&lt;/code> = &lt;code>assumption&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subjectParameter" ordered="false"
+        lowerBound="1" eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="subjectOwningRequirement"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameter&lt;/code> of this &lt;code>RequirementUsage&lt;/code> that is owned via a &lt;code>SubjectMembership&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/parameter #//Usage/nestedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="framedConcern" upperBound="-1"
+        eType="#//ConcernUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="framingRequirement"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConcernUsages&lt;/code> framed by this &lt;code>RequirementUsage&lt;/code>, which are the &lt;code>ownedConcerns&lt;/code> of all &lt;code>FramedConcernMemberships&lt;/code> of the &lt;code>RequirementUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//RequirementUsage/requiredConstraint"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="actorParameter" upperBound="-1"
+        eType="#//PartUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="actorOwningRequirement"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>RequirementUsage&lt;/code> that are owned via &lt;code>ActorMemberships&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedPart #//Step/parameter"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="stakeholderParameter" upperBound="-1"
+        eType="#//PartUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="stakholderOwningRequirement"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>RequirementUsage&lt;/code> that are owned via &lt;code>StakeholderMemberships&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedPart #//Step/parameter"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="RequirementDefinition" eSuperTypes="#//ConstraintDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>RequirementDefinition&lt;/code> is a &lt;code>ConstraintDefinition&lt;/code> that defines a requirement used in the context of a specification as a constraint that a valid solution must satisfy. The specification is relative to a specified subject, possibly in collaboration with one or more external actors.&lt;/p>&#xA;text = documentation.body&#xA;assumedConstraint = ownedFeatureMembership->&#xA;    selectByKind(RequirementConstraintMembership)->&#xA;    select(kind = RequirementConstraintKind::assumption).&#xA;    ownedConstraint&#xA;requiredConstraint = ownedFeatureMembership->&#xA;    selectByKind(RequirementConstraintMembership)->&#xA;    select(kind = RequirementConstraintKind::requirement).&#xA;    ownedConstraint&#xA;subjectParameter =&#xA;    let subjects : OrderedSet(SubjectMembership) = &#xA;        featureMembership->selectByKind(SubjectMembership) in&#xA;    if subjects->isEmpty() then null&#xA;    else subjects->first().ownedSubjectParameter&#xA;    endif&#xA;framedConcern = featureMembership->&#xA;    selectByKind(FramedConcernMembership).&#xA;    ownedConcern&#xA;actorParameter = featureMembership->&#xA;    selectByKind(ActorMembership).&#xA;    ownedActorParameter&#xA;stakeholderParameter = featureMembership->&#xA;    selectByKind(StakholderMembership).&#xA;    ownedStakeholderParameter&#xA;featureMembership->&#x9;&#xA;    selectByKind(SubjectMembership)->&#xA;    size() &lt;= 1&#xA;input->notEmpty() and input->first() = subjectParameter&#xA;specializesFromLibrary('Requirements::RequirementCheck')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="reqId" ordered="false"
+        eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An optional modeler-specified identifier for this &lt;code>RequirementDefinition&lt;/code> (used, e.g., to link it to an original requirement text in some source document), which is the &lt;code>declaredShortName&lt;/code> for the &lt;code>RequirementDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Element/declaredShortName"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" ordered="false" upperBound="-1"
+        eType="ecore:EDataType uml_types.ecore#//String" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An optional textual statement of the requirement represented by this &lt;code>RequirementDefinition&lt;/code>, derived from the &lt;code>bodies&lt;/code> of the &lt;code>documentation&lt;/code> of the &lt;code>RequirementDefinition&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subjectParameter" ordered="false"
+        lowerBound="1" eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="subjectOwningRequirementDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameter&lt;/code> of this &lt;code>RequirementDefinition&lt;/code> that is owned via a &lt;code>SubjectMembership&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/parameter #//Definition/ownedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="actorParameter" upperBound="-1"
+        eType="#//PartUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="actorOwningRequirementDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>RequirementDefinition&lt;/code> that are owned via &lt;code>ActorMemberships&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedPart #//Behavior/parameter"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="stakeholderParameter" upperBound="-1"
+        eType="#//PartUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="stakholderOwiningRequirementDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>RequirementDefinition&lt;/code> that are owned via &lt;code>StakeholderMemberships&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedPart #//Behavior/parameter"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="assumedConstraint" upperBound="-1"
+        eType="#//ConstraintUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="assumingRequirementDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owned &lt;code>ConstraintUsages&lt;/code> that represent assumptions of this &lt;code>RequirementDefinition&lt;/code>, which are the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code> with &lt;code>kind = assumption&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="requiredConstraint" upperBound="-1"
+        eType="#//ConstraintUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="requiringRequirementDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owned &lt;code>ConstraintUsages&lt;/code> that represent requirements of this &lt;code>RequirementDefinition&lt;/code>, derived as the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code> with &lt;code>kind&lt;/code> = &lt;code>requirement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="framedConcern" upperBound="-1"
+        eType="#//ConcernUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="framingRequirementDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConcernUsages&lt;/code> framed by this &lt;code>RequirementDefinition&lt;/code>, which are the &lt;code>ownedConcerns&lt;/code> of all &lt;code>FramedConcernMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//RequirementDefinition/requiredConstraint"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ConstraintDefinition" eSuperTypes="#//OccurrenceDefinition #//Predicate">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ConstraintDefinition&lt;/code> is an &lt;code>OccurrenceDefinition&lt;/code> that is also a &lt;code>Predicate&lt;/code> that defines a constraint that may be asserted to hold on a system or part of a system.&lt;/p>&#xA;&#xA;&#xA;specializesFromLibrary('Constraints::ConstraintCheck')"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ConcernUsage" eSuperTypes="#//RequirementUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ConcernUsage&lt;/code> is a &lt;code>Usage&lt;/code> of a &lt;code>ConcernDefinition&lt;/code>.&lt;/p>&#xA;&#xA; The &lt;code>ownedStakeholder&lt;/code> features of the ConcernUsage shall all subset the &lt;em>&lt;code>ConcernCheck::concernedStakeholders&lt;/code> &lt;/em>feature. If the ConcernUsage is an &lt;code>ownedFeature&lt;/code> of a StakeholderDefinition or StakeholderUsage, then the ConcernUsage shall have an &lt;code>ownedStakeholder&lt;/code> feature that is bound to the &lt;em>&lt;code>self&lt;/code>&lt;/em> feature of its owner.&lt;/p>&#xA;&#xA;specializesFromLibrary('Requirements::concernChecks')&#xA;owningFeatureMembership &lt;> null and&#xA;owningFeatureMembership.oclIsKindOf(FramedConcernMembership) implies&#xA;    specializesFromLibrary('Requirements::RequirementCheck::concerns')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="concernDefinition" ordered="false"
+        eType="#//ConcernDefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedConcern"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The ConcernDefinition that is the single type of this ConcernUsage.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//RequirementUsage/requirementDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ConcernDefinition" eSuperTypes="#//RequirementDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ConcernDefinition&lt;/code> is a &lt;code>RequirementDefinition&lt;/code> that one or more stakeholders may be interested in having addressed. These stakeholders are identified by the &lt;code>ownedStakeholders&lt;/code>of the &lt;code>ConcernDefinition&lt;/code>.&lt;/p>&#xA;&#xA;specializesFromLibrary('Requirements::ConcernCheck')"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CaseUsage" eSuperTypes="#//CalculationUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>CaseUsage&lt;/code> is a &lt;code>Usage&lt;/code> of a &lt;code>CaseDefinition&lt;/code>.&lt;/p>&#xA;objectiveRequirement = &#xA;    let objectives: OrderedSet(RequirementUsage) = &#xA;        featureMembership->&#xA;            selectByKind(ObjectiveMembership).&#xA;            ownedRequirement in&#xA;    if objectives->isEmpty() then null&#xA;    else objectives->first().ownedObjectiveRequirement&#xA;    endif&#xA;featureMembership->&#xA;    selectByKind(ObjectiveMembership)->&#xA;    size() &lt;= 1&#xA;featureMembership->&#xA;&#x9;selectByKind(SubjectMembership)->&#xA;&#x9;size() &lt;= 1&#xA;actorParameter = featureMembership->&#xA;    selectByKind(ActorMembership).&#xA;    ownedActorParameter&#xA;subjectParameter =&#xA;    let subjects : OrderedSet(SubjectMembership) = &#xA;        featureMembership->selectByKind(SubjectMembership) in&#xA;    if subjects->isEmpty() then null&#xA;    else subjects->first().ownedSubjectParameter&#xA;    endif&#xA;input->notEmpty() and input->first() = subjectParameter&#xA;specializeFromLibrary('Cases::cases')&#xA;isComposite and owningType &lt;> null and &#xA;    (owningType.oclIsKindOf(CaseDefinition) or&#xA;     owningType.oclIsKindOf(CaseUsage)) implies&#xA;    specializesFromLibrary('Cases::Case::subcases')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="objectiveRequirement" eType="#//RequirementUsage"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="objectiveOwningCase"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedFeature&lt;/code> of this CaseUsage that is owned via an ObjectiveMembership, and that must redefine, directly or indirectly, the &lt;code>objective&lt;/code> RequirementUsage of the base CaseDefinition Case from the Systems model library.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedRequirement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="caseDefinition" ordered="false"
+        eType="#//CaseDefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedCase"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The CaseDefinition that is the type of this CaseUsage.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//CalculationUsage/calculationDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subjectParameter" ordered="false"
+        lowerBound="1" eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="subjectOwningCase"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameter&lt;/code> of this &lt;code>CaseUsage&lt;/code> that is owned via a SubjectMembership, which must redefine, directly or indirectly, the &lt;code>subject&lt;/code> parameter of the base &lt;code>CaseUsage&lt;/code> &lt;code>&lt;em>Case&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/parameter #//Usage/nestedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="actorParameter" upperBound="-1"
+        eType="#//PartUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="actorOwningCase"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>CaseUsage&lt;/code> that are owned via &lt;code>ActorMemberships&lt;/code>, which must subset, directly or indirectly, the &lt;code>PartUsage&lt;/code> &lt;em>&lt;code>actors&lt;/code>&lt;/em> of the base &lt;code>CaseUsage&lt;/code> &lt;em>Case&lt;/em> from the Systems Model Library.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedPart #//Step/parameter"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CaseDefinition" eSuperTypes="#//CalculationDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>CaseDefinition&lt;/code> is a &lt;code>CalculationDefinition&lt;/code> for a process, often involving collecting evidence or data, relative to a subject, possibly involving the collaboration of one or more other actors, producing a result that meets an objective.&lt;/p>&#xA;objectiveRequirement = &#xA;    let objectives: OrderedSet(RequirementUsage) = &#xA;        featureMembership->&#xA;            selectByKind(ObjectiveMembership).&#xA;            ownedRequirement in&#xA;    if objectives->isEmpty() then null&#xA;    else objectives->first().ownedObjectiveRequirement&#xA;    endif&#xA;featureMembership->&#xA;    selectByKind(ObjectiveMembership)->&#xA;    size() &lt;= 1&#xA;subjectParameter =&#xA;    let subjectMems : OrderedSet(SubjectMembership) = &#xA;        featureMembership->selectByKind(SubjectMembership) in&#xA;    if subjectMems->isEmpty() then null&#xA;    else subjectMems->first().ownedSubjectParameter&#xA;    endif&#xA;actorParameter = featureMembership->&#xA;    selectByKind(ActorMembership).&#xA;    ownedActorParameter&#xA;featureMembership->selectByKind(SubjectMembership)->size() &lt;= 1&#xA;input->notEmpty() and input->first() = subjectParameter&#xA;specializesFromLibrary('Cases::Case')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="objectiveRequirement" eType="#//RequirementUsage"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="objectiveOwningCaseDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>objectiveRequirement&lt;/code> of this &lt;code>CaseDefinition&lt;/code>, that is owned via an &lt;code>ObjectiveMembership&lt;/code>, and will redefine, directly or indirectly, the &lt;code>objective&lt;/code> &lt;code>RequirementUsage&lt;code> of the base &lt;code>CaseDefinition&lt;/code> &lt;code>&lt;em>Case&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedRequirement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subjectParameter" ordered="false"
+        lowerBound="1" eType="#//Usage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="subjectOwningCaseDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameter&lt;/code> of this &lt;code>CaseDefinition&lt;/code> that is owned via a SubjectMembership, which must redefine, directly or indirectly, the &lt;code>subject&lt;/code> parameter of the base &lt;code>CaseDefinition&lt;/code> &lt;code>&lt;em>Case&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/parameter #//Definition/ownedUsage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="actorParameter" upperBound="-1"
+        eType="#//PartUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="actorOwningCaseDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>CaseDefinition&lt;/code> that are owned via &lt;code>ActorMemberships&lt;/code>, which must subset, directly or indirectly, the &lt;code>PartUsage&lt;/code> &lt;em>&lt;code>actors&lt;/code>&lt;/em> of the base &lt;code>CaseDefinition&lt;/code> &lt;em>Case&lt;/em> from the Systems Model Library.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/parameter #//Definition/ownedPart"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CalculationDefinition" eSuperTypes="#//ActionDefinition #//Function">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>CalculationDefinition&lt;/code> is an &lt;coed>ActionDefinition&lt;/code> that also defines a &lt;code>Function&lt;/code> producing a &lt;code>result&lt;/code>.&lt;/p>&#xA;specializesFromLibrary('Calculations::Calculation')&#xA;calculation = action->selectByKind(CalculationUsage)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="calculation" upperBound="-1"
+        eType="#//CalculationUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringCalculationDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>actions&lt;/code> of this &lt;code>CalculationDefinition&lt;/code> that are &lt;code>CalculationUsages&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//ActionDefinition/action #//Function/expression"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ActionDefinition" eSuperTypes="#//OccurrenceDefinition #//Behavior">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ActionDefinition&lt;/code> is a &lt;code>Definition&lt;/code> that is also a &lt;code>Behavior&lt;/code> that defines an &lt;em>&lt;code>Action&lt;/code>&lt;/em> performed by a system or part of a system.&lt;/p>&#xA;specializesFromLibrary('Actions::Action')&#xA;action = usage->selectByKind(ActionUsage)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="action" upperBound="-1"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringActionDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsages&lt;/code> that are &lt;code>steps&lt;/code> in this &lt;code>ActionDefinition&lt;/code>, which define the actions that specify the behavior of the &lt;code>ActionDefinition&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Behavior/step #//Definition/usage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AnalysisCaseUsage" eSuperTypes="#//CaseUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AnalysisCaseUsage&lt;/code> is a &lt;code>Usage&lt;/code> of an &lt;code>AnalysisCaseDefinition&lt;/code>.&lt;/p>&#xA;analysisAction = usage->select(&#xA;    isComposite and&#xA;    specializes('AnalysisCases::AnalysisAction'))&#xA;resultExpression =&#xA;    let results : OrderedSet(ResultExpressionMembership) =&#xA;        featureMembersip->&#xA;            selectByKind(ResultExpressionMembership) in&#xA;    if results->isEmpty() then null&#xA;    else results->first().ownedResultExpression&#xA;    endif&#xA;specializesFromLibrary('AnalysisCases::analysisCases')&#xA;isComposite and owningType &lt;> null and&#xA;    (owningType.oclIsKindOf(AnalysisCaseDefinition) or&#xA;     owningType.oclIsKindOf(AnalysisCaseUsage)) implies&#xA;    specializesFromLibrary('AnalysisCases::AnalysisCase::subAnalysisCases')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="analysisAction" upperBound="-1"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringAnalysisCase"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The composite &lt;code>usages&lt;/code> of the &lt;code>AnalysisCaseUsage&lt;/code> that are defined as &lt;code>AnalysisActions&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/usage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="analysisCaseDefinition"
+        ordered="false" eType="#//AnalysisCaseDefinition" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedAnalysisCase"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>AnalysisCaseDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>AnalysisCaseUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//CaseUsage/caseDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="resultExpression" ordered="false"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="analysisCase"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An &lt;code>Expression&lt;/code> used to compute the &lt;code>result&lt;/code> of the &lt;code>AnalysisCaseUsage&lt;/code>, owned via a &lt;code>ResultExpressionMembership&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AnalysisCaseDefinition" eSuperTypes="#//CaseDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AnalysisCaseDefinition&lt;/code> is a &lt;code>CaseDefinition&lt;/code> for the case of carrying out an analysis.&lt;/p>&#xA;analysisAction = action->select(&#xA;    isComposite and &#xA;    specializes('AnalysisCases::AnalysisAction'))&#xA;resultExpression =&#xA;    let results : OrderedSet(ResultExpressionMembership) =&#xA;        featureMembersip->&#xA;            selectByKind(ResultExpressionMembership) in&#xA;    if results->isEmpty() then null&#xA;    else results->first().ownedResultExpression&#xA;    endif&#xA;specializesFromLibrary('AnalysisCases::AnalysisCase')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="analysisAction" upperBound="-1"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringAnalysisCaseDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The composite &lt;code>actions&lt;/code> of the &lt;code>AnalysisCaseDefinition&lt;/code> that are defined as &lt;code>AnalysisActions&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//ActionDefinition/action"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="resultExpression" ordered="false"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="analysisCaseDefintion"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An &lt;code>Expression&lt;/code> used to compute the &lt;code>result&lt;/code> of the &lt;code>AnalysisCaseDefinition&lt;/code>, owned via a &lt;code>ResultExpressionMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Function/expression #//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="VerificationCaseUsage" eSuperTypes="#//CaseUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>VerificationCaseUsage&lt;/code> is a &lt;/code>Usage&lt;/code> of a &lt;code>VerificationCaseDefinition&lt;/code>.&lt;/p>&#xA;verifiedRequirement =&#xA;    if objectiveRequirement = null then OrderedSet{}&#xA;    else &#xA;        objectiveRequirement.featureMembership->&#xA;            selectByKind(RequirementVerificationMembership).&#xA;            verifiedRequirement->asOrderedSet()&#xA;    endif&#xA;specializesFromLibrary('VerificationCases::verificationCases')&#xA;isComposite and owningType &lt;> null and&#xA;    (owningType.oclIsKindOf(VerificationCaseDefinition) or&#xA;     owningType.oclIsKindOf(VerificationCaseUsage))"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="verificationCaseDefinition"
+        ordered="false" eType="#//VerificationCaseDefinition" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedVerificationCase"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>VerificationCase&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>VerificationCaseUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//CaseUsage/caseDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="verifiedRequirement" upperBound="-1"
+        eType="#//RequirementUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="verifyingCase"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>RequirementUsages&lt;/code> verified by this &lt;code>VerificationCaseUsage&lt;/code>, which are the &lt;code>verifiedRequirements&lt;/code> of all &lt;code>RequirementVerificationMemberships&lt;/code> of the &lt;code>objectiveRequirement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="VerificationCaseDefinition" eSuperTypes="#//CaseDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>VerificationCaseDefinition&lt;/code> is a &lt;code>CaseDefinition&lt;/code> for the purpose of verification of the subject of the case against its requirements.&lt;/p>&#xA;verifiedRequirement =&#xA;    if objectiveRequirement = null then OrderedSet{}&#xA;    else &#xA;        objectiveRequirement.featureMembership->&#xA;            selectByKind(RequirementVerificationMembership).&#xA;            verifiedRequirement->asOrderedSet()&#xA;    endif&#xA;specializesFromLibrary('VerificationCases::VerificationCase')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="verifiedRequirement" upperBound="-1"
+        eType="#//RequirementUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="verifyingCaseDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>RequirementUsages&lt;/code> verified by this &lt;code>VerificationCaseDefinition&lt;/code>, which are the &lt;code>verifiedRequirements&lt;/code> of all &lt;code>RequirementVerificationMemberships&lt;/code> of the &lt;code>objectiveRequirement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="UseCaseUsage" eSuperTypes="#//CaseUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>UseCaseUsage&lt;/code> is a &lt;code>Usage&lt;/code> of a &lt;code>UseCaseDefinition&lt;/code>.&lt;/p>&#xA;includedUseCase = ownedUseCase->&#xA;    selectByKind(IncludeUseCaseUsage).&#xA;    useCaseIncluded&#xA;specializesFromLibrary('UseCases::useCases')&#xA;isComposite and owningType &lt;> null and&#xA;(owningType.oclIsKindOf(UseCaseDefinition) or&#xA; owningType.oclIsKindOf(UseCaseUsage)) implies&#xA;    specializesFromLibrary('UseCases::UseCase::subUseCases')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="useCaseDefinition" ordered="false"
+        eType="#//UseCaseDefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedUseCase"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>UseCaseDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>UseCaseUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//CaseUsage/caseDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="includedUseCase" upperBound="-1"
+        eType="#//UseCaseUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="includingUseCase"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>UseCaseUsages&lt;/code> that are included by this &lt;code>UseCaseUse&lt;/code>, which are the &lt;code>useCaseIncludeds&lt;/code> of the &lt;code>IncludeUseCaseUsages&lt;/code> owned by this &lt;code>UseCaseUsage&lt;code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="UseCaseDefinition" eSuperTypes="#//CaseDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>UseCaseDefinition&lt;/code> is a &lt;code>CaseDefinition&lt;/code> that specifies a set of actions performed by its subject, in interaction with one or more actors external to the subject. The objective is to yield an observable result that is of value to one or more of the actors.&lt;/p>&#xA;&#xA;includedUseCase = ownedUseCase->&#xA;    selectByKind(IncludeUseCaseUsage).&#xA;    useCaseIncluded&#xA;specializesFromLibrary('UseCases::UseCase')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="includedUseCase" upperBound="-1"
+        eType="#//UseCaseUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="includingUseCaseDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>UseCaseUsages&lt;/code> that are included by this &lt;code>UseCaseDefinition&lt;/code>, which are the &lt;code>useCaseIncludeds&lt;/code> of the &lt;code>IncludeUseCaseUsages&lt;/code> owned by this &lt;code>UseCaseDefinition&lt;code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ViewUsage" eSuperTypes="#//PartUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ViewUsage&lt;/code> is a usage of a &lt;code>ViewDefinition&lt;/code> to specify the generation of a view of the &lt;code>members&lt;/code> of a collection of &lt;code>exposedNamespaces&lt;/code>. The &lt;code>ViewUsage&lt;/code> can satisfy more &lt;code>viewpoints&lt;/code> than its definition, and it can specialize the &lt;code>viewRendering&lt;/code> specified by its definition.&lt;p>&#xA;exposedElement = ownedImport->selectByKind(Expose).&#xA;    importedMemberships(Set{}).memberElement->&#xA;    select(elm | includeAsExposed(elm))->&#xA;    asOrderedSet()&#xA;satisfiedViewpoint = ownedRequirement->&#xA;    selectByKind(ViewpointUsage)->&#xA;    select(isComposite)&#xA;viewCondition = featureMembership->&#xA;    selectByKind(ElementFilterMembership).&#xA;    condition&#xA;viewRendering =&#xA;    let renderings: OrderedSet(ViewRenderingMembership) =&#xA;        featureMembership->selectByKind(ViewRenderingMembership) in&#xA;    if renderings->isEmpty() then null&#xA;    else renderings->first().referencedRendering&#xA;    endif&#xA;featureMembership->&#xA;    selectByKind(ViewRenderingMembership)->&#xA;    size() &lt;= 1&#xA;specializesFromLibrary('Views::views')&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(ViewDefinition) or&#xA; owningType.oclIsKindOf(ViewUsage)) implies&#xA;    specializesFromLibrary('Views::View::subviews')"/>
+    </eAnnotations>
+    <eOperations name="includeAsExposed" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Determine whether the given &lt;code>element&lt;/code> meets all the owned and inherited &lt;code>viewConditions&lt;/code>.&lt;/p>&#xA;let metadataFeatures: Sequence(AnnotatingElement) = &#xA;    element.ownedAnnotation.annotatingElement->&#xA;        select(oclIsKindOf(MetadataFeature)) in&#xA;self.membership->selectByKind(ElementFilterMembership).&#xA;    condition->forAll(cond | &#xA;        metadataFeatures->exists(elem | &#xA;            cond.checkCondition(elem)))"/>
+      </eAnnotations>
+      <eParameters name="element" ordered="false" lowerBound="1" eType="#//Element"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="viewDefinition" ordered="false"
+        eType="#//ViewDefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedView"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ViewDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>ViewUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//PartUsage/partDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="satisfiedViewpoint" upperBound="-1"
+        eType="#//ViewpointUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="viewpointSatisfyingView"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>nestedRequirements&lt;/code> of this &lt;code>ViewUsage&lt;/code> that are &lt;code>ViewpointUsages&lt;/code> for (additional) viewpoints satisfied by the &lt;code>ViewUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Usage/nestedRequirement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="exposedElement" upperBound="-1"
+        eType="#//Element" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="exposingView"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;cod>Elements&lt;/code> that are exposed by this &lt;code>ViewUsage&lt;/code>, which are those &lt;code>memberElements&lt;/code> of the imported &lt;code>Memberships&lt;/code> from all the &lt;code>Expose&lt;/code> &lt;code>Relationships&lt;/code> that meet all the owned and inherited &lt;code>viewConditions&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/member"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="viewRendering" ordered="false"
+        eType="#//RenderingUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="renderingOwningView"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>RenderingUsage&lt;/code> to be used to render views defined by this &lt;code>ViewUsage&lt;/code>, which is the &lt;code>referencedRendering&lt;/code> of the &lt;code>ViewRenderingMembership&lt;/code> of the &lt;code>ViewUsage&lt;/code>.&lt;p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="viewCondition" upperBound="-1"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningView"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expressions&lt;/code> related to this &lt;code>ViewUsage&lt;/code> by &lt;code>ElementFilterMemberships&lt;/code>, which specify conditions on &lt;code>Elements&lt;/code> to be rendered in a view.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ViewDefinition" eSuperTypes="#//PartDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ViewDefinition&lt;/code> is a &lt;code>PartDefinition&lt;/code> that specifies how a view artifact is constructed to satisfy a &lt;code>viewpoint&lt;/code>. It specifies a &lt;code>viewConditions&lt;/code> to define the model content to be presented and a &lt;code>viewRendering&lt;/code> to define how the model content is presented.&lt;/p>&#xA;view = usage->selectByKind(ViewUsage)&#xA;satisfiedViewpoint = ownedRequirement->&#xA;    selectByKind(ViewpointUsage)->&#xA;    select(isComposite)&#xA;viewRendering =&#xA;    let renderings: OrderedSet(ViewRenderingMembership) =&#xA;        featureMembership->selectByKind(ViewRenderingMembership) in&#xA;    if renderings->isEmpty() then null&#xA;    else renderings->first().referencedRendering&#xA;    endif&#xA;viewCondition = featureMembership->&#xA;    selectByKind(ElementFilterMembership).&#xA;    condition&#xA;featureMembership->&#xA;    selectByKind(ViewRenderingMembership)->&#xA;    size() &lt;= 1&#xA;specializesFromLibrary('Views::View')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="view" upperBound="-1" eType="#//ViewUsage"
+        volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringView"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>usages&lt;/code> of this &lt;code>ViewDefinition&lt;/code> that are &lt;code>ViewUsages&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/usage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="satisfiedViewpoint" upperBound="-1"
+        eType="#//ViewpointUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="viewpointSatisfyingViewDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The composite &lt;code>ownedRequirements&lt;/code> of this &lt;code>ViewDefinition&lt;/code> that are &lt;code>ViewpointUsages&lt;/code> for viewpoints satisfied by the &lt;code>ViewDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/ownedRequirement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="viewRendering" ordered="false"
+        eType="#//RenderingUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="renderingOwningViewDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>RenderingUsage&lt;/code> to be used to render views defined by this &lt;code>ViewDefinition&lt;/code>, which is the &lt;code>referencedRendering&lt;/code> of the &lt;code>ViewRenderingMembership&lt;/code> of the &lt;code>ViewDefinition&lt;/code>.&lt;p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="viewCondition" upperBound="-1"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningViewDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expressions&lt;/code> related to this &lt;code>ViewDefinition&lt;/code> by &lt;code>ElementFilterMemberships&lt;/code>, which specify conditions on &lt;code>Elements&lt;/code> to be rendered in a view.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ViewpointUsage" eSuperTypes="#//RequirementUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ViewpointUsage&lt;code> is a &lt;code>Usage&lt;/code> of a &lt;code>ViewpointDefinition&lt;/code>.&lt;/p>&#xA;&#xA;&#xA;viewpointStakeholder = framedConcern.featureMemberhsip->&#xA;    selectByKind(StakeholderMembership).&#xA;    ownedStakeholderParameter&#xA;specializesFromLibrary('Views::viewpoints')&#xA;isComposite and owningType &lt;> null and&#xA;(owningType.oclIsKindOf(ViewDefinition) or&#xA; owningType.oclIsKindOf(ViewUsage)) implies&#xA;    specializesFromLibrary('Views::View::viewpointSatisfactions')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="viewpointDefinition" ordered="false"
+        eType="#//ViewpointDefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedViewpoint"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ViewpointDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>ViewpointUsage&lt;code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//RequirementUsage/requirementDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="viewpointStakeholder" upperBound="-1"
+        eType="#//PartUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="viewpointForStakeholder"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>PartUsages&lt;/code> that identify the stakeholders with concerns framed by this &lt;code>ViewpointUsage&lt;/code>, which are the owned and inherited &lt;code>stakeholderParameters&lt;/code> of the &lt;code>framedConcerns&lt;/code> of this &lt;code>ViewpointUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ViewpointDefinition" eSuperTypes="#//RequirementDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ViewpointDefinition&lt;/code> is a &lt;code>RequirementDefinition&lt;/code> that specifies one or more stakeholder concerns that are to be satisfied by creating a view of a model.&lt;/p>&#xA;viewpointStakeholder = framedConcern.featureMemberhsip->&#xA;    selectByKind(StakeholderMembership).&#xA;    ownedStakeholderParameter&#xA;specializesFromLibrary('Views::Viewpoint')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="viewpointStakeholder" upperBound="-1"
+        eType="#//PartUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="viewpointDefinitionForStakeholder"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>PartUsages&lt;/code> that identify the stakeholders with concerns framed by this &lt;code>ViewpointDefinition&lt;/code>, which are the owned and inherited &lt;code>stakeholderParameters&lt;/code> of the &lt;code>framedConcerns&lt;/code> of this &lt;code>ViewpointDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="RenderingUsage" eSuperTypes="#//PartUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>RenderingUsage&lt;/code> is the usage of a &lt;code>RenderingDefinition&lt;/code> to specify the rendering of a specific model view to produce a physical view artifact.&lt;/p>&#xA;&#xA;&#xA;specializeFromLibrary('Views::renderings')&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(RenderingDefinition) or&#xA; owningType.oclIsKindOf(RenderingUsage)) implies&#xA;    specializesFromLibrary('Views::Rendering::subrenderings')&#xA;owningFeatureMembership &lt;> null and&#xA;owningFeatureMembership.oclIsKindOf(ViewRenderingMembership) implies&#xA;    redefinesFromLibrary('Views::View::viewRendering')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="renderingDefinition" ordered="false"
+        eType="#//RenderingDefinition" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedRendering"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>RenderingDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>RenderingUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//PartUsage/partDefinition"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="RenderingDefinition" eSuperTypes="#//PartDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>RenderingDefinition&lt;/code> is a &lt;code>PartDefinition&lt;/code> that defines a specific rendering of the content of a model view (e.g., symbols, style, layout, etc.).&lt;/p>&#xA;rendering = usages->selectByKind(RenderingUsage)&#xA;specializesFromLibrary('Views::Rendering')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="rendering" upperBound="-1"
+        eType="#//RenderingUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringRenderingDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>usages&lt;/code> of a &lt;code>RenderingDefinition&lt;/code> that are &lt;code>RenderingUsages&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Definition/usage"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MetadataUsage" eSuperTypes="#//ItemUsage #//MetadataFeature">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A  &lt;code>MetadataUsage&lt;/code> is a &lt;code>Usage&lt;/code> and a &lt;code>MetadataFeature&lt;/code>, used to annotate other &lt;code>Elements&lt;/code> in a system model with metadata. As a &lt;code>MetadataFeature&lt;/code>, its type must be a &lt;code>Metaclass&lt;/code>, which will nominally be a &lt;code>MetadataDefinition&lt;/code>. However, any kernel &lt;code>Metaclass&lt;/code> is also allowed, to permit use of &lt;code>Metaclasses&lt;/code> from the Kernel Model Libraries.&lt;/p>&#xA;specializesFromLibrary('Metadata::metadataItems')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="metadataDefinition" ordered="false"
+        eType="#//Metaclass" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="definedMetadata"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>MetadataDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>MetadataUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//ItemUsage/itemDefinition #//MetadataFeature/metaclass"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MetadataFeature" eSuperTypes="#//Feature #//AnnotatingElement">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>MetadataFeature&lt;/code> is a &lt;code>Feature&lt;/code> that is an &lt;code>AnnotatingElement&lt;/code> used to annotate another &lt;code>Element&lt;/code> with metadata. It is typed by a &lt;code>Metaclass&lt;/code>. All its &lt;code>ownedFeatures&lt;/code> must redefine &lt;code>features&lt;/code> of its &lt;code>metaclass&lt;/code> and any feature bindings must be model-level evaluable.&lt;/p>&#xA;&#xA;&#xA;specializesFromLibrary(&quot;Metaobjects::metaobjects&quot;)&#xA;isSemantic() implies&#xA;    let annotatedTypes : Sequence(Type) = &#xA;        annotatedElement->selectAsKind(Type) in&#xA;    let baseTypes : Sequence(MetadataFeature) = &#xA;        evaluateFeature(resolveGlobal(&#xA;            'Metaobjects::SemanticMetadata::baseType').&#xA;            oclAsType(Feature))->&#xA;        selectAsKind(MetadataFeature) in&#xA;    annotatedTypes->notEmpty() and &#xA;    baseTypes()->notEmpty() and &#xA;    baseTypes()->first().isSyntactic() implies&#xA;        let annotatedType : Type = annotatedTypes->first() in&#xA;        let baseType : Element = baseTypes->first().syntaxElement() in&#xA;        if annotatedType.oclIsKindOf(Classifier) and &#xA;            baseType.oclIsKindOf(Feature) then&#xA;            baseType.oclAsType(Feature).type->&#xA;                forAll(t | annotatedType.specializes(t))&#xA;        else if baseType.oclIsKindOf(Type) then&#xA;            annotatedType.specializes(baseType.oclAsType(Type))&#xA;        else&#xA;            true&#xA;        endif"/>
+    </eAnnotations>
+    <eOperations name="evaluateFeature" ordered="false" upperBound="-1" eType="#//Element">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>If the given &lt;code>baseFeature&lt;/code> is a &lt;code>feature&lt;/code> of this &lt;code>MetadataFeature&lt;/code>, or is directly or indirectly redefined by a &lt;code>feature&lt;/code>, then return the result of evaluating the appropriate (model-level evaluable) &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> for it (if any), with the MetadataFeature as the target.&lt;/p>&#xA;let selectedFeatures : Sequence(Feature) = feature->&#xA;    select(closure(ownedRedefinition.redefinedFeature)->&#xA;           includes(baseFeature)) in&#xA;if selectedFeatures->isEmpty() then null&#xA;else&#xA;    let selectedFeature : Feature = selectedFeatures->first() in&#xA;    let featureValues : FeatureValue = selectedFeature->&#xA;        closure(ownedRedefinition.redefinedFeature).ownedMember->&#xA;        selectAsKind(FeatureValue) in&#xA;    if featureValues->isEmpty() then null&#xA;    else featureValues->first().value.evaluate(self)&#xA;    endif"/>
+      </eAnnotations>
+      <eParameters name="baseFeature" ordered="false" lowerBound="1" eType="#//Feature"/>
+    </eOperations>
+    <eOperations name="isSemantic" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check if this &lt;code>MetadataFeature&lt;/code> has a &lt;code>metaclass&lt;/code> which is a kind of &lt;code>&lt;em>SemanticMetadata&lt;/code>.&lt;p>&#xA;specializesFromLibrary('Metaobjects::SemanticMetadata')"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="isSyntactic" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check if this &lt;code>MetadataFeature&lt;/code> has a &lt;code>metaclass&lt;/code> that is a kind of &lt;code>&lt;em>KerML::Element&lt;em>&lt;/code> (that is, it is from the reflective abstract syntax model).&lt;/p>&#xA;specializesFromLibrary('KerML::Element')"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="syntaxElement" ordered="false" eType="#//Element">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>If this &lt;code>MetadataFeature&lt;/code> reflectively represents a model element, then return the corresponding &lt;code>Element&lt;code> instance from the MOF abstract syntax representation of the model.&lt;/p>&#xA;isSyntactic()&#xA;No OCL"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="metaclass" ordered="false"
+        eType="#//Metaclass" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typedMetadata"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>type&lt;/code> of this &lt;code>MetadataFeature&lt;/code>, which must be a &lt;code>Metaclass&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Feature/type"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Metaclass" eSuperTypes="#//Structure">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Metaclass&lt;/code> is a &lt;code>Structure&lt;/code> used to type &lt;code>MetadataFeatures&lt;/code>.&lt;/p>&#xA;specializesFromLibrary(&quot;Metaobjects::Metaobject&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="InterfaceDefinition" eSuperTypes="#//ConnectionDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>InterfaceDefinition&lt;/code> is a &lt;code>ConnectionDefinition&lt;/code> all of whose ends are &lt;code>PortUsages&lt;/code>, defining an interface between elements that interact through such ports.&lt;/p>&#xA;specializesFromLibrary(&quot;Interfaces::Interface&quot;)&#xA;ownedEndFeature->size() = 2 implies&#xA;    specializesFromLibrary(&quot;Interfaces::BinaryInterface&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="interfaceEnd" upperBound="-1"
+        eType="#//PortUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="interfaceDefinitionWithEnd"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>PortUsages&lt;/code> that are the &lt;code>connectionEnds&lt;/code> of this &lt;code>InterfaceDefinition&lt;/code>.&#xA;&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//ConnectionDefinition/connectionEnd"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="EventOccurrenceUsage" eSuperTypes="#//OccurrenceUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>EventOccurrenceUsage&lt;/code> is an &lt;code>OccurrenceUsage&lt;/code> that represents another &lt;code>OccurrenceUsage&lt;code> occurring as a &lt;code>&lt;em>suboccurrence&lt;em>&lt;/code> of the containing occurrence of the &lt;code>EventOccurrenceUsage&lt;/code>. Unless it is the &lt;code>EventOccurrenceUsage&lt;/code> itself, the referenced &lt;code>OccurrenceUsage&lt;/code> is related to the &lt;code>EventOccurrenceUsage&lt;code> by a &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationship&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>If the &lt;code>EventOccurrenceUsage&lt;/code> is owned by an &lt;code>OccurrenceDefinition&lt;/code> or &lt;code>OccurrenceUsage&lt;/code>, then it also subsets the &lt;em>&lt;code>timeEnclosedOccurrences&lt;/code>&lt;/em> property of the &lt;code>Class&lt;/code> &lt;em>&lt;code>Occurrence&lt;/code>&lt;/em> from the Kernel Semantic Library model &lt;em>&lt;code>Occurrences&lt;/code>&lt;/em>.&lt;/p>&#xA;eventOccurrence =&#xA;    if ownedReferenceSubsetting = null then self&#xA;    else if ownedReferenceSubsetting.referencedFeature.oclIsKindOf(OccurrenceUsage) then &#xA;        ownedReferenceSubsetting.referencedFeature.oclAsType(OccurrenceUsage)&#xA;    else null&#xA;    endif endif&#xA;ownedReferenceSubsetting &lt;> null implies&#xA;    ownedReferenceSubsetting.referencedFeature.oclIsKindOf(OccurrenceUsage)&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(OccurrenceDefinition) or&#xA; owningType.oclIsKindOf(OccurrenceUsage)) implies&#xA;    specializesFromLibrary(&quot;Occurrences::Occurrence::timeEnclosedOccurrences&quot;)&#xA;isReference"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="eventOccurrence" ordered="false"
+        lowerBound="1" eType="#//OccurrenceUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="referencingOccurrence"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>OccurrenceUsage&lt;/code> referenced as an event by this &lt;code>EventOccurrenceUsage&lt;/code>. It is the &lt;code>referenceFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> for the &lt;code>EventOccurrenceUsage&lt;/code>, if there is one, and, otherwise, the &lt;code>EventOccurrenceUsage&lt;/code> itself.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MetadataDefinition" eSuperTypes="#//ItemDefinition #//Metaclass">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>MetadataDefinition&lt;/code> is an &lt;code>ItemDefinition&lt;/code> that is also a &lt;code>Metaclass&lt;/code>.&lt;/p>&#xA;specializesFromLibrary('Metadata::MetadataItem')"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="BindingConnectorAsUsage" eSuperTypes="#//ConnectorAsUsage #//BindingConnector">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>BindingConnectorAsUsage&lt;/code> is both a &lt;code>BindingConnector&lt;/code> and a &lt;code>ConnectorAsUsage&lt;/code>.&lt;/p>"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="BindingConnector" eSuperTypes="#//Connector">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>BindingConnector&lt;/code> is a binary &lt;code>Connector&lt;/code> that requires its &lt;code>relatedFeatures&lt;/code> to identify the same things (have the same values).&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Links::selfLinks&quot;)&#xA;relatedFeature->size() = 2"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SuccessionFlowConnectionUsage" eSuperTypes="#//FlowConnectionUsage #//SuccessionItemFlow">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>SuccessionFlowConnectionUsage&lt;/code> is a &lt;code>FlowConnectionUsage&lt;/code> that is also a &lt;code>SuccessionItemFlow&lt;/code>.&lt;/p>&#xA;specializesFromLibrary(&quot;Connections::successionFlowConnections&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SuccessionItemFlow" eSuperTypes="#//ItemFlow #//Succession">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>SuccessionItemFlow&lt;/code> is an &lt;code>ItemFlow&lt;/code> that also provides temporal ordering. It classifies &lt;code>&lt;em>Transfers&lt;/em>&lt;/code> that cannot start until the source &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> has completed and that must complete before the target &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> can start.&lt;/p>&#xA;specializesFromLibrary(&quot;Transfers::flowTransfersBefore&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SuccessionAsUsage" eSuperTypes="#//ConnectorAsUsage #//Succession">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>SuccessionAsUsage&lt;/code> is both a &lt;code>ConnectorAsUsage&lt;/code> and a &lt;code>Succession&lt;/code>.&lt;p>"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FlowConnectionDefinition" eSuperTypes="#//ConnectionDefinition #//ActionDefinition #//Interaction">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FlowConnectionDefinition&lt;/code> is a &lt;code>ConnectionDefinition&lt;/code> and &lt;code>ActionDefinition&lt;/code> that is also an &lt;code>Interaction&lt;/code> representing flows between &lt;code>Usages&lt;/code>.&lt;/p>&#xA;specializesFromLibrary(&quot;Connections::MessageConnection&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="RequirementVerificationMembership" eSuperTypes="#//RequirementConstraintMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>RequirementVerificationMembership&lt;/code> is a &lt;code>RequirementConstraintMembership &lt;/code> used in the objective of a &lt;code>VerificationCase&lt;/code> to identify a &lt;code>RequirementUsage&lt;/code> that is verified by the &lt;code>VerificationCase&lt;/code>.&lt;/p>&#xA;kind = RequirementConstraintKind::requirement&#xA;owningType.oclIsKindOf(RequirementUsage) and&#xA;owningType.owningFeatureMembership &lt;> null and&#xA;owningType.owningFeatureMembership.oclIsKindOf(ObjectiveMembership)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedRequirement" ordered="false"
+        lowerBound="1" eType="#//RequirementUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="requirementVerificationMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owned &lt;code>RequirementUsage&lt;/code> that acts as the &lt;code>ownedConstraint&lt;/code> for this &lt;code>RequirementVerificationMembership&lt;/code>. This will either be the &lt;code>verifiedRequirement&lt;/code>, or it will subset the &lt;code>verifiedRequirement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//RequirementConstraintMembership/ownedConstraint"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="verifiedRequirement" ordered="false"
+        lowerBound="1" eType="#//RequirementUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="requirementVerification"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p> The &lt;code>RequirementUsage&lt;/code> that is identified as being verified. It is the &lt;code>referencedConstraint&lt;/code> of the &lt;code>RequirementVerificationMembership&lt;/code> considered as a &lt;code>RequirementConstraintMembership&lt;/code>, which must be a &lt;code>RequirementUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//RequirementConstraintMembership/referencedConstraint"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="RequirementConstraintMembership" eSuperTypes="#//FeatureMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>RequirementConstraintMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> for an assumed or required &lt;code>ConstraintUsage&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;code>.&lt;/p>&#xA;referencedConstraint =&#xA;    let reference : ReferenceSubsetting = &#xA;        ownedConstraint.ownedReferenceSubsetting in&#xA;    if reference = null then ownedConstraint&#xA;    else if not reference.referencedFeature.oclIsKindOf(ConstraintUsage) then null &#xA;    else reference.referencedFeature.oclAsType(ConstraintUsage)&#xA;    endif endif&#xA;owningType.oclIsKindOf(RequirementDefinition) or&#xA;owningType.oclIsKindOf(RequirementUsage)&#xA;ownedConstraint.isComposite"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="kind" ordered="false" lowerBound="1"
+        eType="#//RequirementConstraintKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether the &lt;code>RequirementConstraintMembership&lt;/code> is for an assumed or required &lt;code>ConstraintUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedConstraint" ordered="false"
+        lowerBound="1" eType="#//ConstraintUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="requirementConstraintMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConstraintUsage&lt;/code> that is the &lt;code>ownedMemberFeature&lt;/code> of this &lt;code>RequirementConstraintMembership&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//FeatureMembership/ownedMemberFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referencedConstraint" ordered="false"
+        lowerBound="1" eType="#//ConstraintUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="referencingConstraintMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p> The &lt;code>ConstraintUsage&lt;/code> that is referenced through this &lt;code>RequirementConstraintMembership&lt;/code>. It is the &lt;code>referencedFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> of the &lt;code>ownedConstraint&lt;/code>, if there is one, and, otherwise, the &lt;code>ownedConstraint&lt;/code> itself.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="RequirementConstraintKind">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>RequirementConstraintKind&lt;/code> indicates whether a &lt;code>ConstraintUsage&lt;/code> is an assumption or a requirement in a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code>.&lt;/p>"/>
+    </eAnnotations>
+    <eLiterals name="assumption">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates that a member &lt;code>ConstraintUsage&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code> represents an assumption.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="requirement" value="1">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates that a member &lt;code>ConstraintUsage&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code>represents an requirement.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FramedConcernMembership" eSuperTypes="#//RequirementConstraintMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FramedConcernMembership&lt;/code> is a &lt;code>RequirementConstraintMembership&lt;/code> for a framed &lt;code>ConcernUsage&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code>.&lt;/p>&#xA;kind = RequirementConstraintKind::requirement"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedConcern" ordered="false"
+        lowerBound="1" eType="#//ConcernUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="framedConstraintMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConcernUsage&lt;/code> that is the &lt;code>ownedConstraint&lt;/code> of this &lt;code>FramedConcernMembership&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//RequirementConstraintMembership/ownedConstraint"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referencedConcern" ordered="false"
+        lowerBound="1" eType="#//ConcernUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="referencingConcernMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p> The &lt;code>ConcernUsage&lt;/code> that is referenced through this &lt;code>FramedConcernMembership&lt;/code>. It is the &lt;code>referencedConstraint&lt;/code> of the &lt;code>FramedConcernMembership&lt;/code> considered as a &lt;code>RequirementConstraintMembership&lt;/code>, which must be a &lt;code>ConcernUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//RequirementConstraintMembership/referencedConstraint"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SubjectMembership" eSuperTypes="#//ParameterMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>SubjectMembership&lt;/code> is a &lt;code>ParameterMembership&lt;/code> that indicates that its &lt;code>ownedSubjectParameter&lt;/code> is the subject of its &lt;code>owningType&lt;/code>. The &lt;code>owningType&lt;/code> of a &lt;code>SubjectMembership&lt;/code> must be a &lt;code>RequirementDefinition&lt;/code>, &lt;code>RequirementUsage&lt;/code>, &lt;code>CaseDefinition&lt;/code>, or &lt;code>CaseUsage&lt;/code>.&lt;/p>&#xA;owningType.oclIsType(RequirementDefinition) or&#xA;owningType.oclIsType(RequiremenCaseRequirementDefinition) or&#xA;owningType.oclIsType(CaseDefinition) or&#xA;owningType.oclIsType(CaseUsage)&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedSubjectParameter"
+        ordered="false" lowerBound="1" eType="#//Usage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningSubjectMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Usage&lt;/code&lt; that is the &lt;code>ownedMemberParameter&lt;/code> of this &lt;code>SubjectMembership&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//ParameterMembership/ownedMemberParameter"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ParameterMembership" eSuperTypes="#//FeatureMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ParameterMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> that identifies its &lt;code>memberFeature&lt;/code> as a parameter, which is always owned, and must have a &lt;code>direction&lt;/code>. A &lt;code>ParameterMembership&lt;/code> must be owned by a &lt;code>Behavior&lt;/code> or a &lt;code>Step&lt;/code>.&lt;/p>&#xA;ownedMemberParameter.direction &lt;> null&#xA;owningType.oclIsKindOf(Behavior) or owningType.oclIsKindOf(Step)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMemberParameter" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningParameterMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is identified as a &lt;code>parameter&lt;/code> by this &lt;code>ParameterMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//FeatureMembership/ownedMemberFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ActorMembership" eSuperTypes="#//ParameterMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ActorMembership&lt;/code> is a &lt;code>ParameterMembership&lt;/code> that identifies a &lt;code>PartUsage&lt;/code> as an &lt;em>actor&lt;/em> &lt;code>parameter&lt;/code>, which specifies a role played by an external entity in interaction with the &lt;code>owningType&lt;/code> of the &lt;code>ActorMembership&lt;/code>.&lt;/p>&#xA;owningType.oclIsKindOf(RequirementUsage) or&#xA;owningType.oclIsKindOf(RequirementDefinition) or&#xA;owningType.oclIsKindOf(CaseDefinition) or&#xA;owningType.oclIsKindOf(CaseUsage)&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedActorParameter" ordered="false"
+        lowerBound="1" eType="#//PartUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningActorMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>PartUsage&lt;/code> specifying the actor.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//ParameterMembership/ownedMemberParameter"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="StakeholderMembership" eSuperTypes="#//ParameterMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>StakeholderMembership&lt;/code> is a &lt;code>ParameterMembership&lt;/code> that identifies a &lt;code>PartUsage&lt;/code> as a &lt;code>stakeholderParameter&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code>, which specifies a role played by an entity with concerns framed by the &lt;code>owningType&lt;/code>.&lt;/p>&#xA;owningType.oclIsKindOf(RequirementUsage) or&#xA;owningType.oclIsKindOf(RequirementDefinition)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedStakeholderParameter"
+        ordered="false" lowerBound="1" eType="#//PartUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningStakeholderMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>PartUsage&lt;/code> specifying the stakeholder.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//ParameterMembership/ownedMemberParameter"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SatisfyRequirementUsage" eSuperTypes="#//RequirementUsage #//AssertConstraintUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>SatisfyRequirementUsage&lt;/code> is an &lt;code>AssertConstraintUsage&lt;/code> that asserts, by default, that a satisfied &lt;code>RequirementUsage&lt;/code> is true for a specific &lt;code>satisfyingFeature&lt;/code>, or, if &lt;code>isNegated = true&lt;/code>, that the &lt;code>RequirementUsage&lt;/code> is false. The satisfied &lt;code>RequirementUsage&lt;/code> is related to the &lt;code>SatisfyRequirementUsage&lt;/code> by a &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationship&lt;/code>.&lt;/p>&#xA;satisfyingFeature =&#xA;    let bindings: BindingConnector = ownedMember->&#xA;        selectByKind(BindingConnector)->&#xA;        select(b | b.relatedElement->includes(subjectParameter)) in&#xA;    if bindings->isEmpty() or &#xA;       bindings->first().relatedElement->exits(r | r &lt;> subjectParameter) &#xA;    then null&#xA;    else bindings->first().relatedElement->any(r | r &lt;> subjectParameter)&#xA;    endif&#xA;ownedMember->selectByKind(BindingConnector)->&#xA;    select(b |&#xA;        b.relatedElement->includes(subjectParameter) and&#xA;        b.relatedElement->exists(r | r &lt;> subjectParameter))->&#xA;    size() = 1"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="satisfiedRequirement" ordered="false"
+        lowerBound="1" eType="#//RequirementUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="requirementSatisfaction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>RequirementUsage&lt;/code> that is satisfied by the &lt;code>satisfyingSubject&lt;/code> of this &lt;code>SatisfyRequirementUsage&lt;/code>. It is the &lt;code>assertedConstraint&lt;/code> of the &lt;code>SatisfyRequirementUsage&lt;/code> considered as an &lt;code>AssertConstraintUsage&lt;/code>, which must be a &lt;code>RequirementUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//AssertConstraintUsage/assertedConstraint"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="satisfyingFeature" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="satisfiedRequirement"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that represents the actual subject that is asserted to satisfy the &lt;code>satisfiedRequirement&lt;/code>. The &lt;code>satisfyingFeature&lt;/code> is bound to the &lt;code>subjectParameter&lt;/code> of the &lt;code>SatisfyRequirementUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AssertConstraintUsage" eSuperTypes="#//ConstraintUsage #//Invariant">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AssertConstraintUsage&lt;/code> is a &lt;code>ConstraintUsage&lt;/code> that is also an &lt;code>Invariant&lt;/code> and, so, is asserted to be true (by default). Unless it is the &lt;code>AssertConstraintUsage&lt;/code> itself, the asserted &lt;code>ConstraintUsage&lt;/code> is related to the &lt;code>AssertConstraintUsage&lt;/code> by a ReferenceSubsetting &lt;code>Relationship&lt;/code>.&lt;/p>&#xA;assertedConstraint =&#xA;    if ownedReferenceSubsetting = null then self&#xA;    else ownedReferenceSubsetting.referencedFeature.oclAsType(ConstraintUsage)&#xA;    endif&#xA;if isNegated then&#xA;    specializesFromLibrary('Constraints::negatedConstraints')&#xA;else&#xA;    specializesFromLibrary('Constraints::assertedConstraints')&#xA;endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="assertedConstraint" ordered="false"
+        lowerBound="1" eType="#//ConstraintUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="constraintAssertion"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ConstraintUsage&lt;/code> to be performed by the &lt;code>AssertConstraintUsage&lt;/code>. It is the &lt;code>referenceFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> for the &lt;code>AssertConstraintUsage&lt;/code>, if there is one, and, otherwise, the &lt;code>AssertConstraintUsage&lt;/code> itself.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Invariant" eSuperTypes="#//BooleanExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Invariant&lt;/code> is a &lt;code>BooleanExpression&lt;/code> that is asserted to have a specific &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> result value. If &lt;code>isNegated = false&lt;/code>, then the result is asserted to be true. If &lt;code>isNegated = true&lt;/code>, then the result is asserted to be false.&lt;/p>&#xA;&#xA;if isNegated then&#xA;    specializesFromLibrary(&quot;Performances::falseEvaluations&quot;)&#xA;else&#xA;    specializesFromLibrary(&quot;Performances::trueEvaluations&quot;)&#xA;endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isNegated" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>Invariant&lt;/code> is asserted to be false rather than true.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="JoinNode" eSuperTypes="#//ControlNode">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>JoinNode&lt;/code> is a &lt;code>ControlNode&lt;/code> that waits for the completion of all the predecessor &lt;code>Actions&lt;/code> given by incoming &lt;code>Successions&lt;/code>.&lt;/p>&#xA;sourceConnector->selectByKind(Succession)->size() &lt;= 1&#xA;specializesFromLibrary(&quot;Actions::Action::join&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ControlNode" abstract="true" eSuperTypes="#//ActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ControlNode&lt;/code> is an &lt;code>ActionUsage&lt;/code> that does not have any inherent behavior but provides constraints on incoming and outgoing &lt;code>Successions&lt;/code> that are used to control other &lt;code>Actions&lt;/code>. A &lt;code>ControlNode&lt;/code> must be a composite owned &lt;code>usage&lt;/code> of an &lt;code>ActionDefinition&lt;/code> or &lt;code>ActionUsage&lt;/code>.&lt;/p>&#xA;&#xA;sourceConnector->selectByKind(Succession)->&#xA;    collect(connectorEnd->at(1).multiplicity)->&#xA;    forAll(sourceMult | &#xA;        multiplicityHasBounds(sourceMult, 1, 1))&#xA;owningType &lt;> null and &#xA;(owningType.oclIsKindOf(ActionDefinition) or&#xA; owningType.oclIsKindOf(ActionUsage))&#xA;targetConnector->selectByKind(Succession)->&#xA;    collect(connectorEnd->at(2).multiplicity)->&#xA;    forAll(targetMult | &#xA;        multiplicityHasBounds(targetMult, 1, 1))&#xA;specializesFromLibrary('Action::Action::controls')"/>
+    </eAnnotations>
+    <eOperations name="multiplicityHasBounds" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check that the given &lt;code>Multiplicity&lt;/code> has &lt;code>lowerBound&lt;/code> and &lt;code>upperBound&lt;/code> expressions that are model-level evaluable to the given &lt;code>lower&lt;/code> and &lt;code>upper&lt;/code> values.&lt;/p>&#xA;mult &lt;> null and&#xA;if mult.oclIsKindOf(MultiplicityRange) then&#xA;    mult.oclAsType(MultiplicityRange).hasBounds(lower, upper)&#xA;else&#xA;    mult.allSuperTypes()->exists(&#xA;        oclisKindOf(MultiplicityRange) and&#xA;        oclAsType(MultiplicityRange).hasBounds(lower, upper)&#xA;endif"/>
+      </eAnnotations>
+      <eParameters name="mult" ordered="false" lowerBound="1" eType="#//Multiplicity"/>
+      <eParameters name="lower" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Integer"/>
+      <eParameters name="upper" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//UnlimitedNatural"/>
+    </eOperations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ForkNode" eSuperTypes="#//ControlNode">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ForkNode&lt;/code> is a &lt;code>ControlNode&lt;/code> that must be followed by successor &lt;code>Actions&lt;/code> as given by all its outgoing &lt;code>Successions&lt;/code>.&lt;/p>&#xA;targetConnector->selectByKind(Succession)->size() &lt;= 1&#xA;specializesFromLibrary(&quot;Actions::Action::forks&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MergeNode" eSuperTypes="#//ControlNode">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>MergeNode&lt;/code> is a &lt;code>ControlNode&lt;/code> that asserts the merging of its incoming &lt;code>Successions&lt;/code>. A &lt;code>MergeNode&lt;/code> may have at most one outgoing &lt;code>Successions&lt;/code>.&lt;/p>&#xA;sourceConnector->selectAsKind(Succession)->size() &lt;= 1&#xA;targetConnector->selectByKind(Succession)->&#xA;    collect(connectorEnd->at(1))->&#xA;    forAll(sourceMult |&#xA;        multiplicityHasBounds(sourceMult, 0, 1))&#xA;targetConnector->selectByKind(Succession)->&#xA;    forAll(subsetsChain(this, &#xA;        resolveGlobal(&quot;ControlPerformances::MergePerformance::incomingHBLink&quot;)))&#xA;specializesFromLibrary(&quot;Actions::Action::merges&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ForLoopActionUsage" eSuperTypes="#//LoopActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ForLoopActionUsage&lt;/code> is a &lt;code>LoopActionUsage&lt;/code> that specifies that its &lt;code>bodyClause&lt;/code> &lt;code>ActionUsage&lt;/code> should be performed once for each value, in order, from the sequence of values obtained as the result of the &lt;code>seqArgument&lt;/code> &lt;code>Expression&lt;/code>, with the &lt;code>loopVariable&lt;/code> set to the value for each iteration.&lt;/p>&#xA;seqArgument =&#xA;    let parameter : Feature = inputParameter(1) in&#xA;    if parameter &lt;> null and parameter.oclIsKindOf(Expression) then&#xA;        parameter.oclAsType(Expression)&#xA;    else&#xA;        null&#xA;    endif&#xA;&#xA;isSubactionUsage() implies&#xA;    specializesFromLibrary('Actions::Action::forLoops')&#xA;loopVariable &lt;> null and&#xA;loopVariable.redefinesFromLibrary('Actions::ForLoopAction::var')&#xA;specializesFromLibrary('Actions::forLoopActions')&#xA;loopVariable =&#xA;    if ownedFeature->isEmpty() or &#xA;        not ownedFeature->first().oclIsKindOf(ReferenceUsage) then &#xA;        null&#xA;    else &#xA;        ownedFeature->first().oclAsType(ReferenceUsage)&#xA;    endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="seqArgument" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="forLoopAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> whose result provides the sequence of values to which the &lt;code>loopVariable&lt;/code> is set for each iterative performance of the &lt;code>bodyAction&lt;/code>. It is the owned &lt;code>parameter&lt;/code> that redefines &lt;em>&lt;code>ForLoopAction::body&lt;/code>&lt;/em>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="loopVariable" ordered="false"
+        lowerBound="1" eType="#//ReferenceUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="forLoopAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ownedFeature&lt;/code> of this &lt;co>ForLoopActionUsage&lt;/code> that acts as the loop variable, which is assigned the successive values of the input sequence on each iteration. It is the &lt;code>ownedFeature&lt;/code> that redefines &lt;em>&lt;code>ForLoopAction::var&lt;/code>&lt;/em>.&lt;/p> "/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LoopActionUsage" abstract="true" eSuperTypes="#//ActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LoopActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that specifies that its &lt;code>bodyAction&lt;/code> should be performed repeatedly. Its subclasses &lt;code>WhileLoopActionUsage&lt;/code> and &lt;code>ForLoopActionUsage&lt;/code> provide different ways to determine how many times the &lt;code>bodyAction&lt;/code> should be performed.&lt;/p>&#xA;bodyAction =&#xA;    let parameter : Feature = inputParameter(2) in&#xA;    if parameter &lt;> null and parameter.oclIsKindOf(Action) then&#xA;        parameter.oclAsType(Action)&#xA;    else&#xA;        null&#xA;    endif&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="bodyAction" ordered="false"
+        lowerBound="1" eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="loopAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsage&lt;/code> to be performed repeatedly by the &lt;code>LoopActionUsage&lt;/code>. It is the second &lt;code>parameter&lt;/code> of the &lt;code>LoopActionUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TriggerInvocationExpression" eSuperTypes="#//InvocationExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>TriggerInvocationExpression&lt;code> is an &lt;code>InvocationExpression&lt;/code> that invokes one of the trigger &lt;code>Functions&lt;/code> from the Kernel Semantic Library &lt;code>&lt;em>Triggers&lt;em>&lt;/code> package, as indicated by its &lt;code>kind&lt;/code>.&lt;/p>&#xA;specializesFromLibrary(&#xA;    if kind = TriggerKind::when then&#xA;        'Triggers::TriggerWhen'&#xA;    else if kind = TriggerKind::at then&#xA;        'Triggers::TriggerAt'&#xA;    else &#xA;        'Triggers::TriggerAfter'&#xA;    endif endif&#xA;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="kind" ordered="false" lowerBound="1"
+        eType="#//TriggerKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates which of the &lt;code>Functions&lt;/code> from the &lt;code>&lt;em>Triggers&lt;/em>&lt;/code> model in the Kernel Semantic Library is to be invoked by this &lt;code>TriggerInvocationExpression&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="InvocationExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>InvocationExpression&lt;/code> is an &lt;code>Expression&lt;/code> each of whose input &lt;code>parameters&lt;/code> are bound to the &lt;code>result&lt;/code> of an &lt;code>argument&lt;/code> Expression.&lt;/p>&#xA;&#xA;not ownedTyping->exists(oclIsKindOf(Behavior)) and&#xA;not ownedSubsetting.subsettedFeature.type->exists(oclIsKindOf(Behavior)) implies&#xA;    ownedFeature.selectByKind(BindingConnector)->exists(&#xA;        relatedFeature->includes(self) and&#xA;        relatedFeature->includes(result))&#xA;            &#xA;TBD&#xA;ownedFeature->&#xA;    select(direction = _'in').valuation->&#xA;    select(v | v &lt;> null).value"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="argument" upperBound="-1"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="invocation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>value&lt;/code> &lt;code>Expressions&lt;/code> of the &lt;code>FeatureValues&lt;/code> of the owned input &lt;code>parameters&lt;/code> of the &lt;code>InvocationExpression&lt;/code>."/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Type/ownedFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="TriggerKind">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>TriggerKind&lt;/code> enumerates the kinds of triggers that can be represented by a &lt;code>TriggerInvocationExpression&lt;/code>.&lt;/p>"/>
+    </eAnnotations>
+    <eLiterals name="when">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates a &lt;em>change trigger&lt;/em>, corresponding to the &lt;em>&lt;code>TriggerWhen&lt;/code>&lt;/em> &lt;code>Function&lt;/code> from the &lt;em>&lt;code>Triggers&lt;/code>&lt;/em> model in the Kernel Semantic Library.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="at" value="1">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates an &lt;em>absolute time trigger&lt;/em>, corresponding to the &lt;em>&lt;code>TriggerAt&lt;/code>&lt;/em> &lt;code>Function&lt;/code> from the &lt;em>&lt;code>Triggers&lt;/code>&lt;/em> model in the Kernel Semantic Library.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="after" value="2">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates a &lt;em>relative time trigger&lt;/em>, corresponding to the &lt;em>&lt;code>TriggerAfter&lt;/code>&lt;/em> &lt;code>Function&lt;/code> from the &lt;em>&lt;code>Triggers&lt;/code>&lt;/em> model in the &lt;code>Kernel Semantic Library.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AssignmentActionUsage" eSuperTypes="#//ActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>AssignmentActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that is defined, directly or indirectly, by the &lt;code>ActionDefinition&lt;/code> &lt;em>&lt;code>AssignmentAction&lt;/code>&lt;/em> from the Systems Model Library. It specifies that the value of the &lt;code>referent&lt;/code> &lt;code>Feature&lt;/code>, relative to the target given by the result of the &lt;code>targetArgument&lt;/code> &lt;code>Expression&lt;/code>, should be set to the result of the &lt;code>valueExpression&lt;/code>.&lt;/p>&#xA;&#xA;specializesFromLibrary('Actions::assignmentActions')&#xA;let targetParameter : Feature = inputParameter(1) in&#xA;targetParameter &lt;> null and&#xA;targetParameter.ownedFeature->notEmpty() and&#xA;targetParameter.ownedFeature->first().&#xA;    redefines('AssignmentAction::target::startingAt')&#xA;valueExpression = argument(2)&#xA;targetArgument = argument(1)&#xA;isSubactionUsage() implies&#xA;    specializesFromLibrary('Actions::Action::assignments')&#xA;let targetParameter : Feature = inputParameter(1) in&#xA;targetParameter &lt;> null and&#xA;targetParameter.ownedFeature->notEmpty() and&#xA;targetParameter->first().ownedFeature->notEmpty() and&#xA;targetParameter->first().ownedFeature->first().&#xA;    redefines('AssigmentAction::target::startingAt::accessedFeature')&#xA;let targetParameter : Feature = inputParameter(1) in&#xA;targetParameter &lt;> null and&#xA;targetParameter.ownedFeature->notEmpty() and&#xA;targetParameter->first().ownedFeature->notEmpty() and&#xA;targetParameter->first().ownedFeature->first().redefines(referent)&#xA;referent =&#xA;    let unownedFeatures : Sequence(Feature) = ownedMembership->&#xA;        reject(oclIsKindOf(OwningMembership)).memberElement->&#xA;        selectByKind(Feature) in&#xA;    if unownedFeatures->isEmpty() then null&#xA;    else unownedFeatures->first().oclAsType(Feature)&#xA;    endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="targetArgument" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="assignmentAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> whose value is an occurrence in the domain of the &lt;code>referent&lt;/code> &lt;code>Feature&lt;/code>, for which the value of the &lt;code>referent&lt;/code> will be set to the result of the &lt;code>valueExpression&lt;/code> by this &lt;code>AssignmentActionUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="valueExpression" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="assigningAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> whose result is to be assigned to the &lt;code>referent&lt;/code> &lt;code>Feature&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referent" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="assignment"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> whose value is to be set.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/member"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="IfActionUsage" eSuperTypes="#//ActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>IfActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that specifies that the &lt;code>thenAction&lt;/code> &lt;code>ActionUsage&lt;/code> should be performed if the result of the &lt;code>ifArgument&lt;/code> &lt;code>Expression&lt;/code> is true. It may also optionally specify an &lt;code>elseAction&lt;/code> &lt;code>ActionUsage&lt;/code> that is performed if the result of the &lt;code>ifArgument&lt;/code> is false.&lt;/p>&#xA;thenAction = &#xA;    let parameter : Feature = inputParameter(2) in&#xA;    if parameter &lt;> null and parameter.oclIsKindOf(ActionUsage) then&#xA;        parameter.oclAsType(ActionUsage)&#xA;    else&#xA;        null&#xA;    endif&#xA;isSubactionUsage() implies&#xA;    specializesFromLibrary('Actions::Action::ifSubactions')&#xA;if elseAction = null then&#xA;    specifiesFromLibrary('Actions::ifThenActions')&#xA;else&#xA;    specifiesFromLibrary('Actions::ifThenElseActions')&#xA;endif&#xA;ifArgument = &#xA;    let parameter : Feature = inputParameter(1) in&#xA;    if parameter &lt;> null and parameter.oclIsKindOf(Expression) then&#xA;        parameter.oclAsType(Expression)&#xA;    else&#xA;        null&#xA;    endif&#xA;elseAction = &#xA;    let parameter : Feature = inputParameter(3) in&#xA;    if parameter &lt;> null and parameter.oclIsKindOf(ActionUsage) then&#xA;        parameter.oclAsType(ActionUsage)&#xA;    else&#xA;        null&#xA;    endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="elseAction" ordered="false"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="ifElseAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsage&lt;/code> that is to be performed if the result of the &lt;code>ifArgument&lt;/code> is false. It is the (optional) third &lt;code>parameter&lt;/code> of the &lt;code>IfActionUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="thenAction" ordered="false"
+        lowerBound="1" eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="ifThenAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsage&lt;/code> that is to be performed if the result of the &lt;code>ifArgument&lt;/code> is true. It is the second &lt;code>parameter&lt;code> of the &lt;code>IfActionUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ifArgument" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="ifAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> whose result determines whether the &lt;code>thenAction&lt;/code> or (optionally) the &lt;code>elseAction&lt;/code> is performed. It is the first &lt;code>parameter&lt;code> of the &lt;code>IfActionUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SendActionUsage" eSuperTypes="#//ActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>SendActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that specifies the sending of a payload given by the result of its &lt;code>payloadArgument&lt;/code> &lt;code>Expression&lt;/code> via a &lt;em>&lt;code>MessageTransfer&lt;/code>&lt;/em> whose &lt;em>&lt;code>source&lt;/code>&lt;/em> is given by the result of the &lt;code>senderArgument&lt;/code> &lt;code>Expression&lt;/code> and whose &lt;code>target&lt;/code> is given by the result of the &lt;code>receiverArgument&lt;/code> &lt;code>Expression&lt;/code>. If no &lt;code>senderArgument&lt;/code> is provided, the default is the &lt;em>&lt;code>this&lt;/code>&lt;/em> context for the action. If no &lt;code>receiverArgument&lt;/code> is given, then the receiver is to be determined by, e.g., outgoing &lt;em>&lt;code>Connections&lt;/code>&lt;/em> from the sender.&lt;/p> &#xA;&#xA;senderArgument = argument(2)&#xA;payloadArgument = argument(1)&#xA;inputParameters()->size() >= 3&#xA;receiverArgument = argument(3)&#xA;isSubactionUsage() implies&#xA;    specializesFromLibrary('Actions::Action::acceptSubactions')&#xA;specializesFromLibrary(&quot;Actions::sendActions&quot;)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="receiverArgument" ordered="false"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="sendActionUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An &lt;code>Expression&lt;/code> whose result is bound to the &lt;em>&lt;code>receiver&lt;/code>&lt;/em> input parameter of this &lt;code>SendActionUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="payloadArgument" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="sendingActionUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An &lt;code>Expression&lt;/code> whose result is bound to the &lt;code>&lt;em>payload&lt;/em>&lt;/code> input parameter of this &lt;code>SendActionUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="senderArgument" ordered="false"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="senderActionUsage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An &lt;code>Expression&lt;/code> whose result is bound to the &lt;em>&lt;code>sender&lt;/code>&lt;/em> input parameter of this &lt;code>SendActionUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PerformActionUsage" eSuperTypes="#//ActionUsage #//EventOccurrenceUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>PerformActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that represents the performance of an &lt;code>ActionUsage&lt;/code>. Unless it is the &lt;code>PerformActionUsage&lt;/code> itself, the &lt;code>ActionUsage&lt;/code> to be performed is related to the &lt;code>PerformActionUsage&lt;/code> by a &lt;code>ReferenceSubsetting&lt;/code> relationship. A &lt;code>PerformActionUsage&lt;/code> is also an &lt;code>EventOccurrenceUsage&lt;/code>, with its &lt;code>performedAction&lt;/code> as the &lt;code>eventOccurrence&lt;/code>.&lt;/p>&#xA;ownedReferenceSubsetting &lt;> null implies&#xA;    ownedReferenceSubsetting.referencedFeature.oclIsKindOf(ActionUsage)&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(PartDefinition) or&#xA; owningType.oclIsKindOf(PartUsage)) implies&#xA;    specializesFromLibrary('Parts::Part::performedActions')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="performedAction" ordered="false"
+        lowerBound="1" eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="performingAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsage&lt;/code> to be performed by this &lt;code>PerformedActionUsage&lt;/code>. It is the &lt;code>eventOccurrence&lt;/code> of the &lt;code>PerformActionUsage&lt;/code> considered as an &lt;code>EventOccurrenceUsage&lt;/code>, which must be an &lt;code>ActionUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//EventOccurrenceUsage/eventOccurrence"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="DecisionNode" eSuperTypes="#//ControlNode">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>DecisionNode&lt;/code> is a &lt;code>ControlNode&lt;/code> that makes a selection from its outgoing &lt;code>Successions&lt;/code>.&lt;/p>&#xA;targetConnector->selectByKind(Succession)->size() &lt;= 1&#xA;sourceConnector->selectAsKind(Succession)->&#xA;    collect(connectorEnd->at(2))->&#xA;    forAll(targetMult |&#xA;        multiplicityHasBounds(targetMult, 0, 1))&#xA;specializesFromLibrary(&quot;Actions::Action::decisions&quot;)&#xA;sourceConnector->selectByKind(Succession)->&#xA;    forAll(subsetsChain(this, &#xA;        resolveGlobal(&quot;ControlPerformances::MergePerformance::outgoingHBLink&quot;)))"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="WhileLoopActionUsage" eSuperTypes="#//LoopActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>WhileLoopActionUsage&lt;/code> is a &lt;code>LoopActionUsage&lt;/code> that specifies that the &lt;code>bodyClause&lt;/code> &lt;code>ActionUsage&lt;/code> should be performed repeatedly while the result of the &lt;code>whileArgument&lt;/code> &lt;code>Expression&lt;/code> is true or until the result of the &lt;code>untilArgument&lt;/code> &lt;code>Expression&lt;/code> (if provided) is true. The &lt;code>whileArgument&lt;/code> &lt;code>Expression&lt;/code> is evaluated before each (possible) performance of the &lt;code>bodyClause&lt;/code>, and the &lt;code>untilArgument&lt;/code> &lt;code>Expression&lt;/code> is evaluated after each performance of the &lt;code>bodyClause&lt;/code>.&lt;/p>&#xA;isSubactionUsage() implies&#xA;    specializesFromLibrary('Actions::Action::whileLoops')&#xA;untilArgument =&#xA;    let parameter : Feature = inputParameter(3) in&#xA;    if parameter &lt;> null and parameter.oclIsKindOf(Expression) then&#xA;        parameter.oclAsType(Expression)&#xA;    else&#xA;        null&#xA;    endif&#xA;&#xA;specializesFromLibrary('Actions::whileLoopActions')&#xA;whileArgument =&#xA;    let parameter : Feature = inputParameter(1) in&#xA;    if parameter &lt;> null and parameter.oclIsKindOf(Expression) then&#xA;        parameter.oclAsType(Expression)&#xA;    else&#xA;        null&#xA;    endif&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="whileArgument" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="whileLoopAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> whose result, if true, determines that the &lt;code>bodyAction&lt;/code> should continue to be performed. It is the first owned &lt;code>parameter&lt;/code> of the &lt;code>WhileLoopActionUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="untilArgument" ordered="false"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="untilLoopAction"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> whose result, if false, determines that the &lt;code>bodyAction&lt;/code> should continue to be performed. It is the (optional) third owned &lt;code>parameter&lt;/code> of the &lt;code>WhileLoopActionUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MembershipExpose" eSuperTypes="#//MembershipImport #//Expose">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>MembershipExpose&lt;/code> is an &lt;code>Expose&lt;/code> &lt;code.Relationship&lt;/code> that exposes a specific &lt;code>importedMembership&lt;/code> and, if &lt;code>isRecursive = true&lt;/code>, additional &lt;code>Memberships&lt;/code> recursively.&lt;/p>"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MembershipImport" eSuperTypes="#//Import">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>MembershipImport&lt;/code> is an &lt;code>Import&lt;/code> that imports its &lt;code>importedMembership&lt;/code> into the &lt;code>importOwningNamespace&lt;/code>. If &lt;code>isRecursive = true&lt;/code> and the &lt;code>memberElement&lt;/code> of the &lt;code>importedMembership&lt;/code> is a &lt;code>Namespace&lt;/code>, then the equivalent of a recursive &lt;code>NamespaceImport&lt;/code> is also performed on that &lt;code>Namespace&lt;/code>.&lt;/p>&#xA;&#xA;importedElement = importedMembership.memberElement"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importedMembership" ordered="false"
+        lowerBound="1" eType="#//Membership">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="import"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Membership&lt;/code> to be imported.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Expose" abstract="true" eSuperTypes="#//Import">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>Expose&lt;/code> is an &lt;code>Import&lt;/code> of &lt;code>Memberships&lt;/code> into a &lt;code>ViewUsage&lt;/code> that provide the &lt;code>Elements&lt;/code> to be included in a view. Visibility is always ignored for an &lt;code>Expose&lt;/code> (i.e., &lt;code>isImportAll = true&lt;/code>).&lt;/p>&#xA;isImportAll&#xA;importOwningNamespace.oclIsType(ViewUsage)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="NamespaceExpose" eSuperTypes="#//NamespaceImport #//Expose">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>NamespaceExpose&lt;/code> is an &lt;code>Expose&lt;/code> &lt;code>Relationship&lt;/code> that exposes the &lt;code>Memberships&lt;/code> of a specific &lt;code>importedNamespace&lt;/code> and, if &lt;code>isRecursive = true&lt;/code>, additional &lt;code>Memberships&lt;/code> recursively.&lt;/p>"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="NamespaceImport" eSuperTypes="#//Import">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>NamespaceImport&lt;/code> is an Import that imports &lt;code>Memberships&lt;/code> from its &lt;code>importedNamespace&lt;/code> into the &lt;code>importOwningNamespace&lt;/code>. If &lt;code> isRecursive = false&lt;/code>, then only the visible &lt;code>Memberships&lt;/code> of the &lt;code>importOwningNamespace&lt;/code> are imported. If &lt;code> isRecursive = true&lt;/code>, then, in addition, &lt;code>Memberships&lt;/code> are recursively imported from any &lt;code>ownedMembers&lt;/code> of the &lt;code>importedNamespace&lt;/code> that are &lt;code>Namespaces&lt;/code>.&lt;/p>&#xA;&#xA;importedElement = importedNamespace"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importedNamespace" ordered="false"
+        lowerBound="1" eType="#//Namespace">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="import"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Namespace&lt;/code> whose visible &lt;code>Memberships&lt;/code> are imported by this &lt;code>NamespaceImport&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ViewRenderingMembership" eSuperTypes="#//FeatureMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ViewRenderingMembership&lt;/code> is a &lt;coed>FeatureMembership&lt;/code> that identifies the &lt;code>viewRendering&lt;/code> of a &lt;code>ViewDefinition&lt;/code> or &lt;code>ViewUsage&lt;/code>.&lt;/p>&#xA;referencedRendering =&#xA;    let reference: ReferenceSubsetting = &#xA;        ownedRendering.ownedReferenceSubsetting in&#xA;    if reference = null then ownedRendering&#xA;    else if not reference.referencedFeature.oclIsKindOf(RenderingUsage) then null&#xA;    else reference.referencedFeature.oclAsType(RenderingUsage)&#xA;    endif&#xA;owningType.oclIsKindOf(ViewDefinition) or&#xA;owningType.oclIsKindOf(ViewUsage)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedRendering" ordered="false"
+        lowerBound="1" eType="#//RenderingUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="viewRenderingMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owned &lt;code>RenderingUsage&lt;/code> that is either itself the &lt;code>referencedRendering&lt;/code> or subsets the &lt;code>referencedRendering&lt;/code>."/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//FeatureMembership/ownedMemberFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referencedRendering" ordered="false"
+        lowerBound="1" eType="#//RenderingUsage" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="referencingRenderingMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p> The &lt;code>RenderingUsage&lt;/code> that is referenced through this &lt;code>ViewRenderingMembership&lt;/code>. It is the &lt;code>referencedFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> for the &lt;code>ownedRendering&lt;/code>, if there is one, and, otherwise, the &lt;code>ownedRendering&lt;/code> itself.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ConjugatedPortTyping" eSuperTypes="#//FeatureTyping">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ConjugatedPortTyping&lt;/code> is a &lt;code>FeatureTyping&lt;/code> whose &lt;code>type&lt;/code> is a &lt;code>ConjugatedPortDefinition&lt;/code>. (This relationship is intended to be an abstract-syntax marker for a special surface notation for conjugated typing of ports.)&lt;/p>&#xA;portDefinition = conjugatedPortDefinition.originalPortDefinition"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="portDefinition" ordered="false"
+        lowerBound="1" eType="#//PortDefinition" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="conjugatedPortTyping"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>originalPortDefinition&lt;/code> of the &lt;code>conjugatedPortDefinition&lt;/code> of this &lt;code>ConjugatedPortTyping&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="conjugatedPortDefinition"
+        ordered="false" lowerBound="1" eType="#//ConjugatedPortDefinition">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="typingByConjugatedPort"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>type&lt;/code> of this &lt;code>ConjugatedPortTyping&lt;/code> considered as a &lt;code>FeatureTyping&lt;/code>, which must be a &lt;code>ConjugatedPortDefinition&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//FeatureTyping/type"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ObjectiveMembership" eSuperTypes="#//FeatureMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ObjectiveMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> that indicates that its &lt;code>ownedObjectiveRequirement&lt;/code> is the objective &lt;code>RequirementUsage &lt;code> for its &lt;code>owningType&lt;/code>, which must be a &lt;code>CaseDefinition&lt;/code> or &lt;code>CaseUsage&lt;/code>.&lt;/p>&#xA;owningType.oclIsType(CaseDefinition) or&#xA;owningType.oclIsType(CaseUsage)&#xA;&#xA;ownedObjectiveRequirement.isComposite"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedObjectiveRequirement"
+        ordered="false" lowerBound="1" eType="#//RequirementUsage" volatile="true"
+        transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningObjectiveMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The RequirementUsage that is the &lt;code>ownedMemberFeature&lt;/code> of this RequirementUsage.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//FeatureMembership/ownedMemberFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="StateDefinition" eSuperTypes="#//ActionDefinition">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>StateDefinition&lt;/code> is the &lt;code>Definition&lt;/code> of the &lt;/code>Behavior&lt;/code> of a system or part of a system in a certain state condition.&lt;/p>&#xA;&#xA;&lt;p>A &lt;code>StateDefinition&lt;/code> may be related to up to three of its &lt;code>ownedFeatures&lt;/code> by &lt;code>StateBehaviorMembership&lt;/cod> &lt;code>Relationships&lt;/code>, all of different &lt;code>kinds&lt;/code>, corresponding to the entry, do and exit actions of the &lt;code>StateDefinition&lt;/code>.&lt;/p>&#xA;ownedGeneralization.general->selectByKind(StateDefinition)->&#xA;    forAll(g | g.isParallel = isParallel)&#xA;specializesFromLibrary('States::StateAction')&#xA;ownedMembership->&#xA;    selectByKind(StateSubactionMembership)->&#xA;    isUnique(kind)&#xA;state = action->selectByKind(StateUsage)&#xA;doAction =&#xA;    let doMemberships : Sequence(StateSubactionMembership) =&#xA;        ownedMembership->&#xA;            selectByKind(StateSubactionMembership)->&#xA;            select(kind = StateSubactionKind::do) in&#xA;    if doMemberships->isEmpty() then null&#xA;    else doMemberships->at(1)&#xA;    endif&#xA;entryAction =&#xA;    let entryMemberships : Sequence(StateSubactionMembership) =&#xA;        ownedMembership->&#xA;            selectByKind(StateSubactionMembership)->&#xA;            select(kind = StateSubactionKind::entry) in&#xA;    if entryMemberships->isEmpty() then null&#xA;    else entryMemberships->at(1)&#xA;    endif&#xA;isParallel implies&#xA;    ownedAction.incomingTransition->isEmpty() and&#xA;    ownedAction.outgoingTransition->isEmpty()&#xA;exitAction = &#xA;    let exitMemberships : Sequence(StateSubactionMembership) =&#xA;        ownedMembership->&#xA;            selectByKind(StateSubactionMembership)->&#xA;            select(kind = StateSubactionKind::exit) in&#xA;    if exitMemberships->isEmpty() then null&#xA;    else exitMemberships->at(1)&#xA;    endif"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="state" upperBound="-1"
+        eType="#//StateUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="featuringStateDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>StateUsages&lt;/code>, which are &lt;code>actions&lt;/code> in the &lt;code>StateDefinition&lt;/code>, that specify the discrete states in the behavior defined by the &lt;code>StateDefinition&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//ActionDefinition/action"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="entryAction" ordered="false"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="enteredStateDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateDefinition&lt;/code> to be performed on entry to the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateDefinition&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = entry&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="doAction" ordered="false"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="activeStateDefintion"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateDefinition&lt;/code> to be performed while in the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateDefinition&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = do&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="exitAction" ordered="false"
+        eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="exitedStateDefinition"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateDefinition&lt;/code> to be performed on exit to the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateDefinition&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = exit&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isParallel" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether the &lt;code>ownedStates&lt;/code> of this &lt;code>StateDefinition&lt;/code> are to all be performed in parallel. If true, none of the &lt;code>ownedActions&lt;/code> (which includes &lt;code>ownedStates&lt;/code>) may have any incoming or outgoing &lt;code>Transitions&lt;/code>. If false, only one &lt;code>ownedState&lt;/code> may be performed at a time.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="StateSubactionKind">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>StateSubactionKind&lt;/code> indicates whether the &lt;code>action&lt;/code> of a StateSubactionMembership is an entry, do or exit action.&lt;/p>"/>
+    </eAnnotations>
+    <eLiterals name="entry">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates that the &lt;code>action&lt;/code> of a &lt;code>StateSubactionMembership&lt;/code> is an &lt;code>entryAction&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="do" value="1">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates that the &lt;code>action&lt;/code> of a &lt;code>StateSubactionMembership&lt;/code> is a &lt;code>doAction&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="exit" value="2">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates that the &lt;code>action&lt;/code> of a &lt;code>StateSubactionMembership&lt;/code> is an &lt;code>exitAction&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="StateSubactionMembership" eSuperTypes="#//FeatureMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>StateSubactionMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> for an entry, do or exit &lt;code>ActionUsage&lt;code> of a &lt;code>StateDefinition&lt;/code> or &lt;code>StateUsage&lt;/code>.&lt;/p>&#xA;owningType.oclIsKindOf(StateDefinition) or&#xA;owningType.oclIsKindOf(StateUsage)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="kind" ordered="false" lowerBound="1"
+        eType="#//StateSubactionKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>StateSubactionMembership&lt;/code> is for an &lt;code>entry&lt;code>, &lt;code>do&lt;/code> or &lt;code>exit&lt;/code> &lt;code>ActionUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="action" ordered="false"
+        lowerBound="1" eType="#//ActionUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="stateSubactionMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>ActionUsage&lt;/code> that is the &lt;code>ownedMemberFeature&lt;/code> of this &lt;code>StateSubactionMembership&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//FeatureMembership/ownedMemberFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ExhibitStateUsage" eSuperTypes="#//StateUsage #//PerformActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>ExhibitStateUsage&lt;/code> is a &lt;code>StateUsage&lt;/code> that represents the exhibiting of a &lt;code>StateUsage&lt;/code>. Unless it is the &lt;code>StateUsage&lt;/code> itself, the &lt;code>StateUsage&lt;/code> to be exhibited is related to the &lt;code>ExhibitStateUsage&lt;/code> by a &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationship&lt;/code>. An &lt;code>ExhibitStateUsage&lt;/code> is also a &lt;code>PerformActionUsage&lt;/code>, with its &lt;code>exhibitedState&lt;/code> as the &lt;code>performedAction&lt;/code>.&lt;/p>&#xA;&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(PartDefinition) or&#xA; owningType.oclIsKindOf(PartUsage)) implies&#xA;    specializesFromLibrary('Parts::Part::exhibitedStates')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="exhibitedState" ordered="false"
+        lowerBound="1" eType="#//StateUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="exhibitingState"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>StateUsage&lt;/code> to be exhibited by the &lt;code>ExhibitStateUsage&lt;/code>. It is the &lt;code>performedAction&lt;/code> of the &lt;code>ExhibitStateUsage&lt;/code> considered as a &lt;code>PerformActionUsage&lt;/code>, which must be a &lt;code>StateUsage&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//PerformActionUsage/performedAction"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TransitionFeatureMembership" eSuperTypes="#//FeatureMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>TransitionFeatureMembership&lt;/code> is a &lt;code>FeatureMembership&lt;code> for a trigger, guard or effect of a &lt;code>TransitionUsage&lt;/code>, whose &lt;code>transitionFeature&lt;/code> is a &lt;code>AcceptActionUsage&lt;/code>, &lt;em>&lt;code>Boolean&lt;/code>&lt;/em>-valued &lt;code>Expression&lt;/code> or &lt;code>ActionUsage&lt;/code>, depending on its &lt;code>kind&lt;/code>. &lt;/p>&#xA;kind = TransitionFeatureKind::trigger implies&#xA;    transitionFeature.oclIsKindOf(AcceptActionUsage)&#xA;owningType.oclIsKindOf(TransitionUsage)&#xA;kind = TransitionFeatureKind::guard implies&#xA;    transitionFeature.oclIsKindOf(Expression) and&#xA;    let guard : Expression = transitionFeature.oclIsKindOf(Expression) in&#xA;    guard.result.specializesFromLibrary('ScalarValues::Boolean') and&#xA;    guard.result.multiplicity &lt;> null and&#xA;    guard.result.multiplicity.hasBounds(1,1)&#xA;kind = TransitionFeatureKind::effect implies&#xA;    transitionFeature.oclIsKindOf(ActionUsage)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="kind" ordered="false" lowerBound="1"
+        eType="#//TransitionFeatureKind">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>TransitionFeatureMembership &lt;/code> is for a &lt;code>trigger&lt;/code>, &lt;code>guard&lt;/code> or &lt;code>effect&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="transitionFeature" ordered="false"
+        lowerBound="1" eType="#//Step" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="transitionFeatureMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Step&lt;/code> that is the &lt;code>ownedMemberFeature&lt;/code> of this &lt;code>TransitionFeatureMembership&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//FeatureMembership/ownedMemberFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="TransitionFeatureKind">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>TransitionActionKind&lt;/code> indicates whether the &lt;code>transitionFeature&lt;/code> of a &lt;code>TransitionFeatureMembership&lt;/code> is a trigger, guard or effect.&lt;/p>"/>
+    </eAnnotations>
+    <eLiterals name="trigger">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates that the &lt;code>transitionFeature&lt;/code> of a &lt;code>TransitionFeatureMembership&lt;/code> is a &lt;code>triggerAction&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="guard" value="1">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates that the &lt;code>transitionFeature&lt;/code> of a &lt;code>TransitionFeatureMembership&lt;/code> is a &lt;code>guardExpression&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="effect" value="2">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Indicates that the &lt;code>transitionFeature&lt;/code> of a &lt;code>TransitionFeatureMembership&lt;/code> is an &lt;code>effectAction&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eLiterals>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="IncludeUseCaseUsage" eSuperTypes="#//UseCaseUsage #//PerformActionUsage">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>IncludeUseCaseUsage&lt;/code> is a &lt;code>UseCaseUsage&lt;/code> that represents the inclusion of a &lt;code>UseCaseUsage&lt;/code> by a &lt;code>UseCaseDefinition&lt;/code> or &lt;code>UseCaseUsage&lt;/code>. Unless it is the &lt;code>IncludeUseCaseUsage&lt;/code> itself, the &lt;code>UseCaseUsage&lt;/code> to be included is related to the &lt;code>includedUseCase&lt;/code> by a &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationship&lt;/code>. An &lt;code>IncludeUseCaseUsage&lt;/code> is also a PerformActionUsage, with its &lt;code>useCaseIncluded&lt;/code> as the &lt;code>performedAction&lt;/code>.&lt;/p>&#xA;&#xA;owningType &lt;> null and&#xA;(owningType.oclIsKindOf(UseCaseDefinition) or&#xA; owningType.oclIsKindOf(UseCaseUsage) implies&#xA;    specializesFromLibrary('UseCases::UseCase::includedUseCases')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="useCaseIncluded" ordered="false"
+        lowerBound="1" eType="#//UseCaseUsage" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="useCaseInclusion"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>UseCaseUsage&lt;/code> to be included by this &lt;code>IncludeUseCaseUsage&lt;/code>. It is the &lt;code>performedAction&lt;/code> of the &lt;code>IncludeUseCaseUsage&lt;/code> considered as a &lt;code>PerformActionUsage&lt;/code>, which must be a &lt;code>UseCaseUsage&lt;/code>.&lt;/p> &#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//PerformActionUsage/performedAction"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="EndFeatureMembership" eSuperTypes="#//FeatureMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>EndFeatureMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> that requires its &lt;code>memberFeature&lt;/code> be owned and have &lt;code>isEnd = true&lt;/code>.&lt;/p>&#xA;&#xA;ownedMemberFeature.isEnd"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ReturnParameterMembership" eSuperTypes="#//ParameterMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ReturnParameterMembership&lt;/code> is a &lt;code>ParameterMembership&lt;/code> that indicates that the &lt;code>ownedMemberParameter&lt;/code> is the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of a &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code>. The &lt;code>direction&lt;/code> of the &lt;code>ownedMemberParameter&lt;/code> must be &lt;code>out&lt;/code>.&lt;/p>&#xA;&#xA;owningType.oclIsKindOf(Function) or owningType.oclIsKindOf(Expression)&#xA;ownedMemberParameter.direction = ParameterDirectionKind::out"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ResultExpressionMembership" eSuperTypes="#//FeatureMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>ResultExpressionMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> that indicates that the &lt;code>ownedResultExpression&lt;/code> provides the result values for the &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code> that owns it. The owning &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code> must contain a &lt;code>BindingConnector&lt;/code> between the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the &lt;code>ownedResultExpression&lt;/code> and the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the owning &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code>.&lt;/p>&#xA;&#xA;owningType.oclIsKindOf(Function) or owningType.oclIsKindOf(Expression)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedResultExpression"
+        ordered="false" lowerBound="1" eType="#//Expression" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningResultExpressionMembership"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> that provides the result for the owner of the &lt;code>ResultExpressionMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//FeatureMembership/ownedMemberFeature"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ElementFilterMembership" eSuperTypes="#//OwningMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>ElementFilterMembership&lt;/code> is a &lt;code>Membership&lt;/code> between a &lt;code>Namespace&lt;/code> and a model-level evaluable &lt;code>&lt;em>Boolean&lt;/em>&lt;/code>-valued &lt;code>Expression&lt;/code>, asserting that imported &lt;code>members&lt;/code> of the &lt;code>Namespace&lt;/code> should be filtered using the &lt;code>condition&lt;/code> &lt;code>Expression&lt;/code>. A general &lt;code>Namespace&lt;/code> does not define any specific filtering behavior, but such behavior may be defined for various specialized kinds of &lt;code>Namespaces&lt;/code>.&lt;/p>&#xA;&#xA;condition.isModelLevelEvaluable&#xA;condition.result.specializesFromLibrary('ScalarValues::Boolean')"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="condition" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="owningFilter"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The model-level evaluable &lt;code>Boolean&lt;/code>-valued &lt;code>Expression&lt;/code> used to filter the imported &lt;code>members&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> of this &lt;code>ElementFilterMembership&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//OwningMembership/ownedMemberElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Package" eSuperTypes="#//Namespace">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Package&lt;/code> is a &lt;code>Namespace&lt;/code> used to group &lt;code>Elements&lt;/code>, without any instance-level semantics. It may have one or more model-level evaluable &lt;code>filterCondition&lt;/code> &lt;code>Expressions&lt;/code> used to filter its &lt;code>importedMemberships&lt;/code>. Any imported &lt;code>member&lt;/code> must meet all of the &lt;code>filterConditions&lt;/code>.&lt;/p>&#xA;filterCondition = ownedMembership->&#xA;    selectByKind(ElementFilterMembership).condition"/>
+    </eAnnotations>
+    <eOperations name="includeAsMember" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Determine whether the given &lt;code>element&lt;/code> meets all the &lt;code>filterConditions&lt;/code>.&lt;/p>&#xA;let metadataFeatures: Sequence(AnnotatingElement) = &#xA;    element.ownedAnnotation.annotatingElement->&#xA;        selectByKind(MetadataFeature) in&#xA;    self.filterCondition->forAll(cond | &#xA;        metadataFeatures->exists(elem | &#xA;            cond.checkCondition(elem)))"/>
+      </eAnnotations>
+      <eParameters name="element" ordered="false" lowerBound="1" eType="#//Element"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="filterCondition" upperBound="-1"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="conditionedPackage"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The model-level evaluable &lt;code>&lt;em>Boolean&lt;/em>&lt;/code>-valued &lt;code>Expression&lt;/code> used to filter the &lt;code>members&lt;/code> of this &lt;code>Package&lt;/code>, which are owned by the &lt;code>Package&lt;/code> are via &lt;code>ElementFilterMemberships&lt;/code>.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/ownedMember"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LibraryPackage" eSuperTypes="#//Package">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LibraryPackage&lt;/code> is a &lt;code>Package&lt;/code> that is the container for a model library. A &lt;code>LibraryPackage&lt;/code> is itself a library &lt;code>Element&lt;/code> as are all &lt;code>Elements&lt;/code> that are directly or indirectly contained in it.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isStandard" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>LibraryPackage&lt;/code> contains a standard library model. This should only be set to true for &lt;code>LibraryPackages&lt;/code> in the standard Kernel Model Libraries or in normative model libraries for a language built on KerML.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="OperatorExpression" eSuperTypes="#//InvocationExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>An &lt;code>OperatorExpression&lt;/code> is an &lt;code>InvocationExpression&lt;/code> whose &lt;code>function&lt;/code> is determined by resolving its &lt;code>operator&lt;/code> in the context of one of the standard packages from the Kernel Function Library.&lt;/p>&#xA;let libFunctions : Sequence(Element) = &#xA;    Sequence{&quot;BaseFunctions&quot;, &quot;DataFunctions&quot;, &quot;ControlFunctions&quot;}->&#xA;    collect(ns | resolveGlobal(ns + &quot;::'&quot; + operator + &quot;'&quot;)) in&#xA;libFunctions->includes(function)&#xA;    &#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>An &lt;code>operator&lt;/code> symbol that names a corresponding &lt;code>Function&lt;/code> from one of the standard packages from the Kernel Function Library .&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="operand" upperBound="-1"
+        eType="#//Expression" volatile="true" transient="true" derived="true" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralBoolean" eSuperTypes="#//LiteralExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>&lt;code>LiteralBoolean&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides a &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have type &lt;code>&lt;em>Boolean&lt;/em>&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> value that is the result of evaluating this &lt;code>LiteralBoolean&lt;/code>.&lt;/p>&#xA;&lt;p>The Boolean value that is the result of evaluating this Expression.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LiteralExpression&lt;/code> is an &lt;code>Expression&lt;/code> that provides a basic &lt;code>&lt;em>DataValue&lt;/em>&lt;/code> as a result.&lt;/p>&#xA;&#xA;isModelLevelEvaluable = true&#xA;specializesFromLibrary(&quot;Performances::literalEvaluations&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralInteger" eSuperTypes="#//LiteralExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LiteralInteger&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides an &lt;code>&lt;em>Integer&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have the type &lt;code>&lt;em>Integer&lt;/em>&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Integer">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>&lt;em>Integer&lt;/em>&lt;/code> value that is the result of evaluating this &lt;code>LiteralInteger&lt;/code>.&lt;/p>&#xA;&lt;p>The Integer value that is the result of evaluating this Expression.&lt;/p>&#xA;"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="NullExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>NullExpression&lt;/code> is an &lt;code>Expression&lt;/code> that results in a null value.&lt;/p>&#xA;&#xA;specializesFromLibrary(&quot;Performances::nullEvaluations&quot;)"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralRational" eSuperTypes="#//LiteralExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LiteralRational&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides a &lt;code>&lt;em>Rational&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have the type &lt;code>&lt;em>Rational&lt;/em>&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Real">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The value whose rational approximation is the result of evaluating this &lt;code>LiteralRational&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The Real value that is the result of evaluating this Expression.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SelectExpression" eSuperTypes="#//OperatorExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>SelectExpression&lt;/code> is an &lt;code>OperatorExpression&lt;/code> whose operator is &lt;code>&quot;select&quot;&lt;/code>, which resolves to the &lt;code>Function&lt;/code> &lt;em>&lt;code>ControlFunctions::select&lt;/code>&lt;/em> from the Kernel Functions Library.&lt;/p>"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MetadataAccessExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>MetadataAccessExpression&lt;/code> is an &lt;code>Expression&lt;/code> whose &lt;code>result&lt;/code> is a sequence of instances of &lt;code>Metaclasses&lt;/code> representing all the &lt;code>MetadataFeature&lt;/code> annotations of the &lt;code>referencedElement&lt;/code>. In addition, the sequence includes an instance of the reflective &lt;code>Metaclass&lt;/code> corresponding to the MOF class of the &lt;code>referencedElement&lt;/code>, with values for all the abstract syntax properties of the &lt;code>referencedElement&lt;/code>.&lt;/p>&#xA;specializesFromLibrary(&quot;Performances::metadataAccessEvaluations&quot;)"/>
+    </eAnnotations>
+    <eOperations name="metaclassFeature" ordered="false" lowerBound="1" eType="#//MetadataFeature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return a &lt;code>MetadataFeature&lt;/code> whose &lt;code>annotatedElement&lt;/code> is the &lt;code>referencedElement&lt;/code>, whose &lt;code>metaclass&lt;/code> is the reflective &lt;code>Metaclass&lt;/code> corresponding to the MOF class of the &lt;code>referencedElement&lt;/code> and whose &lt;code>ownedFeatures&lt;/code> are bound to the MOF properties of the &lt;code>referencedElement&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referencedElement" ordered="false"
+        lowerBound="1" eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="accessExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p> The &lt;code>Element&lt;/code> whose metadata is being accessed.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CollectExpression" eSuperTypes="#//OperatorExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>CollectExpression&lt;/code> is an &lt;code>OperatorExpression&lt;/code> whose &lt;code>operator&lt;/code> is &lt;code>&quot;collect&quot;&lt;/code>, which resolves to the &lt;code>Function&lt;/code> &lt;em>&lt;code>ControlFunctions::collect&lt;/code>&lt;/em> from the Kernel Functions Library.&lt;/p>&#xA;operator = &quot;collect&quot;"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralInfinity" eSuperTypes="#//LiteralExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LiteralInfinity&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides the positive infinity value (&lt;code>*&lt;/code>). It's &lt;code>result&lt;/code> must have the type &lt;code>&lt;em>Positive&lt;/em>&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureChainExpression" eSuperTypes="#//OperatorExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FeatureChainExpression&lt;/code> is an &lt;code>OperatorExpression&lt;/code> whose operator is &lt;code>&quot;.&quot;&lt;/code>, which resolves to the &lt;code>Function&lt;/code> &lt;em>&lt;code>ControlFunctions::'.'&lt;/code>&lt;/em> from the Kernel Functions Library. It evaluates to the result of chaining the &lt;code>result&lt;/code> &lt;code>Feature&lt;/code> of its single &lt;code>argument&lt;/code> &lt;code>Expression&lt;/code> with its &lt;code>targetFeature&lt;/code>.&lt;/p>&#xA;let sourceParameter : Feature = sourceTargetFeature() in&#xA;sourceTargetFeature &lt;> null and&#xA;sourceTargetFeature.redefinesFromLibrary(&quot;ControlFunctions::'.'::source::target&quot;)&#xA;let sourceParameter : Feature = sourceTargetFeature() in&#xA;sourceTargetFeature &lt;> null and&#xA;sourceTargetFeature.redefines(targetFeature)&#xA;targetFeature =&#xA;    let nonParameterMemberships : Sequence(Membership) = ownedMembership->&#xA;        reject(oclIsKindOf(ParameterMembership)) in&#xA;    if nonParameterMemberships->isEmpty() or&#xA;       not nonParameterMemberships->first().memberElement.oclIsKindOf(Feature)&#xA;    then null&#xA;    else nonParameterMemberships->first().memberElement.oclAsType(Feature)&#xA;    endif"/>
+    </eAnnotations>
+    <eOperations name="sourceTargetFeature" ordered="false" eType="#//Feature">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Return the first &lt;code>ownedFeature&lt;/code> of the first owned input &lt;code>parameter&lt;/code> of this &lt;code>FeatureChainExpression&lt;/code> (if any).&lt;/p>&#xA;let inputParameters : Feature = ownedFeatures->&#xA;    select(direction = _'in') in&#xA;if inputParameters->isEmpty() or &#xA;   inputParameters->first().ownedFeature->isEmpty()&#xA;then null&#xA;else inputParameters->first().ownedFeature->first()&#xA;endif"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="targetFeature" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="chainExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is accessed by this &lt;code>FeatureChainExpression&lt;code>, which is its first non-&lt;code>parameter&lt;/code> &lt;code>member&lt;/code>.&lt;p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/member"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LiteralString" eSuperTypes="#//LiteralExpression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>LiteralString&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides a &lt;code>&lt;em>String&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have the type &lt;code>&lt;em>String&lt;/em>&lt;/code>.&lt;/p>&#xA;"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>&lt;em>String&lt;/em>&lt;/code> value that is the result of evaluating this &lt;code>LiteralString&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The String value that is the result of evaluating this Expression.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureReferenceExpression" eSuperTypes="#//Expression">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FeatureReferenceExpression&lt;/code> is an &lt;code>Expression&lt;/code> whose &lt;code>result&lt;/code> is bound to a &lt;code>referent&lt;/code> &lt;code>Feature&lt;/code>.&lt;/p>&#xA;referent =&#xA;    let nonParameterMemberships : Sequence(Membership) = ownedMembership->&#xA;        reject(oclIsKindOf(ParameterMembership)) in&#xA;    if nonParameterMemberships->isEmpty() or&#xA;       not nonParameterMemberships->first().memberElement.oclIsKindOf(Feature)&#xA;    then null&#xA;    else nonParameterMemberships->first().memberElement.oclAsType(Feature)&#xA;    endif&#xA;ownedMember->selectByKind(BindingConnector)->exists(b |&#xA;    b.relatedFeatures->includes(targetFeature) and&#xA;    b.relatedFeatures->includes(result))"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="referent" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="referenceExpression"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> that is referenced by this &lt;code>FeatureReferenceExpression&lt;/code>, which is its first non-&lt;code>parameter&lt;/code> &lt;code>member&lt;/code>.&lt;p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Namespace/member"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MultiplicityRange" eSuperTypes="#//Multiplicity">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>MultiplicityRange&lt;/code> is a &lt;code>Multiplicity&lt;/code> whose value is defined to be the (inclusive) range of natural numbers given by the result of a &lt;code>lowerBound&lt;/code> &lt;code>Expression&lt;/code> and the result of an &lt;code>upperBound&lt;/code> &lt;code>Expression&lt;/code>. The result of these &lt;code>Expressions&lt;/code> shall be of type &lt;code>&lt;em>Natural&lt;/em>&lt;/code>. If the result of the &lt;code>upperBound&lt;/code> &lt;code>Expression&lt;/code> is the unbounded value &lt;code>*&lt;/code>, then the specified range includes all natural numbers greater than or equal to the &lt;code>lowerBound&lt;/code> value. If no &lt;code>lowerBound&lt;/code> &lt;code>Expression&lt;/code>, then the default is that the lower bound has the same value as the upper bound, except if the &lt;code>upperBound&lt;/code> evaluates to &lt;code>*&lt;/code>, in which case the default for the lower bound is 0.&lt;/p>&#xA;&#xA;bound->forAll(b | b.featuringType = self.featuringType)&#xA;bound.result->forAll(specializesFromLibrary('ScalarValues::Natural'))&#xA;lowerBound =&#xA;    let ownedMembers : Sequence(Element) = &#xA;        ownedMembership->selectByKind(OwningMembership).ownedMember in&#xA;    if ownedMembers->size() &lt; 2 or &#xA;        not ownedMembers->first().oclIsKindOf(Expression) then null&#xA;    else ownedMembers->first().oclAsType(Expression)&#xA;    endif&#xA;upperBound =&#xA;    let ownedMembers : Sequence(Element) = &#xA;        ownedMembership->selectByKind(OwningMembership).ownedMember in&#xA;    if ownedMembers->isEmpty() or &#xA;       not ownedMembers->last().oclIsKindOf(Expression) &#xA;    then null&#xA;    else ownedMembers->last().oclAsType(Expression)&#xA;    endif "/>
+    </eAnnotations>
+    <eOperations name="hasBounds" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Check whether this &lt;code>MultiplicityRange&lt;/code> represents the range bounded by the given values &lt;code>lower&lt;/code> and &lt;code>upper&lt;/code>, presuming the &lt;code>lowerBound&lt;/code> and &lt;code>upperBound&lt;/code> &lt;code>Expressions&lt;/code> are model-level evaluable.&lt;/p>&#xA;valueOf(upperBound) = upper and&#xA;let lowerValue: UnlimitedNatural = valueOf(lowerBound) in&#xA;(lowerValue = lower or&#xA; lowerValue = null and &#xA;    (lower = upper or &#xA;     lower = 0 and upper = *))&#xA; "/>
+      </eAnnotations>
+      <eParameters name="lower" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Integer"/>
+      <eParameters name="upper" ordered="false" lowerBound="1" eType="ecore:EDataType uml_types.ecore#//UnlimitedNatural"/>
+    </eOperations>
+    <eOperations name="valueOf" ordered="false" eType="ecore:EDataType uml_types.ecore#//UnlimitedNatural">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Evaluate the given &lt;code>bound&lt;/code> &lt;code>Expression&lt;/code> (at model level) and return the result represented as a MOF &lt;code>UnlimitedNatural&lt;/code> value.&lt;/p>&#xA;if bound = null or not bound.isModelLevelEvaluable then &#xA;    null&#xA;else&#xA;    let boundEval: Sequence(Element) = bound.evaluate(owningType) in&#xA;    if boundEval->size() &lt;> 1 then null else&#xA;        let valueEval: Element = boundEval->at(1) in&#xA;        if valueEval.oclIsKindOf(LiteralInfinity) then *&#xA;        else if valueEval.oclIsKindOf(LiteralInteger) then&#xA;            let value : Integer = &#xA;                valueEval.oclAsKindOf(LiteralInteger).value in&#xA;            if value >= 0 then value else null endif&#xA;        else null&#xA;        endif endif&#xA;    endif&#xA;endif "/>
+      </eAnnotations>
+      <eParameters name="bound" ordered="false" eType="#//Expression"/>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="lowerBound" ordered="false"
+        eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="multiplicity"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> whose result provides the lower bound of the &lt;code>MultiplicityRange&lt;/code>. If no &lt;code>lowerBound&lt;/code> &lt;code>Expression&lt;/code> is given, then the lower bound shall have the same value as the upper bound, unless the upper bound is unbounded (&lt;code>*&lt;/code>), in which case the lower bound shall be 0.&lt;/p>&#xA;"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//MultiplicityRange/bound"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="upperBound" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="multiplicity"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="The &lt;code>Expression&lt;/code> whose result is the upper bound of the &lt;code>MultiplicityRange&lt;/code>."/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//MultiplicityRange/bound"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="bound" lowerBound="1" upperBound="2"
+        eType="#//Expression" changeable="false" volatile="true" transient="true"
+        derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="multiplicity"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The owned &lt;code>Expressions&lt;/code> of the &lt;code>MultiplicityRange&lt;/code> whose results provide its bounds. These must be the only &lt;code>ownedMembers&lt;/code> of the &lt;code>MultiplicityRange&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="union"/>
+      <eAnnotations source="redefines" references="#//Namespace/ownedMember"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureValue" eSuperTypes="#//OwningMembership">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>FeatureValue&lt;/code> is a &lt;code>Membership&lt;/code> that identifies a particular member &lt;code>Expression&lt;/code> that provides the value of the &lt;code>Feature&lt;/code> that owns the &lt;code>FeatureValue&lt;/code>. The value is specified as either a bound value or an initial value, and as either a concrete or default value. A &lt;code>Feature&lt;/code> can have at most one &lt;code>FeatureValue&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The result of the &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> is bound to the &lt;code>featureWithValue&lt;/code> using a &lt;code>BindingConnector&lt;/code>. If &lt;code>isInitial = false&lt;/code>, then the &lt;code>featuringType&lt;/code> of the &lt;code>BindingConnector&lt;/code> is the same as the &lt;code>featuringType&lt;/code> of the &lt;code>featureWithValue&lt;/code>. If &lt;code>isInitial = true&lt;/code>, then the &lt;code>featuringType&lt;/code> of the &lt;code>BindingConnector&lt;/code> is restricted to its &lt;code>startShot&lt;/code>.&#xA;&#xA;&lt;p>If &lt;code>isDefault = false&lt;/code>, then the above semantics of the &lt;code>FeatureValue&lt;/code> are realized for the given &lt;code>featureWithValue&lt;/code>. Otherwise, the semantics are realized for any individual of the &lt;code>featuringType&lt;/code> of the &lt;code>featureWithValue&lt;/code>, unless another value is explicitly given for the &lt;code>featureWithValue&lt;/code> for that individual.&lt;/p>&#xA;&#xA;not isDefault implies&#xA;    featureWithValue.ownedMember->&#xA;        selectByKind(BindingConnector)->exists(b |&#xA;            b.relatedFeature->includes(featureWithValue) and&#xA;            b.relatedFeature->includes(value.result) and&#xA;            if not isInitial then &#xA;                b.featuringType = featureWithValue.featuringType&#xA;            else &#xA;                b.featuringType->exists(t |&#xA;                    t.oclIsKindOf(Feature) and&#xA;                    t.oclAsType(Feature).chainingFeature =&#xA;                        Sequence{&#xA;                            resolveGlobal(&quot;Base::things::that&quot;),&#xA;                            resolveGlobal(&quot;Occurrences::Occurrence::startShot&quot;)&#xA;                        }&#xA;                )&#xA;            endif)"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="featureWithValue" ordered="false"
+        lowerBound="1" eType="#//Feature" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="valuation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Feature&lt;/code> to be provided a value.&lt;/p>&#xA;&#xA;&lt;p>The Feature to be provided a value.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="subsets" references="#//Membership/membershipOwningNamespace"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="value" ordered="false"
+        lowerBound="1" eType="#//Expression" volatile="true" transient="true" derived="true">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="expressedValuation"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Expression&lt;/code> that provides the value of the &lt;code>featureWithValue&lt;/code> as its &lt;code>result&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>The Expression that provides the value as a result.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//OwningMembership/ownedMemberElement"/>
+      <eAnnotations source="http://www.omg.org/spec/SysML"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isInitial" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>FeatureValue&lt;/code> specifies a bound value or an initial value for the &lt;code>featureWithValue&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isDefault" ordered="false"
+        lowerBound="1" eType="ecore:EDataType uml_types.ecore#//Boolean" defaultValueLiteral="false">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>Whether this &lt;code>FeatureValue&lt;/code> is a concrete specification of the bound or initial value of the &lt;code>featureWithValue&lt;/code>, or just a default value that may be overridden.&lt;/p>"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Dependency" eSuperTypes="#//Relationship">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="&lt;p>A &lt;code>Dependency&lt;/code> is a &lt;code>Relationship&lt;/code> that indicates that one or more &lt;code>client&lt;/code> &lt;code>Elements&lt;/code> require one more &lt;code>supplier&lt;/code> &lt;code>Elements&lt;/code> for their complete specification. In general, this means that a change to one of the &lt;code>supplier&lt;/code> &lt;code>Elements&lt;/code> may necessitate a change to, or re-specification of, the &lt;code>client&lt;/code> &lt;code>Elements&lt;/code>.&lt;/p>&#xA;&#xA;&lt;p>Note that a &lt;code>Dependency&lt;/code> is entirely a model-level &lt;code>Relationship&lt;/code>, without instance-level semantics.&lt;/p>"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="client" lowerBound="1"
+        upperBound="-1" eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="clientDependency"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> or &lt;code>Elements&lt;/code> dependent on the &lt;code>supplier&lt;/code> &lt;code>Elements&lt;/code>.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/source"/>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="supplier" lowerBound="1"
+        upperBound="-1" eType="#//Element">
+      <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
+        <details key="body" value="supplierDependency"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="&lt;p>The &lt;code>Element&lt;/code> or &lt;code>Elements&lt;/code> on which the &lt;code>client&lt;/code> &lt;code>Elements&lt;/code> depend in some respect.&lt;/p>"/>
+      </eAnnotations>
+      <eAnnotations source="redefines" references="#//Relationship/target"/>
+    </eStructuralFeatures>
+  </eClassifiers>
+</ecore:EPackage>

--- a/gaphor/codegen/uml_types.ecore
+++ b/gaphor/codegen/uml_types.ecore
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="uml_types" nsURI="https://www.omg.org/spec/UML/20161101/PrimitiveTypes"
+    nsPrefix="primitives">
+  <eAnnotations source="http://www.eclipse.org/uml2/2.0.0/UML">
+    <details key="originalName" value="primitiveTypes"/>
+  </eAnnotations>
+  <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
+    <details key="settingDelegates" value="http://www.omg.org/spec/SysML"/>
+  </eAnnotations>
+  <eClassifiers xsi:type="ecore:EDataType" name="Integer" instanceClassName="int">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="Integer is a primitive type representing integer values."/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EDataType" name="Real" instanceClassName="double">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="Real is a primitive type representing the mathematical concept of real."/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EDataType" name="String" instanceClassName="java.lang.String">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="String is a sequence of characters in some suitable character set used to display information about the model. Character sets may include non-Roman alphabets and characters."/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EDataType" name="UnlimitedNatural" instanceClassName="int">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="UnlimitedNatural is a primitive type representing unlimited natural values."/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EDataType" name="Boolean" instanceClassName="boolean">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="Boolean is used for logical expressions, consisting of the predefined values true and false."/>
+    </eAnnotations>
+  </eClassifiers>
+</ecore:EPackage>

--- a/poetry.lock
+++ b/poetry.lock
@@ -69,6 +69,21 @@ tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "autopep8"
+version = "2.0.2"
+description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "autopep8-2.0.2-py2.py3-none-any.whl", hash = "sha256:86e9303b5e5c8160872b2f5ef611161b2893e9bfe8ccc7e2f76385947d57a2f1"},
+    {file = "autopep8-2.0.2.tar.gz", hash = "sha256:f9849cdd62108cb739dbcdbfb7fdcc9a30d1b63c4cc3e1c1f893b5360941b61c"},
+]
+
+[package.dependencies]
+pycodestyle = ">=2.10.0"
+tomli = {version = "*", markers = "python_version < \"3.11\""}
+
+[[package]]
 name = "babel"
 version = "2.12.1"
 description = "Internationalization utilities"
@@ -571,6 +586,20 @@ sphinx = ">=5.0,<7.0"
 sphinx-basic-ng = "*"
 
 [[package]]
+name = "future-fstrings"
+version = "1.2.0"
+description = "A backport of fstrings to python<3.6"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "future_fstrings-1.2.0-py2.py3-none-any.whl", hash = "sha256:90e49598b553d8746c4dc7d9442e0359d038c3039d802c91c0a55505da318c63"},
+    {file = "future_fstrings-1.2.0.tar.gz", hash = "sha256:6cf41cbe97c398ab5a81168ce0dbb8ad95862d3caf23c21e4430627b90844089"},
+]
+
+[package.extras]
+rewrite = ["tokenize-rt (>=3)"]
+
+[[package]]
 name = "gaphas"
 version = "3.11.3"
 description = "Gaphas is a GTK diagramming widget"
@@ -987,6 +1016,113 @@ docs = ["myst-parser", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "
 test = ["ipykernel", "pre-commit", "pytest", "pytest-cov", "pytest-timeout"]
 
 [[package]]
+name = "lxml"
+version = "4.9.3"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
+files = [
+    {file = "lxml-4.9.3-cp27-cp27m-macosx_11_0_x86_64.whl", hash = "sha256:b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c"},
+    {file = "lxml-4.9.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d"},
+    {file = "lxml-4.9.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef"},
+    {file = "lxml-4.9.3-cp27-cp27m-win32.whl", hash = "sha256:2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7"},
+    {file = "lxml-4.9.3-cp27-cp27m-win_amd64.whl", hash = "sha256:4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1"},
+    {file = "lxml-4.9.3-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb"},
+    {file = "lxml-4.9.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e"},
+    {file = "lxml-4.9.3-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991"},
+    {file = "lxml-4.9.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd"},
+    {file = "lxml-4.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c"},
+    {file = "lxml-4.9.3-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8"},
+    {file = "lxml-4.9.3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76"},
+    {file = "lxml-4.9.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23"},
+    {file = "lxml-4.9.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f"},
+    {file = "lxml-4.9.3-cp310-cp310-win32.whl", hash = "sha256:cdb650fc86227eba20de1a29d4b2c1bfe139dc75a0669270033cb2ea3d391b85"},
+    {file = "lxml-4.9.3-cp310-cp310-win_amd64.whl", hash = "sha256:97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d"},
+    {file = "lxml-4.9.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5"},
+    {file = "lxml-4.9.3-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf"},
+    {file = "lxml-4.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a"},
+    {file = "lxml-4.9.3-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f"},
+    {file = "lxml-4.9.3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b"},
+    {file = "lxml-4.9.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120"},
+    {file = "lxml-4.9.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6"},
+    {file = "lxml-4.9.3-cp311-cp311-win32.whl", hash = "sha256:0bfd0767c5c1de2551a120673b72e5d4b628737cb05414f03c3277bf9bed3305"},
+    {file = "lxml-4.9.3-cp311-cp311-win_amd64.whl", hash = "sha256:25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc"},
+    {file = "lxml-4.9.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4"},
+    {file = "lxml-4.9.3-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:48d6ed886b343d11493129e019da91d4039826794a3e3027321c56d9e71505be"},
+    {file = "lxml-4.9.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13"},
+    {file = "lxml-4.9.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9"},
+    {file = "lxml-4.9.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5"},
+    {file = "lxml-4.9.3-cp312-cp312-win_amd64.whl", hash = "sha256:d37017287a7adb6ab77e1c5bee9bcf9660f90ff445042b790402a654d2ad81d8"},
+    {file = "lxml-4.9.3-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:56dc1f1ebccc656d1b3ed288f11e27172a01503fc016bcabdcbc0978b19352b7"},
+    {file = "lxml-4.9.3-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:578695735c5a3f51569810dfebd05dd6f888147a34f0f98d4bb27e92b76e05c2"},
+    {file = "lxml-4.9.3-cp35-cp35m-win32.whl", hash = "sha256:704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d"},
+    {file = "lxml-4.9.3-cp35-cp35m-win_amd64.whl", hash = "sha256:c41bfca0bd3532d53d16fd34d20806d5c2b1ace22a2f2e4c0008570bf2c58833"},
+    {file = "lxml-4.9.3-cp36-cp36m-macosx_11_0_x86_64.whl", hash = "sha256:64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12"},
+    {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5"},
+    {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98"},
+    {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190"},
+    {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_28_x86_64.whl", hash = "sha256:4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2"},
+    {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c"},
+    {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584"},
+    {file = "lxml-4.9.3-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:0c0850c8b02c298d3c7006b23e98249515ac57430e16a166873fc47a5d549287"},
+    {file = "lxml-4.9.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458"},
+    {file = "lxml-4.9.3-cp36-cp36m-win32.whl", hash = "sha256:50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477"},
+    {file = "lxml-4.9.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf"},
+    {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601"},
+    {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129"},
+    {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4"},
+    {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d"},
+    {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693"},
+    {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4"},
+    {file = "lxml-4.9.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a"},
+    {file = "lxml-4.9.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02"},
+    {file = "lxml-4.9.3-cp37-cp37m-win32.whl", hash = "sha256:1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f"},
+    {file = "lxml-4.9.3-cp37-cp37m-win_amd64.whl", hash = "sha256:120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52"},
+    {file = "lxml-4.9.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc"},
+    {file = "lxml-4.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac"},
+    {file = "lxml-4.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db"},
+    {file = "lxml-4.9.3-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce"},
+    {file = "lxml-4.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42"},
+    {file = "lxml-4.9.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa"},
+    {file = "lxml-4.9.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40"},
+    {file = "lxml-4.9.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7"},
+    {file = "lxml-4.9.3-cp38-cp38-win32.whl", hash = "sha256:57aba1bbdf450b726d58b2aea5fe47c7875f5afb2c4a23784ed78f19a0462574"},
+    {file = "lxml-4.9.3-cp38-cp38-win_amd64.whl", hash = "sha256:92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96"},
+    {file = "lxml-4.9.3-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340"},
+    {file = "lxml-4.9.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7"},
+    {file = "lxml-4.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b"},
+    {file = "lxml-4.9.3-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da"},
+    {file = "lxml-4.9.3-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e"},
+    {file = "lxml-4.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d"},
+    {file = "lxml-4.9.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432"},
+    {file = "lxml-4.9.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bb3bb49c7a6ad9d981d734ef7c7193bc349ac338776a0360cc671eaee89bcf69"},
+    {file = "lxml-4.9.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d27be7405547d1f958b60837dc4c1007da90b8b23f54ba1f8b728c78fdb19d50"},
+    {file = "lxml-4.9.3-cp39-cp39-win32.whl", hash = "sha256:8df133a2ea5e74eef5e8fc6f19b9e085f758768a16e9877a60aec455ed2609b2"},
+    {file = "lxml-4.9.3-cp39-cp39-win_amd64.whl", hash = "sha256:4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2"},
+    {file = "lxml-4.9.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35"},
+    {file = "lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0"},
+    {file = "lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3"},
+    {file = "lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b"},
+    {file = "lxml-4.9.3-pp38-pypy38_pp73-macosx_11_0_x86_64.whl", hash = "sha256:5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b"},
+    {file = "lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7"},
+    {file = "lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d"},
+    {file = "lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b"},
+    {file = "lxml-4.9.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a"},
+    {file = "lxml-4.9.3-pp39-pypy39_pp73-macosx_11_0_x86_64.whl", hash = "sha256:ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0"},
+    {file = "lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694"},
+    {file = "lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7"},
+    {file = "lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4"},
+    {file = "lxml-4.9.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9"},
+    {file = "lxml-4.9.3.tar.gz", hash = "sha256:48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c"},
+]
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html5 = ["html5lib"]
+htmlsoup = ["BeautifulSoup4"]
+source = ["Cython (>=0.29.35)"]
+
+[[package]]
 name = "macholib"
 version = "1.16.2"
 description = "Mach-O header analysis and editing"
@@ -1250,6 +1386,20 @@ files = [
 setuptools = "*"
 
 [[package]]
+name = "ordered-set"
+version = "4.1.0"
+description = "An OrderedSet is a custom MutableSet that remembers its order, so that every"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ordered-set-4.1.0.tar.gz", hash = "sha256:694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8"},
+    {file = "ordered_set-4.1.0-py3-none-any.whl", hash = "sha256:046e1132c71fcf3330438a539928932caf51ddbc582496833e23de611de14562"},
+]
+
+[package.extras]
+dev = ["black", "mypy", "pytest"]
+
+[[package]]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
@@ -1474,6 +1624,17 @@ files = [
 ]
 
 [[package]]
+name = "pycodestyle"
+version = "2.11.0"
+description = "Python style guide checker"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycodestyle-2.11.0-py2.py3-none-any.whl", hash = "sha256:5d1013ba8dc7895b548be5afb05740ca82454fd899971563d2ef625d090326f8"},
+    {file = "pycodestyle-2.11.0.tar.gz", hash = "sha256:259bcc17857d8a8b3b4a2327324b79e5f020a13c16074670f9c8c8f872ea76d0"},
+]
+
+[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -1497,6 +1658,40 @@ files = [
 
 [package.dependencies]
 pyparsing = ">=2.1.4"
+
+[[package]]
+name = "pyecore"
+version = "0.13.1"
+description = "A Python(ic) Implementation of the Eclipse Modeling Framework (EMF/Ecore)"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pyecore-0.13.1-py3-none-any.whl", hash = "sha256:9b4e919183432251bc06ff6bf867edb79d07fff9c0516d57c65321c1e9955cba"},
+    {file = "pyecore-0.13.1.tar.gz", hash = "sha256:6462ca6f2003239b78d544b287fe9bef14c1f97277b37e758b3abfd20e8b5f0a"},
+]
+
+[package.dependencies]
+future-fstrings = "*"
+lxml = "*"
+ordered-set = ">=4.0.1"
+restrictedpython = ">=4.0b6"
+
+[[package]]
+name = "pyecoregen"
+version = "0.5.1"
+description = "Model to text framework for PyEcore, including the Ecore to Python generator"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pyecoregen-0.5.1-py3-none-any.whl", hash = "sha256:c7467d91b43b80ca4eb7c9b8c54413c6d6fdbf0f8ee26820a4843b76d5c36b1f"},
+    {file = "pyecoregen-0.5.1.tar.gz", hash = "sha256:3e675ea2f60cf0e0cb0cb9bf4ba41692eb966110bf457f6f38d7a35ebac66d3a"},
+]
+
+[package.dependencies]
+autopep8 = "*"
+jinja2 = "*"
+pyecore = "*"
+pymultigen = "*"
 
 [[package]]
 name = "pygit2"
@@ -1627,6 +1822,16 @@ files = [
 Jinja2 = "*"
 packaging = "*"
 PyYAML = "*"
+
+[[package]]
+name = "pymultigen"
+version = "0.2.0"
+description = "Multi-file frontend for single-file code generators."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pymultigen-0.2.0-py3-none-any.whl", hash = "sha256:b84b8d7227354ba7373db3ea04b0ecc4c87fffc3e980be447c0d0b4428b6f492"},
+]
 
 [[package]]
 name = "pyobjc-core"
@@ -1971,6 +2176,23 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "restrictedpython"
+version = "5.0"
+description = "RestrictedPython is a defined subset of the Python language which allows to provide a program input into a trusted environment."
+optional = false
+python-versions = "*"
+files = [
+    {file = "RestrictedPython-5.0-py2.py3-none-any.whl", hash = "sha256:9bd69505147b0ff8c68f4ff5a275975a3ab66fc43cbf3b61a195650ed767cd4e"},
+    {file = "RestrictedPython-5.0.tar.gz", hash = "sha256:a080569bffdf53371ae3e754ab1732f43054b1bab904fc100f74ba68ac731abc"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[package.extras]
+test = ["pytest", "pytest-mock"]
 
 [[package]]
 name = "rpds-py"
@@ -2620,4 +2842,4 @@ docs = ["furo", "myst-nb", "sphinx", "sphinx-copybutton", "sphinx-intl"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "0bcbc8e3b44a1b302502401e06b901ab7fc2618a69969da38fcbc27bb0cbfeab"
+content-hash = "746fd2c0c0e4b09cd93bf8db8b3da11326a13d3d39be04780a6422be4cbd29d4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ sphinx-copybutton = { version = "^0.5.0", optional = true }
 sphinx-intl = { version = "^2.1.0", optional = true }
 myst-nb = { version = "^0.17.1", optional = true }
 furo = { version = ">=2022,<2024", optional = true }
+pyecore = "^0.13.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1"
@@ -66,6 +67,7 @@ hypothesis = "^6.54.5"
 ipython = "^8.5.0"
 sphinx = ">=4.3,<6.0"
 babelgladeextractor = "^0.7"
+pyecoregen = "^0.5.1"
 
 [tool.poetry.group.lint.dependencies]
 pre-commit = ">=2.20,<4.0"
@@ -176,6 +178,8 @@ c4model.script = """gaphor.codegen.coder:main(
     outfile='gaphor/C4Model/c4model.py',
     supermodelfiles=[('UML', 'models/UML.gaphor')]
     )"""
+kerml = "pyecoregen --with-dependencies -e gaphor/codegen/kerml.ecore -o gaphor/KerML"
+sysmlv2 = "pyecoregen --with-dependencies -e gaphor/codegen/sysmlv2.ecore -o gaphor/SysMLv2"
 lint = "pre-commit run --all-files"
 docs = { "cwd" = "docs", "shell" = "sphinx-build -b html . _build/html" }
 docs-gettext-pot = { "cwd" = "docs", "shell" = "sphinx-build -b gettext . locale" }


### PR DESCRIPTION
This is an initial implementation of what was discussed in #2584, to create our Python data models for SysML v2 by using the SysML Pilot Implementation EMF ecore meta models with pyecore.

I also filed https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/issues/496, since it appears that the SysML ecore doesn't actually depend on the KerML ecore, it redefines everything. To work around this, I did a lot of manual editing of the resulting pyecoregen models. We could work towards getting this fixed upstream and automating any other changes needed.

What does everyone think about this approach?

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2584

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
