### PR TITLE
Replace Black, check toml, refurb with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,13 @@
 repos:
-- repo: https://github.com/psf/black
-  rev: 23.10.0
-  hooks:
-  - id: black
-    types_or: [python, spec]
-    language_version: python3
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.6.1
   hooks:
   - id: mypy
-    types_or: [python, spec]
     additional_dependencies:
     - types-docutils
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
   hooks:
-  - id: check-toml
   - id: check-yaml
     exclude: '.\.gaphor'
   - id: trailing-whitespace
@@ -29,7 +21,5 @@ repos:
   hooks:
   - id: ruff
     args: [--fix]
-- repo: https://github.com/dosisod/refurb
-  rev: v1.22.1
-  hooks:
-  - id: refurb
+  - id: ruff-format
+    types_or: [python, spec]

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -30,17 +30,11 @@ class BlockItem(Classified, ElementPresentation[Block]):
             "show_parts", self.update_shapes
         ).watch("show_references", self.update_shapes).watch(
             "show_values", self.update_shapes
-        ).watch(
-            "show_operations", self.update_shapes
-        ).watch(
+        ).watch("show_operations", self.update_shapes).watch(
             "subject[NamedElement].name"
-        ).watch(
-            "subject[NamedElement].name"
-        ).watch(
+        ).watch("subject[NamedElement].name").watch(
             "subject[NamedElement].namespace.name"
-        ).watch(
-            "subject[Classifier].isAbstract", self.update_shapes
-        ).watch(
+        ).watch("subject[Classifier].isAbstract", self.update_shapes).watch(
             "subject[Class].ownedAttribute.aggregation", self.update_shapes
         )
         operation_watches(self, "Block")

--- a/gaphor/SysML/blocks/interfaceblock.py
+++ b/gaphor/SysML/blocks/interfaceblock.py
@@ -30,17 +30,11 @@ class InterfaceBlockItem(Classified, ElementPresentation[InterfaceBlock]):
             "show_parts", self.update_shapes
         ).watch("show_references", self.update_shapes).watch(
             "show_values", self.update_shapes
-        ).watch(
-            "show_operations", self.update_shapes
-        ).watch(
+        ).watch("show_operations", self.update_shapes).watch(
             "subject[NamedElement].name"
-        ).watch(
-            "subject[NamedElement].name"
-        ).watch(
+        ).watch("subject[NamedElement].name").watch(
             "subject[NamedElement].namespace.name"
-        ).watch(
-            "subject[Classifier].isAbstract", self.update_shapes
-        ).watch(
+        ).watch("subject[Classifier].isAbstract", self.update_shapes).watch(
             "subject[Class].ownedAttribute.aggregation", self.update_shapes
         )
         operation_watches(self, "Block")

--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -61,5 +61,5 @@ class PropertyItem(Named, ElementPresentation[UML.Property]):
                 "justify-content": self.justify(),
                 "dash-style": self.dash(),
             },
-            draw=draw_border
+            draw=draw_border,
         )

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -34,13 +34,9 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
             "show_attributes", self.update_shapes
         ).watch("show_operations", self.update_shapes).watch(
             "subject[NamedElement].name"
-        ).watch(
-            "subject[NamedElement].namespace.name"
-        ).watch(
+        ).watch("subject[NamedElement].namespace.name").watch(
             "subject[Classifier].isAbstract", self.update_shapes
-        ).watch(
-            "subject[AbstractRequirement].externalId", self.update_shapes
-        ).watch(
+        ).watch("subject[AbstractRequirement].externalId", self.update_shapes).watch(
             "subject[AbstractRequirement].text", self.update_shapes
         )
         attribute_watches(self, "Requirement")

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -77,35 +77,21 @@ class AssociationItem(Named, LinePresentation[UML.Association]):
             self.on_association_end_value,
         ).watch(
             f"{base}.appliedStereotype.slot.value", self.on_association_end_value
-        ).watch(
-            f"{base}.classifier", self.on_association_end_value
-        ).watch(
+        ).watch(f"{base}.classifier", self.on_association_end_value).watch(
             f"{base}.visibility", self.on_association_end_value
-        ).watch(
-            f"{base}.lowerValue", self.on_association_end_value
-        ).watch(
+        ).watch(f"{base}.lowerValue", self.on_association_end_value).watch(
             f"{base}.upperValue", self.on_association_end_value
-        ).watch(
-            f"{base}.owningAssociation", self.on_association_end_value
-        ).watch(
+        ).watch(f"{base}.owningAssociation", self.on_association_end_value).watch(
             f"{base}.type[Class].ownedAttribute", self.on_association_end_value
         ).watch(
             f"{base}.type[Interface].ownedAttribute", self.on_association_end_value
         ).watch(
             f"{base}.appliedStereotype.classifier", self.on_association_end_value
-        ).watch(
-            "subject[Association].memberEnd"
-        ).watch(
+        ).watch("subject[Association].memberEnd").watch(
             "subject[Association].ownedEnd"
-        ).watch(
-            "subject[Association].navigableOwnedEnd"
-        ).watch(
-            "show_direction"
-        ).watch(
+        ).watch("subject[Association].navigableOwnedEnd").watch("show_direction").watch(
             "preferred_aggregation", self.on_association_end_value
-        ).watch(
-            "preferred_tail_navigability", self.on_association_end_value
-        )
+        ).watch("preferred_tail_navigability", self.on_association_end_value)
         watch_information_flow(self, "Association", "abstraction")
 
     show_direction: attribute[int] = attribute("show_direction", int, default=False)

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -326,13 +326,9 @@ class AttributesPage(PropertyPageBase):
             "ownedAttribute.isDerived", handler
         ).watch("ownedAttribute.visibility", handler).watch(
             "ownedAttribute.isStatic", handler
-        ).watch(
-            "ownedAttribute.lowerValue", handler
-        ).watch(
+        ).watch("ownedAttribute.lowerValue", handler).watch(
             "ownedAttribute.upperValue", handler
-        ).watch(
-            "ownedAttribute.defaultValue", handler
-        ).watch(
+        ).watch("ownedAttribute.defaultValue", handler).watch(
             "ownedAttribute.typeValue", handler
         )
 
@@ -412,13 +408,9 @@ class OperationsPage(PropertyPageBase):
             "ownedOperation.isAbstract", handler
         ).watch("ownedOperation.visibility", handler).watch(
             "ownedOperation.ownedParameter.lowerValue", handler
-        ).watch(
-            "ownedOperation.ownedParameter.upperValue", handler
-        ).watch(
+        ).watch("ownedOperation.ownedParameter.upperValue", handler).watch(
             "ownedOperation.ownedParameter.typeValue", handler
-        ).watch(
-            "ownedOperation.ownedParameter.defaultValue", handler
-        )
+        ).watch("ownedOperation.ownedParameter.defaultValue", handler)
 
         return unsubscribe_all_on_destroy(
             builder.get_object("operations-editor"), self.watcher

--- a/gaphor/UML/classes/component.py
+++ b/gaphor/UML/classes/component.py
@@ -48,7 +48,7 @@ class ComponentItem(Classified, ElementPresentation):
                 if self.diagram and self.children
                 else JustifyContent.CENTER,
             },
-            draw=draw_border
+            draw=draw_border,
         )
 
 

--- a/gaphor/UML/classes/enumeration.py
+++ b/gaphor/UML/classes/enumeration.py
@@ -38,13 +38,9 @@ class EnumerationItem(Classified, ElementPresentation[UML.Enumeration]):
             "show_operations", self.update_shapes
         ).watch("show_enumerations", self.update_shapes).watch(
             "subject[NamedElement].name"
-        ).watch(
-            "subject[NamedElement].namespace.name"
-        ).watch(
+        ).watch("subject[NamedElement].namespace.name").watch(
             "subject[Enumeration].ownedLiteral", self.update_shapes
-        ).watch(
-            "subject[Enumeration].ownedLiteral.name", self.update_shapes
-        )
+        ).watch("subject[Enumeration].ownedLiteral.name", self.update_shapes)
         attribute_watches(self, "Enumeration")
         operation_watches(self, "Enumeration")
         stereotype_watches(self)

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -185,21 +185,13 @@ class InterfaceItem(Classified, ElementPresentation):
             "show_attributes", self.update_shapes
         ).watch("show_operations", self.update_shapes).watch(
             "subject[NamedElement].name"
-        ).watch(
-            "subject[NamedElement].namespace.name"
-        ).watch(
+        ).watch("subject[NamedElement].namespace.name").watch(
             "subject.appliedStereotype", self.update_shapes
-        ).watch(
-            "subject.appliedStereotype.classifier.name"
-        ).watch(
+        ).watch("subject.appliedStereotype.classifier.name").watch(
             "subject.appliedStereotype.slot", self.update_shapes
-        ).watch(
-            "subject.appliedStereotype.slot.definingFeature.name"
-        ).watch(
+        ).watch("subject.appliedStereotype.slot.definingFeature.name").watch(
             "subject.appliedStereotype.slot.value", self.update_shapes
-        ).watch(
-            "subject[Interface].supplierDependency", self.update_shapes
-        )
+        ).watch("subject[Interface].supplierDependency", self.update_shapes)
         attribute_watches(self, "Interface")
         operation_watches(self, "Interface")
 

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -38,9 +38,7 @@ class ClassItem(Classified, ElementPresentation[UML.Class]):
             "show_attributes", self.update_shapes
         ).watch("show_operations", self.update_shapes).watch(
             "subject[NamedElement].name"
-        ).watch(
-            "subject[NamedElement].namespace.name"
-        ).watch(
+        ).watch("subject[NamedElement].namespace.name").watch(
             "subject[Classifier].isAbstract", self.update_shapes
         )
         attribute_watches(self, "Class")
@@ -108,25 +106,15 @@ def attribute_watches(presentation, cast):
         f"subject[{cast}].ownedAttribute", presentation.update_shapes
     ).watch(
         f"subject[{cast}].ownedAttribute.association", presentation.update_shapes
-    ).watch(
-        f"subject[{cast}].ownedAttribute.name"
-    ).watch(
+    ).watch(f"subject[{cast}].ownedAttribute.name").watch(
         f"subject[{cast}].ownedAttribute.isStatic", presentation.update_shapes
-    ).watch(
-        f"subject[{cast}].ownedAttribute.isDerived"
-    ).watch(
+    ).watch(f"subject[{cast}].ownedAttribute.isDerived").watch(
         f"subject[{cast}].ownedAttribute.visibility"
-    ).watch(
-        f"subject[{cast}].ownedAttribute.lowerValue"
-    ).watch(
+    ).watch(f"subject[{cast}].ownedAttribute.lowerValue").watch(
         f"subject[{cast}].ownedAttribute.upperValue"
-    ).watch(
-        f"subject[{cast}].ownedAttribute.defaultValue"
-    ).watch(
+    ).watch(f"subject[{cast}].ownedAttribute.defaultValue").watch(
         f"subject[{cast}].ownedAttribute.type"
-    ).watch(
-        f"subject[{cast}].ownedAttribute.typeValue"
-    )
+    ).watch(f"subject[{cast}].ownedAttribute.typeValue")
 
 
 def operation_watches(presentation, cast):
@@ -136,17 +124,11 @@ def operation_watches(presentation, cast):
         f"subject[{cast}].ownedOperation.isAbstract", presentation.update_shapes
     ).watch(
         f"subject[{cast}].ownedOperation.isStatic", presentation.update_shapes
-    ).watch(
-        f"subject[{cast}].ownedOperation.visibility"
-    ).watch(
+    ).watch(f"subject[{cast}].ownedOperation.visibility").watch(
         f"subject[{cast}].ownedOperation.ownedParameter.lowerValue"
-    ).watch(
-        f"subject[{cast}].ownedOperation.ownedParameter.upperValue"
-    ).watch(
+    ).watch(f"subject[{cast}].ownedOperation.ownedParameter.upperValue").watch(
         f"subject[{cast}].ownedOperation.ownedParameter.typeValue"
-    ).watch(
-        f"subject[{cast}].ownedOperation.ownedParameter.defaultValue"
-    )
+    ).watch(f"subject[{cast}].ownedOperation.ownedParameter.defaultValue")
 
 
 def attributes_compartment(subject):

--- a/gaphor/UML/classes/stereotype.py
+++ b/gaphor/UML/classes/stereotype.py
@@ -10,9 +10,7 @@ def stereotype_watches(presentation):
         "subject.appliedStereotype.classifier.name"
     ).watch("subject.appliedStereotype.slot", presentation.update_shapes).watch(
         "subject.appliedStereotype.slot.definingFeature.name"
-    ).watch(
-        "subject.appliedStereotype.slot.value", presentation.update_shapes
-    )
+    ).watch("subject.appliedStereotype.slot.value", presentation.update_shapes)
 
 
 def stereotype_compartments(subject):

--- a/gaphor/UML/deletable.py
+++ b/gaphor/UML/deletable.py
@@ -10,9 +10,7 @@ def connector_end_deletable(element: ConnectorEnd) -> bool:
 @deletable.register
 def property_deletable(element: Property) -> bool:
     return not (
-        element.association
-        or element.end
-        or element.itemFlow  # type: ignore[attr-defined]
+        element.association or element.end or element.itemFlow  # type: ignore[attr-defined]
     )
 
 

--- a/gaphor/UML/deployments/artifact.py
+++ b/gaphor/UML/deployments/artifact.py
@@ -43,7 +43,7 @@ class ArtifactItem(Classified, ElementPresentation):
                 if self.diagram and self.children
                 else JustifyContent.CENTER,
             },
-            draw=draw_border
+            draw=draw_border,
         )
 
 

--- a/gaphor/UML/deployments/node.py
+++ b/gaphor/UML/deployments/node.py
@@ -70,7 +70,7 @@ class NodeItem(Classified, ElementPresentation):
                 if self.diagram and self.children
                 else JustifyContent.CENTER,
             },
-            draw=draw_node
+            draw=draw_node,
         )
 
 

--- a/gaphor/codegen/coder.py
+++ b/gaphor/codegen/coder.py
@@ -64,9 +64,7 @@ header = textwrap.dedent(
         relation_one,
     )
 
-    """.format(
-        "ruff"
-    )  # work around tooling triggers
+    """.format("ruff")  # work around tooling triggers
 )
 
 
@@ -105,7 +103,9 @@ def main(
     )
     overrides = Overrides(overridesfile) if overridesfile else None
 
-    with open(outfile, "w", encoding="utf-8") if outfile else contextlib.nullcontext(sys.stdout) as out:  # type: ignore[attr-defined]
+    with open(outfile, "w", encoding="utf-8") if outfile else contextlib.nullcontext(
+        sys.stdout
+    ) as out:  # type: ignore[attr-defined]
         for line in coder(model, super_models, overrides):
             print(line, file=out)
 
@@ -462,8 +462,7 @@ def resolve_attribute_type_values(element_factory: ElementFactory) -> None:
             prop.typeValue = "int"
         elif c := next(
             element_factory.select(
-                lambda e: isinstance(e, UML.Class)
-                and e.name == prop.typeValue  # noqa: B023
+                lambda e: isinstance(e, UML.Class) and e.name == prop.typeValue  # noqa: B023
             ),
             None,
         ):

--- a/gaphor/diagram/general/metadata.py
+++ b/gaphor/diagram/general/metadata.py
@@ -33,13 +33,9 @@ class MetadataItem(ElementPresentation):
             "website", self.update_shapes
         ).watch("description", self.update_shapes).watch(
             "revision", self.update_shapes
-        ).watch(
-            "license", self.update_shapes
-        ).watch(
+        ).watch("license", self.update_shapes).watch(
             "createdOn", self.update_shapes
-        ).watch(
-            "updatedOn", self.update_shapes
-        )
+        ).watch("updatedOn", self.update_shapes)
 
     def update_shapes(self, event=None):
         diagram = self.diagram

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -116,7 +116,13 @@ class ElementPresentation(gaphas.Element, HandlePositionUpdate, Presentation[S])
     _port_sides = ("top", "right", "bottom", "left")
 
     def __init__(self, diagram: Diagram, id=None, shape=None, width=100, height=50):
-        super().__init__(connections=diagram.connections, diagram=diagram, id=id, width=width, height=height)  # type: ignore[call-arg]
+        super().__init__(
+            connections=diagram.connections,
+            diagram=diagram,
+            id=id,
+            width=width,
+            height=height,
+        )  # type: ignore[call-arg]
         self._shape = shape
         for handle in self.handles():
             self.watch_handle(handle)

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -18,9 +18,9 @@ class Layout:
         default_size: tuple[int, int] = (0, 0),
     ):
         self.layout = PangoCairo.create_layout(instant_cairo_context())
-        self.font_id: tuple[
-            str, float | str, FontWeight | None, FontStyle | None
-        ] | None = None
+        self.font_id: (
+            tuple[str, float | str, FontWeight | None, FontStyle | None] | None
+        ) = None
         self.text = ""
         self.width = -1
         self.default_size = default_size

--- a/po/check-babel.py
+++ b/po/check-babel.py
@@ -23,7 +23,10 @@ def invalid(messages):
             yield message, f"Empty placeholder for '{message.id}': '{message.string}'"
 
         if set(id_formats) != set(str_formats):
-            yield message, f"Invalid placeholders for '{message.id}': '{message.string}'"
+            yield (
+                message,
+                f"Invalid placeholders for '{message.id}': '{message.string}'",
+            )
 
         if html_entity.findall(message.string):
             yield message, f"Translation contains HTML entities: '{message.string}'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,9 +261,6 @@ select = [
 [tool.ruff.mccabe]
 max-complexity = 18
 
-[tool.refurb]
-ignore = ["FURB179"]
-
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Ruff format is now in beta and seems to be working well. It provides formatting as a drop-in replacement for Black. Ruff also has built-in pyproject.toml checking, so I removed the check toml hook. Finally, Ruff has some of the rules for refurb included, and will get more over time.

The speed advantage of minimizing pre-commit hooks besides Ruff and mypy is significant.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Black for code formatting

Issue Number: N/A

### What is the new behavior?
Ruff format for code formatting

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
