### PR TITLE
Fix grouping: allow to group to "root"

### DIFF
--- a/gaphor/diagram/group.py
+++ b/gaphor/diagram/group.py
@@ -17,10 +17,10 @@ from gaphor.core.modeling import Diagram, Element, self_and_owners
 
 
 def change_owner(new_parent, element):
-    if element.model is not new_parent.model:
+    if new_parent and element.model is not new_parent.model:
         return False
 
-    if element.owner is new_parent:
+    if new_parent and element.owner is new_parent:
         return False
 
     if new_parent is None and element.owner:

--- a/gaphor/diagram/tests/test_group.py
+++ b/gaphor/diagram/tests/test_group.py
@@ -57,3 +57,12 @@ def test_cannot_change_owner_from_different_models(element_factory):
     parent = other_element_factory.create(Element)
 
     assert not change_owner(parent, diagram)
+
+
+def test_change_owner_to_root(element_factory):
+    diagram = element_factory.create(Diagram)
+    parent = element_factory.create(Element)
+    change_owner(parent, diagram)
+
+    assert change_owner(None, diagram)
+    assert diagram.owner is None


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

In the model browser, elements cannot be dragged to the model root.

Issue Number:  #2734

### What is the new behavior?

Elements can be dragged to root.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
