### PR TITLE
Reduce duplicate GitHub Action runs

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -2,7 +2,13 @@ name: Full Build
 
 on:
   push:
+    branches:
+      - main
+    paths-ignore:
+      - '*.md'
   pull_request:
+    branches:
+      - main
   release:
     types: [published]
 

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -13,6 +13,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   python_version: '3.11'
   mainline_build: ${{ github.ref == 'refs/heads/main' || github.event.label.name == 'translation' || github.event_name == 'release' }}

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -11,6 +11,7 @@ on:
       - main
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   python_version: '3.11'


### PR DESCRIPTION
Currently, when pushing a branch and opening a PR, GitHub Actions runs two complete builds. This PR tries to reduce duplicate runs by only running the full build when:

1. A PR is opened against the main branch
2. Push to the main branch
3. On release
4. On manually trigger a build with workflow dispatch from the actions menu

The tradeoff of this will be that if you want to run GitHub Actions, you'll need to open a draft PR or manually start it from the Actions tab, since pushing to a branch will not start a run.

I also added logic to cancel running previous workflows using concurrency.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
2 full builds for each push of a PR

Issue Number: N/A

### What is the new behavior?
Avoid duplicate builds under most circumstances

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
