### PR TITLE
Fix pipx install error in Linux

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -11,13 +11,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install Poetry (Linux)
-      if: runner.os == 'Linux'
-      run: pipx install --python python${{ inputs.python-version }} --pip-args=--constraint=.github/constraints.txt poetry
-      shell: bash
-    - name: Install Poetry (Windows/macOS)
-      if: runner.os != 'Linux'
-      run: pipx install --pip-args=--constraint=.github/constraints.txt poetry
+    - name: Install Poetry
+      run: pipx install --python ${{ inputs.python-version }} --pip-args=--constraint=.github/constraints.txt poetry
       shell: bash
     - name: Configure Poetry
       run: poetry config virtualenvs.in-project true

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -180,7 +180,7 @@ jobs:
         run: >
           brew update && brew install gtk4 gtksourceview5 libadwaita
           adwaita-icon-theme gobject-introspection graphviz create-dmg upx
-          python-launcher
+          python-launcher pipx && pipx ensurepath
       - name: Set up Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -180,6 +180,7 @@ jobs:
         run: >
           brew update && brew install gtk4 gtksourceview5 libadwaita
           adwaita-icon-theme gobject-introspection graphviz create-dmg upx
+          python-launcher
       - name: Set up Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
@@ -193,6 +194,8 @@ jobs:
       - name: Install Dependencies
         id: install
         uses: ./.github/actions/install
+        with:
+          python-version: ${{ env.python_version }}
       - name: Run Gaphor Tests
         run: poetry run pytest --cov
       - name: Create macOS Application
@@ -345,6 +348,8 @@ jobs:
       - name: Install Dependencies
         id: install
         uses: ./.github/actions/install
+        with:
+          python-version: ${{ env.python_version }}
       - name: Run Gaphor Tests
         run: poetry run pytest --cov
       - name: Create Windows Executables


### PR DESCRIPTION
My [pipx improvement](https://github.com/pypa/pipx/pull/1002) to use pylauncher to get the Python version from earlier in the year was released in pipx 1.3. This allows us to have common code to install using pipx, but also broke the build in Linux because the Linux runners have pylauncher and we weren't using the `--python 3.12` syntax needed.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Linux build is failing

Issue Number: N/A

### What is the new behavior?
Linux build is passing

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
