### PR TITLE
Members in model browser

### DIFF
--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -22,7 +22,7 @@ from typing import Callable
 from gaphor.core.modeling.element import Element
 class NamedElement(Element):
     clientDependency: relation_many[Dependency]
-    memberNamespace: relation_many[Namespace]
+    memberNamespace: relation_one[Namespace]
     name: _attribute[str] = _attribute("name", str)
     namespace: relation_one[Namespace]
     qualifiedName: derived[list[str]]
@@ -807,7 +807,7 @@ NamedElement.qualifiedName = derived(
     lambda obj: [qualifiedName(obj)],
 )
 
-NamedElement.memberNamespace = derivedunion("memberNamespace", Namespace)
+NamedElement.memberNamespace = derivedunion("memberNamespace", Namespace, upper=1)
 Element.directedRelationship.add(NamedElement.supplierDependency)  # type: ignore[attr-defined]
 Element.ownedElement.add(NamedElement.clientDependency)  # type: ignore[attr-defined]
 Element.directedRelationship.add(NamedElement.clientDependency)  # type: ignore[attr-defined]

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -235,14 +235,16 @@ class ModelBrowser(UIComponent, ActionProvider):
     @event_handler(DerivedAdded, DerivedDeleted)
     def on_owned_element_changed(self, event):
         """Ensure we update the node once owned elements change."""
-        if event.property is Element.ownedElement:
+        if event.property in (Element.ownedElement, UML.Namespace.member):
             self.model.notify_child_model(event.element)
 
     @event_handler(DerivedSet)
     def on_owner_changed(self, event: DerivedSet):
         # Should check on ownedElement as well, since it may not have been updated
         # before this thing triggers
-        if (event.property is not Element.owner) or not visible(event.element):
+        if (
+            event.property not in (Element.owner, UML.NamedElement.memberNamespace)
+        ) or not visible(event.element):
             return
         element = event.element
         self.model.remove_element(element, former_owner=event.old_value)

--- a/gaphor/ui/tests/test_modelbrowser.py
+++ b/gaphor/ui/tests/test_modelbrowser.py
@@ -57,22 +57,6 @@ def test_model_browser_remove_element(model_browser, element_factory):
     assert items_changed.removed == 1
 
 
-def test_tree_subtree_changed(model_browser, element_factory):
-    class_ = element_factory.create(UML.Class)
-    package = element_factory.create(UML.Package)
-
-    tree_model = model_browser.model
-    root_model = tree_model.root
-    root_model_changed = ItemChangedHandler()
-    root_model.connect("items-changed", root_model_changed)
-
-    class_.package = package
-
-    assert len(root_model) == 1
-    assert root_model_changed.added == 2
-    assert root_model_changed.removed == 3  # remove + node changed
-
-
 def test_model_browser_add_nested_element(model_browser, element_factory):
     tree_model = model_browser.model
     class_ = element_factory.create(UML.Class)
@@ -116,6 +100,25 @@ def test_model_browser_remove_nested_element(model_browser, element_factory):
     child_model = tree_model.child_model(package_item)
     assert tree_model.tree_item_for_element(package) is not None
     assert child_model is None
+
+
+def test_change_from_member_to_owner(model_browser, element_factory):
+    tree_model = model_browser.model
+    property = element_factory.create(UML.Property)
+    association = element_factory.create(UML.Association)
+    klass = element_factory.create(UML.Class)
+
+    association.memberEnd = property
+    klass.ownedAttribute = property
+
+    association_item = tree_model.tree_item_for_element(association)
+    klass_item = tree_model.tree_item_for_element(klass)
+    property_item = tree_model.tree_item_for_element(property)
+    association_model = tree_model.branches.get(association_item)
+    klass_model = tree_model.branches.get(klass_item)
+
+    assert not association_model
+    assert property_item in klass_model.elements
 
 
 def test_element_name_changed(model_browser, element_factory):

--- a/gaphor/ui/tests/test_treemodel.py
+++ b/gaphor/ui/tests/test_treemodel.py
@@ -254,3 +254,19 @@ def test_tree_model_sort_relationship_item_first(element_factory):
     assert tree_item_sort(a, r) == 1
     assert tree_item_sort(a, b) == -1
     assert tree_item_sort(b, a) == 1
+
+
+def test_element_with_member_and_no_owner(element_factory):
+    tree_model = TreeModel()
+    property = element_factory.create(UML.Property)
+    association = element_factory.create(UML.Association)
+    association.memberEnd = property
+    tree_model.add_element(association)
+    tree_model.add_element(property)
+    association_item = tree_model.tree_item_for_element(association)
+    tree_model.child_model(association_item)
+    property_item = tree_model.tree_item_for_element(property)
+
+    association_model = tree_model.branches.get(association_item)
+
+    assert property_item in association_model.elements

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.19.3">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.21.0">
 <Association id="DCE:12A2B620-4B3C-11D7-B391-02BBFE4396CE">
 <memberEnd>
 <reflist>
@@ -6124,9 +6124,9 @@
 <ref refid="DCE:BAEADF3E-65C6-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:D33A9738-4694-11D7-B567-379CA7034986"/>
 <ref refid="90a6d158-b9b1-11eb-93ad-535118859f0b"/>
-<ref refid="DCE:B7B7E77C-4694-11D7-B567-379CA7034986"/>
 <ref refid="98bdb712-b9b1-11eb-93ad-535118859f0b"/>
 <ref refid="aa8a8fb0-e185-11ea-b7ab-f5b4c130f24e"/>
+<ref refid="DCE:B7B7E77C-4694-11D7-B567-379CA7034986"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -12337,10 +12337,10 @@
 <ref refid="DCE:7D753EF0-464D-11D7-AA08-1B85D5275D8A"/>
 </type>
 <upperValue>
-<val>*</val>
+<val>1</val>
 </upperValue>
 <upperValue>
-<val>*</val>
+<val>1</val>
 </upperValue>
 </Property>
 <Association id="DCE:B0D2CA8A-4B35-11D7-B391-02BBFE4396CE">
@@ -20335,9 +20335,9 @@
 <ref refid="DCE:8F7D73F4-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:D33A1420-4694-11D7-B567-379CA7034986"/>
 <ref refid="DCE:18E7ADF0-4697-11D7-B567-379CA7034986"/>
-<ref refid="DCE:B7B7B610-4694-11D7-B567-379CA7034986"/>
 <ref refid="DCE:7D124DD0-4697-11D7-B567-379CA7034986"/>
 <ref refid="5d8d968e-e96c-11ea-96dc-bf74f1f80424"/>
+<ref refid="DCE:B7B7B610-4694-11D7-B567-379CA7034986"/>
 </reflist>
 </ownedAttribute>
 <package>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When an association end is marked as non-navigable, it ends up in the root of the Model Browser.

Issue Number: Fixes #2731

### What is the new behavior?

Next to `Element.owner`, `NamedElement.memberNamespace` (/`Namespace.member` is used as a fallback to place an element in the Model Browser.

This should reduce the cases where an element ends up in the root of the model unintended.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

After a discussion with @marek-piirikivi on Matrix, we decided it's probably better to support membership in the model browser. The alternatice was to rework how Associations are modeled (#633), but that will become a messy change.