### PR TITLE
Represent activity, interaction and state machine as blocks on block definition diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------
 - Fix missing derive relationship icon in the model browser
 - Fix block not showing parts
+- Represent activity, interaction and state machine as blocks on SysML block definition diagram
 
 2.20.0
 ------

--- a/gaphor/C4Model/toolbox.py
+++ b/gaphor/C4Model/toolbox.py
@@ -3,7 +3,7 @@ from functools import partial
 
 from gaphas.item import SE
 
-from gaphor.C4Model import c4model, diagramitems
+from gaphor.C4Model import c4model
 from gaphor.i18n import gettext, i18nize
 from gaphor.diagram.diagramtoolbox import (
     DiagramType,
@@ -13,9 +13,9 @@ from gaphor.diagram.diagramtoolbox import (
     ToolDef,
     ToolSection,
     general_tools,
-    new_item_factory,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
 )
-from gaphor.UML import diagramitems as uml_items
 from gaphor.UML.actions.actionstoolbox import actions
 from gaphor.UML.classes.classestoolbox import classes
 from gaphor.UML.interactions.interactionstoolbox import interactions
@@ -31,6 +31,7 @@ from gaphor.UML.uml import (
     DataType,
     Enumeration,
     PrimitiveType,
+    Dependency,
 )
 
 
@@ -71,8 +72,7 @@ c4 = ToolSection(
             gettext("Person"),
             "gaphor-c4-person-symbolic",
             "P",
-            new_item_factory(
-                diagramitems.C4PersonItem,
+            new_element_item_factory(
                 c4model.C4Person,
                 config_func=partial(namespace_config, name=i18nize("Person")),
             ),
@@ -83,8 +83,7 @@ c4 = ToolSection(
             gettext("Software System"),
             "gaphor-c4-software-system-symbolic",
             "<Shift>S",
-            new_item_factory(
-                diagramitems.C4ContainerItem,
+            new_element_item_factory(
                 c4model.C4Container,
                 config_func=software_system_config,
             ),
@@ -95,8 +94,7 @@ c4 = ToolSection(
             gettext("Container"),
             "gaphor-c4-container-symbolic",
             "u",
-            new_item_factory(
-                diagramitems.C4ContainerItem,
+            new_element_item_factory(
                 c4model.C4Container,
                 config_func=container_config,
             ),
@@ -107,8 +105,7 @@ c4 = ToolSection(
             gettext("Container: Database"),
             "gaphor-c4-database-symbolic",
             "<Shift>B",
-            new_item_factory(
-                diagramitems.C4DatabaseItem,
+            new_element_item_factory(
                 c4model.C4Database,
                 config_func=container_database_config,
             ),
@@ -119,8 +116,7 @@ c4 = ToolSection(
             gettext("Component"),
             "gaphor-c4-component-symbolic",
             "<Shift>X",
-            new_item_factory(
-                diagramitems.C4ContainerItem,
+            new_element_item_factory(
                 c4model.C4Container,
                 config_func=component_config,
             ),
@@ -131,7 +127,7 @@ c4 = ToolSection(
             gettext("Dependency"),
             "gaphor-dependency-symbolic",
             "d",
-            new_item_factory(uml_items.DependencyItem),
+            new_deferred_element_item_factory(Dependency),
             handle_index=0,
         ),
     ),

--- a/gaphor/RAAML/fta/ftatoolbox.py
+++ b/gaphor/RAAML/fta/ftatoolbox.py
@@ -2,10 +2,15 @@
 
 from functools import partial
 
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
+from gaphor.diagram.diagramtoolbox import (
+    ToolDef,
+    ToolSection,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
+)
 from gaphor.i18n import gettext, i18nize
-from gaphor.RAAML import diagramitems, raaml
-from gaphor.UML import diagramitems as uml_items
+from gaphor.RAAML import raaml
+from gaphor.UML import uml
 from gaphor.UML.toolboxconfig import named_element_config, namespace_config
 
 fta = ToolSection(
@@ -16,7 +21,7 @@ fta = ToolSection(
             gettext("Dependency"),
             "gaphor-dependency-symbolic",
             "<Shift>D",
-            new_item_factory(uml_items.DependencyItem),
+            new_deferred_element_item_factory(uml.Dependency),
             handle_index=0,
         ),
         ToolDef(
@@ -24,8 +29,7 @@ fta = ToolSection(
             gettext("AND Gate"),
             "gaphor-and-symbolic",
             "a",
-            new_item_factory(
-                diagramitems.ANDItem,
+            new_element_item_factory(
                 raaml.AND,
                 config_func=partial(namespace_config, name=i18nize("AND")),
             ),
@@ -35,8 +39,7 @@ fta = ToolSection(
             gettext("OR Gate"),
             "gaphor-or-symbolic",
             "o",
-            new_item_factory(
-                diagramitems.ORItem,
+            new_element_item_factory(
                 raaml.OR,
                 config_func=partial(namespace_config, name=i18nize("OR")),
             ),
@@ -46,8 +49,7 @@ fta = ToolSection(
             gettext("NOT Gate"),
             "gaphor-not-symbolic",
             "n",
-            new_item_factory(
-                diagramitems.NOTItem,
+            new_element_item_factory(
                 raaml.NOT,
                 config_func=partial(namespace_config, name=i18nize("NOT")),
             ),
@@ -57,8 +59,7 @@ fta = ToolSection(
             gettext("Sequence Enforcing (SEQ) Gate"),
             "gaphor-seq-symbolic",
             "<Shift>S",
-            new_item_factory(
-                diagramitems.SEQItem,
+            new_element_item_factory(
                 raaml.SEQ,
                 config_func=partial(namespace_config, name=i18nize("SEQ")),
             ),
@@ -68,8 +69,7 @@ fta = ToolSection(
             gettext("Exclusive OR Gate"),
             "gaphor-xor-symbolic",
             "x",
-            new_item_factory(
-                diagramitems.XORItem,
+            new_element_item_factory(
                 raaml.XOR,
                 config_func=partial(namespace_config, name=i18nize("XOR")),
             ),
@@ -79,8 +79,7 @@ fta = ToolSection(
             gettext("Majority Vote Gate"),
             "gaphor-majority_vote-symbolic",
             "m",
-            new_item_factory(
-                diagramitems.MajorityVoteItem,
+            new_element_item_factory(
                 raaml.MAJORITY_VOTE,
                 config_func=partial(
                     namespace_config, name=i18nize("Majority Vote Gate")
@@ -92,8 +91,7 @@ fta = ToolSection(
             gettext("Inhibit Gate"),
             "gaphor-inhibit-symbolic",
             "i",
-            new_item_factory(
-                diagramitems.InhibitItem,
+            new_element_item_factory(
                 raaml.INHIBIT,
                 config_func=partial(namespace_config, name=i18nize("Inhibit Gate")),
             ),
@@ -103,8 +101,7 @@ fta = ToolSection(
             gettext("Transfer In"),
             "gaphor-transfer-in-symbolic",
             "t",
-            new_item_factory(
-                diagramitems.TransferInItem,
+            new_element_item_factory(
                 raaml.TransferIn,
                 config_func=partial(named_element_config, name=i18nize("Transfer In")),
             ),
@@ -114,8 +111,7 @@ fta = ToolSection(
             gettext("Transfer Out"),
             "gaphor-transfer-out-symbolic",
             "<Shift>T",
-            new_item_factory(
-                diagramitems.TransferOutItem,
+            new_element_item_factory(
                 raaml.TransferOut,
                 config_func=partial(namespace_config, name=i18nize("Transfer Out")),
             ),
@@ -125,8 +121,7 @@ fta = ToolSection(
             gettext("Basic Event"),
             "gaphor-basic-event-symbolic",
             "<Shift>B",
-            new_item_factory(
-                diagramitems.BasicEventItem,
+            new_element_item_factory(
                 raaml.BasicEvent,
                 config_func=partial(namespace_config, name=i18nize("Basic Event")),
             ),
@@ -136,8 +131,7 @@ fta = ToolSection(
             gettext("Conditional Event"),
             "gaphor-conditional-event-symbolic",
             "c",
-            new_item_factory(
-                diagramitems.ConditionalEventItem,
+            new_element_item_factory(
                 raaml.ConditionalEvent,
                 config_func=partial(
                     namespace_config, name=i18nize("Conditional Event")
@@ -149,8 +143,7 @@ fta = ToolSection(
             gettext("Undeveloped Event"),
             "gaphor-undeveloped-event-symbolic",
             "<Shift>U",
-            new_item_factory(
-                diagramitems.UndevelopedEventItem,
+            new_element_item_factory(
                 raaml.Undeveloped,
                 config_func=partial(
                     named_element_config, name=i18nize("Undeveloped Event")
@@ -162,8 +155,7 @@ fta = ToolSection(
             gettext("Dormant Event"),
             "gaphor-dormant-event-symbolic",
             "d",
-            new_item_factory(
-                diagramitems.DormantEventItem,
+            new_element_item_factory(
                 raaml.DormantEvent,
                 config_func=partial(namespace_config, name=i18nize("Dormant Event")),
             ),
@@ -173,8 +165,7 @@ fta = ToolSection(
             gettext("House Event"),
             "gaphor-house-event-symbolic",
             "h",
-            new_item_factory(
-                diagramitems.HouseEventItem,
+            new_element_item_factory(
                 raaml.HouseEvent,
                 config_func=partial(namespace_config, name=i18nize("House Event")),
             ),
@@ -184,8 +175,7 @@ fta = ToolSection(
             gettext("Zero Event"),
             "gaphor-zero-event-symbolic",
             "z",
-            new_item_factory(
-                diagramitems.ZeroEventItem,
+            new_element_item_factory(
                 raaml.ZeroEvent,
                 config_func=partial(namespace_config, name=i18nize("Zero Event")),
             ),
@@ -195,8 +185,7 @@ fta = ToolSection(
             gettext("Top Event"),
             "gaphor-top-event-symbolic",
             "p",
-            new_item_factory(
-                diagramitems.TopEventItem,
+            new_element_item_factory(
                 raaml.TopEvent,
                 config_func=partial(namespace_config, name=i18nize("Top Event")),
             ),
@@ -206,8 +195,7 @@ fta = ToolSection(
             gettext("Intermediate Event"),
             "gaphor-intermediate-event-symbolic",
             "<Shift>I",
-            new_item_factory(
-                diagramitems.IntermediateEventItem,
+            new_element_item_factory(
                 raaml.IntermediateEvent,
                 config_func=partial(
                     namespace_config, name=i18nize("Intermediate Event")

--- a/gaphor/RAAML/stpa/block.py
+++ b/gaphor/RAAML/stpa/block.py
@@ -1,8 +1,13 @@
 from gaphor.diagram.support import represents
 from gaphor.RAAML import raaml
 from gaphor.SysML.blocks import BlockItem
+from gaphor.SysML.blocks.property import PropertyItem
 
 represents(raaml.Situation)(BlockItem)
 represents(raaml.Loss)(BlockItem)
 represents(raaml.Hazard)(BlockItem)
 represents(raaml.ControlStructure)(BlockItem)
+
+represents(raaml.Controller)(PropertyItem)
+represents(raaml.Actuator)(PropertyItem)
+represents(raaml.ControlledProcess)(PropertyItem)

--- a/gaphor/RAAML/stpa/stpatoolbox.py
+++ b/gaphor/RAAML/stpa/stpatoolbox.py
@@ -1,10 +1,14 @@
 """The definition for the STPA section of the RAAML toolbox."""
 
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
+from gaphor.diagram.diagramtoolbox import (
+    ToolDef,
+    ToolSection,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
+)
 from gaphor.i18n import gettext
-from gaphor.RAAML import diagramitems, raaml
-from gaphor.SysML import diagramitems as sysml_items
-from gaphor.UML import diagramitems as uml_items
+from gaphor.RAAML import raaml
+from gaphor.UML import uml
 from gaphor.UML.toolboxconfig import (
     default_namespace,
     named_element_config,
@@ -35,7 +39,7 @@ stpa = ToolSection(
             gettext("Generalization"),
             "gaphor-generalization-symbolic",
             "<Shift>G",
-            new_item_factory(uml_items.GeneralizationItem),
+            new_deferred_element_item_factory(uml.Generalization),
             handle_index=0,
         ),
         ToolDef(
@@ -43,26 +47,21 @@ stpa = ToolSection(
             gettext("Loss"),
             "gaphor-loss-symbolic",
             "<Shift>L",
-            new_item_factory(
-                sysml_items.BlockItem, raaml.Loss, config_func=loss_config
-            ),
+            new_element_item_factory(raaml.Loss, config_func=loss_config),
         ),
         ToolDef(
             "hazard",
             gettext("Hazard"),
             "gaphor-hazard-symbolic",
             "<Shift>H",
-            new_item_factory(
-                sysml_items.BlockItem, raaml.Hazard, config_func=hazard_config
-            ),
+            new_element_item_factory(raaml.Hazard, config_func=hazard_config),
         ),
         ToolDef(
             "situation",
             gettext("Situation"),
             "gaphor-situation-symbolic",
             "s",
-            new_item_factory(
-                sysml_items.BlockItem,
+            new_element_item_factory(
                 raaml.Situation,
                 config_func=namespace_config,
             ),
@@ -72,8 +71,7 @@ stpa = ToolSection(
             gettext("Control Structure"),
             "gaphor-control-structure-symbolic",
             "f",
-            new_item_factory(
-                sysml_items.BlockItem,
+            new_element_item_factory(
                 raaml.ControlStructure,
                 config_func=namespace_config,
             ),
@@ -83,8 +81,7 @@ stpa = ToolSection(
             gettext("Controller"),
             "gaphor-controller-symbolic",
             "w",
-            new_item_factory(
-                sysml_items.PropertyItem,
+            new_element_item_factory(
                 raaml.Controller,
                 config_func=named_element_config,
             ),
@@ -94,8 +91,7 @@ stpa = ToolSection(
             gettext("Actuator"),
             "gaphor-actuator-symbolic",
             "q",
-            new_item_factory(
-                sysml_items.PropertyItem,
+            new_element_item_factory(
                 raaml.Actuator,
                 config_func=named_element_config,
             ),
@@ -105,8 +101,7 @@ stpa = ToolSection(
             gettext("Controlled Process"),
             "gaphor-controlled-process-symbolic",
             "<Shift>P",
-            new_item_factory(
-                sysml_items.PropertyItem,
+            new_element_item_factory(
                 raaml.ControlledProcess,
                 config_func=named_element_config,
             ),
@@ -116,8 +111,7 @@ stpa = ToolSection(
             gettext("Abstract Operational Situation"),
             "gaphor-abstract-operational-situation-symbolic",
             "<Shift>J",
-            new_item_factory(
-                diagramitems.OperationalSituationItem,
+            new_element_item_factory(
                 raaml.AbstractOperationalSituation,
                 config_func=abstract_operational_situation_config,
             ),
@@ -127,8 +121,7 @@ stpa = ToolSection(
             gettext("Operational Situation"),
             "gaphor-operational-situation-symbolic",
             "<Shift>O",
-            new_item_factory(
-                diagramitems.OperationalSituationItem,
+            new_element_item_factory(
                 raaml.OperationalSituation,
                 config_func=namespace_config,
             ),
@@ -138,8 +131,7 @@ stpa = ToolSection(
             gettext("Unsafe Control Action"),
             "gaphor-unsafe-control-action-symbolic",
             "u",
-            new_item_factory(
-                diagramitems.UnsafeControlActionItem,
+            new_element_item_factory(
                 raaml.UnsafeControlAction,
                 config_func=namespace_config,
             ),
@@ -149,8 +141,8 @@ stpa = ToolSection(
             gettext("Relevant To"),
             "gaphor-relevant-to-symbolic",
             "r",
-            new_item_factory(
-                diagramitems.RelevantToItem,
+            new_deferred_element_item_factory(
+                raaml.RelevantTo,
             ),
         ),
         ToolDef(
@@ -158,8 +150,7 @@ stpa = ToolSection(
             gettext("Control Action"),
             "gaphor-control-action-symbolic",
             "<Shift>M",
-            new_item_factory(
-                diagramitems.ControlActionItem,
+            new_element_item_factory(
                 raaml.ControlAction,
                 config_func=namespace_config,
             ),

--- a/gaphor/SysML/blocks/__init__.py
+++ b/gaphor/SysML/blocks/__init__.py
@@ -1,7 +1,12 @@
 import gaphor.SysML.blocks.connectors
 import gaphor.SysML.blocks.datatype
 import gaphor.SysML.blocks.group
-from gaphor.SysML.blocks.block import BlockItem
+from gaphor.SysML.blocks.block import (
+    BlockItem,
+    ActivityAsBlockItem,
+    InteractionAsBlockItem,
+    StateMachineAsBlockItem,
+)
 from gaphor.SysML.blocks.interfaceblock import InterfaceBlockItem
 from gaphor.SysML.blocks.property import PropertyItem
 from gaphor.SysML.blocks.proxyport import ProxyPortItem

--- a/gaphor/SysML/blocks/blockstoolbox.py
+++ b/gaphor/SysML/blocks/blockstoolbox.py
@@ -4,8 +4,12 @@ from gaphas.item import SE
 
 from gaphor import UML
 from gaphor.core import gettext
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
-from gaphor.SysML import diagramitems as sysml_items
+from gaphor.diagram.diagramtoolbox import (
+    ToolDef,
+    ToolSection,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
+)
 from gaphor.SysML import sysml
 from gaphor.UML import diagramitems as uml_items
 from gaphor.UML.classes.classestoolbox import (
@@ -29,9 +33,7 @@ blocks = ToolSection(
             gettext("Block"),
             "gaphor-block-symbolic",
             "<Shift>B",
-            new_item_factory(
-                sysml_items.BlockItem, sysml.Block, config_func=namespace_config
-            ),
+            new_element_item_factory(sysml.Block, config_func=namespace_config),
             handle_index=SE,
         ),
         ToolDef(
@@ -39,8 +41,7 @@ blocks = ToolSection(
             gettext("InterfaceBlock"),
             "gaphor-interface-block-symbolic",
             None,
-            new_item_factory(
-                sysml_items.InterfaceBlockItem,
+            new_element_item_factory(
                 sysml.InterfaceBlock,
                 config_func=namespace_config,
             ),
@@ -51,8 +52,7 @@ blocks = ToolSection(
             gettext("Package"),
             "gaphor-package-symbolic",
             "p",
-            new_item_factory(
-                uml_items.PackageItem,
+            new_element_item_factory(
                 UML.Package,
                 config_func=namespace_config,
             ),
@@ -63,8 +63,8 @@ blocks = ToolSection(
             gettext("Composite Association"),
             "gaphor-composite-association-symbolic",
             "<Shift>Z",
-            new_item_factory(
-                uml_items.AssociationItem,
+            new_deferred_element_item_factory(
+                UML.Association,
                 config_func=composite_association_config,
             ),
         ),
@@ -73,8 +73,8 @@ blocks = ToolSection(
             gettext("Shared Association"),
             "gaphor-shared-association-symbolic",
             "<Shift>Q",
-            new_item_factory(
-                uml_items.AssociationItem,
+            new_deferred_element_item_factory(
+                UML.Association,
                 config_func=shared_association_config,
             ),
         ),
@@ -83,15 +83,15 @@ blocks = ToolSection(
             gettext("Association"),
             "gaphor-association-symbolic",
             "<Shift>A",
-            new_item_factory(uml_items.AssociationItem),
+            new_deferred_element_item_factory(UML.Association),
         ),
         ToolDef(
             "toolbox-direct-association",
             gettext("Direct Association"),
             "gaphor-direct-association-symbolic",
             None,
-            new_item_factory(
-                uml_items.AssociationItem,
+            new_deferred_element_item_factory(
+                UML.Association,
                 config_func=direct_association_config,
             ),
         ),
@@ -100,15 +100,14 @@ blocks = ToolSection(
             gettext("Generalization"),
             "gaphor-generalization-symbolic",
             "<Shift>G",
-            new_item_factory(uml_items.GeneralizationItem),
+            new_deferred_element_item_factory(UML.Generalization),
         ),
         ToolDef(
             "toolbox-value-type",
             gettext("ValueType"),
             "gaphor-value-type-symbolic",
             "<Shift>L",
-            new_item_factory(
-                uml_items.DataTypeItem,
+            new_element_item_factory(
                 sysml.ValueType,
                 config_func=namespace_config,
             ),
@@ -118,8 +117,7 @@ blocks = ToolSection(
             gettext("Enumeration"),
             "gaphor-enumeration-symbolic",
             "<Shift>W",
-            new_item_factory(
-                uml_items.EnumerationItem,
+            new_element_item_factory(
                 UML.Enumeration,
                 config_func=sysml_enumeration_config,
             ),
@@ -130,8 +128,7 @@ blocks = ToolSection(
             gettext("Primitive"),
             "gaphor-primitive-type-symbolic",
             "<Shift>H",
-            new_item_factory(
-                uml_items.DataTypeItem,
+            new_element_item_factory(
                 UML.PrimitiveType,
                 config_func=namespace_config,
             ),

--- a/gaphor/SysML/diagramtype.py
+++ b/gaphor/SysML/diagramtype.py
@@ -11,8 +11,12 @@ class DiagramDefault:
 
 
 class SysMLDiagramType(DiagramType):
-    def __init__(self, id, name, sections, allowed_types=(), defaults=()):
+    def __init__(self, id, create_type, name, sections, allowed_types=(), defaults=()):
         super().__init__(id, name, sections)
+
+        assert issubclass(create_type, SysMLDiagram)
+
+        self.create_type = create_type
         self._allowed_types = allowed_types
         assert all(d.to_type in allowed_types for d in defaults)
         self._defaults = defaults
@@ -33,7 +37,7 @@ class SysMLDiagramType(DiagramType):
                 change_owner(element, new_element)
             element = new_element
 
-        diagram = element_factory.create(SysMLDiagram)
+        diagram = element_factory.create(self.create_type)
         diagram.name = diagram.gettext(self.name)
         diagram.diagramType = self.id
         if element:

--- a/gaphor/SysML/drop.py
+++ b/gaphor/SysML/drop.py
@@ -7,7 +7,7 @@ from gaphor.UML.drop import diagram_has_presentation
 
 @drop.register
 def drop_proxy_port(element: ProxyPort, diagram, x, y):
-    item_class = get_diagram_item(type(element))
+    item_class = get_diagram_item(type(element), type(diagram))
     if not item_class:
         return None
 

--- a/gaphor/SysML/requirements/requirementstoolbox.py
+++ b/gaphor/SysML/requirements/requirementstoolbox.py
@@ -3,8 +3,13 @@
 from gaphas.item import SE
 
 from gaphor.core import gettext
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
-from gaphor.SysML import diagramitems as sysml_items
+from gaphor.diagram.diagramtoolbox import (
+    ToolDef,
+    ToolSection,
+    new_item_factory,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
+)
 from gaphor.SysML import sysml
 from gaphor.UML.classes import ContainmentItem
 from gaphor.UML.toolboxconfig import namespace_config
@@ -17,8 +22,7 @@ requirements = ToolSection(
             gettext("Requirement"),
             "gaphor-requirement-symbolic",
             "r",
-            new_item_factory(
-                sysml_items.RequirementItem,
+            new_element_item_factory(
                 sysml.Requirement,
                 config_func=namespace_config,
             ),
@@ -29,35 +33,35 @@ requirements = ToolSection(
             gettext("Satisfy"),
             "gaphor-satisfy-symbolic",
             "<Shift>I",
-            new_item_factory(sysml_items.SatisfyItem),
+            new_deferred_element_item_factory(sysml.Satisfy),
         ),
         ToolDef(
             "toolbox-derive-reqt-dependency",
             gettext("Derive Requirement"),
             "gaphor-derive-reqt-symbolic",
             "<Shift>D",
-            new_item_factory(sysml_items.DeriveReqtItem),
+            new_deferred_element_item_factory(sysml.DeriveReqt),
         ),
         ToolDef(
             "toolbox-trace-dependency",
             gettext("Trace"),
             "gaphor-trace-symbolic",
             "y",
-            new_item_factory(sysml_items.TraceItem),
+            new_deferred_element_item_factory(sysml.Trace),
         ),
         ToolDef(
             "toolbox-refine-dependency",
             gettext("Refine"),
             "gaphor-refine-symbolic",
             None,
-            new_item_factory(sysml_items.RefineItem),
+            new_deferred_element_item_factory(sysml.Refine),
         ),
         ToolDef(
             "toolbox-verify-dependency",
             gettext("Verify"),
             "gaphor-verify-symbolic",
             "<Shift>V",
-            new_item_factory(sysml_items.VerifyItem),
+            new_deferred_element_item_factory(sysml.Verify),
         ),
         ToolDef(
             "toolbox-containment",

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -299,6 +299,54 @@ class SysMLDiagram(Diagram):
     pass
 
 
+class SysMLBehaviorDiagram(SysMLDiagram):
+    pass
+
+
+class SysMLActivityDiagram(SysMLBehaviorDiagram):
+    pass
+
+
+class SysMLInteractionDiagram(SysMLBehaviorDiagram):
+    pass
+
+
+class SysMLStateMachineDiagram(SysMLBehaviorDiagram):
+    pass
+
+
+class SysMLDiagramWithAssociations(SysMLDiagram):
+    pass
+
+
+class SysMLUseCaseDiagram(SysMLBehaviorDiagram, SysMLDiagramWithAssociations):
+    pass
+
+
+class SysMLStructureDiagram(SysMLDiagramWithAssociations):
+    pass
+
+
+class SysMLRequirementDiagram(SysMLStructureDiagram):
+    pass
+
+
+class SysMLBlockDefinitionDiagram(SysMLStructureDiagram):
+    pass
+
+
+class SysMLPackageDiagram(SysMLStructureDiagram):
+    pass
+
+
+class SysMLInternalBlockDiagram(SysMLStructureDiagram):
+    pass
+
+
+class SysMLParametricDiagram(SysMLInternalBlockDiagram):
+    isConstraintPropertyRounded: _attribute[int] = _attribute("isConstraintPropertyRounded", int, default=False)
+
+
 
 # 23: override AbstractRequirement.derived: derived[AbstractRequirement]
 

--- a/gaphor/SysML/tests/test_diagramtype.py
+++ b/gaphor/SysML/tests/test_diagramtype.py
@@ -1,4 +1,5 @@
 from gaphor.SysML.diagramtype import SysMLDiagramType, DiagramDefault
+from gaphor.SysML.sysml import SysMLDiagram
 from gaphor.UML.uml import NamedElement
 
 
@@ -13,6 +14,7 @@ class MockElementB(NamedElement):
 def test_sysml_diagram_type(element_factory):
     diagram_type = SysMLDiagramType(
         "abc",
+        SysMLDiagram,
         "Defghi",
         (),
         (MockElementA,),
@@ -29,11 +31,13 @@ def test_sysml_diagram_type(element_factory):
     diagram = diagram_type.create(element_factory, mock_a)
     assert diagram.diagramType == "abc"
     assert diagram.name == "Defghi"
+    assert isinstance(diagram, SysMLDiagram)
     assert isinstance(diagram.element, MockElementA)
     assert diagram.element.name == "Mock A"
 
     diagram = diagram_type.create(element_factory, None)
     assert diagram.diagramType == "abc"
     assert diagram.name == "Defghi"
+    assert isinstance(diagram, SysMLDiagram)
     assert isinstance(diagram.element, MockElementA)
     assert diagram.element.name == "New mock element A"

--- a/gaphor/SysML/toolbox.py
+++ b/gaphor/SysML/toolbox.py
@@ -18,6 +18,14 @@ from gaphor.SysML.sysml import (
     Requirement,
     ValueType,
     ProxyPort,
+    SysMLActivityDiagram,
+    SysMLInteractionDiagram,
+    SysMLInternalBlockDiagram,
+    SysMLBlockDefinitionDiagram,
+    SysMLRequirementDiagram,
+    SysMLStateMachineDiagram,
+    SysMLPackageDiagram,
+    SysMLUseCaseDiagram,
 )
 from gaphor.SysML.blocks.blockstoolbox import blocks
 from gaphor.SysML.requirements.requirementstoolbox import requirements
@@ -84,6 +92,7 @@ root = type(None)
 sysml_diagram_types: DiagramTypes = (
     SysMLDiagramType(
         "bdd",
+        SysMLBlockDefinitionDiagram,
         i18nize("New Block Definition Diagram"),
         (blocks,),
         (Block, Package, ConstraintBlock, Activity),
@@ -91,6 +100,7 @@ sysml_diagram_types: DiagramTypes = (
     ),
     SysMLDiagramType(
         "ibd",
+        SysMLInternalBlockDiagram,
         i18nize("New Internal Block Diagram"),
         (internal_blocks,),
         (
@@ -104,6 +114,7 @@ sysml_diagram_types: DiagramTypes = (
     ),
     SysMLDiagramType(
         "pkg",
+        SysMLPackageDiagram,
         i18nize("New Package Diagram"),
         (blocks,),
         (Package,),  # model, modelLibrary, profile
@@ -111,6 +122,7 @@ sysml_diagram_types: DiagramTypes = (
     ),
     SysMLDiagramType(
         "req",
+        SysMLRequirementDiagram,
         i18nize("New Requirement Diagram"),
         (requirements,),
         (
@@ -123,6 +135,7 @@ sysml_diagram_types: DiagramTypes = (
     ),
     SysMLDiagramType(
         "act",
+        SysMLActivityDiagram,
         i18nize("New Activity Diagram"),
         (actions,),
         (Activity,),
@@ -133,6 +146,7 @@ sysml_diagram_types: DiagramTypes = (
     ),
     SysMLDiagramType(
         "sd",
+        SysMLInteractionDiagram,
         i18nize("New Sequence Diagram"),
         (interactions,),
         (Interaction,),
@@ -143,6 +157,7 @@ sysml_diagram_types: DiagramTypes = (
     ),
     SysMLDiagramType(
         "stm",
+        SysMLStateMachineDiagram,
         i18nize("New State Machine Diagram"),
         (states,),
         (StateMachine,),
@@ -153,6 +168,7 @@ sysml_diagram_types: DiagramTypes = (
     ),
     SysMLDiagramType(
         "uc",
+        SysMLUseCaseDiagram,
         i18nize("New Use Case Diagram"),
         (use_cases,),
         (

--- a/gaphor/SysML/toolbox.py
+++ b/gaphor/SysML/toolbox.py
@@ -1,6 +1,5 @@
 """The action definition for the SysML toolbox."""
 
-from gaphor import UML
 from gaphor.i18n import gettext, i18nize
 from gaphor.diagram.diagramtoolbox import (
     DiagramTypes,
@@ -9,19 +8,19 @@ from gaphor.diagram.diagramtoolbox import (
     ToolDef,
     ToolSection,
     general_tools,
-    new_item_factory,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
 )
-from gaphor.SysML import diagramitems as sysml_items
 from gaphor.SysML.sysml import (
     Block,
     ConstraintBlock,
     InterfaceBlock,
     Requirement,
     ValueType,
+    ProxyPort,
 )
 from gaphor.SysML.blocks.blockstoolbox import blocks
 from gaphor.SysML.requirements.requirementstoolbox import requirements
-from gaphor.UML import diagramitems as uml_items
 from gaphor.UML.actions.actionstoolbox import actions
 from gaphor.UML.interactions.interactionstoolbox import interactions
 from gaphor.UML.states.statestoolbox import states
@@ -36,6 +35,8 @@ from gaphor.UML.uml import (
     StateMachine,
     Enumeration,
     UseCase,
+    Connector,
+    Property,
 )
 
 internal_blocks = ToolSection(
@@ -46,23 +47,21 @@ internal_blocks = ToolSection(
             gettext("Connector"),
             "gaphor-connector-symbolic",
             "<Shift>C",
-            new_item_factory(uml_items.ConnectorItem),
+            new_deferred_element_item_factory(Connector),
         ),
         ToolDef(
             "toolbox-property",
             gettext("Property"),
             "gaphor-property-symbolic",
             "o",
-            new_item_factory(
-                sysml_items.PropertyItem, UML.Property, config_func=named_element_config
-            ),
+            new_element_item_factory(Property, config_func=named_element_config),
         ),
         ToolDef(
             "toolbox-proxy-port",
             gettext("Proxy Port"),
             "gaphor-proxyport-symbolic",
             "x",
-            new_item_factory(sysml_items.ProxyPortItem),
+            new_deferred_element_item_factory(ProxyPort),
         ),
     ),
 )

--- a/gaphor/UML/actions/actionstoolbox.py
+++ b/gaphor/UML/actions/actionstoolbox.py
@@ -5,8 +5,12 @@ from gaphas.item import SE
 
 from gaphor import UML
 from gaphor.i18n import gettext, i18nize
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
-from gaphor.UML import diagramitems
+from gaphor.diagram.diagramtoolbox import (
+    ToolDef,
+    ToolSection,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
+)
 from gaphor.UML.recipes import owner_package
 from gaphor.UML.toolboxconfig import namespace_config
 
@@ -67,8 +71,7 @@ actions = ToolSection(
             gettext("Activity"),
             "gaphor-activity-symbolic",
             None,
-            new_item_factory(
-                diagramitems.ActivityItem,
+            new_element_item_factory(
                 UML.Activity,
                 config_func=namespace_config,
             ),
@@ -79,8 +82,7 @@ actions = ToolSection(
             gettext("Action"),
             "gaphor-action-symbolic",
             "a",
-            new_item_factory(
-                diagramitems.ActionItem,
+            new_element_item_factory(
                 UML.Action,
                 config_func=partial(activity_config, name=i18nize("Action")),
             ),
@@ -91,8 +93,7 @@ actions = ToolSection(
             gettext("Call behavior action"),
             "gaphor-call-behavior-action-symbolic",
             "<Alt>a",
-            new_item_factory(
-                diagramitems.CallBehaviorActionItem,
+            new_element_item_factory(
                 UML.CallBehaviorAction,
                 config_func=partial(
                     activity_config, name=i18nize("CallBehaviorAction")
@@ -105,8 +106,7 @@ actions = ToolSection(
             gettext("Value specification action"),
             "gaphor-value-specification-action-symbolic",
             "<Alt>v",
-            new_item_factory(
-                diagramitems.ValueSpecificationActionItem,
+            new_element_item_factory(
                 UML.ValueSpecificationAction,
                 config_func=value_specification_action_config,
             ),
@@ -117,8 +117,7 @@ actions = ToolSection(
             gettext("Initial node"),
             "gaphor-initial-node-symbolic",
             "j",
-            new_item_factory(
-                diagramitems.InitialNodeItem,
+            new_element_item_factory(
                 UML.InitialNode,
                 config_func=activity_config,
             ),
@@ -129,8 +128,7 @@ actions = ToolSection(
             gettext("Activity final node"),
             "gaphor-activity-final-node-symbolic",
             "f",
-            new_item_factory(
-                diagramitems.ActivityFinalNodeItem,
+            new_element_item_factory(
                 UML.ActivityFinalNode,
                 config_func=activity_config,
             ),
@@ -141,8 +139,7 @@ actions = ToolSection(
             gettext("Flow final node"),
             "gaphor-flow-final-node-symbolic",
             "w",
-            new_item_factory(
-                diagramitems.FlowFinalNodeItem,
+            new_element_item_factory(
                 UML.FlowFinalNode,
                 config_func=activity_config,
             ),
@@ -153,8 +150,7 @@ actions = ToolSection(
             gettext("Decision/merge node"),
             "gaphor-decision-node-symbolic",
             "g",
-            new_item_factory(
-                diagramitems.DecisionNodeItem,
+            new_element_item_factory(
                 UML.DecisionNode,
                 config_func=activity_config,
             ),
@@ -165,8 +161,7 @@ actions = ToolSection(
             gettext("Fork/join node"),
             "gaphor-fork-node-symbolic",
             "<Shift>R",
-            new_item_factory(
-                diagramitems.ForkNodeItem,
+            new_element_item_factory(
                 UML.JoinNode,
                 config_func=activity_config,
             ),
@@ -177,8 +172,7 @@ actions = ToolSection(
             gettext("Object node"),
             "gaphor-object-node-symbolic",
             "<Shift>O",
-            new_item_factory(
-                diagramitems.ObjectNodeItem,
+            new_element_item_factory(
                 UML.ObjectNode,
                 config_func=partial(activity_config, name=i18nize("Object node")),
             ),
@@ -189,8 +183,7 @@ actions = ToolSection(
             gettext("Swimlane"),
             "gaphor-activity-partition-symbolic",
             "<Shift>P",
-            new_item_factory(
-                diagramitems.PartitionItem,
+            new_element_item_factory(
                 UML.ActivityPartition,
                 config_func=partition_config,
             ),
@@ -201,22 +194,21 @@ actions = ToolSection(
             gettext("Control flow"),
             "gaphor-control-flow-symbolic",
             "<Shift>F",
-            new_item_factory(diagramitems.ControlFlowItem),
+            new_deferred_element_item_factory(UML.ControlFlow),
         ),
         ToolDef(
             "toolbox-object-flow",
             gettext("Object flow"),
             "gaphor-object-flow-symbolic",
             "<Shift>Y",
-            new_item_factory(diagramitems.ObjectFlowItem),
+            new_deferred_element_item_factory(UML.ObjectFlow),
         ),
         ToolDef(
             "toolbox-send-signal-action",
             gettext("Send signal action"),
             "gaphor-send-signal-action-symbolic",
             None,
-            new_item_factory(
-                diagramitems.SendSignalActionItem,
+            new_element_item_factory(
                 UML.SendSignalAction,
                 config_func=partial(activity_config, name=i18nize("Send signal")),
             ),
@@ -227,8 +219,7 @@ actions = ToolSection(
             gettext("Accept event action"),
             "gaphor-accept-event-action-symbolic",
             None,
-            new_item_factory(
-                diagramitems.AcceptEventActionItem,
+            new_element_item_factory(
                 UML.AcceptEventAction,
                 config_func=partial(activity_config, name=i18nize("Accept event")),
             ),
@@ -239,14 +230,14 @@ actions = ToolSection(
             gettext("Input pin"),
             "gaphor-input-pin-symbolic",
             None,
-            new_item_factory(diagramitems.InputPinItem),
+            new_deferred_element_item_factory(UML.InputPin),
         ),
         ToolDef(
             "toolbox-output-pin",
             gettext("Output pin"),
             "gaphor-output-pin-symbolic",
             None,
-            new_item_factory(diagramitems.OutputPinItem),
+            new_deferred_element_item_factory(UML.OutputPin),
         ),
     ),
 )

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -209,6 +209,7 @@ def draw_decision_node(_box, context, _bounding_box):
 
 
 @represents(UML.ForkNode)
+@represents(UML.JoinNode)
 class ForkNodeItem(Named, Presentation[UML.ForkNode], HandlePositionUpdate):
     """Representation of fork and join node."""
 

--- a/gaphor/UML/actions/tests/test_partition.py
+++ b/gaphor/UML/actions/tests/test_partition.py
@@ -1,7 +1,7 @@
 import pytest
 
 from gaphor import UML
-from gaphor.diagram.diagramtoolbox import new_item_factory
+from gaphor.diagram.diagramtoolbox import new_element_item_factory
 from gaphor.diagram.tests.fixtures import copy_and_paste_link, copy_clear_and_paste_link
 from gaphor.UML.actions.actionstoolbox import partition_config
 from gaphor.UML.actions.partition import PartitionItem
@@ -9,8 +9,7 @@ from gaphor.UML.actions.partition import PartitionItem
 
 @pytest.fixture
 def partition_item_factory():
-    return new_item_factory(
-        PartitionItem,
+    return new_element_item_factory(
         UML.ActivityPartition,
         config_func=partition_config,
     )
@@ -18,7 +17,7 @@ def partition_item_factory():
 
 @pytest.fixture
 def partition_item(partition_item_factory, diagram):
-    return partition_item_factory(diagram)
+    return partition_item_factory.create_item(diagram)
 
 
 def test_partition_placement_adds_two_partitions(partition_item: PartitionItem):

--- a/gaphor/UML/classes/classestoolbox.py
+++ b/gaphor/UML/classes/classestoolbox.py
@@ -4,7 +4,13 @@ from gaphas.item import SE
 
 from gaphor import UML
 from gaphor.core import gettext
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
+from gaphor.diagram.diagramtoolbox import (
+    ToolDef,
+    ToolSection,
+    new_item_factory,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
+)
 from gaphor.UML import diagramitems
 from gaphor.UML.toolboxconfig import namespace_config
 
@@ -29,9 +35,7 @@ classes = ToolSection(
             gettext("Class"),
             "gaphor-class-symbolic",
             "c",
-            new_item_factory(
-                diagramitems.ClassItem, UML.Class, config_func=namespace_config
-            ),
+            new_element_item_factory(UML.Class, config_func=namespace_config),
             handle_index=SE,
         ),
         ToolDef(
@@ -39,8 +43,7 @@ classes = ToolSection(
             gettext("Interface"),
             "gaphor-interface-symbolic",
             "i",
-            new_item_factory(
-                diagramitems.InterfaceItem,
+            new_element_item_factory(
                 UML.Interface,
                 config_func=namespace_config,
             ),
@@ -51,8 +54,7 @@ classes = ToolSection(
             gettext("Package"),
             "gaphor-package-symbolic",
             "p",
-            new_item_factory(
-                diagramitems.PackageItem,
+            new_element_item_factory(
                 UML.Package,
                 config_func=namespace_config,
             ),
@@ -63,8 +65,7 @@ classes = ToolSection(
             gettext("Component"),
             "gaphor-component-symbolic",
             "o",
-            new_item_factory(
-                diagramitems.ComponentItem,
+            new_element_item_factory(
                 UML.Component,
                 config_func=namespace_config,
             ),
@@ -82,8 +83,8 @@ classes = ToolSection(
             gettext("Composite Association"),
             "gaphor-composite-association-symbolic",
             "<Shift>Z",
-            new_item_factory(
-                diagramitems.AssociationItem,
+            new_deferred_element_item_factory(
+                UML.Association,
                 config_func=composite_association_config,
             ),
         ),
@@ -92,8 +93,8 @@ classes = ToolSection(
             gettext("Shared Association"),
             "gaphor-shared-association-symbolic",
             "<Shift>Q",
-            new_item_factory(
-                diagramitems.AssociationItem,
+            new_deferred_element_item_factory(
+                UML.Association,
                 config_func=shared_association_config,
             ),
         ),
@@ -102,15 +103,15 @@ classes = ToolSection(
             gettext("Association"),
             "gaphor-association-symbolic",
             "<Shift>A",
-            new_item_factory(diagramitems.AssociationItem),
+            new_deferred_element_item_factory(UML.Association),
         ),
         ToolDef(
             "toolbox-direct-association",
             gettext("Direct Association"),
             "gaphor-direct-association-symbolic",
             None,
-            new_item_factory(
-                diagramitems.AssociationItem,
+            new_deferred_element_item_factory(
+                UML.Association,
                 config_func=direct_association_config,
             ),
         ),
@@ -119,7 +120,7 @@ classes = ToolSection(
             gettext("Dependency"),
             "gaphor-dependency-symbolic",
             "<Shift>D",
-            new_item_factory(diagramitems.DependencyItem),
+            new_deferred_element_item_factory(UML.Dependency),
             handle_index=0,
         ),
         ToolDef(
@@ -127,7 +128,7 @@ classes = ToolSection(
             gettext("Generalization"),
             "gaphor-generalization-symbolic",
             "<Shift>G",
-            new_item_factory(diagramitems.GeneralizationItem),
+            new_deferred_element_item_factory(UML.Generalization),
             handle_index=0,
         ),
         ToolDef(
@@ -135,15 +136,14 @@ classes = ToolSection(
             gettext("Interface Realization"),
             "gaphor-interface-realization-symbolic",
             "<Shift>I",
-            new_item_factory(diagramitems.InterfaceRealizationItem),
+            new_deferred_element_item_factory(UML.InterfaceRealization),
         ),
         ToolDef(
             "toolbox-data-type",
             gettext("DataType"),
             "gaphor-data-type-symbolic",
             "<Shift>L",
-            new_item_factory(
-                diagramitems.DataTypeItem,
+            new_element_item_factory(
                 UML.DataType,
                 config_func=namespace_config,
             ),
@@ -154,8 +154,7 @@ classes = ToolSection(
             gettext("Enumeration"),
             "gaphor-enumeration-symbolic",
             "<Shift>W",
-            new_item_factory(
-                diagramitems.EnumerationItem,
+            new_element_item_factory(
                 UML.Enumeration,
                 config_func=namespace_config,
             ),
@@ -166,8 +165,7 @@ classes = ToolSection(
             gettext("Primitive"),
             "gaphor-primitive-type-symbolic",
             "<Shift>H",
-            new_item_factory(
-                diagramitems.DataTypeItem,
+            new_element_item_factory(
                 UML.PrimitiveType,
                 config_func=namespace_config,
             ),

--- a/gaphor/UML/deployments/deploymentstoolbox.py
+++ b/gaphor/UML/deployments/deploymentstoolbox.py
@@ -4,8 +4,7 @@ from gaphas.item import SE
 
 from gaphor import UML
 from gaphor.core import gettext
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
-from gaphor.UML import diagramitems
+from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_element_item_factory
 from gaphor.UML.toolboxconfig import namespace_config
 
 deployments: ToolSection = ToolSection(
@@ -16,8 +15,7 @@ deployments: ToolSection = ToolSection(
             gettext("Artifact"),
             "gaphor-artifact-symbolic",
             "h",
-            new_item_factory(
-                diagramitems.ArtifactItem,
+            new_element_item_factory(
                 UML.Artifact,
                 config_func=namespace_config,
             ),
@@ -28,8 +26,7 @@ deployments: ToolSection = ToolSection(
             gettext("Node"),
             "gaphor-node-symbolic",
             "n",
-            new_item_factory(
-                diagramitems.NodeItem,
+            new_element_item_factory(
                 UML.Node,
                 config_func=namespace_config,
             ),
@@ -40,8 +37,7 @@ deployments: ToolSection = ToolSection(
             gettext("Device"),
             "gaphor-device-symbolic",
             "d",
-            new_item_factory(
-                diagramitems.NodeItem,
+            new_element_item_factory(
                 UML.Device,
                 config_func=namespace_config,
             ),

--- a/gaphor/UML/drop.py
+++ b/gaphor/UML/drop.py
@@ -8,7 +8,7 @@ from gaphor.diagram.support import get_diagram_item, get_diagram_item_metadata
 
 @drop.register
 def drop_relationship(element: UML.Relationship, diagram, x, y):
-    item_class = get_diagram_item(type(element))
+    item_class = get_diagram_item(type(element), type(diagram))
     if not item_class:
         return None
 
@@ -64,7 +64,7 @@ def drop_message(element: UML.Message, diagram, x, y):
 
 
 def _drop(element, head_element, tail_element, diagram, x, y):
-    item_class = get_diagram_item(type(element))
+    item_class = get_diagram_item(type(element), type(diagram))
     if not item_class:
         return None
 

--- a/gaphor/UML/interactions/interactionstoolbox.py
+++ b/gaphor/UML/interactions/interactionstoolbox.py
@@ -5,8 +5,12 @@ from gaphas.segment import Segment
 
 from gaphor import UML
 from gaphor.core import gettext
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
-from gaphor.UML import diagramitems
+from gaphor.diagram.diagramtoolbox import (
+    ToolDef,
+    ToolSection,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
+)
 from gaphor.UML.recipes import owner_package
 from gaphor.UML.toolboxconfig import namespace_config
 
@@ -57,8 +61,7 @@ interactions = ToolSection(
             gettext("Interaction"),
             "gaphor-interaction-symbolic",
             "<Shift>N",
-            new_item_factory(
-                diagramitems.InteractionItem,
+            new_element_item_factory(
                 UML.Interaction,
                 config_func=namespace_config,
             ),
@@ -69,8 +72,7 @@ interactions = ToolSection(
             gettext("Lifeline"),
             "gaphor-lifeline-symbolic",
             "v",
-            new_item_factory(
-                diagramitems.LifelineItem,
+            new_element_item_factory(
                 UML.Lifeline,
                 config_func=interaction_config,
             ),
@@ -81,7 +83,7 @@ interactions = ToolSection(
             gettext("Execution Specification"),
             "gaphor-execution-specification-symbolic",
             None,
-            new_item_factory(diagramitems.ExecutionSpecificationItem),
+            new_deferred_element_item_factory(UML.ExecutionSpecification),
             handle_index=0,
         ),
         ToolDef(
@@ -89,15 +91,15 @@ interactions = ToolSection(
             gettext("Message"),
             "gaphor-message-symbolic",
             "M",
-            new_item_factory(diagramitems.MessageItem),
+            new_deferred_element_item_factory(UML.Message),
         ),
         ToolDef(
             "toolbox-reflexive-message",
             gettext("Reflexive message"),
             "gaphor-reflexive-message-symbolic",
             None,
-            new_item_factory(
-                diagramitems.MessageItem, config_func=reflexive_message_config
+            new_deferred_element_item_factory(
+                UML.Message, config_func=reflexive_message_config
             ),
         ),
     ),

--- a/gaphor/UML/profiles/profilestoolbox.py
+++ b/gaphor/UML/profiles/profilestoolbox.py
@@ -4,8 +4,12 @@ from gaphas.item import SE
 
 from gaphor import UML
 from gaphor.core import gettext
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
-from gaphor.UML import diagramitems
+from gaphor.diagram.diagramtoolbox import (
+    ToolDef,
+    ToolSection,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
+)
 from gaphor.UML.toolboxconfig import namespace_config
 
 
@@ -22,8 +26,7 @@ profiles: ToolSection = ToolSection(
             gettext("Profile"),
             "gaphor-profile-symbolic",
             "r",
-            new_item_factory(
-                diagramitems.PackageItem,
+            new_element_item_factory(
                 UML.Profile,
                 config_func=namespace_config,
             ),
@@ -34,9 +37,7 @@ profiles: ToolSection = ToolSection(
             gettext("Metaclass"),
             "gaphor-metaclass-symbolic",
             "m",
-            new_item_factory(
-                diagramitems.ClassItem, UML.Class, config_func=metaclass_config
-            ),
+            new_element_item_factory(UML.Class, config_func=metaclass_config),
             handle_index=SE,
         ),
         ToolDef(
@@ -44,8 +45,7 @@ profiles: ToolSection = ToolSection(
             gettext("Stereotype"),
             "gaphor-stereotype-symbolic",
             "z",
-            new_item_factory(
-                diagramitems.ClassItem,
+            new_element_item_factory(
                 UML.Stereotype,
                 config_func=namespace_config,
             ),
@@ -56,14 +56,14 @@ profiles: ToolSection = ToolSection(
             gettext("Extension"),
             "gaphor-extension-symbolic",
             "<Shift>E",
-            new_item_factory(diagramitems.ExtensionItem),
+            new_deferred_element_item_factory(UML.Extension),
         ),
         ToolDef(
             "toolbox-import",
             gettext("Import"),
             "gaphor-import-symbolic",
             "<Shift>M",
-            new_item_factory(diagramitems.PackageImportItem),
+            new_deferred_element_item_factory(UML.PackageImport),
             handle_index=0,
         ),
     ),

--- a/gaphor/UML/states/statestoolbox.py
+++ b/gaphor/UML/states/statestoolbox.py
@@ -6,8 +6,12 @@ from gaphas.item import SE
 
 from gaphor import UML
 from gaphor.core import gettext
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
-from gaphor.UML import diagramitems
+from gaphor.diagram.diagramtoolbox import (
+    ToolDef,
+    ToolSection,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
+)
 from gaphor.UML.recipes import owner_package
 from gaphor.UML.toolboxconfig import namespace_config
 
@@ -63,8 +67,7 @@ states = ToolSection(
             gettext("State Machine"),
             "gaphor-state-machine-symbolic",
             None,
-            new_item_factory(
-                diagramitems.StateMachineItem,
+            new_element_item_factory(
                 UML.StateMachine,
                 config_func=namespace_config,
             ),
@@ -75,8 +78,7 @@ states = ToolSection(
             gettext("State"),
             "gaphor-state-symbolic",
             "s",
-            new_item_factory(
-                diagramitems.StateItem,
+            new_element_item_factory(
                 UML.State,
                 config_func=state_config,
             ),
@@ -87,8 +89,7 @@ states = ToolSection(
             gettext("Initial Pseudostate"),
             "gaphor-initial-pseudostate-symbolic",
             None,
-            new_item_factory(
-                diagramitems.PseudostateItem,
+            new_element_item_factory(
                 UML.Pseudostate,
                 partial(pseudostate_config, kind="initial"),
             ),
@@ -99,8 +100,7 @@ states = ToolSection(
             gettext("Final State"),
             "gaphor-final-state-symbolic",
             None,
-            new_item_factory(
-                diagramitems.FinalStateItem,
+            new_element_item_factory(
                 UML.FinalState,
                 config_func=state_machine_config,
             ),
@@ -111,15 +111,14 @@ states = ToolSection(
             gettext("Transition"),
             "gaphor-transition-symbolic",
             "<Shift>T",
-            new_item_factory(diagramitems.TransitionItem),
+            new_deferred_element_item_factory(UML.Transition),
         ),
         ToolDef(
             "toolbox-shallow-history-pseudostate",
             gettext("Shallow History Pseudostate"),
             "gaphor-shallow-history-pseudostate-symbolic",
             None,
-            new_item_factory(
-                diagramitems.PseudostateItem,
+            new_element_item_factory(
                 UML.Pseudostate,
                 partial(pseudostate_config, kind="shallowHistory"),
             ),
@@ -130,8 +129,7 @@ states = ToolSection(
             gettext("Deep History Pseudostate"),
             "gaphor-deep-history-pseudostate-symbolic",
             None,
-            new_item_factory(
-                diagramitems.PseudostateItem,
+            new_element_item_factory(
                 UML.Pseudostate,
                 partial(pseudostate_config, kind="deepHistory"),
             ),
@@ -142,8 +140,7 @@ states = ToolSection(
             gettext("Join Pseudostate"),
             "gaphor-join-pseudostate-symbolic",
             None,
-            new_item_factory(
-                diagramitems.PseudostateItem,
+            new_element_item_factory(
                 UML.Pseudostate,
                 partial(pseudostate_config, kind="join"),
             ),
@@ -154,8 +151,7 @@ states = ToolSection(
             gettext("Fork Pseudostate"),
             "gaphor-fork-pseudostate-symbolic",
             None,
-            new_item_factory(
-                diagramitems.PseudostateItem,
+            new_element_item_factory(
                 UML.Pseudostate,
                 partial(pseudostate_config, kind="fork"),
             ),
@@ -166,8 +162,7 @@ states = ToolSection(
             gettext("Junction Pseudostate"),
             "gaphor-junction-pseudostate-symbolic",
             None,
-            new_item_factory(
-                diagramitems.PseudostateItem,
+            new_element_item_factory(
                 UML.Pseudostate,
                 partial(pseudostate_config, kind="junction"),
             ),
@@ -178,8 +173,7 @@ states = ToolSection(
             gettext("Choice Pseudostate"),
             "gaphor-choice-pseudostate-symbolic",
             None,
-            new_item_factory(
-                diagramitems.PseudostateItem,
+            new_element_item_factory(
                 UML.Pseudostate,
                 partial(pseudostate_config, kind="choice"),
             ),
@@ -190,8 +184,7 @@ states = ToolSection(
             gettext("Entry Point Pseudostate"),
             "gaphor-entry-point-pseudostate-symbolic",
             None,
-            new_item_factory(
-                diagramitems.PseudostateItem,
+            new_element_item_factory(
                 UML.Pseudostate,
                 partial(pseudostate_config, kind="entryPoint"),
             ),
@@ -202,8 +195,7 @@ states = ToolSection(
             gettext("Exit Point Pseudostate"),
             "gaphor-exit-point-pseudostate-symbolic",
             None,
-            new_item_factory(
-                diagramitems.PseudostateItem,
+            new_element_item_factory(
                 UML.Pseudostate,
                 partial(pseudostate_config, kind="exitPoint"),
             ),
@@ -214,8 +206,7 @@ states = ToolSection(
             gettext("Terminate Pseudostate"),
             "gaphor-terminate-pseudostate-symbolic",
             None,
-            new_item_factory(
-                diagramitems.PseudostateItem,
+            new_element_item_factory(
                 UML.Pseudostate,
                 partial(pseudostate_config, kind="terminate"),
             ),

--- a/gaphor/UML/tests/test_activity.py
+++ b/gaphor/UML/tests/test_activity.py
@@ -26,7 +26,7 @@ def item_factory(request):
 
 @pytest.mark.parametrize("item_factory", activity_node_names, indirect=True)
 def test_create_action_should_create_an_activity(diagram, item_factory):
-    action = item_factory(diagram)
+    action = item_factory.create_item(diagram)
 
     assert action.subject.activity
     assert action.subject.owner is action.subject.activity
@@ -37,7 +37,7 @@ def test_create_action_should_add_to_existing_activity(
     diagram, item_factory, element_factory
 ):
     activity = element_factory.create(UML.Activity)
-    action = item_factory(diagram)
+    action = item_factory.create_item(diagram)
 
     assert action.subject.activity is activity
 
@@ -50,6 +50,6 @@ def test_create_action_should_add_to_existing_activity_in_package(
     diagram.element = package
     activity = element_factory.create(UML.Activity)
     activity.package = package
-    action = item_factory(diagram)
+    action = item_factory.create_item(diagram)
 
     assert action.subject.activity is activity

--- a/gaphor/UML/tests/test_interactions.py
+++ b/gaphor/UML/tests/test_interactions.py
@@ -23,7 +23,7 @@ def lifeline_factory():
 def test_create_lifeline_on_diagram_should_create_an_interaction(
     diagram, lifeline_factory
 ):
-    lifeline = lifeline_factory(diagram)
+    lifeline = lifeline_factory.create_item(diagram)
 
     assert lifeline.subject.interaction
 
@@ -32,7 +32,7 @@ def test_create_lifeline_on_diagram_should_use_existing_interaction(
     diagram, lifeline_factory, element_factory
 ):
     interaction = element_factory.create(UML.Interaction)
-    lifeline = lifeline_factory(diagram)
+    lifeline = lifeline_factory.create_item(diagram)
 
     assert lifeline.subject.interaction is interaction
 
@@ -42,7 +42,7 @@ def test_create_lifeline_on_diagram_in_package_should_create_an_interaction(
 ):
     package = element_factory.create(UML.Package)
     diagram.element = package
-    lifeline = lifeline_factory(diagram)
+    lifeline = lifeline_factory.create_item(diagram)
 
     assert lifeline.subject.interaction
     assert lifeline.subject.interaction.package is package
@@ -51,6 +51,6 @@ def test_create_lifeline_on_diagram_in_package_should_create_an_interaction(
 def test_create_lifeline_over_interaction_uses_that_interaction(
     diagram, interaction, lifeline_factory
 ):
-    lifeline = lifeline_factory(diagram, parent=interaction)
+    lifeline = lifeline_factory.create_item(diagram, parent=interaction)
 
     assert lifeline.subject.interaction is interaction.subject

--- a/gaphor/UML/tests/test_state_machine.py
+++ b/gaphor/UML/tests/test_state_machine.py
@@ -31,7 +31,7 @@ def item_factory(request):
 def test_create_state_on_diagram_should_create_a_state_machine_with_region(
     diagram, item_factory
 ):
-    state = item_factory(diagram)
+    state = item_factory.create_item(diagram)
 
     assert state.subject.container
     assert state.subject.container.stateMachine
@@ -42,7 +42,7 @@ def test_create_state_should_add_to_existing_state_machine(
     diagram, item_factory, element_factory
 ):
     state_machine = element_factory.create(UML.StateMachine)
-    state = item_factory(diagram)
+    state = item_factory.create_item(diagram)
     region = state.subject.container
 
     assert region
@@ -57,7 +57,7 @@ def test_create_state_should_add_to_existing_state_machine_and_region(
     region = element_factory.create(UML.Region)
     region.stateMachine = state_machine
 
-    state = item_factory(diagram)
+    state = item_factory.create_item(diagram)
 
     assert state.subject.container is region
 
@@ -74,7 +74,7 @@ def test_create_state_should_add_to_existing_state_machine_and_region_in_package
     diagram.element = package
     state_machine.package = package
 
-    state = item_factory(diagram)
+    state = item_factory.create_item(diagram)
 
     assert state.subject.container is region
 
@@ -89,6 +89,6 @@ def test_create_state_should_add_to_existing_state_machine_in_package(
     diagram.element = package
     state_machine.package = package
 
-    state = item_factory(diagram)
+    state = item_factory.create_item(diagram)
 
     assert state.subject.container.stateMachine is state_machine

--- a/gaphor/UML/usecases/usecasetoolbox.py
+++ b/gaphor/UML/usecases/usecasetoolbox.py
@@ -4,8 +4,12 @@ from gaphas.item import SE
 
 from gaphor import UML
 from gaphor.core import gettext
-from gaphor.diagram.diagramtoolbox import ToolDef, ToolSection, new_item_factory
-from gaphor.UML import diagramitems
+from gaphor.diagram.diagramtoolbox import (
+    ToolDef,
+    ToolSection,
+    new_element_item_factory,
+    new_deferred_element_item_factory,
+)
 from gaphor.UML.toolboxconfig import namespace_config
 
 use_cases = ToolSection(
@@ -16,8 +20,7 @@ use_cases = ToolSection(
             gettext("Use case"),
             "gaphor-use-case-symbolic",
             "u",
-            new_item_factory(
-                diagramitems.UseCaseItem,
+            new_element_item_factory(
                 UML.UseCase,
                 config_func=namespace_config,
             ),
@@ -28,8 +31,7 @@ use_cases = ToolSection(
             gettext("Actor"),
             "gaphor-actor-symbolic",
             "t",
-            new_item_factory(
-                diagramitems.ActorItem,
+            new_element_item_factory(
                 UML.Actor,
                 config_func=namespace_config,
             ),
@@ -40,14 +42,14 @@ use_cases = ToolSection(
             gettext("Association"),
             "gaphor-association-symbolic",
             "<Shift>J",
-            new_item_factory(diagramitems.AssociationItem),
+            new_deferred_element_item_factory(UML.Association),
         ),
         ToolDef(
             "toolbox-include",
             gettext("Include"),
             "gaphor-include-symbolic",
             "<Shift>U",
-            new_item_factory(diagramitems.IncludeItem),
+            new_deferred_element_item_factory(UML.Include),
             handle_index=0,
         ),
         ToolDef(
@@ -55,7 +57,7 @@ use_cases = ToolSection(
             gettext("Extend"),
             "gaphor-extend-symbolic",
             "<Shift>X",
-            new_item_factory(diagramitems.ExtendItem),
+            new_deferred_element_item_factory(UML.Extend),
             handle_index=0,
         ),
     ),

--- a/gaphor/diagram/drop.py
+++ b/gaphor/diagram/drop.py
@@ -8,7 +8,7 @@ from gaphor.diagram.support import get_diagram_item
 
 @singledispatch
 def drop(element: Element, diagram: Diagram, x: float, y: float):
-    if item_class := get_diagram_item(type(element)):
+    if item_class := get_diagram_item(type(element), type(diagram)):
         item = diagram.create(item_class)
         assert item
 

--- a/gaphor/diagram/support.py
+++ b/gaphor/diagram/support.py
@@ -1,46 +1,118 @@
 """For ease of creation, maintain a mapping from Element to Diagram Item."""
 
-from typing import Dict
+from typing import Dict, NamedTuple, Type, List, Iterable
 
-from gaphor.core.modeling import Element, Presentation
+from gaphor.core.modeling import Element, Presentation, Diagram
 
 
-def represents(uml_element, **metadata):
+class ElementRepresentationInfo(NamedTuple):
+    element_cls: Type[Element]
+    presentation_cls: Type[Presentation]
+    diagram_cls: Type[Diagram]
+    metadata: dict[str, object]
+
+
+def represents(uml_element, diagram_type=Diagram, **metadata):
     """A decorator to assign a default Element type to a diagram item."""
 
     def wrapper(presentation):
-        set_diagram_item(uml_element, presentation, metadata)
+        set_diagram_item(uml_element, diagram_type, presentation, metadata)
         return presentation
 
     return wrapper
 
 
-# Map elements to their (default) representation.
-_element_to_item_map: Dict[Element, Presentation] = {}
-_item_to_metadata_map: Dict[Presentation, dict[str, object]] = {}
+_element_to_item_map: Dict[Element, List[ElementRepresentationInfo]] = {}
 
 
-def get_diagram_item(element_cls):
+def closest_instance(
+    item: Type,
+    options: Iterable,
+    project=lambda x: x,
+):
+    """ "Returns class from the options that is closest to the item class"""
+    occurrences = [
+        (
+            opt,
+            len(
+                [
+                    o
+                    for o in options
+                    if issubclass(project(o), project(opt))
+                    and issubclass(item, project(o))
+                ]
+            ),
+        )
+        for opt in options
+    ]
+
+    _, opt = min((count, opt) for opt, count in occurrences if count)
+
+    return opt
+
+
+def get_diagram_item(element_cls, diagram_cls):
     global _element_to_item_map
-    return _element_to_item_map.get(element_cls)
+
+    if options := _element_to_item_map.get(element_cls):
+        info = closest_instance(
+            diagram_cls,
+            options,
+            lambda info: info.diagram_cls,
+        )
+
+        return info.presentation_cls
+
+    return None
+
+
+def has_diagram_item(element_class) -> bool:
+    return element_class in _element_to_item_map
+
+
+def diagram_item_has_element(item_class) -> bool:
+    for _, presentations in _element_to_item_map.items():
+        element_presentations = [
+            presentation_cls for _, presentation_cls, _, _ in presentations
+        ]
+        if item_class in element_presentations:
+            return True
+
+    return False
 
 
 def get_diagram_item_metadata(item_cls):
-    global _item_to_metadata_map
-    return _item_to_metadata_map.get(item_cls, {})
+    metadatas = []
+    for _, representations in _element_to_item_map.items():
+        element_item_metadatas = [
+            metadata
+            for _, presentation_cls, _, metadata in representations
+            if item_cls is presentation_cls
+        ]
+        metadatas.extend(element_item_metadatas)
+
+    return metadatas[0] if metadatas else {}
 
 
 def get_model_element(item_cls):
-    global _element_to_item_map
     elements = [
         element
-        for element, presentation in _element_to_item_map.items()
-        if item_cls is presentation
+        for element, representations in _element_to_item_map.items()
+        if item_cls
+        in [presentation_cls for _, presentation_cls, _, _ in representations]
     ]
+
     return elements[0] if elements else None
 
 
-def set_diagram_item(element, item, metadata):
-    assert element not in _element_to_item_map
-    _element_to_item_map[element] = item
-    _item_to_metadata_map[item] = metadata
+def set_diagram_item(element, diagram_cls, item, metadata):
+    if element not in _element_to_item_map:
+        _element_to_item_map[element] = []
+
+    assert diagram_cls not in [
+        diagram for _, _, diagram, _ in _element_to_item_map[element]
+    ], "No duplicates"
+
+    _element_to_item_map[element].append(
+        ElementRepresentationInfo(element, item, diagram_cls, metadata)
+    )

--- a/gaphor/diagram/tests/test_support.py
+++ b/gaphor/diagram/tests/test_support.py
@@ -1,0 +1,25 @@
+from gaphor.diagram.support import closest_instance
+
+
+def test_closest_instance():
+    class A:
+        pass
+
+    class B:
+        pass
+
+    class C(A):
+        pass
+
+    class D(A):
+        pass
+
+    class E(B):
+        pass
+
+    class F(E):
+        pass
+
+    assert closest_instance(A, (A, B, C, D)) is A
+    assert closest_instance(F, (A, B, C, D)) is B
+    assert closest_instance(C, (A, B, C, D)) is C

--- a/gaphor/diagram/tools/__init__.py
+++ b/gaphor/diagram/tools/__init__.py
@@ -38,7 +38,7 @@ def apply_magnet_tool_set(view, modeling_language, event_manager):
 
 
 def apply_placement_tool_set(
-    view, item_factory, modeling_language, event_manager, handle_index
+    view, diagram, item_factory, modeling_language, event_manager, handle_index
 ):
     view.remove_all_controllers()
     view.add_controller(view_focus_tool(view))
@@ -49,7 +49,9 @@ def apply_placement_tool_set(
         )
     )
     view.add_controller(
-        drop_zone_tool(view, item_factory.item_class, item_factory.subject_class)
+        drop_zone_tool(
+            view, item_factory.item_class(diagram), item_factory.subject_class()
+        )
     )
     add_basic_tools(view, modeling_language, event_manager)
 

--- a/gaphor/diagram/tools/placement.py
+++ b/gaphor/diagram/tools/placement.py
@@ -61,7 +61,7 @@ def on_drag_begin(gesture, start_x, start_y, placement_state):
 def create_item(view, factory, x, y):
     selection = view.selection
     parent = selection.dropzone_item
-    item = factory(view.model, parent)
+    item = factory.create_item(view.model, parent)
     x, y = view.get_matrix_v2i(item).transform_point(x, y)
     item.matrix.translate(x, y)
     view.model.update_now({item})

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -153,8 +153,10 @@ class DiagramPage:
         tool_def = get_tool_def(self.modeling_language, tool_name)
         item_factory = tool_def.item_factory
         handle_index = tool_def.handle_index
+
         return apply_placement_tool_set(
             self.view,
+            diagram=self.diagram,
             item_factory=item_factory,
             modeling_language=self.modeling_language,
             event_manager=self.event_manager,

--- a/models/SysML.gaphor
+++ b/models/SysML.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.19.3">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.20.0">
 <Diagram id="7273ceab-20df-11ea-9209-e76c3117c943">
 <name>
 <val>Profiles</val>
@@ -3283,6 +3283,12 @@
 <head_subject>
 <ref refid="b5026069-2109-11ea-ab0b-c72c0738acd2"/>
 </head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="b5026068-2109-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -3309,6 +3315,12 @@
 <head_subject>
 <ref refid="bb09a981-2109-11ea-ab0b-c72c0738acd2"/>
 </head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="bb09a980-2109-11ea-ab0b-c72c0738acd2"/>
 </subject>
@@ -4232,9 +4244,9 @@
 </name>
 <ownedAttribute>
 <reflist>
+<ref refid="bb09a982-2109-11ea-ab0b-c72c0738acd2"/>
 <ref refid="c261498d-210a-11ea-ab0b-c72c0738acd2"/>
 <ref refid="2da498ee-4bc2-11ec-8e7f-0456e5e540ed"/>
-<ref refid="bb09a982-2109-11ea-ab0b-c72c0738acd2"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -12945,11 +12957,24 @@ otherwise MRO can not be resolved.</val>
 <ownedDiagram>
 <reflist>
 <ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
 </reflist>
 </ownedDiagram>
 <ownedType>
 <reflist>
 <ref refid="0ccaf652-292b-11ee-aad9-e38f5215237c"/>
+<ref refid="b09a23f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="c31a393c-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="d260c2f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="d98a0152-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="ebbb8684-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="9f2c24d2-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="c4abca46-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="db64c1c0-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="e1957030-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="edfa7c9e-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="0244d24e-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="09c46174-3e51-11ee-b5e8-ab0577c5eba0"/>
 </reflist>
 </ownedType>
 <package>
@@ -12964,19 +12989,33 @@ otherwise MRO can not be resolved.</val>
 <ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
 </element>
 <name>
-<val>Diagrams</val>
+<val>Structure diagrams</val>
 </name>
 <ownedPresentation>
 <reflist>
 <ref refid="05044ba8-292b-11ee-aad9-e38f5215237c"/>
 <ref refid="0ccaf653-292b-11ee-aad9-e38f5215237c"/>
+<ref refid="0244d24f-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="edfa7c9f-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="c4abca47-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="db64c1c1-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="e1957031-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="9f2c24d3-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="09c46175-3e51-11ee-b5e8-ab0577c5eba0"/>
 <ref refid="19ddfa38-292b-11ee-aad9-e38f5215237c"/>
+<ref refid="279390f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="26cc8f62-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="1e679a06-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="cc9df27e-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="a5eaef38-3e50-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="1d211000-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="2a92887c-3e51-11ee-b5e8-ab0577c5eba0"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
 <ClassItem id="05044ba8-292b-11ee-aad9-e38f5215237c">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 192.610595703125, 141.22471618652344)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 220.63547755892705, 141.22471618652344)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -13015,8 +13054,15 @@ otherwise MRO can not be resolved.</val>
 <presentation>
 <reflist>
 <ref refid="0ccaf653-292b-11ee-aad9-e38f5215237c"/>
+<ref refid="a935fef2-3e51-11ee-b5e8-ab0577c5eba0"/>
 </reflist>
 </presentation>
+<specialization>
+<reflist>
+<ref refid="b9bbdf94-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="a5eaef39-3e50-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</specialization>
 </Stereotype>
 <ClassItem id="0ccaf653-292b-11ee-aad9-e38f5215237c">
 <matrix>
@@ -13061,7 +13107,7 @@ otherwise MRO can not be resolved.</val>
 <val>(1.0, 0.0, 0.0, 1.0, 247.76829528808594, 198.07798767089844)</val>
 </matrix>
 <points>
-<val>[(22.867182270841113, 108.30506896972656), (18.7200927734375, 12.146728515625)]</val>
+<val>[(22.867182270841113, 108.30506896972656), (46.74497462923955, 12.146728515625)]</val>
 </points>
 <head-connection>
 <ref refid="0ccaf653-292b-11ee-aad9-e38f5215237c"/>
@@ -13139,4 +13185,1164 @@ otherwise MRO can not be resolved.</val>
 <val>owner</val>
 </value>
 </Slot>
+<Diagram id="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0">
+<diagramType>
+<val></val>
+</diagramType>
+<element>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</element>
+<name>
+<val>Behavior diagrams</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="a935fef2-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="b09a23f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="c31a393d-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="d260c2f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="d98a0153-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="ebbb8685-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="15aa250e-3e52-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="b8987a6e-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="f7e53b8a-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="ff1381fa-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="03033864-3e52-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="094de93a-3e52-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="1a3f9c5c-3e52-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<ClassItem id="a935fef2-3e51-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 444.596923828125, 150.9772491455078)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>108.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="0ccaf652-292b-11ee-aad9-e38f5215237c"/>
+</subject>
+</ClassItem>
+<ClassItem id="b09a23f9-3e51-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 415.096923828125, 295.9077453613281)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>167.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="b09a23f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<Stereotype id="b09a23f8-3e51-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="b9bbdf94-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLBehaviorDiagram</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="b09a23f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specialization>
+<reflist>
+<ref refid="f8ccead4-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="fffab746-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="03033865-3e52-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="0a63ff1c-3e52-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</specialization>
+</Stereotype>
+<Generalization id="b9bbdf94-3e51-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="0ccaf652-292b-11ee-aad9-e38f5215237c"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="b8987a6e-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="b09a23f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<ClassItem id="c31a393d-3e51-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 38.36474609375, 484.8130187988281)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>161.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="c31a393c-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<Stereotype id="c31a393c-3e51-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="f8ccead4-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLActivityDiagram</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="c31a393d-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+</Stereotype>
+<Generalization id="f8ccead4-3e51-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="b09a23f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="f7e53b8a-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="c31a393c-3e51-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<ClassItem id="d260c2f9-3e51-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 354.096923828125, 484.8130187988281)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>181.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="d260c2f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<Stereotype id="d260c2f8-3e51-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="fffab746-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLInteractionDiagram</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="d260c2f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+</Stereotype>
+<Generalization id="fffab746-3e51-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="b09a23f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="ff1381fa-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="d260c2f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<ClassItem id="d98a0153-3e51-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 643.4129028320312, 484.8130187988281)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>200.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="d98a0152-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<Stereotype id="d98a0152-3e51-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="03033865-3e52-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLStateMachineDiagram</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="d98a0153-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+</Stereotype>
+<Generalization id="03033865-3e52-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="b09a23f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="03033864-3e52-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="d98a0152-3e51-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<ClassItem id="ebbb8685-3e51-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 948.0758056640625, 484.8130187988281)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>165.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="ebbb8684-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<Stereotype id="ebbb8684-3e51-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="0a63ff1c-3e52-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="1a3f9c5d-3e52-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLUseCaseDiagram</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="ebbb8685-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+</Stereotype>
+<Generalization id="0a63ff1c-3e52-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="b09a23f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="094de93a-3e52-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="ebbb8684-3e51-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<Generalization id="1a3f9c5d-3e52-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="9f2c24d2-3e50-11ee-b5e8-ab0577c5eba0"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="1a3f9c5c-3e52-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="ebbb8684-3e51-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<ClassItem id="15aa250e-3e52-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 1043.9351806640625, 295.9077453613281)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>223.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="9f2c24d2-3e50-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<Stereotype id="9f2c24d2-3e50-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="a5eaef39-3e50-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLDiagramWithAssociations</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="15aa250e-3e52-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="9f2c24d3-3e50-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specialization>
+<reflist>
+<ref refid="1a3f9c5d-3e52-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="cdcbd04e-3e50-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</specialization>
+</Stereotype>
+<Generalization id="a5eaef39-3e50-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="0ccaf652-292b-11ee-aad9-e38f5215237c"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="a5eaef38-3e50-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="9f2c24d2-3e50-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<GeneralizationItem id="b8987a6e-3e51-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="b9bbdf94-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 494.579833984375, 211.9207000732422)</val>
+</matrix>
+<points>
+<val>[(4.01708984375, 83.98704528808594), (4.01708984375, 13.056549072265625)]</val>
+</points>
+<head-connection>
+<ref refid="b09a23f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="a935fef2-3e51-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
+<GeneralizationItem id="f7e53b8a-3e51-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="f8ccead4-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 449.705078125, 364.6034393310547)</val>
+</matrix>
+<points>
+<val>[(-285.3087921142578, 120.20957946777344), (-285.3087921142578, 45.7296142578125), (0.0, 45.7296142578125), (0.0, 5.3043060302734375)]</val>
+</points>
+<head-connection>
+<ref refid="c31a393d-3e51-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="b09a23f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
+<GeneralizationItem id="ff1381fa-3e51-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="fffab746-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 474.559814453125, 363.5047149658203)</val>
+</matrix>
+<points>
+<val>[(0.0, 121.30830383300781), (0.0, 6.4030303955078125)]</val>
+</points>
+<head-connection>
+<ref refid="d260c2f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="b09a23f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
+<GeneralizationItem id="03033864-3e52-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="03033865-3e52-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 527.9100952148438, 361.73573303222656)</val>
+</matrix>
+<points>
+<val>[(146.747314453125, 123.07728576660156), (146.747314453125, 75.44741821289062), (0.0, 75.44741821289062), (0.0, 8.172012329101562)]</val>
+</points>
+<head-connection>
+<ref refid="d98a0153-3e51-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="b09a23f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
+<GeneralizationItem id="094de93a-3e52-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="0a63ff1c-3e52-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 582.096923828125, 341.475341796875)</val>
+</matrix>
+<points>
+<val>[(448.4788818359375, 143.33767700195312), (448.4788818359375, 68.85771179199219), (-22.152587890625, 68.85771179199219), (-22.152587890625, 28.432403564453125)]</val>
+</points>
+<head-connection>
+<ref refid="ebbb8685-3e51-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="b09a23f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
+<GeneralizationItem id="1a3f9c5c-3e52-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="9d0806ac-3e51-11ee-b5e8-ab0577c5eba0"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="1a3f9c5d-3e52-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 1079.4031982421875, 360.1521301269531)</val>
+</matrix>
+<points>
+<val>[(0.0, 124.660888671875), (0.0, 9.755615234375)]</val>
+</points>
+<head-connection>
+<ref refid="ebbb8685-3e51-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="15aa250e-3e52-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
+<Stereotype id="c4abca46-3e50-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="cdcbd04e-3e50-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLStructureDiagram</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="c4abca47-3e50-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specialization>
+<reflist>
+<ref refid="1f42a0d8-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="1d211001-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="279390f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+<ref refid="26cc8f63-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</specialization>
+</Stereotype>
+<Generalization id="cdcbd04e-3e50-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="9f2c24d2-3e50-11ee-b5e8-ab0577c5eba0"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="cc9df27e-3e50-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="c4abca46-3e50-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<Stereotype id="db64c1c0-3e50-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="1f42a0d8-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLRequirementDiagram</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="db64c1c1-3e50-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+</Stereotype>
+<Generalization id="1f42a0d8-3e51-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="c4abca46-3e50-11ee-b5e8-ab0577c5eba0"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="1e679a06-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="db64c1c0-3e50-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<Stereotype id="e1957030-3e50-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="1d211001-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLBlockDefinitionDiagram</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="e1957031-3e50-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+</Stereotype>
+<Generalization id="1d211001-3e51-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="c4abca46-3e50-11ee-b5e8-ab0577c5eba0"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="1d211000-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="e1957030-3e50-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<Stereotype id="edfa7c9e-3e50-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="279390f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLPackageDiagram</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="edfa7c9f-3e50-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+</Stereotype>
+<Generalization id="279390f9-3e51-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="c4abca46-3e50-11ee-b5e8-ab0577c5eba0"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="279390f8-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="edfa7c9e-3e50-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<Stereotype id="0244d24e-3e51-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="26cc8f63-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLInternalBlockDiagram</val>
+</name>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="0244d24f-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specialization>
+<reflist>
+<ref refid="2a92887d-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</specialization>
+</Stereotype>
+<Generalization id="26cc8f63-3e51-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="c4abca46-3e50-11ee-b5e8-ab0577c5eba0"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="26cc8f62-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="0244d24e-3e51-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<Stereotype id="09c46174-3e51-11ee-b5e8-ab0577c5eba0">
+<generalization>
+<reflist>
+<ref refid="2a92887d-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</generalization>
+<name>
+<val>SysMLParametricDiagram</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="6a70cfda-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="fd10d6be-292a-11ee-aad9-e38f5215237c"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="09c46175-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+</Stereotype>
+<Generalization id="2a92887d-3e51-11ee-b5e8-ab0577c5eba0">
+<general>
+<ref refid="0244d24e-3e51-11ee-b5e8-ab0577c5eba0"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="2a92887c-3e51-11ee-b5e8-ab0577c5eba0"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="09c46174-3e51-11ee-b5e8-ab0577c5eba0"/>
+</specific>
+</Generalization>
+<Property id="6a70cfda-3e51-11ee-b5e8-ab0577c5eba0">
+<class_>
+<ref refid="09c46174-3e51-11ee-b5e8-ab0577c5eba0"/>
+</class_>
+<defaultValue>
+<val>false</val>
+</defaultValue>
+<name>
+<val>isConstraintPropertyRounded</val>
+</name>
+<typeValue>
+<val>bool</val>
+</typeValue>
+</Property>
+<GeneralizationItem id="279390f8-3e51-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="279390f9-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 329.5102136697284, 639.8076301961921)</val>
+</matrix>
+<points>
+<val>[(398.8261922660783, 150.25407634677663), (398.8261922660783, 0.8202689737298101), (17.47266596894349, 0.8202689737298101)]</val>
+</points>
+<head-connection>
+<ref refid="edfa7c9f-3e50-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="c4abca47-3e50-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
+<GeneralizationItem id="26cc8f62-3e51-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="26cc8f63-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 288.88576672805834, 663.4783155467305)</val>
+</matrix>
+<points>
+<val>[(46.81106020762388, 126.58339099623822), (46.81106020762388, 14.149583623191347)]</val>
+</points>
+<head-connection>
+<ref refid="0244d24f-3e51-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="c4abca47-3e50-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
+<GeneralizationItem id="1e679a06-3e51-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="1f42a0d8-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 228.93280620635676, 650.3740165362988)</val>
+</matrix>
+<points>
+<val>[(-445.8513451684991, 139.68769000666998), (-445.8513451684991, -9.746117366376893), (-52.949926567684884, -9.746117366376893)]</val>
+</points>
+<head-connection>
+<ref refid="db64c1c1-3e50-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="c4abca47-3e50-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
+<GeneralizationItem id="cc9df27e-3e50-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="cdcbd04e-3e50-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 283.82379150390625, 514.078125)</val>
+</matrix>
+<points>
+<val>[(-18.193822367830762, 89.54977416992188), (-17.335403442382812, 10.468017578125)]</val>
+</points>
+<head-connection>
+<ref refid="c4abca47-3e50-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="9f2c24d3-3e50-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
+<GeneralizationItem id="a5eaef38-3e50-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="a5eaef39-3e50-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 277.71392822265625, 364.31341552734375)</val>
+</matrix>
+<points>
+<val>[(-7.0784506637292, 86.23272705078125), (-7.0784506637292, 16.06964111328125)]</val>
+</points>
+<head-connection>
+<ref refid="9f2c24d3-3e50-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="0ccaf653-292b-11ee-aad9-e38f5215237c"/>
+</tail-connection>
+</GeneralizationItem>
+<ClassItem id="0244d24f-3e51-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 307.2763961980016, 790.0617065429688)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>196.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="0244d24e-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<ClassItem id="edfa7c9f-3e50-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 646.3364059358066, 790.0617065429688)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>164.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="edfa7c9e-3e50-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<ClassItem id="c4abca47-3e50-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 175.98287963867188, 603.6278991699219)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>171.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="c4abca46-3e50-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<ClassItem id="db64c1c1-3e50-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, -320.3854138766023, 790.0617065429688)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>193.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="db64c1c0-3e50-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<ClassItem id="e1957031-3e50-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 22.7349873614856, 790.0617065429688)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>210.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="e1957030-3e50-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<ClassItem id="9f2c24d3-3e50-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 149.98287963867188, 450.546142578125)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>223.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="9f2c24d2-3e50-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<ClassItem id="09c46175-3e51-11ee-b5e8-ab0577c5eba0">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 250.77639619800124, 953.8709744695378)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>309.0</val>
+</width>
+<height>
+<val>83.0</val>
+</height>
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="09c46174-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+</ClassItem>
+<GeneralizationItem id="1d211000-3e51-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="1d211001-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 260.3230609580912, 666.9198764238672)</val>
+</matrix>
+<points>
+<val>[(-51.33467289656778, 123.14183011910154), (-51.33467289656767, 10.708022746054667)]</val>
+</points>
+<head-connection>
+<ref refid="e1957031-3e50-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="c4abca47-3e50-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
+<GeneralizationItem id="2a92887c-3e51-11ee-b5e8-ab0577c5eba0">
+<diagram>
+<ref refid="0210b378-292b-11ee-aad9-e38f5215237c"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="2a92887d-3e51-11ee-b5e8-ab0577c5eba0"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 402.2039447493554, 847.4775536415742)</val>
+</matrix>
+<points>
+<val>[(3.072451448645836, 106.39342082796361), (3.072451448646177, 16.584152901394532)]</val>
+</points>
+<head-connection>
+<ref refid="09c46175-3e51-11ee-b5e8-ab0577c5eba0"/>
+</head-connection>
+<tail-connection>
+<ref refid="0244d24f-3e51-11ee-b5e8-ab0577c5eba0"/>
+</tail-connection>
+</GeneralizationItem>
 </gaphor>


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->

#### Separate item only factory from item with element factory in toolbox and support specifying diagram specific items

In order to support creating diagram specific items for the element,
it is important that element representations are consistent between toolbox added items
and dragged element created items. For that, toolbox no longer is allowed to specify both
item and element - new_element_item() must be used instead.

represents() takes now additional parameter of the diagram class where the item can be represented on.

#### Add missing SysML diagrams in the sysml model

According to the SysML specification. Necessary to precisely select diagram types. Also, potentially, enables to support all kinds of diagram specific representations - such as adding frame with ports/parameters.

#### Use correct SysML diagram types

SysML toolbox diagram definitions should use correct SysML diagram types.

####  Add ActivityAsBlock, InteractionAsBlock, StateMachineAsBlock diagram items for SysML block definition diagram

SysML specification defines a construct called "<BehaviorElement> as block" which enables to represent behavioral element on block definition diagram to define behavioral compositions.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #https://github.com/gaphor/gaphor/issues/2640

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

It does not explicitly break anything, but the representations wont start working without re-creating the elements on the block definition diagram. Additionally, SysML diagrams will also be either Diagram or SysMLDiagram. It is rather easy to refactor these things, but I would prefer to make it explicit for the user.

### Other information
