### PR TITLE
Build on CI with a Fedora 39 image

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -50,44 +50,45 @@ jobs:
     name: Linux (Wheel) with Python ${{ matrix.python_version }}
     needs: lint
     runs-on: ubuntu-22.04
+    container: fedora:39
     timeout-minutes: 30
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       matrix:
-        python_version: ['3.10', '3.11', '3.12']
+        python_version: ['3.11', '3.12']
     outputs:
       targz: gaphor-${{ steps.install.outputs.version }}.tar.gz
       wheel: gaphor-${{ steps.install.outputs.version }}-py3-none-any.whl
       version: ${{ steps.install.outputs.version }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
-        with:
-          egress-policy: audit
-
+      - name: Install Linux Dependencies
+        run: >
+          dnf install -y gcc git gobject-introspection-devel
+          cairo-gobject-devel graphviz pkg-config gtk4 gtksourceview5-devel
+          libadwaita-devel cairo-devel upx python${{ matrix.python_version }}
+          python${{ matrix.python_version }}-devel python-launcher
+          xorg-x11-server-Xvfb
+      - name: Install pip
+        run: python${{ matrix.python_version }} -m ensurepip
+      - name: Install pipx
+        run: |
+          py -${{ matrix.python_version }} -m pip install pipx
+          echo "/github/home/.local/bin" >> $GITHUB_PATH
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Install Linux Dependencies
-        run: >
-          sudo apt-get update -qq && sudo apt-get install -qq --no-install-recommends upx
-          gir1.2-gtk-4.0 libgirepository1.0-dev libgtksourceview-5-dev libadwaita-1-dev
-          graphviz
-      - name: Set up Python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
-        with:
-          python-version: ${{ matrix.python_version }}
-          allow-prereleases: true
+      - name: Set ownership of Checkout directory
+        run: chown -R $(id -u):$(id -g) $PWD
       - name: Use Python Dependency Cache
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-22.04
+          key: ${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}-39
       - name: Install Dependencies
         id: install
         uses: ./.github/actions/install
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python_version }}
       - name: Run Gaphor Tests
         run: xvfb-run poetry run pytest --cov
       - name: Upload Code Coverage to Code Climate

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -63,22 +63,20 @@ jobs:
     steps:
       - name: Install Linux Dependencies
         run: >
-          dnf install -y gcc git gobject-introspection-devel
-          cairo-gobject-devel graphviz pkg-config gtk4 gtksourceview5-devel
-          libadwaita-devel cairo-devel upx python${{ matrix.python_version }}
-          python${{ matrix.python_version }}-devel python-launcher
-          xorg-x11-server-Xvfb
-      - name: Install pip
-        run: python${{ matrix.python_version }} -m ensurepip
-      - name: Install pipx
-        run: |
-          py -${{ matrix.python_version }} -m pip install pipx
-          echo "/github/home/.local/bin" >> $GITHUB_PATH
+          dnf install -y gcc git graphviz pkg-config python-launcher upx
+          xorg-x11-server-Xvfb gtk4 gobject-introspection-devel
+          cairo-gobject-devel gtksourceview5-devel libadwaita-devel cairo-devel
+          python${{ matrix.python_version }}-devel
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set ownership of Checkout directory
+      - name: Set ownership of checkout directory
         run: chown -R $(id -u):$(id -g) $PWD
+      - name: Install pipx
+        run: |
+          python${{ matrix.python_version }} -m ensurepip
+          py -${{ matrix.python_version }} -m pip install pipx
+          echo "/github/home/.local/bin" >> $GITHUB_PATH
       - name: Use Python Dependency Cache
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:


### PR DESCRIPTION
This PR changes from using the default Ubuntu runner on GitHub Actions to using Fedora 39. :star_struck:  This allows us to have more recently released versions of GTK and related dependencies to test against, and should unblock #2756 and #2320.

Additionally, I dropped the Python 3.10 build since Python 3.12 is now released.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Linux tests are run on Ubuntu 22.10

Issue Number: N/A

### What is the new behavior?
Linux tests are run on Fedora 39

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
I initially tried to use a Ubuntu 23.10 image, but I ran in to a lot of problems installing the different versions of Python using the deadsnakes PPA. Ubuntu disables ensurepip and pip wasn't working outside a virtualenv. Fedora was much smoother to get going.