### PR TITLE
Fix style sheets docs spelling error

### DIFF
--- a/docs/style_sheets.md
+++ b/docs/style_sheets.md
@@ -86,7 +86,7 @@ of CSS. Below you'll find a summary of all CSS features supported by Gaphor.
 ``*``                         All items on the diagram, including the diagram itself.
 ``node component``            Any component item which is a descendant of a node.
 ``node > component``          A component item which is a child of a node.
-``generaliation[subject]``    A generalization item with a subject present.
+``generalization[subject]``   A generalization item with a subject present.
 ``class[name=Foo]``           A class with name "Foo".
 ``diagram[name^=draft]``      A diagram with a name starting with "draft".
 ``diagram[name$=draft]``      A diagram with a name ends with "draft".


### PR DESCRIPTION
Fixes a misspelling of the word `generalization` in the style sheets documentation.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [x] Documentation content changes

### What is the current behavior?
In the `Supported selectors` section of the style sheets documentation, `generalization` is misspelled as `generaliation`.

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
