### PR TITLE
Add types for parameters

### DIFF
--- a/gaphor/UML/actions/activity.py
+++ b/gaphor/UML/actions/activity.py
@@ -99,7 +99,9 @@ class ActivityParameterNodeItem(AttachedPresentation[UML.ActivityParameterNode])
 
         self.watch("subject[ActivityParameterNode].parameter.name").watch(
             "subject[ActivityParameterNode].parameter.type.name"
-        ).watch("show_type").watch("show_direction")
+        ).watch("subject[ActivityParameterNode].parameter.direction").watch(
+            "show_type"
+        ).watch("show_direction")
 
     show_type: attribute[int] = attribute("show_type", int, default=False)
     show_direction: attribute[int] = attribute("show_direction", int, default=False)

--- a/gaphor/UML/actions/activity.py
+++ b/gaphor/UML/actions/activity.py
@@ -1,4 +1,5 @@
 from gaphor import UML
+from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.presentation import (
     AttachedPresentation,
     Classified,
@@ -89,14 +90,25 @@ class ActivityParameterNodeItem(AttachedPresentation[UML.ActivityParameterNode])
             id,
             shape=Box(
                 Text(
-                    text=lambda: self.subject.parameter.name or "",
+                    text=self._format_name,
                 ),
                 style={"padding": (4, 12, 4, 12), "min-width": 120},
                 draw=draw_border,
             ),
         )
 
-        self.watch("subject[ActivityParameterNode].parameter.name")
+        self.watch("subject[ActivityParameterNode].parameter.name").watch("show_type")
+
+    show_type: attribute[int] = attribute("show_type", int, default=False)
 
     def update(self, context):
         self.width, self.height = super().update(context)
+
+    def _format_name(self):
+        if not (self.subject and self.subject.parameter):
+            return ""
+
+        name = self.subject.parameter.name or ""
+        if self.show_type and self.subject.type:
+            return f"{name}: {self.subject.type.name or ''}"
+        return name

--- a/gaphor/UML/actions/activity.py
+++ b/gaphor/UML/actions/activity.py
@@ -97,9 +97,12 @@ class ActivityParameterNodeItem(AttachedPresentation[UML.ActivityParameterNode])
             ),
         )
 
-        self.watch("subject[ActivityParameterNode].parameter.name").watch("show_type")
+        self.watch("subject[ActivityParameterNode].parameter.name").watch(
+            "subject[ActivityParameterNode].parameter.type.name"
+        ).watch("show_type").watch("show_direction")
 
     show_type: attribute[int] = attribute("show_type", int, default=False)
+    show_direction: attribute[int] = attribute("show_direction", int, default=False)
 
     def update(self, context):
         self.width, self.height = super().update(context)
@@ -107,8 +110,15 @@ class ActivityParameterNodeItem(AttachedPresentation[UML.ActivityParameterNode])
     def _format_name(self):
         if not (self.subject and self.subject.parameter):
             return ""
+        parameter = self.subject.parameter
+        name = parameter.name or ""
+        type = (parameter.type.name) if self.show_type and parameter.type else None
+        direction = parameter.direction if self.show_direction else None
 
-        name = self.subject.parameter.name or ""
-        if self.show_type and self.subject.type:
-            return f"{name}: {self.subject.type.name or ''}"
+        if type and direction:
+            return f"{direction} {name}: {type}"
+        elif type:
+            return f"{name}: {type}"
+        elif direction:
+            return f"{direction} {name}"
         return name

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -17,8 +17,9 @@ from gaphor.diagram.propertypages import (
 from gaphor.diagram.propertypages import (
     new_builder as diagram_new_builder,
 )
-from gaphor.UML.actions.activity import ActivityItem
+from gaphor.UML.actions.activity import ActivityItem, ActivityParameterNodeItem
 from gaphor.UML.propertypages import (
+    TypedElementPropertyPage,
     create_list_store,
     list_item_factory,
     list_view_key_handler,
@@ -201,3 +202,6 @@ class ActivityParameterNodeNamePropertyPage(PropertyPageBase):
     def _on_name_changed(self, entry):
         if self.subject.parameter.name != entry.get_text():
             self.subject.parameter.name = entry.get_text()
+
+
+PropertyPages.register(ActivityParameterNodeItem)(TypedElementPropertyPage)

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -204,34 +204,44 @@ class ActivityParameterNodeNamePropertyPage(PropertyPageBase):
             self.subject.parameter.name = entry.get_text()
 
 
-@PropertyPages.register(UML.ActivityParameterNode)
+@PropertyPages.register(ActivityParameterNodeItem)
 class ActivityParameterNodeDirectionPropertyPage(PropertyPageBase):
     DIRECTION = UML.Parameter.direction.values
     order = 40
 
-    def __init__(self, subject):
+    def __init__(self, item):
         super().__init__()
-        self.subject = subject
+        self.item = item
 
     def construct(self):
-        if not (self.subject and self.subject.parameter):
+        if not (self.item.subject and self.item.subject.parameter):
             return
 
         builder = new_builder(
             "parameter-direction-editor",
             signals={
                 "parameter-direction-changed": (self._on_parameter_direction_changed,),
+                "show-direction-changed": (self._on_show_direction_changed,),
             },
         )
 
         direction = builder.get_object("parameter-direction")
-        direction.set_selected(self.DIRECTION.index(self.subject.parameter.direction))
+        direction.set_selected(
+            self.DIRECTION.index(self.item.subject.parameter.direction)
+        )
+
+        show_direction = builder.get_object("show-direction")
+        show_direction.set_active(self.item.show_direction)
 
         return builder.get_object("parameter-direction-editor")
 
     @transactional
     def _on_parameter_direction_changed(self, dropdown, _pspec):
-        self.subject.parameter.direction = self.DIRECTION[dropdown.get_selected()]
+        self.item.subject.parameter.direction = self.DIRECTION[dropdown.get_selected()]
+
+    @transactional
+    def _on_show_direction_changed(self, button, _gspec):
+        self.item.show_direction = button.get_active()
 
 
 PropertyPages.register(ActivityParameterNodeItem)(TypedElementPropertyPage)

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -205,6 +205,13 @@ class ActivityParameterNodeNamePropertyPage(PropertyPageBase):
 
 
 @PropertyPages.register(ActivityParameterNodeItem)
+class ActivityParameterNodeTypePropertyPage(TypedElementPropertyPage):
+    @property
+    def typed_element(self):
+        return self.item.subject.parameter
+
+
+@PropertyPages.register(ActivityParameterNodeItem)
 class ActivityParameterNodeDirectionPropertyPage(PropertyPageBase):
     DIRECTION = UML.Parameter.direction.values
     order = 40
@@ -242,6 +249,3 @@ class ActivityParameterNodeDirectionPropertyPage(PropertyPageBase):
     @transactional
     def _on_show_direction_changed(self, button, _gspec):
         self.item.show_direction = button.get_active()
-
-
-PropertyPages.register(ActivityParameterNodeItem)(TypedElementPropertyPage)

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -204,4 +204,34 @@ class ActivityParameterNodeNamePropertyPage(PropertyPageBase):
             self.subject.parameter.name = entry.get_text()
 
 
+@PropertyPages.register(UML.ActivityParameterNode)
+class ActivityParameterNodeDirectionPropertyPage(PropertyPageBase):
+    DIRECTION = UML.Parameter.direction.values
+    order = 40
+
+    def __init__(self, subject):
+        super().__init__()
+        self.subject = subject
+
+    def construct(self):
+        if not (self.subject and self.subject.parameter):
+            return
+
+        builder = new_builder(
+            "parameter-direction-editor",
+            signals={
+                "parameter-direction-changed": (self._on_parameter_direction_changed,),
+            },
+        )
+
+        direction = builder.get_object("parameter-direction")
+        direction.set_selected(self.DIRECTION.index(self.subject.parameter.direction))
+
+        return builder.get_object("parameter-direction-editor")
+
+    @transactional
+    def _on_parameter_direction_changed(self, dropdown, _pspec):
+        self.subject.parameter.direction = self.DIRECTION[dropdown.get_selected()]
+
+
 PropertyPages.register(ActivityParameterNodeItem)(TypedElementPropertyPage)

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -365,6 +365,28 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
     </style>
   </object>
 
+  <object class="GtkBox" id="parameter-direction-editor">
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkDropDown" id="parameter-direction">
+        <property name="model">
+          <object class="GtkStringList">
+            <items>
+              <item translatable="yes">In/Out</item>
+              <item translatable="yes">In</item>
+              <item translatable="yes">Out</item>
+              <item translatable="yes">Return</item>
+            </items>
+          </object>
+        </property>
+        <signal name="notify::selected" handler="parameter-direction-changed" swapped="no"/>
+      </object>
+    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
   <object class="GtkBox" id="pin-editor">
     <property name="orientation">vertical</property>
     <child>

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -382,6 +382,22 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <signal name="notify::selected" handler="parameter-direction-changed" swapped="no"/>
       </object>
     </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Direction</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-direction">
+            <signal name="notify::active" handler="show-direction-changed" swapped="no" />
+          </object>
+        </child>
+      </object>
+    </child>
     <style>
       <class name="propertypage"/>
     </style>

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -2,7 +2,7 @@ from gi.repository import Gdk
 
 from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
-from gaphor.UML.actions.activity import ActivityItem
+from gaphor.UML.actions.activity import ActivityItem, ActivityParameterNodeItem
 from gaphor.UML.actions.activitypropertypage import (
     ActivityItemPage,
     ActivityParameterNodeDirectionPropertyPage,
@@ -198,27 +198,29 @@ def test_construct_activity_item_property_page(create):
     assert widget
 
 
-def test_construct_activity_parameter_node_direction_property_page(element_factory):
-    subject = element_factory.create(UML.ActivityParameterNode)
-    subject.parameter = element_factory.create(UML.Parameter)
+def test_construct_activity_parameter_node_direction_property_page(
+    create, element_factory
+):
+    node_item = create(ActivityParameterNodeItem, UML.ActivityParameterNode)
+    node_item.subject.parameter = element_factory.create(UML.Parameter)
 
-    property_page = ActivityParameterNodeDirectionPropertyPage(subject)
+    property_page = ActivityParameterNodeDirectionPropertyPage(node_item)
     widget = property_page.construct()
 
     assert widget
 
 
-def test_construct_activity_parameter_node_direction_changed(element_factory):
-    subject = element_factory.create(UML.ActivityParameterNode)
-    subject.parameter = element_factory.create(UML.Parameter)
+def test_construct_activity_parameter_node_direction_changed(create, element_factory):
+    node_item = create(ActivityParameterNodeItem, UML.ActivityParameterNode)
+    node_item.subject.parameter = element_factory.create(UML.Parameter)
 
-    property_page = ActivityParameterNodeDirectionPropertyPage(subject)
+    property_page = ActivityParameterNodeDirectionPropertyPage(node_item)
     widget = property_page.construct()
 
     direction = find(widget, "parameter-direction")
     direction.set_selected(3)
 
-    assert subject.parameter.direction == "return"
+    assert node_item.subject.parameter.direction == "return"
 
 
 class ControllerStub:

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -5,6 +5,7 @@ from gaphor.diagram.tests.fixtures import find
 from gaphor.UML.actions.activity import ActivityItem
 from gaphor.UML.actions.activitypropertypage import (
     ActivityItemPage,
+    ActivityParameterNodeDirectionPropertyPage,
     ActivityParameterNodeNamePropertyPage,
     activity_parameter_node_model,
     list_view_key_handler,
@@ -78,7 +79,7 @@ def test_update_model_when_new_parameter_added(create, element_factory):
     assert property_page.model.get_n_items() == 2  # one + empty row
 
 
-def test_activity_parameter_node_name_editing(create, element_factory):
+def test_activity_parameter_node_name_editing(element_factory):
     subject = element_factory.create(UML.ActivityParameterNode)
     subject.parameter = element_factory.create(UML.Parameter)
     property_page = ActivityParameterNodeNamePropertyPage(subject)
@@ -188,13 +189,36 @@ def test_activity_parameter_node_reorder_first_node_up(create, element_factory):
     assert activity_item.subject.node[1] is node_two
 
 
-def test_construct_activity_itemproperty_page(create):
+def test_construct_activity_item_property_page(create):
     activity_item = create(ActivityItem, UML.Activity)
 
     property_page = ActivityItemPage(activity_item)
     widget = property_page.construct()
 
     assert widget
+
+
+def test_construct_activity_parameter_node_direction_property_page(element_factory):
+    subject = element_factory.create(UML.ActivityParameterNode)
+    subject.parameter = element_factory.create(UML.Parameter)
+
+    property_page = ActivityParameterNodeDirectionPropertyPage(subject)
+    widget = property_page.construct()
+
+    assert widget
+
+
+def test_construct_activity_parameter_node_direction_changed(element_factory):
+    subject = element_factory.create(UML.ActivityParameterNode)
+    subject.parameter = element_factory.create(UML.Parameter)
+
+    property_page = ActivityParameterNodeDirectionPropertyPage(subject)
+    widget = property_page.construct()
+
+    direction = find(widget, "parameter-direction")
+    direction.set_selected(3)
+
+    assert subject.parameter.direction == "return"
 
 
 class ControllerStub:

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -7,6 +7,7 @@ from gaphor.UML.actions.activitypropertypage import (
     ActivityItemPage,
     ActivityParameterNodeDirectionPropertyPage,
     ActivityParameterNodeNamePropertyPage,
+    ActivityParameterNodeTypePropertyPage,
     activity_parameter_node_model,
     list_view_key_handler,
 )
@@ -193,6 +194,16 @@ def test_construct_activity_item_property_page(create):
     activity_item = create(ActivityItem, UML.Activity)
 
     property_page = ActivityItemPage(activity_item)
+    widget = property_page.construct()
+
+    assert widget
+
+
+def test_construct_activity_parameter_node_type_property_page(create, element_factory):
+    node_item = create(ActivityParameterNodeItem, UML.ActivityParameterNode)
+    node_item.subject.parameter = element_factory.create(UML.Parameter)
+
+    property_page = ActivityParameterNodeTypePropertyPage(node_item)
     widget = property_page.construct()
 
     assert widget

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -19,7 +19,7 @@ def _dummy_handler(*args):
 @PropertyPages.register(AssociationItem)
 class AssociationPropertyPage(PropertyPageBase):
     NAVIGABILITY = (None, False, True)
-    AGGREGATION = ("none", "shared", "composite")
+    AGGREGATION = UML.Property.aggregation.values
 
     order = 20
 

--- a/gaphor/UML/propertypages.py
+++ b/gaphor/UML/propertypages.py
@@ -16,15 +16,22 @@ class TypedElementPropertyPage(PropertyPageBase):
     order = 31
 
     def __init__(self, item):
-        assert (not item.subject) or isinstance(
-            item.subject, UML.TypedElement
-        ), item.subject
         super().__init__()
         self.item = item
 
+        assert (not item.subject) or isinstance(
+            self.typed_element, UML.TypedElement
+        ), item.subject
+
+    @property
+    def typed_element(self):
+        return self.item.subject
+
     def construct(self):
-        if not self.item.subject:
+        if not self.typed_element:
             return
+
+        typed_element = self.typed_element
 
         builder = new_builder(
             "typed-element-editor",
@@ -34,15 +41,13 @@ class TypedElementPropertyPage(PropertyPageBase):
         )
 
         dropdown = builder.get_object("element-type")
-        model = list_of_classifiers(self.item.subject.model, UML.Classifier)
+        model = list_of_classifiers(typed_element.model, UML.Classifier)
         dropdown.set_model(model)
 
-        if self.item.subject.type:
+        if typed_element.type:
             dropdown.set_selected(
                 next(
-                    n
-                    for n, lv in enumerate(model)
-                    if lv.value == self.item.subject.type.id
+                    n for n, lv in enumerate(model) if lv.value == typed_element.type.id
                 )
             )
 
@@ -58,13 +63,13 @@ class TypedElementPropertyPage(PropertyPageBase):
 
     @transactional
     def _on_property_type_changed(self, dropdown, _pspec):
-        subject = self.item.subject
+        typed_element = self.typed_element
         if id := dropdown.get_selected_item().value:
-            element = subject.model.lookup(id)
+            element = typed_element.model.lookup(id)
             assert isinstance(element, UML.Type)
-            subject.type = element
+            typed_element.type = element
         else:
-            del subject.type
+            del typed_element.type
 
     @transactional
     def _on_show_type_change(self, button, _gparam):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Types cannot be defined on parameter nodes

Issue Number: #2482

### What is the new behavior?

Types are supported.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

<img width="1154" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/1ae4caf6-cec6-4442-b44c-99cf225120a1">

@sz332 Should the direction be visible in the diagram as well (similar to `Show Type`)?

Update: direction can be toggled.