### PR TITLE
Add SysML diagram frame item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Catch errors when a clipboard is empty
 - Fix DnD file opening on macOS
 - Fix libadwaita 1.4.0 missing for hypothesis tests
+- Replace ActivityItem specific property page with Activity specific property page
 
 2.22.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix DnD file opening on macOS
 - Fix libadwaita 1.4.0 missing for hypothesis tests
 - Replace ActivityItem specific property page with Activity specific property page
+- Replace diagram header with diagram frame item
 
 2.22.0
 ------

--- a/gaphor/SysML/__init__.py
+++ b/gaphor/SysML/__init__.py
@@ -1,3 +1,4 @@
+import gaphor.SysML.deletable
 import gaphor.SysML.diagramlabel
 import gaphor.SysML.drop
 import gaphor.SysML.iconname

--- a/gaphor/SysML/blocks/connectors.py
+++ b/gaphor/SysML/blocks/connectors.py
@@ -9,31 +9,42 @@ from gaphor.SysML.blocks.block import BlockItem
 from gaphor.SysML.blocks.interfaceblock import InterfaceBlockItem
 from gaphor.SysML.blocks.property import PropertyItem
 from gaphor.SysML.blocks.proxyport import ProxyPortItem
+from gaphor.SysML.diagramtype import DiagramFrameItem
 from gaphor.UML.deployments import ConnectorItem
 
 
 @Connector.register(InterfaceBlockItem, ProxyPortItem)
 @Connector.register(BlockItem, ProxyPortItem)
 @Connector.register(PropertyItem, ProxyPortItem)
+@Connector.register(DiagramFrameItem, ProxyPortItem)
 class BlockProperyProxyPortConnector:
     def __init__(
         self,
-        block_or_property: Union[BlockItem, PropertyItem, InterfaceBlockItem],
+        element: Union[BlockItem, PropertyItem, DiagramFrameItem, InterfaceBlockItem],
         proxy_port: ProxyPortItem,
     ) -> None:
-        self.element = block_or_property
+        self.element = element
         self.proxy_port = proxy_port
 
     def allow(self, handle: Handle, port: Port) -> bool:
-        return (
-            bool(self.element.diagram)
-            and self.element.diagram is self.proxy_port.diagram
-            and (
+        # Early return when diagrams are not the same
+        if (
+            not bool(self.element.diagram)
+            or self.element.diagram is not self.proxy_port.diagram
+        ):
+            return False
+
+        if isinstance(self.element, DiagramFrameItem):
+            # Allow only on blocks
+            return isinstance(self.element.subject, sysml.Block) and isinstance(
+                self.element.subject, UML.EncapsulatedClassifier
+            )
+        else:
+            return (
                 isinstance(self.element.subject, UML.EncapsulatedClassifier)
                 or isinstance(self.element.subject, UML.Property)
                 and isinstance(self.element.subject.type, UML.EncapsulatedClassifier)
             )
-        )
 
     def connect(self, handle: Handle, port: Port) -> bool:
         """Connect and reconnect at model level.

--- a/gaphor/SysML/deletable.py
+++ b/gaphor/SysML/deletable.py
@@ -1,0 +1,7 @@
+from gaphor.diagram.deletable import deletable
+from gaphor.SysML.diagramframe import DiagramFrameItem
+
+
+@deletable.register
+def deletable_diagram_frame_item(item: DiagramFrameItem):
+    return False

--- a/gaphor/SysML/diagramframe.py
+++ b/gaphor/SysML/diagramframe.py
@@ -1,0 +1,155 @@
+from gaphas.geometry import Rectangle
+
+from gaphor.core.modeling import DrawContext, UpdateContext
+from gaphor.core.styling import (
+    FontWeight,
+    TextAlign,
+)
+from gaphor.diagram.diagramlabel import diagram_label
+from gaphor.diagram.presentation import (
+    Classified,
+    ElementPresentation,
+    connect,
+)
+from gaphor.diagram.shapes import (
+    cairo_state,
+)
+from gaphor.diagram.text import Layout
+from gaphor.UML.actions.activity import ActivityParameterNodeItem
+from gaphor.UML.uml import Activity, ActivityParameterNode
+
+
+class DiagramFrameItem(Classified, ElementPresentation):
+    def __init__(self, diagram, id=None):
+        super().__init__(diagram, id)
+
+        self.watch("diagram[Diagram].name", self.update_shapes).watch(
+            "diagram[Diagram].diagramType", self.update_shapes
+        ).watch("diagram[Diagram].element", self.update_element).watch(
+            "subject", self.update_element
+        ).watch("subject[Activity].node", self.update_frame_attachments).watch(
+            "diagram[Diagram].element[NamedElement].name", self.update_shapes
+        )
+
+    def update_element(self, event=None):
+        if not self.diagram or not self.diagram.element:
+            return
+
+        self.subject = self.diagram.element
+        self.update_shapes()
+        self.update_frame_attachments()
+
+    def postload(self):
+        super().postload()
+        self.update_frame_attachments()
+
+    def update_shapes(self, event=None):
+        if not self.diagram:
+            return
+
+        self.shape = DiagramFrameShape(
+            kind=self.diagram.diagramType,
+            label=diagram_label(self.diagram),
+        )
+
+    def update_frame_attachments(self, event=None):
+        if not self.subject:
+            return
+
+        if isinstance(self.subject, Activity):
+            self.update_activity_parameters()
+
+    def update_activity_parameters(self):
+        assert self.diagram.element == self.subject
+        assert isinstance(self.subject, Activity)
+
+        diagram = self.diagram
+        subject = self.subject
+
+        assert isinstance(subject, Activity)
+
+        parameter_nodes = (
+            [p for p in subject.node if isinstance(p, ActivityParameterNode)]
+            if subject
+            else []
+        )
+        parameter_items = {
+            i.subject: i
+            for i in self.children
+            if isinstance(i, ActivityParameterNodeItem)
+        }
+
+        for node in parameter_nodes:
+            if node not in parameter_items:
+                item = diagram.create(
+                    ActivityParameterNodeItem, parent=self, subject=node
+                )
+                item.matrix.translate(0, 10)
+                connect(item, item.handles()[0], self)
+
+        for node in parameter_items:
+            if node not in parameter_nodes:
+                del self.children[parameter_items[node]]
+
+
+class DiagramFrameShape:
+    def __init__(self, kind: str, label: str):
+        self._kind_layout = self._create_layout(kind, FontWeight.BOLD)
+        self._label_layout = self._create_layout(f" {label}", FontWeight.NORMAL)
+
+        self._kind_size = self._kind_layout.size()
+        self._label_size = self._label_layout.size()
+        self._margin = 5
+
+    def _create_layout(self, text: str, font_weight: FontWeight):
+        layout = Layout()
+        layout.set(
+            text=text,
+            font={
+                "font-weight": font_weight,
+                "text-align": TextAlign.LEFT,
+                "font-family": "sans",
+                "font-size": 12,
+            },
+        )
+
+        return layout
+
+    def size(self, context: UpdateContext):
+        kind_w, kind_h = self._kind_size
+        label_w, label_h = self._label_size
+
+        self._header_width = 2 * self._margin + kind_w + label_w
+        self._header_height = 2 * self._margin + max(kind_h, label_h)
+
+        width = self._header_width + 30
+        height = self._header_height + 50
+
+        return width, height
+
+    def draw(self, context: DrawContext, bounding_box: Rectangle):
+        cr = context.cairo
+        x, y, width, height = bounding_box
+
+        cr.set_dash((), 0)
+        cr.rectangle(x, y, width, height)
+        cr.move_to(x, y + self._header_height)
+        cr.line_to(x + self._header_width, y + self._header_height)
+        cr.line_to(x + self._header_width + 10, y + self._header_height - 10)
+        cr.line_to(x + self._header_width + 10, y)
+        cr.line_to(x, y)
+        cr.close_path()
+
+        with cairo_state(context.cairo) as cr:
+            if text_color := context.style.get("text-color"):
+                cr.set_source_rgba(*text_color)
+
+            cr.move_to(x + self._margin, y + self._margin)
+            w, _ = self._kind_size
+            self._kind_layout.show_layout(cr, w, default_size=(w, self._header_height))
+
+            cr.move_to(x + self._margin + w, y + self._margin)
+            w, _ = self._label_size
+            self._label_layout.show_layout(cr, w, default_size=(w, self._header_height))
+
+        cr.stroke()

--- a/gaphor/SysML/diagramitems.py
+++ b/gaphor/SysML/diagramitems.py
@@ -1,3 +1,4 @@
 from gaphor.SysML.allocations import *
 from gaphor.SysML.blocks import *
 from gaphor.SysML.requirements import *
+from gaphor.SysML.diagramframe import DiagramFrameItem

--- a/gaphor/SysML/diagramlabel.py
+++ b/gaphor/SysML/diagramlabel.py
@@ -1,4 +1,4 @@
-from gaphor.diagram.diagramlabel import diagram_label
+from gaphor.diagram.diagramlabel import diagram_label, paint_diagram_type
 from gaphor.SysML.sysml import Block, ConstraintBlock, Requirement, SysMLDiagram
 from gaphor.UML.uml import Activity, Interaction, Package, Profile, StateMachine
 
@@ -28,3 +28,8 @@ def sysml_diagram_label(diagram):
         )
     # TODO: SysML specification does not allow parentless elements, but since it is not constrained (yet), it may happen.
     return diagram.name
+
+
+@paint_diagram_type.register(SysMLDiagram)
+def sysml_paint_diagram_type(diagram) -> bool:
+    return False

--- a/gaphor/SysML/diagramtype.py
+++ b/gaphor/SysML/diagramtype.py
@@ -2,6 +2,7 @@ from gaphor.diagram.diagramtoolbox import DiagramType
 from gaphor.diagram.general.diagramitem import DiagramItem
 from gaphor.diagram.group import change_owner
 from gaphor.diagram.support import represents
+from gaphor.SysML.diagramframe import DiagramFrameItem
 from gaphor.SysML.sysml import SysMLDiagram
 
 represents(SysMLDiagram)(DiagramItem)
@@ -42,5 +43,9 @@ class SysMLDiagramType(DiagramType):
         diagram.diagramType = self.id
         if element:
             change_owner(element, diagram)
+
+        frame = diagram.create(DiagramFrameItem, subject=diagram.element)
+        frame.width = max(600, frame.width)
+        frame.height = max(400, frame.height)
 
         return diagram

--- a/gaphor/SysML/tests/test_diagramitems.py
+++ b/gaphor/SysML/tests/test_diagramitems.py
@@ -5,6 +5,7 @@ from gaphor.diagram.general import CommentLineItem
 from gaphor.diagram.presentation import Classified, Named
 from gaphor.diagram.support import get_model_element
 from gaphor.SysML import diagramitems
+from gaphor.SysML.diagramframe import DiagramFrameItem
 from gaphor.UML import Classifier, NamedElement
 
 
@@ -28,7 +29,7 @@ def all_items_and_elements():
     [cls for cls in diagramitems.__dict__.values() if _issubclass(cls, Presentation)],
 )
 def test_all_diagram_items_have_a_model_element_mapping(item_class):
-    if item_class is CommentLineItem:
+    if item_class in (CommentLineItem, DiagramFrameItem):
         assert not get_model_element(item_class)
     else:
         assert get_model_element(item_class)

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -16,7 +16,6 @@ from gaphor.diagram.propertypages import (
 from gaphor.diagram.propertypages import (
     new_builder as diagram_new_builder,
 )
-from gaphor.UML.actions.activity import ActivityItem
 from gaphor.UML.classes.classespropertypages import on_keypress_event
 
 new_builder = new_resource_builder("gaphor.UML.actions")
@@ -25,11 +24,11 @@ new_builder = new_resource_builder("gaphor.UML.actions")
 class ActivityParameters(EditableTreeModel):
     """GTK tree model to edit class attributes."""
 
-    def __init__(self, item):
-        super().__init__(item, cols=(str, object))
+    def __init__(self, subject):
+        super().__init__(subject, cols=(str, object))
 
     def get_rows(self):
-        for node in self._item.subject.node:
+        for node in self._item.node:
             if isinstance(node, UML.ActivityParameterNode):
                 yield [format(node.parameter), node]
 
@@ -37,7 +36,7 @@ class ActivityParameters(EditableTreeModel):
         model = self._item.model
         node = model.create(UML.ActivityParameterNode)
         node.parameter = model.create(UML.Parameter)
-        self._item.subject.node = node
+        self._item.node = node
         return node
 
     @transactional
@@ -51,29 +50,29 @@ class ActivityParameters(EditableTreeModel):
             row[0] = format(node.parameter)
 
     def swap_objects(self, o1, o2):
-        return self._item.subject.node.swap(o1, o2)
+        return self._item.node.swap(o1, o2)
 
     def sync_model(self, new_order):
-        self._item.subject.node.order(
+        self._item.node.order(
             lambda key: new_order.index(key) if key in new_order else -1
         )
 
 
-@PropertyPages.register(ActivityItem)
-class ActivityItemPage(PropertyPageBase):
+@PropertyPages.register(UML.Activity)
+class ActivityPropertyPage(PropertyPageBase):
     order = 40
 
-    def __init__(self, item: ActivityItem):
-        self.item = item
-        self.watcher = item.subject and item.subject.watcher()
+    def __init__(self, subject: UML.Activity):
+        self.subject = subject
+        self.watcher = subject and subject.watcher()
 
     def construct(self):
-        subject = self.item.subject
+        subject = self.subject
 
         if not subject:
             return
 
-        self.model = ActivityParameters(self.item)
+        self.model = ActivityParameters(subject)
 
         builder = new_builder(
             "activity-editor",

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -4,15 +4,15 @@ from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
 from gaphor.UML.actions.activity import ActivityItem
 from gaphor.UML.actions.activitypropertypage import (
-    ActivityItemPage,
     ActivityParameterNodeNamePropertyPage,
     ActivityParameters,
+    ActivityPropertyPage,
 )
 
 
 def test_activity_parameter_node_editing(create):
     activity_item = create(ActivityItem, UML.Activity)
-    model = ActivityParameters(activity_item)
+    model = ActivityParameters(activity_item.subject)
     model.append([None, None])
     path = Gtk.TreePath.new_first()
     iter = model.get_iter(path)
@@ -35,7 +35,7 @@ def test_activity_parameter_node_reorder(create, element_factory):
     node2 = activity_parameter_node("param2")
     node3 = activity_parameter_node("param3")
 
-    list_store = ActivityParameters(activity_item)
+    list_store = ActivityParameters(activity_item.subject)
 
     new_order = [node3, node1, node2]
     list_store.sync_model(new_order)
@@ -47,7 +47,7 @@ def test_activity_parameter_node_reorder(create, element_factory):
 
 def test_activity_page_add_attribute(create):
     activity_item = create(ActivityItem, UML.Activity)
-    property_page = ActivityItemPage(activity_item)
+    property_page = ActivityPropertyPage(activity_item.subject)
 
     property_page.construct()
     iter = property_page.model.get_iter((0,))

--- a/gaphor/diagram/diagramlabel.py
+++ b/gaphor/diagram/diagramlabel.py
@@ -4,3 +4,8 @@ from functools import singledispatch
 @singledispatch
 def diagram_label(diagram):
     return diagram.name
+
+
+@singledispatch
+def paint_diagram_type(diagram) -> bool:
+    return bool(diagram.diagramType)

--- a/gaphor/diagram/painter.py
+++ b/gaphor/diagram/painter.py
@@ -12,7 +12,7 @@ from cairo import LINE_JOIN_ROUND
 from gi.repository import GLib, Pango, PangoCairo
 
 from gaphor.core.modeling.diagram import DrawContext, StyledDiagram, StyledItem
-from gaphor.diagram.diagramlabel import diagram_label
+from gaphor.diagram.diagramlabel import diagram_label, paint_diagram_type
 from gaphor.diagram.selection import Selection
 
 
@@ -62,7 +62,8 @@ class DiagramTypePainter:
 
     def paint(self, _items, cr):
         diagram = self.diagram
-        if not diagram.diagramType:
+
+        if not paint_diagram_type(diagram):
             return
         style = diagram.style(StyledDiagram(diagram))
         layout = PangoCairo.create_layout(cr)

--- a/gaphor/diagram/tools/shortcut.py
+++ b/gaphor/diagram/tools/shortcut.py
@@ -2,7 +2,10 @@ from gaphas.view import GtkView
 from gi.repository import Gdk, Gtk
 
 from gaphor.core import Transaction
-from gaphor.core.modeling import Presentation, self_and_owners
+from gaphor.core.modeling import Presentation
+from gaphor.diagram.deletable import deletable
+from gaphor.event import Notification
+from gaphor.i18n import gettext
 
 
 def shortcut_tool(view, event_manager):
@@ -29,6 +32,9 @@ def delete_selected_items(view: GtkView, event_manager):
         items = view.selection.selected_items
         for i in list(items):
             assert isinstance(i, Presentation)
-            if i.subject and i.subject in self_and_owners(i.diagram):
-                del i.diagram.element
-            i.unlink()
+            if deletable(i):
+                i.unlink()
+            else:
+                event_manager.handle(
+                    Notification(gettext("Selected diagram item is not deletable"))
+                )

--- a/gaphor/diagram/tools/tests/test_shortcut.py
+++ b/gaphor/diagram/tools/tests/test_shortcut.py
@@ -20,6 +20,7 @@ def test_delete_selected_items(create, diagram, event_manager):
     assert not diagram.ownedPresentation
 
 
+# TODO: Do we still want this feature?
 def test_delete_selected_owner(create, diagram, event_manager):
     package_item = create(PackageItem, UML.Package)
     diagram.element = package_item.subject


### PR DESCRIPTION
* Refactors activity item property page as just activity property page, because it did not have item-specific properties. Prerequisite for diagram frame property page.
* Ensures that all SysML diagrams have a frame presenting diagram's element.
* Diagram frame item's property page is the same as the underlying element's property page.
* Migrates older models to automatically attach the frame item on SysML diagrams; replaces a single diagram's element representation, if present, with diagram frame item.

It makes it more explicit what element the diagram represents; what are its interfaces, if any. Overall, the diagrams would look much clearer, conforms better with SysML specification, and allows to be future compatible and control better the way each diagram looks like and "behaves".

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Currently, the diagram frame is attached to the diagram page. In order to get the ports/parameters of the diagram's element; you need to drag the element from the model browser onto the diagram and get the ports/parameters from there.

Issue Number: #2213 (partially)

### What is the new behavior?

See top description.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

Kinda. It modifies existing SysML diagrams to include diagram frame; and replaces diagram's element representation (only if one is found) with a frame item. So, existing diagrams are expected to change.

### Other information

This is prerequisite to complete parametric modelling. I did not want to do this without the proper frame.

It would support potential future features such as preventing adding activities onto activity diagram, instead, when dropping activity, we can automatically replace this with CallBehaviorAction; or when the activity was dropped on the Action, we can convert the Action into CallBehaviorAction → I see this as a great user experience improvement.

https://github.com/gaphor/gaphor/assets/45357878/7ecac5f8-9708-4a65-b460-5298e09c4f46
