### PR TITLE
Replace deprecated use of CssProvider.load_from_data

### DIFF
--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -234,16 +234,9 @@ class DiagramPage:
         style = self.diagram.style(StyledDiagram(self.diagram, dark_mode=dark_mode))
 
         bg = style.get("background-color", (0.0, 0.0, 0.0, 0.0))
-        # TODO: Temporary, until this is supported by PyGObject
-        if (Gtk.get_major_version(), Gtk.get_minor_version()) > (4, 8):
-            self.diagram_css.load_from_data(
-                f".{self._css_class()} {{ background-color: rgba({int(255*bg[0])}, {int(255*bg[1])}, {int(255*bg[2])}, {bg[3]}); }}",
-                -1,
-            )
-        else:
-            self.diagram_css.load_from_data(
-                f".{self._css_class()} {{ background-color: rgba({int(255*bg[0])}, {int(255*bg[1])}, {int(255*bg[2])}, {bg[3]}); }}".encode()
-            )
+        self.diagram_css.load_from_string(
+            f".{self._css_class()} {{ background-color: rgba({int(255*bg[0])}, {int(255*bg[1])}, {int(255*bg[2])}, {bg[3]}); }}",
+        )
 
         view = self.view
         item_painter = ItemPainter(view.selection, dark_mode)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

`Gtk.CssProvider.load_from_data` is deprecated in GTK 4.12:

```
gaphor/ui/tests/test_handletool.py::test_iconnect
  /Users/arjan/Development/gaphor/.venv/lib/python3.11/site-packages/gi/overrides/Gtk.py:1641: DeprecationWarning: Gtk.CssProvider.load_from_data is deprecated
    super(CssProvider, self).load_from_data(text, length)
```

Issue Number: #2231

### What is the new behavior?

Replace by `Gtk.CssProvider.load_from_string`.

However, this API is introduced in GTK 4.12.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

GTK 4.12+ is required once this change is merged.
