### PR TITLE
Fix wrong path in project flatpak manifest

### DIFF
--- a/org.gaphor.Gaphor.json
+++ b/org.gaphor.Gaphor.json
@@ -65,7 +65,7 @@
       "buildsystem": "simple",
       "build-commands": [
         "pip3 install --ignore-installed --prefix=${FLATPAK_DEST} .",
-        "install -D org.gaphor.Gaphor.gschema.xml /app/share/glib-2.0/schemas/org.gaphor.Gaphor.gschema.xml",
+        "install -D data/org.gaphor.Gaphor.gschema.xml /app/share/glib-2.0/schemas/org.gaphor.Gaphor.gschema.xml",
         "glib-compile-schemas /app/share/glib-2.0/schemas"
       ],
       "sources": [


### PR DESCRIPTION
When opening the project with Builder and trying to run it, the build is failing due to the wrong path for the gschema settings definition.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Build fails due to file not found

Issue Number: N/A

### What is the new behavior?
Build passes and project runs.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
