### PR TITLE
Proxy Port Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 2.21.1
 ------
-(Unreleased)
+- Add proxy port to the closest port owning item
+- Allow adding existing proxy port on the owner block property
+- Fix proxy port drag icon
 
 2.21.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 2.21.1
 ------
 - Add proxy port to the closest port owning item
-- Allow adding existing proxy port on the owner block property
+- Allow adding existing proxy port on the owning block's property
 - Fix proxy port drag icon
 
 2.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add proxy port to the closest port owning item
 - Allow adding existing proxy port on the owning block's property
 - Fix proxy port drag icon
+- Allow removing proxy port element only if the item from any diagram gets removed
 
 2.21.0
 ------

--- a/gaphor/SysML/blocks/connectors.py
+++ b/gaphor/SysML/blocks/connectors.py
@@ -21,7 +21,6 @@ class BlockProperyProxyPortConnector:
         block_or_property: Union[BlockItem, PropertyItem, InterfaceBlockItem],
         proxy_port: ProxyPortItem,
     ) -> None:
-        assert block_or_property.diagram is proxy_port.diagram
         self.element = block_or_property
         self.proxy_port = proxy_port
 
@@ -54,6 +53,7 @@ class BlockProperyProxyPortConnector:
 
         # This raises the item in the item hierarchy
         assert proxy_port.diagram
+        assert self.element.diagram is proxy_port.diagram
         proxy_port.change_parent(self.element)
 
         return True

--- a/gaphor/SysML/blocks/connectors.py
+++ b/gaphor/SysML/blocks/connectors.py
@@ -61,10 +61,8 @@ class BlockProperyProxyPortConnector:
     def disconnect(self, handle: Handle) -> None:
         proxy_port = self.proxy_port
         if proxy_port.subject and proxy_port.diagram:
-            subject = proxy_port.subject
-            del proxy_port.subject
             proxy_port.change_parent(None)
-            subject.unlink()
+            proxy_port.subject = None
 
 
 @Connector.register(ProxyPortItem, ConnectorItem)

--- a/gaphor/SysML/tests/test_drop.py
+++ b/gaphor/SysML/tests/test_drop.py
@@ -33,3 +33,38 @@ def test_drop_proxy_port(diagram, element_factory):
         diagram.connections.get_connection(item.handles()[0]).connected
         is block.presentation[0]
     )
+
+
+def test_drop_proxy_port_on_property(diagram, element_factory):
+    block = element_factory.create(sysml.Block)
+    prop = element_factory.create(UML.Property)
+    prop.type = block
+
+    property_item = drop(prop, diagram, 0, 0)
+    assert property_item
+
+    port = element_factory.create(sysml.ProxyPort)
+    assert not drop(
+        port, diagram, 0, 0
+    ), "unable to add port when there is no item that it can be attached to"
+
+    block.ownedPort.append(port)
+
+    port_item = drop(port, diagram, 0, 0)
+    assert isinstance(port_item, ProxyPortItem), "port was added"
+    assert port_item in property_item.children, "port is attached to the property item"
+
+    property_item_2 = drop(prop, diagram, 500, 500)
+    assert property_item_2
+
+    port_item = drop(port, diagram, 500, 500)
+    assert isinstance(port_item, ProxyPortItem), "port was added"
+    assert (
+        port_item in property_item_2.children
+    ), "port is attached to the second property item"
+
+    port_item = drop(port, diagram, 100, 200)
+    assert isinstance(port_item, ProxyPortItem), "port was added"
+    assert (
+        port_item in property_item.children
+    ), "port is attached to the first property item"

--- a/gaphor/SysML/toolbox.py
+++ b/gaphor/SysML/toolbox.py
@@ -60,7 +60,7 @@ internal_blocks = ToolSection(
         ToolDef(
             "toolbox-proxy-port",
             gettext("Proxy Port"),
-            "gaphor-proxyport-symbolic",
+            "gaphor-proxy-port-symbolic",
             "x",
             new_item_factory(sysml_items.ProxyPortItem),
         ),

--- a/gaphor/ui/icons/Makefile
+++ b/gaphor/ui/icons/Makefile
@@ -19,7 +19,7 @@ ICONS=diagram \
 	value-specification-action \
 	call-behavior-action \
 	value-type \
-	proxyport \
+	proxy-port \
 	package \
 	containment \
 	interface \

--- a/gaphor/ui/icons/hicolor/scalable/actions/gaphor-proxy-port-symbolic.svg
+++ b/gaphor/ui/icons/hicolor/scalable/actions/gaphor-proxy-port-symbolic.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="15.006711"
+   height="15.996095"
+   viewBox="0 0 3.9705255 4.2323002"
+   version="1.1"
+   id="svg4268"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4262" />
+  <metadata
+     id="metadata4265">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     id="proxy-port"
+     transform="translate(-70.025569,-19.074788)">
+    <g
+       id="path908-1">
+      <path
+         style="color:#000000;fill:#000000;fill-opacity:0;stroke-width:0.424742;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+         d="m 71.562552,19.818019 v 2.842817 l 2.221091,-1e-6 v -2.842816 z"
+         id="path2448" />
+      <path
+         style="color:#000000;fill:#000000;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+         d="m 71.5625,19.605469 a 0.21239224,0.21239224 0 0 0 -0.212891,0.21289 v 2.841797 a 0.21239224,0.21239224 0 0 0 0.212891,0.212891 h 2.220703 a 0.21239224,0.21239224 0 0 0 0.212891,-0.212891 v -2.841797 a 0.21239224,0.21239224 0 0 0 -0.212891,-0.21289 z m 0.212891,0.425781 h 1.794921 v 2.417969 h -1.794921 z"
+         id="path2450" />
+    </g>
+    <path
+       style="color:#000000;fill:#000000;stroke-width:0.529167;stroke-linecap:square;stroke-linejoin:round;-inkscape-stroke:none"
+       d="m 70.025569,19.074788 v 0.529167 h 1.323951 v 3.176033 h -1.323951 v 0.5271 h 1.5875 a 0.26460981,0.26460981 0 0 0 0.263549,-0.26355 v -3.7052 a 0.26460981,0.26460981 0 0 0 -0.263549,-0.26355 z"
+       id="rect4893-97-8" />
+  </g>
+</svg>

--- a/gaphor/ui/icons/stencil.svg
+++ b/gaphor/ui/icons/stencil.svg
@@ -2299,8 +2299,8 @@
   </g>
   <g
      style="display:inline"
-     inkscape:label="proxyport"
-     id="proxyport"
+     inkscape:label="proxy-port"
+     id="proxy-port"
      inkscape:groupmode="layer">
     <g
        id="path908-1">


### PR DESCRIPTION
I added additional check to see if there exists an item on the diagram that may own the proxy port.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2612

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Additionally fixed proxy port drag icon. Automatically generated icon name is "proxy-port".