### PR TITLE
Settings cleanup

### DIFF
--- a/gaphor/i18n.py
+++ b/gaphor/i18n.py
@@ -57,7 +57,7 @@ def translation(lang) -> _gettext.GNUTranslations | _gettext.NullTranslations:
     return _gettext.NullTranslations()
 
 
-if settings and settings.get_boolean("use-english"):
+if settings.use_english:
     gettext = translation("en_US.UTF-8").gettext
 else:
     gettext = translation(os.getenv("LANG") or _get_os_language()).gettext

--- a/gaphor/settings.py
+++ b/gaphor/settings.py
@@ -1,6 +1,7 @@
 """Application settings support for Gaphor."""
 
 import logging
+from enum import Enum
 
 from gi.repository import Gio
 
@@ -9,21 +10,60 @@ APPLICATION_ID = "org.gaphor.Gaphor"
 logger = logging.getLogger(__name__)
 
 
-class Settings(Gio.Settings):
+class StyleVariant(Enum):
+    SYSTEM = 0
+    DARK = 1
+    LIGHT = 2
+
+
+class Settings:
     """Gaphor settings."""
 
-    @classmethod
-    def new(cls) -> Gio.Settings | None:
-        """Create a new Settings object."""
+    def __init__(self):
         schema_source = Gio.SettingsSchemaSource.get_default()
-        if schema_source.lookup(APPLICATION_ID, False):
-            gio_settings = Gio.Settings.new(APPLICATION_ID)
-            gio_settings.__class__ = Settings
-            return gio_settings
-        logger.info(
-            "Settings schema not found and settings won't be saved, run `poe install-schemas`"
+        self._gio_settings = (
+            Gio.Settings.new(APPLICATION_ID)
+            if schema_source.lookup(APPLICATION_ID, False)
+            else None
         )
-        return None
+        if not self._gio_settings:
+            logger.warning(
+                "Settings schema not found and settings won't be saved, run `poe install-schemas`"
+            )
+
+    @property
+    def style_variant(self) -> StyleVariant:
+        return (
+            StyleVariant(self._gio_settings.get_enum("style-variant"))
+            if self._gio_settings
+            else StyleVariant.SYSTEM
+        )
+
+    @style_variant.setter
+    def style_variant(self, style_variant: StyleVariant):
+        if self._gio_settings:
+            self._gio_settings.set_enum("style-variant", style_variant.value)
+
+    def bind_style_variant(self, target, prop):
+        # Bind with mapping not supported by PyGObject: https://gitlab.gnome.org/GNOME/pygobject/-/issues/98
+        # To bind to a function that can map between guint and a string
+        if self._gio_settings:
+            style_variant = self._gio_settings.get_enum("style-variant")
+            target.set_property(prop, style_variant)
+
+    @property
+    def use_english(self) -> bool:
+        return (  # type: ignore[no-any-return]
+            self._gio_settings.get_boolean("use-english")
+            if self._gio_settings
+            else False
+        )
+
+    def bind_use_english(self, target, prop):
+        if self._gio_settings:
+            self._gio_settings.bind(
+                "use-english", target, prop, Gio.SettingsBindFlags.DEFAULT
+            )
 
 
-settings = Settings.new()
+settings = Settings()

--- a/gaphor/settings.py
+++ b/gaphor/settings.py
@@ -51,6 +51,15 @@ class Settings:
             style_variant = self._gio_settings.get_enum("style-variant")
             target.set_property(prop, style_variant)
 
+    def style_variant_changed(self, callback):
+        if self._gio_settings:
+
+            def _on_changed(_settings, _name):
+                callback(self.style_variant)
+
+            self._gio_settings.connect("changed::style-variant", _on_changed)
+            callback(self.style_variant)
+
     @property
     def use_english(self) -> bool:
         return (  # type: ignore[no-any-return]

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -78,10 +78,19 @@ def run(argv: list[str]) -> int:
             for file in files:
                 application.new_session(filename=file.get_path())
 
+    def update_color_scheme(style_variant: StyleVariant):
+        gtk_app.get_style_manager().set_color_scheme(
+            {
+                StyleVariant.DARK: Adw.ColorScheme.FORCE_DARK,
+                StyleVariant.LIGHT: Adw.ColorScheme.FORCE_LIGHT,
+            }.get(style_variant, Adw.ColorScheme.DEFAULT)
+        )
+
     gtk_app = Adw.Application(
         application_id=APPLICATION_ID, flags=Gio.ApplicationFlags.HANDLES_OPEN
     )
-    update_color_scheme(gtk_app, settings.style_variant)
+
+    settings.style_variant_changed(update_color_scheme)
     gtk_app.exit_code = 0
     add_main_options(gtk_app)
     gtk_app.connect("startup", app_startup)
@@ -100,15 +109,6 @@ def add_main_options(gtk_app):
         GLib.OptionArg.NONE,
         "Run self test and exit",
         None,
-    )
-
-
-def update_color_scheme(app: Adw.Application, style_variant: StyleVariant):
-    app.get_style_manager().set_color_scheme(
-        {
-            StyleVariant.DARK: Adw.ColorScheme.FORCE_DARK,
-            StyleVariant.LIGHT: Adw.ColorScheme.FORCE_LIGHT,
-        }.get(style_variant, Adw.ColorScheme.DEFAULT)
     )
 
 

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -16,9 +16,8 @@ from gi.repository import Adw, Gio, GLib, Gtk, GtkSource
 from gaphor.application import Application, Session
 from gaphor.core import event_handler
 from gaphor.event import ActiveSessionChanged, ApplicationShutdown, SessionCreated
+from gaphor.settings import APPLICATION_ID, settings, StyleVariant
 from gaphor.ui.actiongroup import apply_application_actions
-
-APPLICATION_ID = "org.gaphor.Gaphor"
 
 Adw.init()
 GtkSource.init()
@@ -82,6 +81,7 @@ def run(argv: list[str]) -> int:
     gtk_app = Adw.Application(
         application_id=APPLICATION_ID, flags=Gio.ApplicationFlags.HANDLES_OPEN
     )
+    update_color_scheme(gtk_app, settings.style_variant)
     gtk_app.exit_code = 0
     add_main_options(gtk_app)
     gtk_app.connect("startup", app_startup)
@@ -100,6 +100,15 @@ def add_main_options(gtk_app):
         GLib.OptionArg.NONE,
         "Run self test and exit",
         None,
+    )
+
+
+def update_color_scheme(app: Adw.Application, style_variant: StyleVariant):
+    app.get_style_manager().set_color_scheme(
+        {
+            StyleVariant.DARK: Adw.ColorScheme.FORCE_DARK,
+            StyleVariant.LIGHT: Adw.ColorScheme.FORCE_LIGHT,
+        }.get(style_variant, Adw.ColorScheme.DEFAULT)
     )
 
 

--- a/gaphor/ui/help/__init__.py
+++ b/gaphor/ui/help/__init__.py
@@ -15,7 +15,7 @@ from gaphor.application import distribution
 from gaphor.core import action
 from gaphor.i18n import translated_ui_string, gettext
 from gaphor.settings import settings, StyleVariant
-from gaphor.ui import update_color_scheme
+
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +74,6 @@ class HelpService(Service, ActionProvider):
                 settings.style_variant =  StyleVariant.LIGHT
             else:
                 settings.style_variant =  StyleVariant.SYSTEM
-            update_color_scheme(gtk_app, settings.style_variant)
 
     def _on_use_english_selected(self, switch_row: Adw.SwitchRow, param) -> None:
         if self.preferences_window:

--- a/gaphor/ui/help/__init__.py
+++ b/gaphor/ui/help/__init__.py
@@ -65,7 +65,7 @@ class HelpService(Service, ActionProvider):
         shortcuts.set_visible(True)
         return shortcuts
 
-    def _on_dark_mode_selected(self, combo_row: Adw.ComboRow, param) -> None:
+    def _on_style_variant_selected(self, combo_row: Adw.ComboRow, param) -> None:
         if gtk_app := self.application.gtk_app:
             selected = combo_row.props.selected_item
             if selected.props.string == "Dark":
@@ -95,15 +95,15 @@ class HelpService(Service, ActionProvider):
         self.preferences_window.set_modal(True)
         self.preferences_window.set_transient_for(self.window)
 
-        dark_mode_selection: Adw.ComboRow = builder.get_object("dark_mode_selection")
+        style_variant: Adw.ComboRow = builder.get_object("style_variant")
         use_english: Adw.SwitchRow = builder.get_object("use_english")
 
         settings.bind_use_english(use_english, "active")
         use_english.connect("notify::active", self._on_use_english_selected)
 
-        settings.bind_style_variant(dark_mode_selection, "selected")
-        dark_mode_selection.connect(
-            "notify::selected-item", self._on_dark_mode_selected
+        settings.bind_style_variant(style_variant, "selected")
+        style_variant.connect(
+            "notify::selected-item", self._on_style_variant_selected
         )
 
         self.preferences_window.set_visible(True)

--- a/gaphor/ui/help/preferences.ui
+++ b/gaphor/ui/help/preferences.ui
@@ -11,7 +11,7 @@
                     <object class="AdwPreferencesGroup">
                         <property name="title" translatable="true">Colors</property>
                         <child>
-                            <object class="AdwComboRow" id="dark_mode_selection">
+                            <object class="AdwComboRow" id="style_variant">
                                 <property name="title">Force Dark or Light Color Scheme</property>
                                 <property name="model">
                                     <object class="GtkStringList">

--- a/gaphor/ui/tests/test_help.py
+++ b/gaphor/ui/tests/test_help.py
@@ -18,8 +18,8 @@ def test_preferences(builder):
 
 
 def test_preferences_dark_mode(builder):
-    dark_mode_selection = builder.get_object("dark_mode_selection")
-    assert dark_mode_selection.get_selected() == 0
+    style_variant = builder.get_object("style_variant")
+    assert style_variant.get_selected() == 0
 
 
 def test_preferences_use_english(builder):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

If a preferred color scheme is selected, it's not set when you (re)start the application.

Issue Number: N/A

### What is the new behavior?

I made the Settings object a more rich object and moved many of the settings there. This makes the interface we have to use easier (no optional `None` object).

Changed the message that settings cannot be loaded to warning, so it's shown before the logging module is configured.

The application color scheme is updated according to the setting in a reactive fashion.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
