### PR TITLE
PyInstaller Spec File Updates

### DIFF
--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -1,4 +1,3 @@
-import logging
 import os
 import sys
 import time

--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -29,7 +29,9 @@ mo_files = [
 def get_version() -> Version:
     project_dir = Path.cwd().parent
     f = project_dir / "pyproject.toml"
-    return Version(tomllib.loads(f.read_text())["tool"]["poetry"]["version"])
+    return Version(
+        tomllib.loads(f.read_text(encoding="utf-8"))["tool"]["poetry"]["version"]
+    )
 
 
 def collect_entry_points(*names):

--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -1,12 +1,8 @@
 import os
-import sys
 import time
 from pathlib import Path
 
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
+import tomllib
 
 import pyinstaller_versionfile
 from packaging.version import Version


### PR DESCRIPTION
Small updates to the spec file:

1. Fix PEP 597 encoding error
2. Remove an unused import
3. Remove a version check, since all builds of Gaphor should be with Python 3.11+.


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Encoding warnings during CI/CD pipeline runs

Issue Number: N/A

### What is the new behavior?
Fewer warnings

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
