### PR TITLE
Replace in-app notificatins by Adwaita Toasts

### DIFF
--- a/gaphor/ui/help/preferences.ui
+++ b/gaphor/ui/help/preferences.ui
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
     <requires lib="gtk" version="4.0"/>
+    <requires lib="adw" version="1.0"/>
     <object class="AdwPreferencesWindow" id="preferences">
         <property name="title" translatable="true">Preferences</property>
         <child>

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -211,7 +211,7 @@ class MainWindow(Service, ActionProvider):
 
         window.connect("notify::is-active", self._on_window_active)
 
-        self.in_app_notifier = InAppNotifier(builder)
+        self.in_app_notifier = InAppNotifier(main_content)
         em = self.event_manager
         em.subscribe(self._on_undo_manager_state_changed)
         em.subscribe(self._on_action_enabled)

--- a/gaphor/ui/mainwindow.ui
+++ b/gaphor/ui/mainwindow.ui
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
+  <requires lib="adw" version="1.0"/>
   <object class="GtkPopoverMenu" id="hamburger">
   </object>
   <object class="GtkPopoverMenu" id="recent-files">
@@ -89,39 +90,7 @@
       </object>
     </child>
     <child>
-      <object class="GtkOverlay" id="main-content">
-        <property name="name">overlay</property>
-        <child type="overlay">
-          <object class="GtkRevealer" id="notification-revealer">
-            <property name="halign">center</property>
-            <property name="valign">start</property>
-            <property name="child">
-              <object class="GtkBox">
-                <property name="halign">center</property>
-                <property name="valign">start</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkLabel" id="notification-message">
-                    <property name="margin-start">6</property>
-                    <property name="label">Here goes a short informative message.</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkButton" id="notification-close">
-                    <child>
-                      <object class="GtkImage">
-                        <property name="icon_name">window-close-symbolic</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <style>
-                  <class name="app-notification"/>
-                </style>
-              </object>
-            </property>
-          </object>
-        </child>
+      <object class="AdwToastOverlay" id="main-content">
       </object>
     </child>
   </object>

--- a/gaphor/ui/tests/test_notifier.py
+++ b/gaphor/ui/tests/test_notifier.py
@@ -1,26 +1,32 @@
 import pytest
+from gi.repository import Adw
 
 from gaphor.event import Notification
-from gaphor.ui.mainwindow import new_builder
 from gaphor.ui.notification import InAppNotifier
 
 
 @pytest.fixture
-def builder():
-    return new_builder()
-
-
-@pytest.fixture
-def in_app_notifier(builder):
-    return InAppNotifier(builder)
-
-
-def test_notifier_has_widgets(in_app_notifier):
-    assert in_app_notifier.revealer
-    assert in_app_notifier.message_label
+def in_app_notifier():
+    return InAppNotifier(Adw.ToastOverlay.new())
 
 
 def test_notifier_can_handle_message(in_app_notifier):
-    in_app_notifier.handle(Notification("a message"))
+    toast = in_app_notifier.handle(Notification("a message"))
 
-    assert in_app_notifier.revealer.get_reveal_child()
+    assert toast
+
+
+def test_notifier_can_collapse_multiple_messages(in_app_notifier):
+    toast1 = in_app_notifier.handle(Notification("a message"))
+    toast2 = in_app_notifier.handle(Notification("a message"))
+
+    assert toast1
+    assert not toast2
+
+
+def test_notifier_show_messages_when_previous_message_is_dismissed(in_app_notifier):
+    toast1 = in_app_notifier.handle(Notification("a message"))
+    toast1.dismiss()
+    toast2 = in_app_notifier.handle(Notification("a message"))
+
+    assert toast2


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

We've been using old-skool in-app notifications till now. The Preferences window already uses toasts.

Issue Number: #2760

### What is the new behavior?

We use toasts :)

<img width="1248" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/bcb9cfde-0354-4dc9-96cd-612aef8817b6">
