### PR TITLE
Fix macOS build

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -6,7 +6,7 @@ outputs:
     value: ${{ steps.meta.outputs.version }}
 inputs:
   python-version:
-    description: 'Python version number for Linux'
+    description: 'Python version. Can be a version python$V or $V depending on the platform.'
     required: false
 runs:
   using: composite

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -180,7 +180,6 @@ jobs:
         run: >
           brew update && brew install gtk4 gtksourceview5 libadwaita
           adwaita-icon-theme gobject-introspection graphviz create-dmg upx
-          python-launcher pipx && pipx ensurepath
       - name: Set up Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
@@ -195,7 +194,7 @@ jobs:
         id: install
         uses: ./.github/actions/install
         with:
-          python-version: ${{ env.python_version }}
+          python-version: python${{ env.python_version }}
       - name: Run Gaphor Tests
         run: poetry run pytest --cov
       - name: Create macOS Application


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The macOS build fails when installing dependencies with an error:

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3-3.12
Target /usr/local/bin/2to3-3.12
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3-3.12'
```

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Pipx is said to be pre-installed on all runners. Although it doesn't seem to work on all.
It looks like the WIndows runner is dependent on python-launcher.

For macOS we do not need that per se. Hence I removed it and just changed the python version so it matches the old style (`python3.12`).

