### PR TITLE
Update labeler to be compatible with v5 release

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,19 @@
 packaging:
-  - _packaging/**/*
+  - changed-files:
+    - any-glob-to-any-file: '_packaging/**/*'
 translation:
-  - po/*
-  - docs/locale/**/*
+  - changed-files:
+    - any-glob-to-any-file: 'po/*'
+    - any-glob-to-any-file: 'docs/locale/**/*'
 documentation:
-  - docs/*.md
-  - docs/*.rst
-  - '*.md'
+  - changed-files:
+    - any-glob-to-any-file: 'docs/*.md'
+    - any-glob-to-any-file: 'docs/*.rst'
+    - any-glob-to-any-file: '*.md'
 python:
-  - gaphor/**/*.py
+  - changed-files:
+    - any-glob-to-any-file: 'gaphor/**/*.py'
 skip-changelog:
-  - .pre-commit-config.yaml
-  - .all-contributorsrc
+  - changed-files:
+    - any-glob-to-any-file: '.pre-commit-config.yaml'
+    - any-glob-to-any-file: '.all-contributorsrc'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,6 +20,3 @@ jobs:
     - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        # Prevent labels removed until next major labeler release
-        # https://github.com/actions/labeler/issues/442
-        sync-labels: ''

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,3 +20,4 @@ jobs:
     - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: false


### PR DESCRIPTION
The labeler action updated to v5 which was a breaking change. It passed the tests here:
https://github.com/gaphor/gaphor/actions/runs/7093586044

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Labeler action has broken the build

Issue Number: N/A

### What is the new behavior?
The build passes now

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

### Other information
