### PR TITLE
Convert Stereotype property editors to ListView

### DIFF
--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -21,6 +21,7 @@ from gaphor.UML.actions.activity import ActivityItem
 from gaphor.UML.propertypages import (
     create_list_store,
     list_item_factory,
+    list_view_activated,
     list_view_key_handler,
     text_field_handlers,
     update_list_store,
@@ -114,7 +115,8 @@ class ActivityItemPage(PropertyPageBase):
             "activity-editor",
             "parameters-info",
             signals={
-                "list-view-key-pressed": (list_view_key_handler,),
+                "parameter-activated": (list_view_activated,),
+                "parameter-key-pressed": (list_view_key_handler,),
                 "parameters-info-clicked": (self.on_parameters_info_clicked,),
             },
         )

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -318,9 +318,10 @@
                 </child>
                 <child>
                   <object class="GtkEventControllerKey">
-                    <signal name="key-pressed" handler="list-view-key-pressed" />
+                    <signal name="key-pressed" handler="parameter-key-pressed" />
                   </object>
                 </child>
+                <signal name="activate" handler="parameter-activated" />
               </object>
             </property>
           </object>

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -1,3 +1,5 @@
+from gi.repository import Gtk
+
 from gaphor import UML
 from gaphor.core.format import format, parse
 from gaphor.diagram.propertypages import (
@@ -33,10 +35,12 @@ class AssociationPropertyPage(PropertyPageBase):
         subject = end.subject
 
         if UML.recipes.get_stereotypes(subject):
-            model, toggle_handler, set_value_handler = stereotype_model(subject)
+            model = stereotype_model(subject)
+
+            # TODO: Add real event handlers
             return model, {
-                f"{end_name}-toggle-stereotype": toggle_handler,
-                f"{end_name}-set-slot-value": set_value_handler,
+                f"{end_name}-toggle-stereotype": (_dummy_handler,),
+                f"{end_name}-set-slot-value": (_dummy_handler,),
             }
         return None, {
             f"{end_name}-toggle-stereotype": (_dummy_handler,),
@@ -59,7 +63,8 @@ class AssociationPropertyPage(PropertyPageBase):
 
         if stereotypes_model:
             stereotype_list = builder.get_object(f"{end_name}-stereotype-list")
-            stereotype_list.set_model(stereotypes_model)
+            selection = Gtk.SingleSelection.new(stereotypes_model)
+            stereotype_list.set_model(selection)
         else:
             stereotype_frame = builder.get_object(f"{end_name}-stereotype-frame")
             stereotype_frame.set_visible(False)

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -23,6 +23,7 @@ from gaphor.UML.propertypages import (
     check_button_handlers,
     create_list_store,
     list_item_factory,
+    list_view_activated,
     list_view_key_handler,
     text_field_handlers,
     update_list_store,
@@ -210,6 +211,7 @@ class AttributesPage(PropertyPageBase):
             "attributes-editor",
             "attributes-info",
             signals={
+                "attributes-activated": (list_view_activated,),
                 "attributes-key-pressed": (list_view_key_handler,),
                 "show-attributes-changed": (self.on_show_attributes_changed,),
                 "attributes-info-clicked": (self.on_attributes_info_clicked,),
@@ -366,6 +368,7 @@ class OperationsPage(PropertyPageBase):
             "operations-editor",
             "operations-info",
             signals={
+                "operations-activated": (list_view_activated,),
                 "operations-key-pressed": (list_view_key_handler,),
                 "show-operations-changed": (self.on_show_operations_changed,),
                 "operations-info-clicked": (self.on_operations_info_clicked,),

--- a/gaphor/UML/classes/enumerationpropertypages.py
+++ b/gaphor/UML/classes/enumerationpropertypages.py
@@ -18,6 +18,7 @@ from gaphor.UML.classes.enumeration import EnumerationItem
 from gaphor.UML.propertypages import (
     create_list_store,
     list_item_factory,
+    list_view_activated,
     list_view_key_handler,
     text_field_handlers,
     update_list_store,
@@ -100,6 +101,7 @@ class EnumerationPage(PropertyPageBase):
             "enumerations-editor",
             "enumerations-info",
             signals={
+                "enumerations-activated": (list_view_activated,),
                 "enumerations-key-pressed": (list_view_key_handler,),
                 "show-enumerations-changed": (self.on_show_enumerations_changed,),
                 "enumerations-info-clicked": (self.on_enumerations_info_clicked,),

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -133,7 +133,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
                     </style>
                     <child>
                       <object class="GtkColumnViewColumn">
-                        <property name="title" translatable="yes">Attributes</property>
+                        <property name="title" translatable="yes">Stereotypes</property>
                       </object>
                     </child>
                     <child>
@@ -251,7 +251,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
                     </style>
                     <child>
                       <object class="GtkColumnViewColumn">
-                        <property name="title" translatable="yes">Attributes</property>
+                        <property name="title" translatable="yes">Stereotypes</property>
                       </object>
                     </child>
                     <child>

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -337,6 +337,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
                     <signal name="key-pressed" handler="attributes-key-pressed" />
                   </object>
                 </child>
+                <signal name="activate" handler="attributes-activated" />
               </object>
             </property>
           </object>
@@ -543,6 +544,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
                     <signal name="key-pressed" handler="operations-key-pressed" />
                   </object>
                 </child>
+                <signal name="activate" handler="operations-activated" />
               </object>
             </property>
           </object>
@@ -641,6 +643,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
                     <signal name="key-pressed" handler="enumerations-key-pressed" />
                   </object>
                 </child>
+                <signal name="activate" handler="enumerations-activated" />
               </object>
             </property>
           </object>

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -125,43 +125,26 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <child>
               <object class="GtkFrame" id="head-stereotype-frame">
                 <property name="child">
-                  <object class="GtkTreeView" id="head-stereotype-list">
+                  <object class="GtkColumnView" id="head-stereotype-list">
+                    <property name="height-request">112</property>
                     <property name="focusable">1</property>
-                    <child internal-child="selection">
-                      <object class="GtkTreeSelection"/>
-                    </child>
+                    <style>
+                      <class name="data-table"/>
+                    </style>
                     <child>
-                      <object class="GtkTreeViewColumn">
+                      <object class="GtkColumnViewColumn">
                         <property name="title" translatable="yes">Attributes</property>
-                        <child>
-                          <object class="GtkCellRendererToggle">
-                            <signal name="toggled" handler="head-toggle-stereotype" swapped="no"/>
-                          </object>
-                          <attributes>
-                            <attribute name="visible">3</attribute>
-                            <attribute name="active">2</attribute>
-                          </attributes>
-                        </child>
-                        <child>
-                          <object class="GtkCellRendererText"/>
-                          <attributes>
-                            <attribute name="text">0</attribute>
-                          </attributes>
-                        </child>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkTreeViewColumn">
-                        <property name="title" translatable="yes">Value</property>
-                        <child>
-                          <object class="GtkCellRendererText">
-                            <signal name="edited" handler="head-set-slot-value" swapped="no"/>
-                          </object>
-                          <attributes>
-                            <attribute name="editable">4</attribute>
-                            <attribute name="text">1</attribute>
-                          </attributes>
-                        </child>
+                      <object class="GtkColumnViewColumn">
+                        <property name="title" translatable="yes">Values</property>
+                        <property name="expand">1</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEventControllerKey">
+                        <signal name="key-pressed" handler="head-stereotype-key-pressed" />
                       </object>
                     </child>
                   </object>
@@ -260,44 +243,26 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <child>
               <object class="GtkFrame" id="tail-stereotype-frame">
                 <property name="child">
-                  <object class="GtkTreeView" id="tail-stereotype-list">
+                  <object class="GtkColumnView" id="tail-stereotype-list">
+                    <property name="height-request">112</property>
                     <property name="focusable">1</property>
-                    <child internal-child="selection">
-                      <object class="GtkTreeSelection"/>
-                    </child>
+                    <style>
+                      <class name="data-table"/>
+                    </style>
                     <child>
-                      <object class="GtkTreeViewColumn">
+                      <object class="GtkColumnViewColumn">
                         <property name="title" translatable="yes">Attributes</property>
-                        <child>
-                          <object class="GtkCellRendererToggle">
-                            <signal name="toggled" handler="tail-toggle-stereotype" swapped="no"/>
-                          </object>
-                          <attributes>
-                            <attribute name="visible">3</attribute>
-                            <attribute name="active">2</attribute>
-                          </attributes>
-                        </child>
-                        <child>
-                          <object class="GtkCellRendererText"/>
-                          <attributes>
-                            <attribute name="text">0</attribute>
-                          </attributes>
-                        </child>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkTreeViewColumn">
-                        <property name="title" translatable="yes">Value</property>
-                        <signal name="clicked" handler="tail-set-slot-value" swapped="no"/>
-                        <child>
-                          <object class="GtkCellRendererText">
-                            <signal name="edited" handler="tail-set-slot-value" swapped="no"/>
-                          </object>
-                          <attributes>
-                            <attribute name="editable">4</attribute>
-                            <attribute name="text">1</attribute>
-                          </attributes>
-                        </child>
+                      <object class="GtkColumnViewColumn">
+                        <property name="title" translatable="yes">Values</property>
+                        <property name="expand">1</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEventControllerKey">
+                        <signal name="key-pressed" handler="tail-stereotype-key-pressed" />
                       </object>
                     </child>
                   </object>

--- a/gaphor/UML/classes/tests/test_associationpropertypages.py
+++ b/gaphor/UML/classes/tests/test_associationpropertypages.py
@@ -42,3 +42,29 @@ def test_association_property_page_invert_direction(diagram, element_factory):
     property_page._on_invert_direction_change(None)
 
     assert item.tail_subject is item.subject.memberEnd[0]
+
+
+def metaclass_and_stereotype(element_factory):
+    metaclass = element_factory.create(UML.Class)
+    metaclass.name = "Element"
+    stereotype = element_factory.create(UML.Stereotype)
+    stereotype.name = "Stereotype"
+    UML.recipes.create_extension(metaclass, stereotype)
+    return metaclass, stereotype
+
+
+def test_association_property_with_stereotype(diagram, element_factory):
+    end1 = element_factory.create(UML.Class)
+    end2 = element_factory.create(UML.Class)
+    item = diagram.create(
+        UML.classes.AssociationItem, subject=UML.recipes.create_association(end1, end2)
+    )
+    item.head_subject = item.subject.memberEnd[0]
+    item.tail_subject = item.subject.memberEnd[1]
+    metclass, stereotype = metaclass_and_stereotype(element_factory)
+
+    property_page = AssociationPropertyPage(item)
+
+    widget = property_page.construct()
+
+    assert widget

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -66,7 +66,7 @@
                 </style>
                 <child>
                   <object class="GtkColumnViewColumn">
-                    <property name="title" translatable="yes">Attributes</property>
+                    <property name="title" translatable="yes">Stereotypes</property>
                   </object>
                 </child>
                 <child>

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -75,11 +75,11 @@
                     <property name="expand">1</property>
                   </object>
                 </child>
-                <child>
+                <!-- <child>
                   <object class="GtkEventControllerKey">
                     <signal name="key-pressed" handler="stereotype-key-pressed" />
                   </object>
-                </child>
+                </child> -->
               </object>
             </property>
           </object>

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -58,42 +58,26 @@
         <child>
           <object class="GtkFrame">
             <property name="child">
-              <object class="GtkTreeView" id="stereotype-list">
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection"/>
-                </child>
+              <object class="GtkColumnView" id="stereotype-list">
+                <property name="height-request">112</property>
+                <property name="focusable">1</property>
+                <style>
+                  <class name="data-table"/>
+                </style>
                 <child>
-                  <object class="GtkTreeViewColumn">
+                  <object class="GtkColumnViewColumn">
                     <property name="title" translatable="yes">Attributes</property>
-                    <child>
-                      <object class="GtkCellRendererToggle">
-                        <signal name="toggled" handler="toggle-stereotype" swapped="no"/>
-                      </object>
-                      <attributes>
-                        <attribute name="visible">3</attribute>
-                        <attribute name="active">2</attribute>
-                      </attributes>
-                    </child>
-                    <child>
-                      <object class="GtkCellRendererText"/>
-                      <attributes>
-                        <attribute name="text">0</attribute>
-                      </attributes>
-                    </child>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkTreeViewColumn">
-                    <property name="title" translatable="yes">Value</property>
-                    <child>
-                      <object class="GtkCellRendererText">
-                        <signal name="edited" handler="set-slot-value" swapped="no"/>
-                      </object>
-                      <attributes>
-                        <attribute name="editable">4</attribute>
-                        <attribute name="text">1</attribute>
-                      </attributes>
-                    </child>
+                  <object class="GtkColumnViewColumn">
+                    <property name="title" translatable="yes">Values</property>
+                    <property name="expand">1</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkEventControllerKey">
+                    <signal name="key-pressed" handler="stereotype-key-pressed" />
                   </object>
                 </child>
               </object>

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -75,11 +75,11 @@
                     <property name="expand">1</property>
                   </object>
                 </child>
-                <!-- <child>
+                <child>
                   <object class="GtkEventControllerKey">
                     <signal name="key-pressed" handler="stereotype-key-pressed" />
                   </object>
-                </child> -->
+                </child>
               </object>
             </property>
           </object>

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -80,6 +80,7 @@
                     <signal name="key-pressed" handler="stereotype-key-pressed" />
                   </object>
                 </child>
+                <signal name="activate" handler="stereotype-activated" />
               </object>
             </property>
           </object>

--- a/gaphor/UML/profiles/stereotype-cell.ui
+++ b/gaphor/UML/profiles/stereotype-cell.ui
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="GtkColumnViewCell">
+      <object name="GtkBox">
+        <property name="orientation">horizontal</property>
+        <child>
+          <object class="GtkCheckButton">
+            <property name="halign">center</property>
+            <binding name="active">
+              <lookup name="applied" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
+                <lookup name="item">GtkColumnViewCell</lookup>
+              </lookup>
+            </binding>
+            <binding name="visible">
+              <lookup name="checkbox_visible" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
+                <lookup name="item">GtkColumnViewCell</lookup>
+              </lookup>
+            </binding>
+            <signal name="toggled" handler="on_toggled" object="GtkColumnViewCell" swapped="no"/>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <binding name="label">
+              <lookup name="name" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
+                <lookup name="item">GtkColumnViewCell</lookup>
+              </lookup>
+            </binding>
+          </object>
+        </child>
+      </object>
+    </property>
+  </template>
+</interface>

--- a/gaphor/UML/profiles/stereotype-name-cell.ui
+++ b/gaphor/UML/profiles/stereotype-name-cell.ui
@@ -21,7 +21,7 @@
                 <lookup name="item">GtkColumnViewCell</lookup>
               </lookup>
             </binding>
-            <!-- <signal name="toggled" handler="on_toggled" object="GtkColumnViewCell" swapped="no"/> -->
+            <signal name="toggled" handler="on_toggled" object="GtkColumnViewCell" swapped="no"/>
           </object>
         </child>
         <child>

--- a/gaphor/UML/profiles/stereotype-name-cell.ui
+++ b/gaphor/UML/profiles/stereotype-name-cell.ui
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <template class="GtkColumnViewCell">
-      <object name="GtkBox">
+    <property name="child">
+      <object class="GtkBox">
         <property name="orientation">horizontal</property>
+        <binding name="css-classes">
+          <lookup name="indent_classes" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
+            <lookup name="item">GtkColumnViewCell</lookup>
+          </lookup>
+        </binding>
         <child>
           <object class="GtkCheckButton">
-            <property name="halign">center</property>
             <binding name="active">
               <lookup name="applied" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
                 <lookup name="item">GtkColumnViewCell</lookup>
@@ -16,7 +21,7 @@
                 <lookup name="item">GtkColumnViewCell</lookup>
               </lookup>
             </binding>
-            <signal name="toggled" handler="on_toggled" object="GtkColumnViewCell" swapped="no"/>
+            <!-- <signal name="toggled" handler="on_toggled" object="GtkColumnViewCell" swapped="no"/> -->
           </object>
         </child>
         <child>

--- a/gaphor/UML/profiles/stereotype-name-cell.ui
+++ b/gaphor/UML/profiles/stereotype-name-cell.ui
@@ -4,6 +4,11 @@
     <property name="child">
       <object class="GtkBox">
         <property name="orientation">horizontal</property>
+        <binding name="sensitive">
+          <lookup name="sensitive" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
+            <lookup name="item">GtkColumnViewCell</lookup>
+          </lookup>
+        </binding>
         <binding name="css-classes">
           <lookup name="indent_classes" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
             <lookup name="item">GtkColumnViewCell</lookup>

--- a/gaphor/UML/profiles/stereotype-value-cell.ui
+++ b/gaphor/UML/profiles/stereotype-value-cell.ui
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="GtkColumnViewCell">
+    <property name="child">
+      <object class="TextField">
+        <binding name="placeholder-text">
+          <lookup name="placeholder_text" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
+            <lookup name="item">GtkColumnViewCell</lookup>
+          </lookup>
+        </binding>
+        <binding name="readonly-text">
+          <lookup name="slot_value" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
+            <lookup name="item">GtkColumnViewCell</lookup>
+          </lookup>
+        </binding>
+        <binding name="editable-text">
+          <lookup name="slot_value" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
+            <lookup name="item">GtkColumnViewCell</lookup>
+          </lookup>
+        </binding>
+        <binding name="can_edit">
+          <lookup name="can_edit" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
+            <lookup name="item">GtkColumnViewCell</lookup>
+          </lookup>
+        </binding>
+        <binding name="editing">
+          <lookup name="editing" type="gaphor+UML+profiles+stereotypepropertypages+StereotypeView">
+            <lookup name="item">GtkColumnViewCell</lookup>
+          </lookup>
+        </binding>
+        <child>
+          <object class="GtkGestureClick">
+            <property name="button">1</property>
+            <signal name="pressed" handler="on_double_click" />
+          </object>
+        </child>
+        <signal name="done-editing" handler="on_done_editing" object="GtkColumnViewCell" swapped="no" />
+      </object>
+    </property>
+  </template>
+</interface>

--- a/gaphor/UML/profiles/stereotype-value-cell.ui
+++ b/gaphor/UML/profiles/stereotype-value-cell.ui
@@ -28,12 +28,6 @@
             <lookup name="item">GtkColumnViewCell</lookup>
           </lookup>
         </binding>
-        <child>
-          <object class="GtkGestureClick">
-            <property name="button">1</property>
-            <signal name="pressed" handler="on_double_click" />
-          </object>
-        </child>
         <signal name="done-editing" handler="on_done_editing" object="GtkColumnViewCell" swapped="no" />
       </object>
     </property>

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -32,7 +32,7 @@ class StereotypePage(PropertyPageBase):
             "stereotypes-editor",
             signals={
                 "show-stereotypes-changed": (self._on_show_stereotypes_change,),
-                "stereotype-key-pressed": (key_handler,),
+                "stereotype-key-pressed": (stereotype_key_handler,),
             },
         )
 
@@ -46,35 +46,39 @@ class StereotypePage(PropertyPageBase):
         stereotype_list = builder.get_object("stereotype-list")
         model = stereotype_model(subject)
 
-        def on_stereotype_toggled(cell):
-            button = cell.get_child().get_first_child()
-            view = cell.get_item()
-            view.applied = button.get_active()
-            update_stereotype_model(model)
-
-        for column, factory in zip(
-            stereotype_list.get_columns(),
-            [
-                name_list_item_factory(
-                    signal_handlers={
-                        "on_toggled": (on_stereotype_toggled,),
-                    },
-                ),
-                value_list_item_factory(
-                    signal_handlers=text_field_handlers("slot_value"),
-                ),
-            ],
-        ):
-            column.set_factory(factory)
-
-        selection = Gtk.SingleSelection.new(model)
-        stereotype_list.set_model(selection)
+        stereotype_set_model_with_interaction(stereotype_list, model)
 
         return builder.get_object("stereotypes-editor")
 
     @transactional
     def _on_show_stereotypes_change(self, button, gparam):
         self.item.show_stereotypes = button.get_active()
+
+
+def stereotype_set_model_with_interaction(stereotype_list, model):
+    def on_stereotype_toggled(cell):
+        button = cell.get_child().get_first_child()
+        view = cell.get_item()
+        view.applied = button.get_active()
+        update_stereotype_model(model)
+
+    for column, factory in zip(
+        stereotype_list.get_columns(),
+        [
+            name_list_item_factory(
+                signal_handlers={
+                    "on_toggled": (on_stereotype_toggled,),
+                },
+            ),
+            value_list_item_factory(
+                signal_handlers=text_field_handlers("slot_value"),
+            ),
+        ],
+    ):
+        column.set_factory(factory)
+
+    selection = Gtk.SingleSelection.new(model)
+    stereotype_list.set_model(selection)
 
 
 class StereotypeView(GObject.Object):
@@ -227,7 +231,7 @@ def value_list_item_factory(signal_handlers=None):
 
 
 @transactional
-def key_handler(ctrl, keyval, _keycode, state):
+def stereotype_key_handler(ctrl, keyval, _keycode, state):
     list_view = ctrl.get_widget()
     selection = list_view.get_model()
     item = selection.get_selected_item()

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -47,11 +47,18 @@ class StereotypePage(PropertyPageBase):
 
         stereotype_list = builder.get_object("stereotype-list")
 
+        def on_stereotype_toggled(cell):
+            button = cell.get_child().get_first_child()
+            view = cell.get_item()
+            view.applied = button.get_active()
+
         for column, factory in zip(
             stereotype_list.get_columns(),
             [
                 name_list_item_factory(
-                    signal_handlers=None,
+                    signal_handlers={
+                        "on_toggled": (on_stereotype_toggled,),
+                    },
                 ),
                 value_list_item_factory(
                     signal_handlers=None,
@@ -117,7 +124,7 @@ class StereotypeView(GObject.Object):
 
     @GObject.Property(type=bool, default=False)
     def applied(self):
-        return bool(self.attr)
+        return bool(self.instance)
 
     @applied.setter  # type: ignore[no-redef]
     @transactional

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -41,7 +41,7 @@ class StereotypePage(PropertyPageBase):
         if hasattr(self.item, "show_stereotypes"):
             show_stereotypes.set_active(self.item.show_stereotypes)
         else:
-            show_stereotypes.unparent()
+            show_stereotypes.get_parent().unparent()
 
         stereotype_list = builder.get_object("stereotype-list")
         model = stereotype_model(subject)

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -32,6 +32,7 @@ class StereotypePage(PropertyPageBase):
             "stereotypes-editor",
             signals={
                 "show-stereotypes-changed": (self._on_show_stereotypes_change,),
+                "stereotype-activated": (stereotype_activated,),
                 "stereotype-key-pressed": (stereotype_key_handler,),
             },
         )
@@ -126,7 +127,7 @@ class StereotypeView(GObject.Object):
         instance = self.instance
         if value and not instance:
             UML.recipes.apply_stereotype(self.target, self.stereotype)
-        elif instance:
+        elif not value and instance:
             UML.recipes.remove_stereotype(self.target, self.stereotype)
 
     @GObject.Property(type=bool, default=False)
@@ -226,6 +227,17 @@ def value_list_item_factory(signal_handlers=None):
         Gtk.Builder.BuilderScope(signal_handlers),
         GLib.Bytes.new(ui_string.encode("utf-8")),
     )
+
+
+@transactional
+def stereotype_activated(list_view, _row):
+    selection = list_view.get_model()
+    item = selection.get_selected_item()
+
+    if item.attr:
+        item.start_editing()
+    else:
+        item.applied = not item.applied
 
 
 @transactional

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -114,9 +114,7 @@ class StereotypeView(GObject.Object):
 
     @GObject.Property(type=str, default="", flags=GObject.ParamFlags.READABLE)
     def name(self):
-        if self.attr:
-            return self.attr.name or ""
-        return self.stereotype.name or ""
+        return (self.attr.name if self.attr else self.stereotype.name) or ""
 
     @GObject.Property(type=bool, default=False)
     def applied(self):

--- a/gaphor/UML/profiles/tests/test_stereotypepage.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepage.py
@@ -17,7 +17,7 @@ def class_(diagram, element_factory):
     del class_
 
 
-def test_stereotype_page_with_no_stereotype(diagram, class_):
+def test_stereotype_page_with_no_stereotype(class_):
     """Test the Stereotype Property Page not created for a Class."""
 
     editor = StereotypePage(class_)
@@ -26,7 +26,7 @@ def test_stereotype_page_with_no_stereotype(diagram, class_):
     assert page is None
 
 
-def test_stereotype_page_with_stereotype(element_factory, diagram, class_):
+def test_stereotype_page_with_stereotype(element_factory, class_):
     """Test creation of a Stereotype Property Page."""
 
     # Create a stereotype applicable to Class types:
@@ -43,6 +43,6 @@ def test_stereotype_page_with_stereotype(element_factory, diagram, class_):
 
     stereotype_view = find(page, "stereotype-list")
 
-    assert isinstance(stereotype_view, Gtk.ListView)
+    assert isinstance(stereotype_view, Gtk.ColumnView)
     assert len(stereotype_view.get_model()) == 1
     assert page is not None

--- a/gaphor/UML/profiles/tests/test_stereotypepage.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepage.py
@@ -43,6 +43,6 @@ def test_stereotype_page_with_stereotype(element_factory, diagram, class_):
 
     stereotype_view = find(page, "stereotype-list")
 
-    assert isinstance(stereotype_view, Gtk.TreeView)
+    assert isinstance(stereotype_view, Gtk.ListView)
     assert len(stereotype_view.get_model()) == 1
     assert page is not None

--- a/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
@@ -2,8 +2,6 @@ from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
 from gaphor.UML.profiles.stereotypepropertypages import (
     StereotypePage,
-    set_value,
-    toggle_stereotype,
 )
 
 
@@ -46,7 +44,8 @@ def test_stereotype_property_page_apply_stereotype(diagram, element_factory):
     property_page = create_property_page(diagram, element_factory)
     item = property_page.item
     model = get_model(property_page)
-    toggle_stereotype(None, (0,), item.subject, model)
+    view = model[0]
+    view.applied = True
 
     assert stereotype in item.subject.appliedStereotype[0].classifier
 
@@ -62,9 +61,10 @@ def test_stereotype_property_page_slot_value(diagram, element_factory):
     property_page = create_property_page(diagram, element_factory)
     item = property_page.item
     model = get_model(property_page)
-    toggle_stereotype(None, (0,), item.subject, model)
-    set_value(None, (0, 0), "test", model)
-    slot = item.subject.appliedStereotype[0].slot[0]
+    model[0].applied = True
+    model[1].slot_value = "test"
+    applied_stereotype = item.subject.appliedStereotype[0]
+    slot = applied_stereotype.slot[0]
 
     assert stereotype.ownedAttribute[0] is slot.definingFeature
     assert "test" == slot.value
@@ -79,10 +79,10 @@ def test_inherited_stereotype(diagram, element_factory):
     property_page = create_property_page(diagram, element_factory)
     model = get_model(property_page)
 
-    assert model[(0,)]
-    assert model[(0,)][0] == "Stereotype"
-    assert model[(1,)]
-    assert model[(1,)][0] == "SubStereotype"
+    assert model[0]
+    assert model[0].name == "Stereotype"
+    assert model[1]
+    assert model[1].name == "SubStereotype"
 
 
 def test_inherited_stereotype_with_attributes(diagram, element_factory):
@@ -97,9 +97,9 @@ def test_inherited_stereotype_with_attributes(diagram, element_factory):
     property_page = create_property_page(diagram, element_factory)
     model = get_model(property_page)
 
-    assert model[(0,)]
-    assert model[(0,)][0] == "Stereotype"
-    assert model[(0, 0)][0] == "Attr"
-    assert model[(1,)]
-    assert model[(1,)][0] == "SubStereotype"
-    assert model[(1, 0)][0] == "Attr"
+    assert model[0]
+    assert model[0].name == "Stereotype"
+    assert model[1].name == "Attr"
+    assert model[2]
+    assert model[2].name == "SubStereotype"
+    assert model[3].name == "Attr"

--- a/gaphor/UML/propertypages.py
+++ b/gaphor/UML/propertypages.py
@@ -130,18 +130,12 @@ def update_list_store(
 
 
 def text_field_handlers(model_field: str):
-    def on_double_click(ctrl, n_press, x, y):
-        if n_press == 2:
-            text = ctrl.get_widget()
-            text.start_editing()
-
     def on_done_editing(list_item, should_commit):
         text = list_item.get_child()
         if should_commit:
             setattr(list_item.get_item(), model_field, text.editable_text)
 
     return {
-        "on_double_click": on_double_click,
         "on_done_editing": on_done_editing,
     }
 
@@ -154,6 +148,15 @@ def check_button_handlers(model_field: str):
     return {
         "on_toggled": on_toggled,
     }
+
+
+@transactional
+def list_view_activated(list_view, _row):
+    """Default action for activation: start editing."""
+    selection = list_view.get_model()
+    item = selection.get_selected_item()
+
+    item.start_editing()
 
 
 @transactional

--- a/gaphor/UML/propertypages.py
+++ b/gaphor/UML/propertypages.py
@@ -83,7 +83,7 @@ def list_of_classifiers(element_factory, required_type):
 
 
 def list_item_factory(
-    ui_filename, klass, attribute, placeholder_text=None, signal_handlers=None
+    ui_filename, klass, attribute, placeholder_text="", signal_handlers=None
 ):
     ui_string = translated_ui_string("gaphor.UML", ui_filename).format(
         gtype_name=klass.__gtype__.name,

--- a/gaphor/UML/text-field-cell.ui
+++ b/gaphor/UML/text-field-cell.ui
@@ -19,12 +19,6 @@
             <lookup name="item">GtkColumnViewCell</lookup>
           </lookup>
         </binding>
-        <child>
-          <object class="GtkGestureClick">
-            <property name="button">1</property>
-            <signal name="pressed" handler="on_double_click" />
-          </object>
-        </child>
         <signal name="done-editing" handler="on_done_editing" object="GtkColumnViewCell" swapped="no" />
       </object>
     </property>

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -103,18 +103,21 @@ frame > textview {
   padding: 6px;
 }
 
-listview .row {
-  padding: 2px 0;
+row {
+  min-height: 24px;
 }
 
-/* Needed only for tables with check boxes */
 .data-table checkbutton {
   padding: 0px;
 }
 
-.data-table row {
-  min-height: 24px;
-}
+.data-table box checkbutton {
+  margin-right: 4px;
+ }
+
+.data-table .stereotype-value {
+  padding-left: 24px;
+ }
 
 textfield text {
   background-color: @theme_bg_color;

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -108,12 +108,12 @@ listview .row {
 }
 
 /* Needed only for tables with check boxes */
-.data-table cell checkbutton {
+.data-table checkbutton {
   padding: 0px;
 }
 
-.data-table textfield {
-  padding: 3px 6px;
+.data-table row {
+  min-height: 24px;
 }
 
 textfield text {
@@ -163,7 +163,6 @@ textfield text selection {
   margin: 6px;
 }
 
-/* For toolbox and greeter */
 flowboxchild:hover {
   background-color: @shade_color;
 }

--- a/test-models/stereotypes.gaphor
+++ b/test-models/stereotypes.gaphor
@@ -1,0 +1,679 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.22.1">
+<StyleSheet id="58d6989a-66f8-11ec-b4c8-0456e5e540ed"/>
+<Package id="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed">
+<name>
+<val>Application</val>
+</name>
+<ownedDiagram>
+<reflist>
+<ref refid="fd7641e6-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</ownedDiagram>
+<ownedType>
+<reflist>
+<ref refid="07d182e0-a40c-11ee-a988-be7f4daace3f"/>
+<ref refid="0af47cd4-a40c-11ee-a988-be7f4daace3f"/>
+<ref refid="1156b092-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</ownedType>
+</Package>
+<Diagram id="58d6c536-66f8-11ec-b4c8-0456e5e540ed">
+<element>
+<ref refid="bdc4a786-a40b-11ee-a988-be7f4daace3f"/>
+</element>
+<name>
+<val>Stereotypes</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="508888a4-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="52f9a8a2-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="70c278f0-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="54a81bde-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="74062214-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<Class id="5087f27c-a40b-11ee-a988-be7f4daace3f">
+<name>
+<val>Element</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="5542f096-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="749d98d8-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="bdc4a786-a40b-11ee-a988-be7f4daace3f"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="508888a4-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Class>
+<ClassItem id="508888a4-a40b-11ee-a988-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 130.0, 164.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>70.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="5087f27c-a40b-11ee-a988-be7f4daace3f"/>
+</subject>
+</ClassItem>
+<Stereotype id="52f93afc-a40b-11ee-a988-be7f4daace3f">
+<instanceSpecification>
+<reflist>
+<ref refid="21a137ec-a40c-11ee-a988-be7f4daace3f"/>
+<ref refid="322f2948-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</instanceSpecification>
+<name>
+<val>Timed</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="5542c5da-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="5a96491c-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="bdc4a786-a40b-11ee-a988-be7f4daace3f"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="52f9a8a2-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Stereotype>
+<ClassItem id="52f9a8a2-a40b-11ee-a988-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 57.5, 323.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>115.0</val>
+</width>
+<height>
+<val>89.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="52f93afc-a40b-11ee-a988-be7f4daace3f"/>
+</subject>
+</ClassItem>
+<ExtensionItem id="54a81bde-a40b-11ee-a988-be7f4daace3f">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="55428c64-a40b-11ee-a988-be7f4daace3f"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 141.0, 207.0)</val>
+</matrix>
+<points>
+<val>[(27.01724137931035, 27.0), (-26.0, 116.0)]</val>
+</points>
+<head-connection>
+<ref refid="508888a4-a40b-11ee-a988-be7f4daace3f"/>
+</head-connection>
+<tail-connection>
+<ref refid="52f9a8a2-a40b-11ee-a988-be7f4daace3f"/>
+</tail-connection>
+</ExtensionItem>
+<Extension id="55428c64-a40b-11ee-a988-be7f4daace3f">
+<memberEnd>
+<reflist>
+<ref refid="5542c5da-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="5542f096-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</memberEnd>
+<ownedEnd>
+<ref refid="5542f096-a40b-11ee-a988-be7f4daace3f"/>
+</ownedEnd>
+<package>
+<ref refid="bdc4a786-a40b-11ee-a988-be7f4daace3f"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="54a81bde-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Extension>
+<Property id="5542c5da-a40b-11ee-a988-be7f4daace3f">
+<association>
+<ref refid="55428c64-a40b-11ee-a988-be7f4daace3f"/>
+</association>
+<class_>
+<ref refid="52f93afc-a40b-11ee-a988-be7f4daace3f"/>
+</class_>
+<name>
+<val>baseClass</val>
+</name>
+<type>
+<ref refid="5087f27c-a40b-11ee-a988-be7f4daace3f"/>
+</type>
+</Property>
+<ExtensionEnd id="5542f096-a40b-11ee-a988-be7f4daace3f">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="55428c64-a40b-11ee-a988-be7f4daace3f"/>
+</association>
+<class_>
+<ref refid="5087f27c-a40b-11ee-a988-be7f4daace3f"/>
+</class_>
+<type>
+<ref refid="52f93afc-a40b-11ee-a988-be7f4daace3f"/>
+</type>
+</ExtensionEnd>
+<Property id="5a96491c-a40b-11ee-a988-be7f4daace3f">
+<class_>
+<ref refid="52f93afc-a40b-11ee-a988-be7f4daace3f"/>
+</class_>
+<name>
+<val>interval</val>
+</name>
+<slot>
+<reflist>
+<ref refid="2389a332-a40c-11ee-a988-be7f4daace3f"/>
+<ref refid="35cbc52a-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</slot>
+</Property>
+<Stereotype id="70c1ce8c-a40b-11ee-a988-be7f4daace3f">
+<instanceSpecification>
+<reflist>
+<ref refid="185f1f1e-a40c-11ee-a988-be7f4daace3f"/>
+<ref refid="30e01fe8-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</instanceSpecification>
+<name>
+<val>Tagged</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="749d4d10-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="8241e8a4-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="bdc4a786-a40b-11ee-a988-be7f4daace3f"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="70c278f0-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Stereotype>
+<ClassItem id="70c278f0-a40b-11ee-a988-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 195.0, 323.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>115.0</val>
+</width>
+<height>
+<val>89.0</val>
+</height>
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="70c1ce8c-a40b-11ee-a988-be7f4daace3f"/>
+</subject>
+</ClassItem>
+<ExtensionItem id="74062214-a40b-11ee-a988-be7f4daace3f">
+<diagram>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="749cd844-a40b-11ee-a988-be7f4daace3f"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 169.0, 223.0)</val>
+</matrix>
+<points>
+<val>[(26.0, 11.0), (83.5, 100.0)]</val>
+</points>
+<head-connection>
+<ref refid="508888a4-a40b-11ee-a988-be7f4daace3f"/>
+</head-connection>
+<tail-connection>
+<ref refid="70c278f0-a40b-11ee-a988-be7f4daace3f"/>
+</tail-connection>
+</ExtensionItem>
+<Extension id="749cd844-a40b-11ee-a988-be7f4daace3f">
+<memberEnd>
+<reflist>
+<ref refid="749d4d10-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="749d98d8-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</memberEnd>
+<ownedEnd>
+<ref refid="749d98d8-a40b-11ee-a988-be7f4daace3f"/>
+</ownedEnd>
+<package>
+<ref refid="bdc4a786-a40b-11ee-a988-be7f4daace3f"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="74062214-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Extension>
+<Property id="749d4d10-a40b-11ee-a988-be7f4daace3f">
+<association>
+<ref refid="749cd844-a40b-11ee-a988-be7f4daace3f"/>
+</association>
+<class_>
+<ref refid="70c1ce8c-a40b-11ee-a988-be7f4daace3f"/>
+</class_>
+<name>
+<val>baseClass</val>
+</name>
+<type>
+<ref refid="5087f27c-a40b-11ee-a988-be7f4daace3f"/>
+</type>
+</Property>
+<ExtensionEnd id="749d98d8-a40b-11ee-a988-be7f4daace3f">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="749cd844-a40b-11ee-a988-be7f4daace3f"/>
+</association>
+<class_>
+<ref refid="5087f27c-a40b-11ee-a988-be7f4daace3f"/>
+</class_>
+<type>
+<ref refid="70c1ce8c-a40b-11ee-a988-be7f4daace3f"/>
+</type>
+</ExtensionEnd>
+<Property id="8241e8a4-a40b-11ee-a988-be7f4daace3f">
+<class_>
+<ref refid="70c1ce8c-a40b-11ee-a988-be7f4daace3f"/>
+</class_>
+<name>
+<val>tag</val>
+</name>
+<slot>
+<reflist>
+<ref refid="1c937e22-a40c-11ee-a988-be7f4daace3f"/>
+<ref refid="3e6c783c-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</slot>
+<typeValue>
+<val>str</val>
+</typeValue>
+</Property>
+<Profile id="bdc4a786-a40b-11ee-a988-be7f4daace3f">
+<name>
+<val>Profile</val>
+</name>
+<ownedDiagram>
+<reflist>
+<ref refid="58d6c536-66f8-11ec-b4c8-0456e5e540ed"/>
+</reflist>
+</ownedDiagram>
+<ownedType>
+<reflist>
+<ref refid="5087f27c-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="70c1ce8c-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="52f93afc-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="55428c64-a40b-11ee-a988-be7f4daace3f"/>
+<ref refid="749cd844-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</ownedType>
+</Profile>
+<Diagram id="fd7641e6-a40b-11ee-a988-be7f4daace3f">
+<diagramType>
+<val></val>
+</diagramType>
+<element>
+<ref refid="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed"/>
+</element>
+<name>
+<val>Application</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="07d20aee-a40c-11ee-a988-be7f4daace3f"/>
+<ref refid="0af537d2-a40c-11ee-a988-be7f4daace3f"/>
+<ref refid="10af7c78-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<Class id="07d182e0-a40c-11ee-a988-be7f4daace3f">
+<appliedStereotype>
+<reflist>
+<ref refid="185f1f1e-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</appliedStereotype>
+<name>
+<val>A</val>
+</name>
+<package>
+<ref refid="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="07d20aee-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Class>
+<ClassItem id="07d20aee-a40c-11ee-a988-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 68.0390625, 144.54296875)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>114.0</val>
+</width>
+<height>
+<val>112.0</val>
+</height>
+<diagram>
+<ref refid="fd7641e6-a40b-11ee-a988-be7f4daace3f"/>
+</diagram>
+<show_stereotypes>
+<val>1</val>
+</show_stereotypes>
+<subject>
+<ref refid="07d182e0-a40c-11ee-a988-be7f4daace3f"/>
+</subject>
+</ClassItem>
+<Class id="0af47cd4-a40c-11ee-a988-be7f4daace3f">
+<appliedStereotype>
+<reflist>
+<ref refid="21a137ec-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</appliedStereotype>
+<name>
+<val>B</val>
+</name>
+<package>
+<ref refid="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="0af537d2-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Class>
+<ClassItem id="0af537d2-a40c-11ee-a988-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 358.0, 144.54296875)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>112.0</val>
+</height>
+<diagram>
+<ref refid="fd7641e6-a40b-11ee-a988-be7f4daace3f"/>
+</diagram>
+<show_stereotypes>
+<val>1</val>
+</show_stereotypes>
+<subject>
+<ref refid="0af47cd4-a40c-11ee-a988-be7f4daace3f"/>
+</subject>
+</ClassItem>
+<AssociationItem id="10af7c78-a40c-11ee-a988-be7f4daace3f">
+<diagram>
+<ref refid="fd7641e6-a40b-11ee-a988-be7f4daace3f"/>
+</diagram>
+<head_subject>
+<ref refid="115748fe-a40c-11ee-a988-be7f4daace3f"/>
+</head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="1156b092-a40c-11ee-a988-be7f4daace3f"/>
+</subject>
+<tail_subject>
+<ref refid="115796c4-a40c-11ee-a988-be7f4daace3f"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 147.0, 180.0)</val>
+</matrix>
+<points>
+<val>[(35.0390625, 20.54296875), (211.0, 20.54296875)]</val>
+</points>
+<head-connection>
+<ref refid="07d20aee-a40c-11ee-a988-be7f4daace3f"/>
+</head-connection>
+<tail-connection>
+<ref refid="0af537d2-a40c-11ee-a988-be7f4daace3f"/>
+</tail-connection>
+</AssociationItem>
+<Association id="1156b092-a40c-11ee-a988-be7f4daace3f">
+<memberEnd>
+<reflist>
+<ref refid="115748fe-a40c-11ee-a988-be7f4daace3f"/>
+<ref refid="115796c4-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</memberEnd>
+<ownedEnd>
+<reflist>
+<ref refid="115748fe-a40c-11ee-a988-be7f4daace3f"/>
+<ref refid="115796c4-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</ownedEnd>
+<package>
+<ref refid="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="10af7c78-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="115748fe-a40c-11ee-a988-be7f4daace3f">
+<appliedStereotype>
+<reflist>
+<ref refid="30e01fe8-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="1156b092-a40c-11ee-a988-be7f4daace3f"/>
+</association>
+<name>
+<val>a</val>
+</name>
+<owningAssociation>
+<ref refid="1156b092-a40c-11ee-a988-be7f4daace3f"/>
+</owningAssociation>
+<type>
+<ref refid="07d182e0-a40c-11ee-a988-be7f4daace3f"/>
+</type>
+</Property>
+<Property id="115796c4-a40c-11ee-a988-be7f4daace3f">
+<appliedStereotype>
+<reflist>
+<ref refid="322f2948-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="1156b092-a40c-11ee-a988-be7f4daace3f"/>
+</association>
+<name>
+<val>b</val>
+</name>
+<owningAssociation>
+<ref refid="1156b092-a40c-11ee-a988-be7f4daace3f"/>
+</owningAssociation>
+<type>
+<ref refid="0af47cd4-a40c-11ee-a988-be7f4daace3f"/>
+</type>
+</Property>
+<InstanceSpecification id="185f1f1e-a40c-11ee-a988-be7f4daace3f">
+<classifier>
+<reflist>
+<ref refid="70c1ce8c-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="07d182e0-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="1c937e22-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="1c937e22-a40c-11ee-a988-be7f4daace3f">
+<definingFeature>
+<ref refid="8241e8a4-a40b-11ee-a988-be7f4daace3f"/>
+</definingFeature>
+<owningInstance>
+<ref refid="185f1f1e-a40c-11ee-a988-be7f4daace3f"/>
+</owningInstance>
+<value>
+<val>tag-balue</val>
+</value>
+</Slot>
+<InstanceSpecification id="21a137ec-a40c-11ee-a988-be7f4daace3f">
+<classifier>
+<reflist>
+<ref refid="52f93afc-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="0af47cd4-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="2389a332-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="2389a332-a40c-11ee-a988-be7f4daace3f">
+<definingFeature>
+<ref refid="5a96491c-a40b-11ee-a988-be7f4daace3f"/>
+</definingFeature>
+<owningInstance>
+<ref refid="21a137ec-a40c-11ee-a988-be7f4daace3f"/>
+</owningInstance>
+<value>
+<val>12</val>
+</value>
+</Slot>
+<InstanceSpecification id="30e01fe8-a40c-11ee-a988-be7f4daace3f">
+<classifier>
+<reflist>
+<ref refid="70c1ce8c-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="115748fe-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="3e6c783c-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<InstanceSpecification id="322f2948-a40c-11ee-a988-be7f4daace3f">
+<classifier>
+<reflist>
+<ref refid="52f93afc-a40b-11ee-a988-be7f4daace3f"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="115796c4-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="35cbc52a-a40c-11ee-a988-be7f4daace3f"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="35cbc52a-a40c-11ee-a988-be7f4daace3f">
+<definingFeature>
+<ref refid="5a96491c-a40b-11ee-a988-be7f4daace3f"/>
+</definingFeature>
+<owningInstance>
+<ref refid="322f2948-a40c-11ee-a988-be7f4daace3f"/>
+</owningInstance>
+<value>
+<val>42</val>
+</value>
+</Slot>
+<Slot id="3e6c783c-a40c-11ee-a988-be7f4daace3f">
+<definingFeature>
+<ref refid="8241e8a4-a40b-11ee-a988-be7f4daace3f"/>
+</definingFeature>
+<owningInstance>
+<ref refid="30e01fe8-a40c-11ee-a988-be7f4daace3f"/>
+</owningInstance>
+<value>
+<val>foo</val>
+</value>
+</Slot>
+</gaphor>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?



Issue Number: #2231 , #2155

### What is the new behavior?

Stereotype property page is using `Gtk.ColumnView`, the modern alternative to `Gtk.TreeView`.

The stereotype view is somewhat simplified (no expander buttons). I expect this will work, as long as there are not too many stereotypes applicable for an element. Values for unapplied stereotypes are insensitive.

<img width="1154" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/37340383-44de-4334-8f6b-b2a04440ef34">

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

* fix removal of "Show Stereotypes" option.
* Reworked all `ColumnView` property editors to start editing on the `activate` signal (double-click or <kbd>Enter</kbd>).