### PR TITLE
Fix About dialog links on macOS

### DIFF
--- a/gaphor/ui/help/__init__.py
+++ b/gaphor/ui/help/__init__.py
@@ -3,9 +3,10 @@
 (help browser anyone?)
 """
 
+import webbrowser
 import sys
 
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk
 
 from gaphor.abc import ActionProvider, Service
 from gaphor.application import distribution
@@ -37,7 +38,7 @@ class HelpService(Service, ActionProvider):
 
         about.set_version(distribution().version)
         about.set_transient_for(self.window)
-
+        about.connect("activate-link", activate_link)
         about.set_modal(True)
         about.set_visible(True)
 
@@ -56,3 +57,11 @@ class HelpService(Service, ActionProvider):
 
         shortcuts.set_visible(True)
         return shortcuts
+
+
+def activate_link(window, uri):
+    """D-Bus does not work on macOS, so we open URL's ourselves.
+    """
+    if sys.platform == "darwin":
+        GObject.signal_stop_emission_by_name(window, "activate-link")
+        webbrowser.open(uri)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Links in the About dialog on macOS are not opened

Issue Number: #2798

### What is the new behavior?

Open the links ourselves, since we cannot rely on D-Bus.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
