### PR TITLE
Update ⓘ icon, so it also shows on macOS

### DIFF
--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -340,7 +340,7 @@
         <child>
           <object class="GtkLabel" id="parameters-info-icon">
             <property name="halign">end</property>
-            <property name="label" translatable="yes">🛈 Help</property>
+            <property name="label" translatable="yes">ⓘ Help</property>
             <child>
               <object class="GtkPopover" id="parameters-info">
                 <property name="visible">0</property>

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -64,7 +64,7 @@
             <child>
               <object class="GtkLabel" id="head-info-icon">
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">🛈 Help</property>
+                <property name="label" translatable="yes">ⓘ Help</property>
                 <child>
                   <object class="GtkPopover" id="head-info">
                     <property name="visible">0</property>
@@ -199,7 +199,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <child>
               <object class="GtkLabel" id="tail-info-icon">
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">🛈 Help</property>
+                <property name="label" translatable="yes">ⓘ Help</property>
                 <child>
                   <object class="GtkPopover" id="tail-info">
                     <property name="visible">0</property>
@@ -399,7 +399,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <child>
           <object class="GtkLabel" id="attributes-info-icon">
             <property name="halign">end</property>
-            <property name="label" translatable="yes">🛈 Help</property>
+            <property name="label" translatable="yes">ⓘ Help</property>
 
             <child>
               <object class="GtkPopover" id="attributes-info">
@@ -634,7 +634,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
           <object class="GtkLabel" id="operations-info-icon">
             <property name="visible">1</property>
             <property name="halign">end</property>
-            <property name="label" translatable="yes">🛈 Help</property>
+            <property name="label" translatable="yes">ⓘ Help</property>
             <child>
               <object class="GtkPopover" id="operations-info">
                 <property name="visible">0</property>
@@ -742,7 +742,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
           <object class="GtkLabel" id="enumerations-info-icon">
             <property name="visible">1</property>
             <property name="halign">end</property>
-            <property name="label" translatable="yes">🛈 Help</property>
+            <property name="label" translatable="yes">ⓘ Help</property>
 
             <child>
               <object class="GtkPopover" id="enumerations-info">

--- a/po/ca.po
+++ b/po/ca.po
@@ -792,7 +792,7 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
+msgid "ⓘ Help"
 msgstr ""
 
 #: gaphor/UML/actions/propertypages.ui:288

--- a/po/cs.po
+++ b/po/cs.po
@@ -755,8 +755,8 @@ msgstr "Parametr Uzlů"
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Nápověda"
+msgid "ⓘ Help"
+msgstr "ⓘ Nápověda"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/de.po
+++ b/po/de.po
@@ -754,8 +754,8 @@ msgstr "Knotenparameter"
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Hilfe"
+msgid "ⓘ Help"
+msgstr "ⓘ Hilfe"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/es.po
+++ b/po/es.po
@@ -751,8 +751,8 @@ msgstr "Nodos de parámetros"
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Ayuda"
+msgid "ⓘ Help"
+msgstr "ⓘ Ayuda"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -761,8 +761,8 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Ohje"
+msgid "ⓘ Help"
+msgstr "ⓘ Ohje"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -773,8 +773,8 @@ msgstr "Paramètres des Nœuds"
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Aide"
+msgid "ⓘ Help"
+msgstr "ⓘ Aide"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/gaphor.pot
+++ b/po/gaphor.pot
@@ -749,7 +749,7 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
+msgid "ⓘ Help"
 msgstr ""
 
 #: gaphor/UML/actions/propertypages.ui:288

--- a/po/gl.po
+++ b/po/gl.po
@@ -759,8 +759,8 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Axuda"
+msgid "ⓘ Help"
+msgstr "ⓘ Axuda"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -754,8 +754,8 @@ msgstr "Čvorovi parametara"
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Pomoć"
+msgid "ⓘ Help"
+msgstr "ⓘ Pomoć"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -754,8 +754,8 @@ msgstr "Paraméter csomópontok"
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Súgó"
+msgid "ⓘ Help"
+msgstr "ⓘ Súgó"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/it.po
+++ b/po/it.po
@@ -811,7 +811,7 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
+msgid "ⓘ Help"
 msgstr ""
 
 #: gaphor/UML/actions/propertypages.ui:288

--- a/po/ja.po
+++ b/po/ja.po
@@ -778,7 +778,7 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
+msgid "ⓘ Help"
 msgstr ""
 
 #: gaphor/UML/actions/propertypages.ui:288

--- a/po/ko.po
+++ b/po/ko.po
@@ -793,7 +793,7 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
+msgid "ⓘ Help"
 msgstr ""
 
 #: gaphor/UML/actions/propertypages.ui:288

--- a/po/nl.po
+++ b/po/nl.po
@@ -751,8 +751,8 @@ msgstr "Parameter­knoop"
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Help"
+msgid "ⓘ Help"
+msgstr "ⓘ Help"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -754,7 +754,7 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
+msgid "ⓘ Help"
 msgstr ""
 
 #: gaphor/UML/actions/propertypages.ui:288

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -757,8 +757,8 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Ajuda"
+msgid "ⓘ Help"
+msgstr "ⓘ Ajuda"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -752,8 +752,8 @@ msgstr "Узлы Параметров"
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Справка"
+msgid "ⓘ Help"
+msgstr "ⓘ Справка"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -753,7 +753,7 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
+msgid "ⓘ Help"
 msgstr ""
 
 #: gaphor/UML/actions/propertypages.ui:288

--- a/po/sv.po
+++ b/po/sv.po
@@ -777,8 +777,8 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Hjälp"
+msgid "ⓘ Help"
+msgstr "ⓘ Hjälp"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -752,7 +752,7 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
+msgid "ⓘ Help"
 msgstr ""
 
 #: gaphor/UML/actions/propertypages.ui:288

--- a/po/tr.po
+++ b/po/tr.po
@@ -754,8 +754,8 @@ msgstr "Parametre Düğümleri"
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 Yardım"
+msgid "ⓘ Help"
+msgstr "ⓘ Yardım"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -757,8 +757,8 @@ msgstr ""
 #: gaphor/UML/classes/propertypages.ui:402
 #: gaphor/UML/classes/propertypages.ui:637
 #: gaphor/UML/classes/propertypages.ui:745
-msgid "🛈 Help"
-msgstr "🛈 帮助"
+msgid "ⓘ Help"
+msgstr "ⓘ 帮助"
 
 #: gaphor/UML/actions/propertypages.ui:288
 msgid ""


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The Info icon for help is not showing.

Issue Number: N/A

### What is the new behavior?

Replaced by `ⓘ`. Now it shows

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Should check if it looks okay on Linux and Windows too.
