### PR TITLE
Support state entry, exit, do behavior selection amongst the existing behaviors via dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------
 - Fix missing derive relationship icon in the model browser
 - Fix block not showing parts
+- Support state entry, exit, do behavior selection amongst the existing behaviors via dropdown
 
 2.20.0
 ------

--- a/gaphor/UML/states/propertypages.ui
+++ b/gaphor/UML/states/propertypages.ui
@@ -19,33 +19,51 @@
           <object class="GtkLabel">
             <property name="label" translatable="yes">Entry</property>
             <property name="xalign">0</property>
+            <style>
+              <class name="title" />
+            </style>
           </object>
         </child>
         <child>
-          <object class="GtkEntry" id="entry">
-            <signal name="changed" handler="entry-changed"/>
+          <object class="GtkDropDown" id="entry">
+            <property name="enable-search">1</property>
+            <property name="expression">
+              <lookup type="LabelValue" name="label" />
+            </property>
           </object>
         </child>
         <child>
           <object class="GtkLabel">
             <property name="label" translatable="yes">Exit</property>
             <property name="xalign">0</property>
+            <style>
+              <class name="title" />
+            </style>
           </object>
         </child>
         <child>
-          <object class="GtkEntry" id="exit">
-            <signal name="changed" handler="exit-changed"/>
+          <object class="GtkDropDown" id="exit">
+            <property name="enable-search">1</property>
+            <property name="expression">
+              <lookup type="LabelValue" name="label" />
+            </property>
           </object>
         </child>
         <child>
           <object class="GtkLabel">
-            <property name="label" translatable="yes">Do Activity</property>
+            <property name="label" translatable="yes">Do activity</property>
             <property name="xalign">0</property>
+            <style>
+              <class name="title" />
+            </style>
           </object>
         </child>
         <child>
-          <object class="GtkEntry" id="do-activity">
-            <signal name="changed" handler="do-activity-changed" swapped="no"/>
+          <object class="GtkDropDown" id="do-activity">
+            <property name="enable-search">1</property>
+            <property name="expression">
+              <lookup type="LabelValue" name="label" />
+            </property>
           </object>
         </child>
         <style>

--- a/gaphor/UML/states/tests/test_propertypages.py
+++ b/gaphor/UML/states/tests/test_propertypages.py
@@ -9,36 +9,111 @@ from gaphor.UML.states.state import StateItem
 
 
 def test_state_property_page_entry(element_factory):
+    # Create some behavior elements
+    opt1 = element_factory.create(UML.Activity)
+    opt1.name = "option 1"
+
+    opt2 = element_factory.create(UML.Interaction)
+    opt2.name = "option 2"
+
+    # Create subject property page
     subject = element_factory.create(UML.State)
     property_page = StatePropertyPage(subject)
 
     widget = property_page.construct()
-    entry = find(widget, "entry")
-    entry.set_text("test")
+    do_activity = find(widget, "entry")
 
-    assert subject.entry.name == "test"
+    do_activity.set_selected(0)
+    assert not subject.entry
+
+    do_activity.set_selected(1)
+    assert (
+        subject.entry
+        and isinstance(subject.entry, UML.Activity)
+        and subject.entry.name == "option 1"
+    )
+
+    do_activity.set_selected(2)
+    assert (
+        subject.entry
+        and isinstance(subject.entry, UML.Interaction)
+        and subject.entry.name == "option 2"
+    )
+
+    do_activity.set_selected(0)
+    assert not subject.entry
 
 
 def test_state_property_page_exit(element_factory):
+    # Create some behavior elements
+    opt1 = element_factory.create(UML.Activity)
+    opt1.name = "option 1"
+
+    opt2 = element_factory.create(UML.Interaction)
+    opt2.name = "option 2"
+
+    # Create subject property page
     subject = element_factory.create(UML.State)
     property_page = StatePropertyPage(subject)
 
     widget = property_page.construct()
-    exit = find(widget, "exit")
-    exit.set_text("test")
+    do_activity = find(widget, "exit")
 
-    assert subject.exit.name == "test"
+    do_activity.set_selected(0)
+    assert not subject.exit
+
+    do_activity.set_selected(1)
+    assert (
+        subject.exit
+        and isinstance(subject.exit, UML.Activity)
+        and subject.exit.name == "option 1"
+    )
+
+    do_activity.set_selected(2)
+    assert (
+        subject.exit
+        and isinstance(subject.exit, UML.Interaction)
+        and subject.exit.name == "option 2"
+    )
+
+    do_activity.set_selected(0)
+    assert not subject.exit
 
 
 def test_state_property_page_do_activity(element_factory):
+    # Create some behavior elements
+    opt1 = element_factory.create(UML.Activity)
+    opt1.name = "option 1"
+
+    opt2 = element_factory.create(UML.Interaction)
+    opt2.name = "option 2"
+
+    # Create subject property page
     subject = element_factory.create(UML.State)
     property_page = StatePropertyPage(subject)
 
     widget = property_page.construct()
     do_activity = find(widget, "do-activity")
-    do_activity.set_text("test")
 
-    assert subject.doActivity.name == "test"
+    do_activity.set_selected(0)
+    assert not subject.doActivity
+
+    do_activity.set_selected(1)
+    assert (
+        subject.doActivity
+        and isinstance(subject.doActivity, UML.Activity)
+        and subject.doActivity.name == "option 1"
+    )
+
+    do_activity.set_selected(2)
+    assert (
+        subject.doActivity
+        and isinstance(subject.doActivity, UML.Interaction)
+        and subject.doActivity.name == "option 2"
+    )
+
+    do_activity.set_selected(0)
+    assert not subject.doActivity
 
 
 def test_transition_property_page(element_factory):


### PR DESCRIPTION
### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

Adds drop-down selection to select entry, exit, do behaviors amongst the existing behaviors.

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, a textfield is used to define entry, exit, do behaviors which always create new activities. It is not possible to select existing activities.

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Ideally, I would like to preserve the option to create the behavior when it does not exist on the property page; or defer its creation at the later point and just keep it as a text.