### PR TITLE
Less padding around windows on macOS

### DIFF
--- a/gaphor/ui/styling-macos.css
+++ b/gaphor/ui/styling-macos.css
@@ -1,0 +1,21 @@
+/*
+ * Styling workarounds on macOS.
+ *
+ * The issue: shadows defined by libadwaita are very wide: up to 60px.
+ * The shadow is drawn inside the (clickable) window.
+ *
+ * These styles change the (window) background to be a lot more compact.
+ * This results in a smaller shadow around the window, and as such a
+ * smaller click surface for the whole window, making it feel less awkward
+ * when you click just outside the window.
+ *
+ * See: https://gitlab.gnome.org/GNOME/gtk/-/issues/6255
+ */
+ .csd {
+    box-shadow: 2px 3px 12px 6px alpha(black, .2),
+                0px 0px 0px 1px alpha(black, .1);
+}
+.csd:backdrop {
+    box-shadow: 2px 3px 12px 6px alpha(black, .1),
+                0px 0px 0px 1px alpha(black, .1);
+}

--- a/gaphor/ui/styling.py
+++ b/gaphor/ui/styling.py
@@ -1,4 +1,5 @@
 import importlib
+import sys
 
 from gi.repository import Gdk, Gtk
 
@@ -21,6 +22,9 @@ def init_styling():
     style_provider = Gtk.CssProvider()
     css_file = importlib.resources.files("gaphor.ui") / "styling.css"
     style_provider.load_from_path(str(css_file))
+    if sys.platform == "darwin":
+        macos_css_file = importlib.resources.files("gaphor.ui") / "styling-macos.css"
+        style_provider.load_from_path(str(macos_css_file))
 
     Gtk.StyleContext.add_provider_for_display(
         Gdk.Display.get_default(),


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The Adwaita theme draws a wide shadow around the window. This shadow is part of the view on macOS.

You can see this easily when you open a file. The parent window is overlayed with a "sheet":

<img width="922" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/f04db470-7611-4f07-89ae-08d70cdac48e">

### What is the new behavior?

The shadow has been tweaked to look more like a macOS shadow, and the shadow size is smaller. This improves the usability: the big (invisible) border is gone, so if you click on an underlying window, it will actually work.

<img width="912" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/fcd90faf-c782-44f3-9fb4-b2167e10f62f">


Also the shadow looks a bit more mac-like:

<img width="846" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/2ce786bb-f1ba-4a21-8425-ea881eaad563">


### Other information

GTK issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/6255
