### PR TITLE
Fixed Profile is created instead of Stereotype in model browser

### DIFF
--- a/gaphor/UML/toolbox.py
+++ b/gaphor/UML/toolbox.py
@@ -30,6 +30,7 @@ from gaphor.UML.uml import (
     Node,
     Package,
     Profile,
+    Stereotype,
     StateMachine,
     UseCase,
 )
@@ -84,6 +85,6 @@ uml_element_types = (
     ElementCreateInfo(
         "statemachine", i18nize("New State Machine"), StateMachine, (Package,)
     ),
-    ElementCreateInfo("stereotype", i18nize("New Stereotype"), Profile, (Package,)),
+    ElementCreateInfo("stereotype", i18nize("New Stereotype"), Stereotype, (Package,)),
     ElementCreateInfo("usecase", i18nize("New Use Case"), UseCase, (Package,)),
 )


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When user wants to add a new stereotype to the model in the model browser a profile is being created.

Issue Number: #2606 

### What is the new behavior?

A stereotype is created as expected.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
