### PR TITLE
Apply custom window shadow to macOS and Windows

### DIFF
--- a/gaphor/ui/styling-box-shadow.css
+++ b/gaphor/ui/styling-box-shadow.css
@@ -1,7 +1,7 @@
 /*
- * Styling workarounds on macOS.
+ * Styling workarounds on macOS and Windows.
  *
- * The issue: shadows defined by libadwaita are very wide: up to 60px.
+ * The issue: shadows defined by LibAdwaita are very wide: up to 60px.
  * The shadow is drawn inside the (clickable) window.
  *
  * These styles change the (window) background to be a lot more compact.
@@ -11,11 +11,14 @@
  *
  * See: https://gitlab.gnome.org/GNOME/gtk/-/issues/6255
  */
- .csd {
-    box-shadow: 2px 3px 12px 6px alpha(black, .2),
-                0px 0px 0px 1px alpha(black, .1);
+
+.csd {
+    box-shadow: 0 3px 9px 1px alpha(black, 0.35),
+                0 0 0 1px alpha(black, 0.18);
 }
+
 .csd:backdrop {
-    box-shadow: 2px 3px 12px 6px alpha(black, .1),
-                0px 0px 0px 1px alpha(black, .1);
+    box-shadow: 0 3px 9px 1px transparent,
+                0 2px 6px 2px alpha(black, 0.1),
+                0 0 0 1px alpha(black, 0.06);
 }

--- a/gaphor/ui/styling.py
+++ b/gaphor/ui/styling.py
@@ -20,11 +20,14 @@ class Styling(Service):
 
 def init_styling():
     style_provider = Gtk.CssProvider()
-    css_file = importlib.resources.files("gaphor.ui") / "styling.css"
-    style_provider.load_from_path(str(css_file))
-    if sys.platform == "darwin":
-        macos_css_file = importlib.resources.files("gaphor.ui") / "styling-macos.css"
-        style_provider.load_from_path(str(macos_css_file))
+    css = (importlib.resources.files("gaphor.ui") / "styling.css").read_text(
+        encoding="utf-8"
+    )
+    if sys.platform in ("darwin", "win32"):
+        css += (
+            importlib.resources.files("gaphor.ui") / "styling-box-shadow.css"
+        ).read_text(encoding="utf-8")
+    style_provider.load_from_string(css)
 
     Gtk.StyleContext.add_provider_for_display(
         Gdk.Display.get_default(),


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

As discussed in #2952, the shadow for macOS is very wide, and the shadow is drawn as part of the `NSView`, hence mouse clicks are consumed.

The same issue appears on Windows.

Issue Number: N/A

### What is the new behavior?

Update the window shadow style for both macOS and Windows.

The shadow style is now resembling the default shadow style in GTK.

I found that `CssProvider.load_from_path()` does not cascade, so only the shadow styling was loaded. This has been fixed.