### PR TITLE
Fine grained CSS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------
 - Support types for parameters
 - Restore windows in maximized and full-screen state
+- Fine grained CSS: elements in a presentation item can be changed from CSS (experimental)
 - Very long element names are now wrapped
 - Format files accessed from Flatpak via portals
 - Update Property Editor to use Gtk.ColumnView and ListView

--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -42,6 +42,7 @@ a = Analysis(  # type: ignore
     pathex=["../"],
     binaries=[],
     datas=[
+        ("../gaphor/diagram.css", "gaphor"),
         ("../gaphor/ui/layout.xml", "gaphor/ui"),
         ("../gaphor/ui/styling*.css", "gaphor/ui"),
         ("../gaphor/ui/*.png", "gaphor/ui"),

--- a/docs/style-sheet-examples.gaphor
+++ b/docs/style-sheet-examples.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.13.0">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.22.1">
 <Package id="9d588440-d7c2-11ea-b8c5-37ef9fca94cd">
 <name>
 <val>style-sheets</val>
@@ -14,6 +14,7 @@
 <ref refid="b1cdfe7e-d7c6-11ea-b8c5-37ef9fca94cd"/>
 <ref refid="380f8d3c-fd67-11ec-9897-a87eeaeedf68"/>
 <ref refid="98156b60-78ce-11ed-825f-0456e5e540ed"/>
+<ref refid="3803e134-a98d-11ee-b5e8-be7f4daace3f"/>
 </reflist>
 </ownedDiagram>
 <ownedType>
@@ -29,6 +30,7 @@
 <ref refid="d165979e-d7c4-11ea-b8c5-37ef9fca94cd"/>
 <ref refid="d419722e-d7c6-11ea-b8c5-37ef9fca94cd"/>
 <ref refid="a28fadf8-78ce-11ed-825f-0456e5e540ed"/>
+<ref refid="4accd6f4-a98d-11ee-b5e8-be7f4daace3f"/>
 </reflist>
 </ownedType>
 </Package>
@@ -109,6 +111,11 @@ diagram[name=todo] comment[body^="TODO"] {
 diagram[name=controlflow] controlflow {
   dash-style: 0;
 }
+
+diagram[name=abstract] :is(name, operation)[isabstract]::after {
+  content: " {abstract}"
+}
+
 </val>
 </styleSheet>
 </StyleSheet>
@@ -629,9 +636,6 @@ diagram[name=controlflow] controlflow {
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="b2db9e86-d7c4-11ea-b8c5-37ef9fca94cd"/>
 </subject>
@@ -664,9 +668,6 @@ diagram[name=controlflow] controlflow {
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="d165979e-d7c4-11ea-b8c5-37ef9fca94cd"/>
 </subject>
@@ -881,9 +882,6 @@ diagram[name=controlflow] controlflow {
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="d419722e-d7c6-11ea-b8c5-37ef9fca94cd"/>
 </subject>
@@ -1143,6 +1141,9 @@ diagram[name=controlflow] controlflow {
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="ad76aadc-78ce-11ed-825f-0456e5e540ed"/>
 </subject>
@@ -1175,4 +1176,81 @@ diagram[name=controlflow] controlflow {
 <ref refid="a6b17eca-78ce-11ed-825f-0456e5e540ed"/>
 </target>
 </ControlFlow>
+<Diagram id="3803e134-a98d-11ee-b5e8-be7f4daace3f">
+<diagramType>
+<val></val>
+</diagramType>
+<element>
+<ref refid="9d588440-d7c2-11ea-b8c5-37ef9fca94cd"/>
+</element>
+<name>
+<val>abstract</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="4acd6d9e-a98d-11ee-b5e8-be7f4daace3f"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<Class id="4accd6f4-a98d-11ee-b5e8-be7f4daace3f">
+<isAbstract>
+<val>1</val>
+</isAbstract>
+<name>
+<val>MyClass</val>
+</name>
+<ownedOperation>
+<reflist>
+<ref refid="6d5189b8-a98d-11ee-b5e8-be7f4daace3f"/>
+<ref refid="6651b9bc-a98d-11ee-b5e8-be7f4daace3f"/>
+</reflist>
+</ownedOperation>
+<package>
+<ref refid="9d588440-d7c2-11ea-b8c5-37ef9fca94cd"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="4acd6d9e-a98d-11ee-b5e8-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Class>
+<ClassItem id="4acd6d9e-a98d-11ee-b5e8-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 112.53125, 101.546875)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>187.0</val>
+</width>
+<height>
+<val>98.0</val>
+</height>
+<diagram>
+<ref refid="3803e134-a98d-11ee-b5e8-be7f4daace3f"/>
+</diagram>
+<subject>
+<ref refid="4accd6f4-a98d-11ee-b5e8-be7f4daace3f"/>
+</subject>
+</ClassItem>
+<Operation id="6651b9bc-a98d-11ee-b5e8-be7f4daace3f">
+<class_>
+<ref refid="4accd6f4-a98d-11ee-b5e8-be7f4daace3f"/>
+</class_>
+<isAbstract>
+<val>1</val>
+</isAbstract>
+<name>
+<val>myOperation</val>
+</name>
+</Operation>
+<Operation id="6d5189b8-a98d-11ee-b5e8-be7f4daace3f">
+<class_>
+<ref refid="4accd6f4-a98d-11ee-b5e8-be7f4daace3f"/>
+</class_>
+<name>
+<val>normalOperation</val>
+</name>
+</Operation>
 </gaphor>

--- a/docs/style_sheets.md
+++ b/docs/style_sheets.md
@@ -112,6 +112,8 @@ of CSS. Below you'll find a summary of all CSS features supported by Gaphor.
 ``:not()``                    Negate the selector.
 
                               E.g. ``:not([subject])``: Any item that has no "subject".
+``::after``                   Provide extra content after a text.
+                              Only the ``content`` property is supported.
 ============================= ============================
 ```
 
@@ -203,6 +205,16 @@ family, size, weight.
 * `dash-style` is a list of numbers (line, gap, line, gap, …)
 * `line-style` only has an effect when defined on a `diagram`. A sloppiness
   factor can be provided in the range of -2 to 2.
+
+### Pseudo elements
+
+Currently, only the `::after` pseudo element is supported.
+
+```{eval-rst}
+======================= =======================================
+``content``             Extra content to be shown after a text.
+======================= =======================================
+```
 
 ### Diagram styles
 
@@ -413,6 +425,23 @@ comment[body^="TODO"] {
 ```{diagram} todo
 :model: style-sheets
 :alt: highlighted todo note
+```
+
+### Emphesize abstract classes and operations
+
+It may be that the italic font used is not distinguishable enough to differentiate between
+concrete and abstract classes or operations.
+To make this work we check if the `isAbstract` attribute is set on the element:
+
+```css
+:is(name, operation)[isabstract]::after {
+  content: " {abstract}"
+}
+```
+
+```{diagram} abstract
+:model: style-sheets
+:alt: emphasize abstract elements
 ```
 
 ## System Style Sheet

--- a/docs/style_sheets.md
+++ b/docs/style_sheets.md
@@ -417,9 +417,6 @@ comment[body^="TODO"] {
 
 ## System Style Sheet
 
-```{literalinclude} ../gaphor/core/modeling/stylesheet.py
+```{literalinclude} ../gaphor/diagram.css
 :language: css
-:dedent: 4
-:start-after: /* --start-system-style-sheet-- */
-:end-before: /* --end-system-style-sheet-- */
 ```

--- a/gaphor/C4Model/diagramitems/container.py
+++ b/gaphor/C4Model/diagramitems/container.py
@@ -1,7 +1,7 @@
 from gaphor.C4Model import c4model
-from gaphor.core.styling import FontWeight, JustifyContent, TextAlign
-from gaphor.diagram.presentation import ElementPresentation, Named
-from gaphor.diagram.shapes import Box, Text, draw_border
+from gaphor.core.styling import JustifyContent
+from gaphor.diagram.presentation import ElementPresentation, Named, text_name
+from gaphor.diagram.shapes import Box, CssNode, Text, draw_border
 from gaphor.diagram.support import represents
 
 
@@ -18,27 +18,27 @@ class C4ContainerItem(Named, ElementPresentation):
 
     def update_shapes(self, event=None):
         diagram = self.diagram
-        text_align = (
-            TextAlign.LEFT if self.diagram and self.children else TextAlign.CENTER
-        )
         self.shape = Box(
-            Text(
-                text=lambda: self.subject.name or "",
-                style={"font-weight": FontWeight.BOLD, "text-align": text_align},
-            ),
-            Text(
-                text=lambda: self.subject.technology
-                and f"[{diagram.gettext(self.subject.type)}: {self.subject.technology}]"
-                or f"[{diagram.gettext(self.subject.type)}]",
-                style={"font-size": "x-small", "text-align": text_align},
+            text_name(self),
+            CssNode(
+                "technology",
+                self.subject,
+                Text(
+                    text=lambda: self.subject.technology
+                    and f"[{diagram.gettext(self.subject.type)}: {self.subject.technology}]"
+                    or f"[{diagram.gettext(self.subject.type)}]",
+                ),
             ),
             *(
                 ()
                 if self.children
                 else (
-                    Text(
-                        text=lambda: self.subject.description or "",
-                        style={"padding": (4, 4, 0, 4), "text-align": text_align},
+                    CssNode(
+                        "description",
+                        self.subject,
+                        Text(
+                            text=lambda: self.subject.description or "",
+                        ),
                     ),
                 )
             ),

--- a/gaphor/C4Model/diagramitems/database.py
+++ b/gaphor/C4Model/diagramitems/database.py
@@ -1,6 +1,6 @@
 from gaphor.C4Model import c4model
-from gaphor.core.styling import FontWeight, JustifyContent, TextAlign
-from gaphor.diagram.presentation import ElementPresentation, Named
+from gaphor.core.styling import JustifyContent, TextAlign
+from gaphor.diagram.presentation import ElementPresentation, Named, text_name
 from gaphor.diagram.shapes import Box, Text, ellipse, stroke
 from gaphor.diagram.support import represents
 
@@ -19,10 +19,7 @@ class C4DatabaseItem(Named, ElementPresentation):
         diagram = self.diagram
         self.shape = Box(
             Box(
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={"font-weight": FontWeight.BOLD},
-                ),
+                text_name(self),
                 Text(
                     text=lambda: self.subject.technology
                     and f"[{diagram.gettext(self.subject.type)}: {self.subject.technology}]"

--- a/gaphor/C4Model/diagramitems/person.py
+++ b/gaphor/C4Model/diagramitems/person.py
@@ -1,8 +1,8 @@
 from math import pi
 
 from gaphor.C4Model import c4model
-from gaphor.core.styling import FontWeight, JustifyContent, TextAlign
-from gaphor.diagram.presentation import ElementPresentation, Named
+from gaphor.core.styling import JustifyContent, TextAlign
+from gaphor.diagram.presentation import ElementPresentation, Named, text_name
 from gaphor.diagram.shapes import Box, Text, stroke
 from gaphor.diagram.support import represents
 
@@ -18,10 +18,7 @@ class C4PersonItem(Named, ElementPresentation):
     def update_shapes(self, event=None):
         self.shape = Box(
             Box(
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={"font-weight": FontWeight.BOLD},
-                ),
+                text_name(self),
                 Text(
                     text=lambda: f"[{self.diagram.gettext('Person')}]",
                     style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/andgate.py
+++ b/gaphor/RAAML/fta/andgate.py
@@ -9,10 +9,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR, DEFAULT_FTA_MINOR
 from gaphor.UML.recipes import stereotypes_str
@@ -37,13 +37,7 @@ class ANDItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("AND Gate")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/basicevent.py
+++ b/gaphor/RAAML/fta/basicevent.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, ellipse, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR
 from gaphor.UML.recipes import stereotypes_str
@@ -35,13 +35,7 @@ class BasicEventItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("Basic Event")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/conditionalevent.py
+++ b/gaphor/RAAML/fta/conditionalevent.py
@@ -4,10 +4,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.basicevent import draw_basic_event
 from gaphor.UML.recipes import stereotypes_str
@@ -32,13 +32,7 @@ class ConditionalEventItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("Conditional Event")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/dormantevent.py
+++ b/gaphor/RAAML/fta/dormantevent.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, draw_diamond
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.undevelopedevent import draw_undeveloped_event
 from gaphor.UML.recipes import stereotypes_str
@@ -35,13 +35,7 @@ class DormantEventItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("Dormant Event")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/houseevent.py
+++ b/gaphor/RAAML/fta/houseevent.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR, DEFAULT_FTA_MINOR
 from gaphor.UML.recipes import stereotypes_str
@@ -35,13 +35,7 @@ class HouseEventItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("House Event")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/inhibitgate.py
+++ b/gaphor/RAAML/fta/inhibitgate.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR
 from gaphor.UML.recipes import stereotypes_str
@@ -35,13 +35,7 @@ class InhibitItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("Inhibit Gate")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/intermediateevent.py
+++ b/gaphor/RAAML/fta/intermediateevent.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, Text, draw_border
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.UML.recipes import stereotypes_str
 
@@ -32,13 +32,7 @@ class IntermediateEventItem(Classified, ElementPresentation):
                         self.subject, [self.diagram.gettext("Intermediate Event")]
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={
-                        "font-weight": FontWeight.BOLD,
-                        "font-style": FontStyle.NORMAL,
-                    },
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/majorityvotegate.py
+++ b/gaphor/RAAML/fta/majorityvotegate.py
@@ -9,10 +9,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR, DEFAULT_FTA_MINOR
 from gaphor.UML.recipes import stereotypes_str
@@ -39,13 +39,7 @@ class MajorityVoteItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("Majority Vote Gate")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/notgate.py
+++ b/gaphor/RAAML/fta/notgate.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR, DEFAULT_FTA_MINOR
 from gaphor.UML.recipes import stereotypes_str
@@ -35,13 +35,7 @@ class NOTItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("NOT Gate")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/orgate.py
+++ b/gaphor/RAAML/fta/orgate.py
@@ -9,10 +9,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR, DEFAULT_FTA_MINOR
 from gaphor.UML.recipes import stereotypes_str
@@ -37,13 +37,7 @@ class ORItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("OR Gate")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/seqgate.py
+++ b/gaphor/RAAML/fta/seqgate.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.andgate import draw_and_gate
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR, DEFAULT_FTA_MINOR
@@ -36,13 +36,7 @@ class SEQItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("Sequence Enforcing Gate")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/topevent.py
+++ b/gaphor/RAAML/fta/topevent.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, Text, draw_border
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.UML.recipes import stereotypes_str
 
@@ -32,13 +32,7 @@ class TopEventItem(Classified, ElementPresentation):
                         self.subject, [self.diagram.gettext("Top Event")]
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={
-                        "font-weight": FontWeight.BOLD,
-                        "font-style": FontStyle.NORMAL,
-                    },
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/transferin.py
+++ b/gaphor/RAAML/fta/transferin.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR
 from gaphor.UML.recipes import stereotypes_str
@@ -35,13 +35,7 @@ class TransferInItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("Transfer In")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/transferout.py
+++ b/gaphor/RAAML/fta/transferout.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR
 from gaphor.RAAML.fta.transferin import draw_transfer_in
@@ -36,13 +36,7 @@ class TransferOutItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("Transfer Out")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/undevelopedevent.py
+++ b/gaphor/RAAML/fta/undevelopedevent.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, draw_diamond
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import WIDE_FTA_HEIGHT, WIDE_FTA_WIDTH
 from gaphor.UML.recipes import stereotypes_str
@@ -35,13 +35,7 @@ class UndevelopedEventItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("Undeveloped Event")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/xorgate.py
+++ b/gaphor/RAAML/fta/xorgate.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR, DEFAULT_FTA_MINOR
 from gaphor.RAAML.fta.orgate import draw_or_gate
@@ -36,13 +36,7 @@ class XORItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("XOR Gate")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/fta/zeroevent.py
+++ b/gaphor/RAAML/fta/zeroevent.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.RAAML.fta.constants import DEFAULT_FTA_MAJOR, DEFAULT_FTA_MINOR
 from gaphor.RAAML.fta.houseevent import draw_house_event
@@ -36,13 +36,7 @@ class ZeroEventItem(Classified, ElementPresentation):
                     self.subject, [self.diagram.gettext("Zero Event")]
                 ),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/RAAML/stpa/controlaction.py
+++ b/gaphor/RAAML/stpa/controlaction.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, Text, draw_border
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.UML.recipes import stereotypes_str
 
@@ -32,13 +32,7 @@ class ControlActionItem(Classified, ElementPresentation):
                         self.subject, [self.diagram.gettext("Control Action")]
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={
-                        "font-weight": FontWeight.BOLD,
-                        "font-style": FontStyle.NORMAL,
-                    },
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/RAAML/stpa/operationalsituation.py
+++ b/gaphor/RAAML/stpa/operationalsituation.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, Text, draw_border
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.UML.recipes import stereotypes_str
 
@@ -33,13 +33,7 @@ class OperationalSituationItem(Classified, ElementPresentation):
                         self.subject, [self.diagram.gettext("Operational Situation")]
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={
-                        "font-weight": FontWeight.BOLD,
-                        "font-style": FontStyle.NORMAL,
-                    },
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/RAAML/stpa/unsafecontrolaction.py
+++ b/gaphor/RAAML/stpa/unsafecontrolaction.py
@@ -7,10 +7,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, Text, draw_border
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.RAAML import raaml
 from gaphor.UML.recipes import stereotypes_str
 
@@ -32,13 +32,7 @@ class UnsafeControlActionItem(Classified, ElementPresentation):
                         self.subject, [self.diagram.gettext("Unsafe Control Action")]
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={
-                        "font-weight": FontWeight.BOLD,
-                        "font-style": FontStyle.NORMAL,
-                    },
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -7,15 +7,13 @@ from gaphor.diagram.presentation import (
 )
 from gaphor.diagram.shapes import (
     Box,
+    CssNode,
     JustifyContent,
     Text,
-    TextAlign,
-    WhiteSpace,
     draw_border,
     draw_top_separator,
 )
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle
 from gaphor.SysML.sysml import Block, ValueType
 from gaphor.UML.classes.klass import attributes_compartment, operation_watches
 from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
@@ -92,6 +90,7 @@ class BlockItem(Classified, ElementPresentation[Block]):
                         lambda a: isinstance(a.type, Block)
                         and a.aggregation
                         and a.aggregation == "composite",
+                        "part",
                     )
                 ]
                 or []
@@ -103,6 +102,7 @@ class BlockItem(Classified, ElementPresentation[Block]):
                     self.block_compartment(
                         self.diagram.gettext("references"),
                         lambda a: a.aggregation and a.aggregation == "shared",
+                        "reference",
                     )
                 ]
                 or []
@@ -115,6 +115,7 @@ class BlockItem(Classified, ElementPresentation[Block]):
                         self.diagram.gettext("values"),
                         lambda a: isinstance(a.type, ValueType)
                         and a.aggregation == "composite",
+                        "value",
                     )
                 ]
                 or []
@@ -142,28 +143,15 @@ class BlockItem(Classified, ElementPresentation[Block]):
             draw=draw_border,
         )
 
-    def block_compartment(self, name, predicate):
+    def block_compartment(self, name, predicate, css_name):
         # We need to fix the attribute value, since the for loop changes it.
         def lazy_format(attribute):
             return lambda: format_property(attribute) or self.diagram.gettext("unnamed")
 
         return Box(
-            Text(
-                text=name,
-                style={
-                    "padding": (0, 0, 4, 0),
-                    "font-size": "x-small",
-                    "font-style": FontStyle.ITALIC,
-                },
-            ),
+            CssNode("heading", self.subject, Text(text=name)),
             *(
-                Text(
-                    text=lazy_format(attribute),
-                    style={
-                        "text-align": TextAlign.LEFT,
-                        "white-space": WhiteSpace.NOWRAP,
-                    },
-                )
+                CssNode(css_name, attribute, Text(text=lazy_format(attribute)))
                 for attribute in self.subject.ownedAttribute
                 if predicate(attribute)
             ),
@@ -182,22 +170,9 @@ class BlockItem(Classified, ElementPresentation[Block]):
             )
 
         return Box(
-            Text(
-                text=name,
-                style={
-                    "padding": (0, 0, 4, 0),
-                    "font-size": "x-small",
-                    "font-style": FontStyle.ITALIC,
-                },
-            ),
+            CssNode("heading", self.subject, Text(text=name)),
             *(
-                Text(
-                    text=lazy_format(operation),
-                    style={
-                        "text-align": TextAlign.LEFT,
-                        "white-space": WhiteSpace.NOWRAP,
-                    },
-                )
+                CssNode("operation", operation, Text(text=lazy_format(operation)))
                 for operation in self.subject.ownedOperation
             ),
             style={

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -3,6 +3,7 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import (
     Box,
@@ -14,7 +15,7 @@ from gaphor.diagram.shapes import (
     draw_top_separator,
 )
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
+from gaphor.diagram.text import FontStyle
 from gaphor.SysML.sysml import Block, ValueType
 from gaphor.UML.classes.klass import attributes_compartment, operation_watches
 from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
@@ -72,15 +73,7 @@ class BlockItem(Classified, ElementPresentation[Block]):
                         self.subject, self.additional_stereotypes()
                     )
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={
-                        "font-weight": FontWeight.BOLD,
-                        "font-style": FontStyle.ITALIC
-                        if self.subject and self.subject.isAbstract
-                        else FontStyle.NORMAL,
-                    },
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/SysML/blocks/interfaceblock.py
+++ b/gaphor/SysML/blocks/interfaceblock.py
@@ -3,6 +3,7 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import (
     Box,
@@ -13,7 +14,7 @@ from gaphor.diagram.shapes import (
     draw_top_separator,
 )
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
+from gaphor.diagram.text import FontStyle
 from gaphor.SysML.sysml import InterfaceBlock, ValueType
 from gaphor.UML.classes.klass import attributes_compartment, operation_watches
 from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
@@ -71,15 +72,7 @@ class InterfaceBlockItem(Classified, ElementPresentation[InterfaceBlock]):
                         self.subject, self.additional_stereotypes()
                     )
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={
-                        "font-weight": FontWeight.BOLD,
-                        "font-style": FontStyle.ITALIC
-                        if self.subject and self.subject.isAbstract
-                        else FontStyle.NORMAL,
-                    },
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/SysML/blocks/interfaceblock.py
+++ b/gaphor/SysML/blocks/interfaceblock.py
@@ -7,14 +7,13 @@ from gaphor.diagram.presentation import (
 )
 from gaphor.diagram.shapes import (
     Box,
+    CssNode,
     JustifyContent,
     Text,
-    TextAlign,
     draw_border,
     draw_top_separator,
 )
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle
 from gaphor.SysML.sysml import InterfaceBlock, ValueType
 from gaphor.UML.classes.klass import attributes_compartment, operation_watches
 from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
@@ -89,6 +88,7 @@ class InterfaceBlockItem(Classified, ElementPresentation[InterfaceBlock]):
                     self.block_compartment(
                         self.diagram.gettext("references"),
                         lambda a: not a.association and a.aggregation != "composite",
+                        "reference",
                     )
                 ]
                 or []
@@ -101,6 +101,7 @@ class InterfaceBlockItem(Classified, ElementPresentation[InterfaceBlock]):
                         self.diagram.gettext("values"),
                         lambda a: isinstance(a.type, ValueType)
                         and a.aggregation == "composite",
+                        "value",
                     )
                 ]
                 or []
@@ -128,22 +129,19 @@ class InterfaceBlockItem(Classified, ElementPresentation[InterfaceBlock]):
             draw=draw_border,
         )
 
-    def block_compartment(self, name, predicate):
+    def block_compartment(self, name, predicate, css_name):
         # We need to fix the attribute value, since the for loop changes it.
         def lazy_format(attribute):
             return lambda: format_property(attribute) or self.diagram.gettext("unnamed")
 
         return Box(
-            Text(
-                text=name,
-                style={
-                    "padding": (0, 0, 4, 0),
-                    "font-size": "x-small",
-                    "font-style": FontStyle.ITALIC,
-                },
+            CssNode(
+                "heading",
+                self.subject,
+                Text(text=name),
             ),
             *(
-                Text(text=lazy_format(attribute), style={"text-align": TextAlign.LEFT})
+                CssNode(css_name, attribute, Text(text=lazy_format(attribute)))
                 for attribute in self.subject.ownedAttribute
                 if predicate(attribute)
             ),
@@ -162,16 +160,13 @@ class InterfaceBlockItem(Classified, ElementPresentation[InterfaceBlock]):
             )
 
         return Box(
-            Text(
-                text=name,
-                style={
-                    "padding": (0, 0, 4, 0),
-                    "font-size": "x-small",
-                    "font-style": FontStyle.ITALIC,
-                },
+            CssNode(
+                "heading",
+                self.subject,
+                Text(text=name),
             ),
             *(
-                Text(text=lazy_format(operation), style={"text-align": TextAlign.LEFT})
+                CssNode("operation", operation, Text(text=lazy_format(operation)))
                 for operation in self.subject.ownedOperation
             ),
             style={

--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -4,9 +4,9 @@ from typing import Sequence, Union
 
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import FontWeight, JustifyContent
+from gaphor.core.styling import JustifyContent
 from gaphor.diagram.presentation import ElementPresentation, Named
-from gaphor.diagram.shapes import Box, Text, draw_border
+from gaphor.diagram.shapes import Box, CssNode, Text, draw_border
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.stereotype import stereotype_compartments
 from gaphor.UML.recipes import stereotypes_str
@@ -48,12 +48,15 @@ class PropertyItem(Named, ElementPresentation[UML.Property]):
                 Text(
                     text=lambda: stereotypes_str(self.subject),
                 ),
-                Text(
-                    text=lambda: format_property(
-                        self.subject, type=True, multiplicity=True
-                    )
-                    or "",
-                    style={"font-weight": FontWeight.BOLD},
+                CssNode(
+                    "name",
+                    self.subject,
+                    Text(
+                        text=lambda: format_property(
+                            self.subject, type=True, multiplicity=True
+                        )
+                        or "",
+                    ),
                 ),
                 style={"padding": (12, 4, 12, 4)},
             ),

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -7,7 +7,6 @@ from gaphor.diagram.presentation import (
 )
 from gaphor.diagram.shapes import (
     Box,
-    JustifyContent,
     Text,
     TextAlign,
     draw_border,
@@ -64,7 +63,6 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
                 ),
                 style={
                     "padding": (12, 4, 12, 4),
-                    "justify-content": JustifyContent.START,
                 },
             ),
             *(
@@ -81,9 +79,6 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
             ),
             *(self.show_stereotypes and stereotype_compartments(self.subject) or []),
             self.id_and_text_compartment(),
-            style={
-                "justify-content": JustifyContent.START,
-            },
             draw=draw_border,
         )
 

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -3,6 +3,7 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import (
     Box,
@@ -13,7 +14,6 @@ from gaphor.diagram.shapes import (
     draw_top_separator,
 )
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.SysML.sysml import Requirement
 from gaphor.UML.classes.klass import (
     attribute_watches,
@@ -57,15 +57,7 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
                         self.subject, [self.diagram.gettext("requirement")]
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={
-                        "font-weight": FontWeight.BOLD,
-                        "font-style": FontStyle.ITALIC
-                        if self.subject and self.subject.isAbstract
-                        else FontStyle.NORMAL,
-                    },
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/UML/classes/component.py
+++ b/gaphor/UML/classes/component.py
@@ -2,8 +2,8 @@
 
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import FontWeight, JustifyContent
-from gaphor.diagram.presentation import Classified, ElementPresentation
+from gaphor.core.styling import JustifyContent
+from gaphor.diagram.presentation import Classified, ElementPresentation, text_name
 from gaphor.diagram.shapes import Box, Text, cairo_state, draw_border
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.stereotype import stereotype_compartments
@@ -33,10 +33,7 @@ class ComponentItem(Classified, ElementPresentation):
                 Text(
                     text=lambda: stereotypes_str(self.subject),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={"font-weight": FontWeight.BOLD},
-                ),
+                text_name(self),
                 style={
                     "padding": (4, 32, 4, 4),
                     "justify-content": JustifyContent.START,

--- a/gaphor/UML/classes/datatype.py
+++ b/gaphor/UML/classes/datatype.py
@@ -2,11 +2,12 @@ import logging
 
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import FontStyle, FontWeight, JustifyContent
+from gaphor.core.styling import JustifyContent
 from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, Text, draw_border
 from gaphor.diagram.support import represents
@@ -69,15 +70,7 @@ class DataTypeItem(Classified, ElementPresentation[UML.DataType]):
                         self.subject, self.additional_stereotypes()
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={
-                        "font-weight": FontWeight.BOLD,
-                        "font-style": FontStyle.ITALIC
-                        if self.subject and self.subject.isAbstract
-                        else FontStyle.NORMAL,
-                    },
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/UML/classes/enumeration.py
+++ b/gaphor/UML/classes/enumeration.py
@@ -2,14 +2,14 @@ import logging
 
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import JustifyContent, TextAlign
+from gaphor.core.styling import JustifyContent
 from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
     text_name,
 )
-from gaphor.diagram.shapes import Box, Text, draw_border, draw_top_separator
+from gaphor.diagram.shapes import Box, CssNode, Text, draw_border, draw_top_separator
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.klass import (
     attribute_watches,
@@ -113,11 +113,12 @@ def enumerations_compartment(subject):
 
     return Box(
         *(
-            Text(
-                text=lazy_format(literal.name),
-                style={
-                    "text-align": TextAlign.LEFT,
-                },
+            CssNode(
+                "enumeration",
+                literal,
+                Text(
+                    text=lazy_format(literal.name),
+                ),
             )
             for literal in subject.ownedLiteral
         ),

--- a/gaphor/UML/classes/enumeration.py
+++ b/gaphor/UML/classes/enumeration.py
@@ -2,11 +2,12 @@ import logging
 
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import FontStyle, FontWeight, JustifyContent, TextAlign
+from gaphor.core.styling import JustifyContent, TextAlign
 from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, Text, draw_border, draw_top_separator
 from gaphor.diagram.support import represents
@@ -73,15 +74,7 @@ class EnumerationItem(Classified, ElementPresentation[UML.Enumeration]):
                         ],
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={
-                        "font-weight": FontWeight.BOLD,
-                        "font-style": FontStyle.ITALIC
-                        if self.subject and self.subject.isAbstract
-                        else FontStyle.NORMAL,
-                    },
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/UML/classes/enumerationpropertypages.py
+++ b/gaphor/UML/classes/enumerationpropertypages.py
@@ -86,7 +86,7 @@ def update_enumeration_model(store: Gio.ListStore, enum: UML.Enumeration) -> Non
 class EnumerationPage(PropertyPageBase):
     """An editor for enumeration literals for an enumeration."""
 
-    order = 20
+    order = 19
 
     def __init__(self, item):
         super().__init__()

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -77,7 +77,7 @@ from gaphas.item import NE, NW, SE, SW
 from gaphor import UML
 from gaphor.core.modeling.presentation import literal_eval
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import FontWeight, JustifyContent
+from gaphor.core.styling import JustifyContent
 from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
@@ -326,12 +326,7 @@ class InterfaceItem(Classified, ElementPresentation):
             Text(
                 text=lambda: stereotypes_str(self.subject),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.NORMAL if connectors else FontWeight.BOLD
-                },
-            ),
+            text_name(self),
         )
 
     def draw_interface_ball_and_socket(self, _box, context, _bounding_box):

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -82,6 +82,7 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, draw_border, stroke
 from gaphor.diagram.support import represents
@@ -283,10 +284,7 @@ class InterfaceItem(Classified, ElementPresentation):
                         self.subject, (self.diagram.gettext("interface"),)
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={"font-weight": FontWeight.BOLD},
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -4,14 +4,13 @@ from gaphor import UML
 from gaphor.core.format import format
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import (
-    FontStyle,
-    FontWeight,
     JustifyContent,
 )
 from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     from_package_str,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, CssNode, Text, draw_border, draw_top_separator
 from gaphor.diagram.support import represents
@@ -65,19 +64,7 @@ class ClassItem(Classified, ElementPresentation[UML.Class]):
                         self.subject, self.additional_stereotypes()
                     ),
                 ),
-                CssNode(
-                    "name",
-                    self.subject,
-                    Text(
-                        text=lambda: self.subject.name or "",
-                        style={
-                            "font-weight": FontWeight.BOLD,
-                            "font-style": FontStyle.ITALIC
-                            if self.subject and self.subject.isAbstract
-                            else FontStyle.NORMAL,
-                        },
-                    ),
-                ),
+                text_name(self),
                 Text(
                     text=lambda: from_package_str(self),
                     style={"font-size": "x-small"},

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -7,9 +7,6 @@ from gaphor.core.styling import (
     FontStyle,
     FontWeight,
     JustifyContent,
-    TextAlign,
-    TextDecoration,
-    WhiteSpace,
 )
 from gaphor.diagram.presentation import (
     Classified,
@@ -138,7 +135,7 @@ def operation_watches(presentation, cast):
 
 
 def attributes_compartment(subject):
-    # We need to fix the attribute value, since the for loop changes it.
+    # We need to scope the attribute value, since the for loop changes it.
     def lazy_format(attribute):
         return lambda: format(attribute)
 
@@ -149,13 +146,6 @@ def attributes_compartment(subject):
                 attribute,
                 Text(
                     text=lazy_format(attribute),
-                    style={
-                        "text-align": TextAlign.LEFT,
-                        "text-decoration": TextDecoration.UNDERLINE
-                        if attribute.isStatic
-                        else TextDecoration.NONE,
-                        "white-space": WhiteSpace.NOWRAP,
-                    },
                 ),
             )
             for attribute in subject.ownedAttribute
@@ -183,16 +173,6 @@ def operations_compartment(subject):
                 operation,
                 Text(
                     text=lazy_format(operation),
-                    style={
-                        "text-align": TextAlign.LEFT,
-                        "font-style": FontStyle.ITALIC
-                        if operation.isAbstract
-                        else FontStyle.NORMAL,
-                        "text-decoration": TextDecoration.UNDERLINE
-                        if operation.isStatic
-                        else TextDecoration.NONE,
-                        "white-space": WhiteSpace.NOWRAP,
-                    },
                 ),
             )
             for operation in subject.ownedOperation

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -16,7 +16,7 @@ from gaphor.diagram.presentation import (
     ElementPresentation,
     from_package_str,
 )
-from gaphor.diagram.shapes import Box, Text, draw_border, draw_top_separator
+from gaphor.diagram.shapes import Box, CssNode, Text, draw_border, draw_top_separator
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
 from gaphor.UML.recipes import stereotypes_str
@@ -68,14 +68,18 @@ class ClassItem(Classified, ElementPresentation[UML.Class]):
                         self.subject, self.additional_stereotypes()
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={
-                        "font-weight": FontWeight.BOLD,
-                        "font-style": FontStyle.ITALIC
-                        if self.subject and self.subject.isAbstract
-                        else FontStyle.NORMAL,
-                    },
+                CssNode(
+                    "name",
+                    self.subject,
+                    Text(
+                        text=lambda: self.subject.name or "",
+                        style={
+                            "font-weight": FontWeight.BOLD,
+                            "font-style": FontStyle.ITALIC
+                            if self.subject and self.subject.isAbstract
+                            else FontStyle.NORMAL,
+                        },
+                    ),
                 ),
                 Text(
                     text=lambda: from_package_str(self),
@@ -140,15 +144,19 @@ def attributes_compartment(subject):
 
     return Box(
         *(
-            Text(
-                text=lazy_format(attribute),
-                style={
-                    "text-align": TextAlign.LEFT,
-                    "text-decoration": TextDecoration.UNDERLINE
-                    if attribute.isStatic
-                    else TextDecoration.NONE,
-                    "white-space": WhiteSpace.NOWRAP,
-                },
+            CssNode(
+                "attribute",
+                attribute,
+                Text(
+                    text=lazy_format(attribute),
+                    style={
+                        "text-align": TextAlign.LEFT,
+                        "text-decoration": TextDecoration.UNDERLINE
+                        if attribute.isStatic
+                        else TextDecoration.NONE,
+                        "white-space": WhiteSpace.NOWRAP,
+                    },
+                ),
             )
             for attribute in subject.ownedAttribute
             if not attribute.association
@@ -170,18 +178,22 @@ def operations_compartment(subject):
 
     return Box(
         *(
-            Text(
-                text=lazy_format(operation),
-                style={
-                    "text-align": TextAlign.LEFT,
-                    "font-style": FontStyle.ITALIC
-                    if operation.isAbstract
-                    else FontStyle.NORMAL,
-                    "text-decoration": TextDecoration.UNDERLINE
-                    if operation.isStatic
-                    else TextDecoration.NONE,
-                    "white-space": WhiteSpace.NOWRAP,
-                },
+            CssNode(
+                "operation",
+                operation,
+                Text(
+                    text=lazy_format(operation),
+                    style={
+                        "text-align": TextAlign.LEFT,
+                        "font-style": FontStyle.ITALIC
+                        if operation.isAbstract
+                        else FontStyle.NORMAL,
+                        "text-decoration": TextDecoration.UNDERLINE
+                        if operation.isStatic
+                        else TextDecoration.NONE,
+                        "white-space": WhiteSpace.NOWRAP,
+                    },
+                ),
             )
             for operation in subject.ownedOperation
         ),

--- a/gaphor/UML/classes/package.py
+++ b/gaphor/UML/classes/package.py
@@ -1,10 +1,14 @@
 """Package diagram item."""
 
 from gaphor import UML
-from gaphor.diagram.presentation import ElementPresentation, Named, from_package_str
+from gaphor.diagram.presentation import (
+    ElementPresentation,
+    Named,
+    from_package_str,
+    text_name,
+)
 from gaphor.diagram.shapes import Box, JustifyContent, Text, cairo_state, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontWeight
 from gaphor.UML.recipes import stereotypes_str
 
 
@@ -29,10 +33,7 @@ class PackageItem(Named, ElementPresentation):
                     or (),
                 ),
             ),
-            Text(
-                text=lambda: self.subject and self.subject.name or "",
-                style={"font-weight": FontWeight.BOLD},
-            ),
+            text_name(self),
             Text(
                 text=lambda: from_package_str(self),
                 style={"font-size": "x-small"},

--- a/gaphor/UML/classes/stereotype.py
+++ b/gaphor/UML/classes/stereotype.py
@@ -1,8 +1,8 @@
 """Support code for dealing with stereotypes in diagrams."""
 
 from gaphor.core.format import format
-from gaphor.core.styling import JustifyContent, TextAlign, WhiteSpace
-from gaphor.diagram.shapes import Box, Text, draw_top_separator
+from gaphor.core.styling import JustifyContent
+from gaphor.diagram.shapes import Box, CssNode, Text, draw_top_separator
 
 
 def stereotype_watches(presentation):
@@ -33,19 +33,22 @@ def _create_stereotype_compartment(appliedStereotype):
 
     if slots:
         return Box(
-            Text(
-                text=lazy_format(appliedStereotype.classifier[0])
-                if appliedStereotype.classifier
-                else "",
-                style={"padding": (0, 0, 4, 0)},
+            CssNode(
+                "heading",
+                appliedStereotype.classifier,
+                Text(
+                    text=lazy_format(appliedStereotype.classifier[0])
+                    if appliedStereotype.classifier
+                    else "",
+                ),
             ),
             *(
-                Text(
-                    text=lazy_format(slot),
-                    style={
-                        "text-align": TextAlign.LEFT,
-                        "white-space": WhiteSpace.NOWRAP,
-                    },
+                CssNode(
+                    "slot",
+                    slot,
+                    Text(
+                        text=lazy_format(slot),
+                    ),
                 )
                 for slot in slots
             ),

--- a/gaphor/UML/deployments/artifact.py
+++ b/gaphor/UML/deployments/artifact.py
@@ -2,8 +2,8 @@
 
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import FontWeight, JustifyContent
-from gaphor.diagram.presentation import Classified, ElementPresentation
+from gaphor.core.styling import JustifyContent
+from gaphor.diagram.presentation import Classified, ElementPresentation, text_name
 from gaphor.diagram.shapes import Box, Text, cairo_state, draw_border
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.stereotype import stereotype_compartments
@@ -31,10 +31,7 @@ class ArtifactItem(Classified, ElementPresentation):
                 Text(
                     text=lambda: stereotypes_str(self.subject),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={"font-weight": FontWeight.BOLD},
-                ),
+                text_name(self),
                 style={"padding": (4, 32, 4, 4)},
                 draw=draw_artifact_icon,
             ),

--- a/gaphor/UML/deployments/node.py
+++ b/gaphor/UML/deployments/node.py
@@ -17,10 +17,9 @@ module.
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import JustifyContent
-from gaphor.diagram.presentation import Classified, ElementPresentation
+from gaphor.diagram.presentation import Classified, ElementPresentation, text_name
 from gaphor.diagram.shapes import Box, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontWeight
 from gaphor.UML.classes.stereotype import stereotype_compartments
 from gaphor.UML.recipes import stereotypes_str
 
@@ -56,10 +55,7 @@ class NodeItem(Classified, ElementPresentation):
                         or (),
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={"font-weight": FontWeight.BOLD},
-                ),
+                text_name(self),
                 style={
                     "padding": (4, 4, 4, 4),
                     "justify-content": JustifyContent.START,

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -31,9 +31,8 @@ from gaphas.solver.constraint import BaseConstraint
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.presentation import ElementPresentation, Named
-from gaphor.diagram.shapes import Box, Text, cairo_state, stroke
+from gaphor.diagram.shapes import Box, CssNode, Text, cairo_state, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontWeight
 from gaphor.UML.recipes import stereotypes_str
 
 
@@ -166,9 +165,12 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
             Text(
                 text=lambda: stereotypes_str(self.subject),
             ),
-            Text(
-                text=self._format_name,
-                style={"font-weight": FontWeight.BOLD},
+            CssNode(
+                "name",
+                self.subject,
+                Text(
+                    text=self._format_name,
+                ),
             ),
             draw=self.draw_lifeline,
         )

--- a/gaphor/UML/states/state.py
+++ b/gaphor/UML/states/state.py
@@ -57,7 +57,7 @@ class StateItem(ElementPresentation[UML.State], Named):
             style={"padding": (4, 4, 4, 4), "justify-content": JustifyContent.START},
             draw=draw_top_separator,
         )
-        if not any(t.text() for t in compartment.children):
+        if not any(t.text() for t in compartment.children):  # type: ignore[attr-defined]
             compartment = Box()
 
         self.shape = Box(

--- a/gaphor/UML/states/statemachine.py
+++ b/gaphor/UML/states/statemachine.py
@@ -5,8 +5,8 @@ from gaphas.types import Pos
 from gaphor import UML
 from gaphor.core.modeling.element import Element
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import FontWeight, JustifyContent
-from gaphor.diagram.presentation import Classified, ElementPresentation
+from gaphor.core.styling import JustifyContent
+from gaphor.diagram.presentation import Classified, ElementPresentation, text_name
 from gaphor.diagram.shapes import Box, Text, draw_border
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.stereotype import stereotype_compartments, stereotype_watches
@@ -40,10 +40,7 @@ class StateMachineItem(Classified, ElementPresentation[UML.StateMachine]):
                         self.subject, [self.diagram.gettext("statemachine")]
                     ),
                 ),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={"font-weight": FontWeight.BOLD},
-                ),
+                text_name(self),
                 style={"padding": (4, 4, 4, 4)},
             ),
             *(self.show_stereotypes and stereotype_compartments(self.subject) or []),

--- a/gaphor/UML/usecases/actor.py
+++ b/gaphor/UML/usecases/actor.py
@@ -10,10 +10,9 @@ from gaphas.position import Position
 from gaphas.solver import REQUIRED, STRONG, variable
 
 from gaphor import UML
-from gaphor.diagram.presentation import Classified, ElementPresentation
+from gaphor.diagram.presentation import Classified, ElementPresentation, text_name
 from gaphor.diagram.shapes import Box, IconBox, Text, stroke
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.UML.recipes import stereotypes_str
 
 HEAD = 11
@@ -76,15 +75,7 @@ class ActorItem(Classified, ElementPresentation):
             Text(
                 text=lambda: stereotypes_str(self.subject),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.ITALIC
-                    if self.subject and self.subject.isAbstract
-                    else FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
         )
 
     def update(self, context):

--- a/gaphor/UML/usecases/usecase.py
+++ b/gaphor/UML/usecases/usecase.py
@@ -1,10 +1,9 @@
 """Use case diagram item."""
 
 from gaphor import UML
-from gaphor.diagram.presentation import Classified, ElementPresentation
+from gaphor.diagram.presentation import Classified, ElementPresentation, text_name
 from gaphor.diagram.shapes import Box, Text, draw_ellipse
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle, FontWeight
 from gaphor.UML.recipes import stereotypes_str
 
 
@@ -24,15 +23,9 @@ class UseCaseItem(Classified, ElementPresentation):
             Text(
                 text=lambda: stereotypes_str(self.subject),
             ),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "padding": (4, 4, 4, 4),
-                    "font-weight": FontWeight.BOLD,
-                    "font-style": FontStyle.ITALIC
-                    if self.subject and self.subject.isAbstract
-                    else FontStyle.NORMAL,
-                },
+            Box(
+                text_name(self),
+                style={"padding": (4, 4, 4, 4)},
             ),
             draw=draw_ellipse,
         )

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -134,15 +134,16 @@ class StyledDiagram:
     ):
         self.diagram = diagram
         self.selection = selection or gaphas.selection.Selection()
+        self.pseudo: str | None = None
         self.dark_mode = dark_mode
 
     def name(self) -> str:
         return "diagram"
 
-    def parent(self):
+    def parent(self) -> StyleNode | None:
         return None
 
-    def children(self) -> Iterator[StyledItem]:
+    def children(self) -> Iterator[StyleNode]:
         return (
             StyledItem(item, self.selection, dark_mode=self.dark_mode)
             for item in self.diagram.get_all_items()
@@ -153,11 +154,8 @@ class StyledDiagram:
         fields = name.split(".")
         return " ".join(map(attrstr, rgetattr(self.diagram, fields))).strip()
 
-    def state(self):
+    def state(self) -> Sequence[str]:
         return ()
-
-    def pseudo(self):
-        return None
 
 
 class StyledItem:
@@ -171,20 +169,20 @@ class StyledItem:
         self,
         item: Presentation,
         selection: gaphas.selection.Selection | None = None,
-        pseudo_element: str | None = None,
+        pseudo: str | None = None,
         dark_mode: bool | None = None,
     ):
         assert item.diagram
         self.item = item
         self.diagram = item.diagram
         self.selection = selection
-        self.pseudo_element = pseudo_element
+        self.pseudo = pseudo
         self.dark_mode = dark_mode
 
     def name(self) -> str:
         return type(self.item).__name__.removesuffix("Item").lower()
 
-    def parent(self) -> StyledItem | StyledDiagram:
+    def parent(self) -> StyleNode | None:
         parent = self.item.parent
         return (
             StyledItem(parent, self.selection, dark_mode=self.dark_mode)
@@ -192,7 +190,7 @@ class StyledItem:
             else StyledDiagram(self.diagram, self.selection, self.dark_mode)
         )
 
-    def children(self) -> Iterator[StyledItem]:
+    def children(self) -> Iterator[StyleNode]:
         selection = self.selection
         return (
             StyledItem(child, selection, dark_mode=self.dark_mode)
@@ -220,9 +218,6 @@ class StyledItem:
             if selection
             else ()
         )
-
-    def pseudo(self) -> str | None:
-        return self.pseudo_element
 
 
 P = TypeVar("P", bound=Presentation)

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -156,6 +156,17 @@ class StyledDiagram:
     def state(self) -> Sequence[str]:
         return ()
 
+    def __hash__(self):
+        return hash((self.diagram, self.state(), self.dark_mode))
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, StyledDiagram)
+            and self.diagram == other.diagram
+            and self.state() == other.state()
+            and self.dark_mode == other.dark_mode
+        )
+
 
 class StyledItem:
     """Wrapper to allow style information to be retrieved.
@@ -168,14 +179,13 @@ class StyledItem:
         self,
         item: Presentation,
         selection: gaphas.selection.Selection | None = None,
-        pseudo: str | None = None,
         dark_mode: bool | None = None,
     ):
         assert item.diagram
         self.item = item
         self.diagram = item.diagram
         self.selection = selection
-        self.pseudo = pseudo
+        self.pseudo: str | None = None
         self.dark_mode = dark_mode
 
     def name(self) -> str:
@@ -217,6 +227,17 @@ class StyledItem:
             )
             if selection
             else ()
+        )
+
+    def __hash__(self):
+        return hash((self.item, self.state(), self.dark_mode))
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, StyledItem)
+            and self.item == other.item
+            and self.state() == other.state()
+            and self.dark_mode == other.dark_mode
         )
 
 

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -305,7 +305,7 @@ class Diagram(Element):
 
     def style(self, node: StyleNode) -> Style:
         style_sheet = self.styleSheet
-        return style_sheet.match(node) if style_sheet else FALLBACK_STYLE
+        return style_sheet.compute_style(node) if style_sheet else FALLBACK_STYLE
 
     def gettext(self, message):
         """Translate a message to the language used in the model."""

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -144,7 +144,7 @@ class StyledDiagram:
 
     def children(self) -> Iterator[StyledItem]:
         return (
-            StyledItem(item, self.selection)
+            StyledItem(item, self.selection, dark_mode=self.dark_mode)
             for item in self.diagram.get_all_items()
             if not item.parent
         )
@@ -155,6 +155,9 @@ class StyledDiagram:
 
     def state(self):
         return ()
+
+    def pseudo(self):
+        return None
 
 
 class StyledItem:
@@ -168,12 +171,14 @@ class StyledItem:
         self,
         item: Presentation,
         selection: gaphas.selection.Selection | None = None,
+        pseudo_element: str | None = None,
         dark_mode: bool | None = None,
     ):
         assert item.diagram
         self.item = item
         self.diagram = item.diagram
         self.selection = selection
+        self.pseudo_element = pseudo_element
         self.dark_mode = dark_mode
 
     def name(self) -> str:
@@ -182,14 +187,17 @@ class StyledItem:
     def parent(self) -> StyledItem | StyledDiagram:
         parent = self.item.parent
         return (
-            StyledItem(parent, self.selection, self.dark_mode)
+            StyledItem(parent, self.selection, dark_mode=self.dark_mode)
             if parent
             else StyledDiagram(self.diagram, self.selection, self.dark_mode)
         )
 
     def children(self) -> Iterator[StyledItem]:
         selection = self.selection
-        return (StyledItem(child, selection) for child in self.item.children)
+        return (
+            StyledItem(child, selection, dark_mode=self.dark_mode)
+            for child in self.item.children
+        )
 
     def attribute(self, name: str) -> str:
         fields = name.split(".")
@@ -212,6 +220,9 @@ class StyledItem:
             if selection
             else ()
         )
+
+    def pseudo(self) -> str | None:
+        return self.pseudo_element
 
 
 P = TypeVar("P", bound=Presentation)

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -49,7 +49,6 @@ FALLBACK_STYLE: Style = {
     "color": (0, 0, 0, 1),
     "font-family": "sans",
     "font-size": 14,
-    "line-width": 2,
     "padding": (0, 0, 0, 0),
 }
 
@@ -196,6 +195,7 @@ class StyledItem:
             StyledItem(child, selection, dark_mode=self.dark_mode)
             for child in self.item.children
         )
+        # TODO: Return css nodes in a Presentation (traverse shapes) to make :has() and :empty work
 
     def attribute(self, name: str) -> str:
         fields = name.split(".")

--- a/gaphor/core/modeling/stylesheet.py
+++ b/gaphor/core/modeling/stylesheet.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.resources
 import textwrap
 
 from gaphor.core.modeling.element import Element
@@ -7,65 +8,8 @@ from gaphor.core.modeling.event import AttributeUpdated
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import CompiledStyleSheet, Style, StyleNode
 
-SYSTEM_STYLE_SHEET = textwrap.dedent(
-    """\
-    /* --start-system-style-sheet-- */
-    * {
-      --opaque-background-color: white;
-      background-color: transparent;
-      color: black;
-      font-size: 14;
-      line-width: 2;
-      padding: 0;
-    }
-
-    *:drop {
-      color: #1a5fb4;
-      line-width: 3;
-    }
-
-    *:disabled {
-      opacity: 0.5;
-    }
-
-    @media light-mode {
-      * {
-        --opaque-background-color: #fafafa;
-      }
-    }
-
-    @media dark-mode {
-      * {
-        --opaque-background-color: #242424;
-        color: white;
-      }
-
-      *:drop {
-        color: #62a0ea;
-      }
-    }
-
-    dependency,
-    interfacerealization {
-      dash-style: 7 5;
-    }
-
-    dependency[on_folded_interface = true],
-    interfacerealization[on_folded_interface = true] {
-      dash-style: 0;
-    }
-
-    controlflow {
-      dash-style: 9 3;
-    }
-
-    proxyport,
-    activityparameternode,
-    executionspecification {
-      background-color: var(--opaque-background-color);
-    }
-    /* --end-system-style-sheet-- */
-    """
+SYSTEM_STYLE_SHEET = (importlib.resources.files("gaphor") / "diagram.css").read_text(
+    "utf-8"
 )
 
 DEFAULT_STYLE_SHEET = textwrap.dedent(

--- a/gaphor/core/modeling/stylesheet.py
+++ b/gaphor/core/modeling/stylesheet.py
@@ -48,8 +48,8 @@ class StyleSheet(Element):
             self.styleSheet,
         )
 
-    def match(self, node: StyleNode) -> Style:
-        return self._compiled_style_sheet.match(node)
+    def compute_style(self, node: StyleNode) -> Style:
+        return self._compiled_style_sheet.compute_style(node)
 
     def postload(self):
         super().postload()

--- a/gaphor/core/styling/__init__.py
+++ b/gaphor/core/styling/__init__.py
@@ -147,12 +147,12 @@ class CompiledStyleSheet:
     @functools.lru_cache(maxsize=1000)
     def compute_style(self, node: StyleNode) -> Style:
         return merge_styles(
-            {"-gaphor-style-node": node, "-gaphor-compiled-style-sheet": self},
             *(
                 declarations
                 for _specificity, _order, declarations, pred in self.selectors
                 if pred(node)
-            )
+            ),
+            {"-gaphor-style-node": node, "-gaphor-compiled-style-sheet": self}
         )
 
 

--- a/gaphor/core/styling/__init__.py
+++ b/gaphor/core/styling/__init__.py
@@ -144,7 +144,7 @@ class CompiledStyleSheet:
             key=operator.itemgetter(0, 1),
         )
 
-    @functools.lru_cache(maxsize=1000)
+    # @functools.lru_cache(maxsize=1000)
     def compute_style(self, node: StyleNode) -> Style:
         return merge_styles(
             *(
@@ -158,7 +158,7 @@ class CompiledStyleSheet:
 
 class PseudoStyleNode:
 
-    def __init__(self, node: StyleNode, psuedo: str):
+    def __init__(self, node: StyleNode, psuedo: str | None):
         self._node = node
         self.pseudo = psuedo
         self.dark_mode = node.dark_mode

--- a/gaphor/core/styling/__init__.py
+++ b/gaphor/core/styling/__init__.py
@@ -56,6 +56,10 @@ Style = TypedDict(
 
 
 class StyleNode(Protocol):
+
+    pseudo: str | None
+    dark_mode: bool | None
+
     def name(self) -> str:
         ...
 
@@ -69,9 +73,6 @@ class StyleNode(Protocol):
         ...
 
     def state(self) -> Sequence[str]:
-        ...
-
-    def pseudo(self) -> str | None:
         ...
 
 

--- a/gaphor/core/styling/__init__.py
+++ b/gaphor/core/styling/__init__.py
@@ -64,6 +64,8 @@ Style = TypedDict(
     total=False,
 )
 
+INHERITED_DECLARATIONS = ("color", "font-family", "font-size", "font-style", "font-weight", "text-align", "text-color", "white-space")
+
 
 class StyleNode(Protocol):
 
@@ -84,6 +86,7 @@ class StyleNode(Protocol):
 
     def state(self) -> Sequence[str]:
         ...
+
 
 class PseudoStyleNode:
 

--- a/gaphor/core/styling/__init__.py
+++ b/gaphor/core/styling/__init__.py
@@ -187,7 +187,7 @@ class CompiledStyleSheet:
         )
 
     @functools.lru_cache(maxsize=1000)
-    def match(self, node: StyleNode) -> Style:
+    def compute_style(self, node: StyleNode) -> Style:
         # TODO: make after_style lazy
         after_style = merge_styles(*(
             declarations

--- a/gaphor/core/styling/__init__.py
+++ b/gaphor/core/styling/__init__.py
@@ -31,6 +31,7 @@ Style = TypedDict(
         "background-color": Color,
         "border-radius": Number,
         "color": Color,
+        "content": str,
         "dash-style": Sequence[Number],
         "padding": Padding,
         "font-family": str,
@@ -68,6 +69,9 @@ class StyleNode(Protocol):
         ...
 
     def state(self) -> Sequence[str]:
+        ...
+
+    def pseudo(self) -> str | None:
         ...
 
 

--- a/gaphor/core/styling/compiler.py
+++ b/gaphor/core/styling/compiler.py
@@ -227,4 +227,4 @@ def compile_pseudo_element_selector(selector: selectors.PseudoElementSelector):
     if name != "after":
         raise selectors.SelectorError("Unknown pseudo-element", name)
 
-    return lambda el: name == el.pseudo()
+    return lambda el: name == el.pseudo

--- a/gaphor/core/styling/compiler.py
+++ b/gaphor/core/styling/compiler.py
@@ -219,3 +219,12 @@ def compile_functional_pseudo_class_selector(
         return lambda el: any(sel(el) for sel, _ in sub_selectors)
     elif name == "not":
         return lambda el: not any(sel(el) for sel, _ in sub_selectors)
+
+
+@compile_node.register
+def compile_pseudo_element_selector(selector: selectors.PseudoElementSelector):
+    name = selector.name
+    if name != "after":
+        raise selectors.SelectorError("Unknown pseudo-element", name)
+
+    return lambda el: name == el.pseudo()

--- a/gaphor/core/styling/declarations.py
+++ b/gaphor/core/styling/declarations.py
@@ -250,3 +250,10 @@ def parse_line_style(prop, value) -> float:
                 return float(factor)
     # "normal" value:
     return 0.0
+
+
+@declarations.register(
+    "content",
+)
+def parse_content(prop, value) -> str:
+    return value or ""

--- a/gaphor/core/styling/declarations.py
+++ b/gaphor/core/styling/declarations.py
@@ -7,9 +7,9 @@ import tinycss2.color3
 from tinycss2.ast import FunctionBlock
 from tinycss2.parser import parse_declaration_list
 
-Color = Tuple[float, float, float, float]  # RGBA
-Padding = Tuple[float, float, float, float]  # top/right/bottom/left
 Number = Union[int, float]
+Color = Tuple[float, float, float, float]  # RGBA
+Padding = Tuple[Number, Number, Number, Number]  # top/right/bottom/left
 
 
 class TextAlign(Enum):
@@ -51,6 +51,10 @@ class WhiteSpace(Enum):
     NOWRAP = "nowrap"
 
 
+class Var(NamedTuple):
+    name: str
+
+
 FONT_SIZE_VALUES = {
     "x-small": 3 / 4,
     "small": 8 / 9,
@@ -72,10 +76,6 @@ def parse_declarations(declaration_list):
             )
         elif decl.type == "error":
             yield "error", decl
-
-
-class Var(NamedTuple):
-    name: str
 
 
 class _Declarations:

--- a/gaphor/core/styling/inherit.py
+++ b/gaphor/core/styling/inherit.py
@@ -36,6 +36,16 @@ class InheritingStyleNode:
     def state(self) -> Sequence[str]:
         return self._parent.state()
 
+    def __hash__(self):
+        return hash((self._parent, self._child))
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, InheritingStyleNode)
+            and self._parent == other._parent
+            and self._child == other._child
+        )
+
 
 def inherit_style(style: Style, child: StyleNode) -> Style:
     parent: StyleNode | None = style.get(  # type: ignore[assignment]

--- a/gaphor/core/styling/inherit.py
+++ b/gaphor/core/styling/inherit.py
@@ -1,0 +1,56 @@
+from typing import Iterator, Sequence
+
+from gaphor.core.styling import Style, StyleNode, merge_styles
+
+INHERITED_DECLARATIONS = (
+    "color",
+    "font-family",
+    "font-size",
+    "font-style",
+    "font-weight",
+    "text-align",
+    "text-color",
+    "white-space",
+)
+
+
+class InheritingStyleNode:
+    def __init__(self, parent: StyleNode, child: StyleNode):
+        self._parent = parent
+        self._child = child
+        self.pseudo = parent.pseudo
+        self.dark_mode = parent.dark_mode
+
+    def name(self) -> str:
+        return self._child.name()
+
+    def parent(self) -> StyleNode | None:
+        return self._parent
+
+    def children(self) -> Iterator[StyleNode]:
+        return self._child.children()
+
+    def attribute(self, name: str) -> str:
+        return self._child.attribute(name)
+
+    def state(self) -> Sequence[str]:
+        return self._parent.state()
+
+
+def inherit_style(style: Style, child: StyleNode) -> Style:
+    parent: StyleNode | None = style.get(  # type: ignore[assignment]
+        "-gaphor-style-node"
+    )
+    if not parent:
+        return style
+
+    node = InheritingStyleNode(parent, child)
+    compiled_style_sheet = style.get("-gaphor-compiled-style-sheet")
+
+    sub_style = compiled_style_sheet.match(node)  # type: ignore[attr-defined]
+
+    return merge_styles(
+        {n: v for n, v in style.items() if n in INHERITED_DECLARATIONS},  # type: ignore[arg-type]
+        {"padding": (0, 0, 0, 0)},
+        sub_style,
+    )

--- a/gaphor/core/styling/inherit.py
+++ b/gaphor/core/styling/inherit.py
@@ -1,6 +1,6 @@
 from typing import Iterator, Sequence
 
-from gaphor.core.styling import Style, StyleNode, merge_styles
+from gaphor.core.styling import CompiledStyleSheet, Style, StyleNode, merge_styles
 
 INHERITED_DECLARATIONS = (
     "color",
@@ -55,9 +55,9 @@ def inherit_style(style: Style, child: StyleNode) -> Style:
         return style
 
     node = InheritingStyleNode(parent, child)
-    compiled_style_sheet = style.get("-gaphor-compiled-style-sheet")
+    compiled_style_sheet: CompiledStyleSheet = style.get("-gaphor-compiled-style-sheet")  # type: ignore[assignment]
 
-    sub_style = compiled_style_sheet.match(node)  # type: ignore[attr-defined]
+    sub_style = compiled_style_sheet.compute_style(node)
 
     return merge_styles(
         {n: v for n, v in style.items() if n in INHERITED_DECLARATIONS},  # type: ignore[arg-type]

--- a/gaphor/core/styling/inherit.py
+++ b/gaphor/core/styling/inherit.py
@@ -54,10 +54,9 @@ def inherit_style(style: Style, child: StyleNode) -> Style:
     if not parent:
         return style
 
-    node = InheritingStyleNode(parent, child)
     compiled_style_sheet: CompiledStyleSheet = style.get("-gaphor-compiled-style-sheet")  # type: ignore[assignment]
 
-    sub_style = compiled_style_sheet.compute_style(node)
+    sub_style = compiled_style_sheet.compute_style(InheritingStyleNode(parent, child))
 
     return merge_styles(
         {n: v for n, v in style.items() if n in INHERITED_DECLARATIONS},  # type: ignore[arg-type]

--- a/gaphor/core/styling/tests/test_compiler.py
+++ b/gaphor/core/styling/tests/test_compiler.py
@@ -12,6 +12,7 @@ class Node:
         children=None,
         attributes=None,
         state=(),
+        pseudo=None,
         dark_mode=None,
     ):
         if attributes is None:
@@ -21,6 +22,7 @@ class Node:
         self._children = children or []
         self._attributes = attributes
         self._state = state
+        self._pseudo = pseudo
         self.dark_mode = dark_mode
 
         if parent:
@@ -42,6 +44,9 @@ class Node:
 
     def state(self):
         return self._state
+
+    def pseudo(self):
+        return self._pseudo
 
 
 def test_node_test_object_parent_child():
@@ -298,6 +303,17 @@ def test_has_pseudo_selector_with_combinator_is_not_supported():
     error, payload = next(compile_style_sheet(css))
 
     assert error == "error"
+
+
+def test_parse_empty_pseudo_element():
+    css = "node::after {}"
+
+    (selector, specificity), payload = next(compile_style_sheet(css))
+
+    assert payload == {}
+    assert not selector(Node("node"))
+    assert selector(Node("node", pseudo="after"))
+    assert specificity == (0, 0, 2)
 
 
 def test_has_and_is_selector():

--- a/gaphor/core/styling/tests/test_compiler.py
+++ b/gaphor/core/styling/tests/test_compiler.py
@@ -22,7 +22,7 @@ class Node:
         self._children = children or []
         self._attributes = attributes
         self._state = state
-        self._pseudo = pseudo
+        self.pseudo = pseudo
         self.dark_mode = dark_mode
 
         if parent:
@@ -44,9 +44,6 @@ class Node:
 
     def state(self):
         return self._state
-
-    def pseudo(self):
-        return self._pseudo
 
 
 def test_node_test_object_parent_child():

--- a/gaphor/core/styling/tests/test_css.py
+++ b/gaphor/core/styling/tests/test_css.py
@@ -383,3 +383,13 @@ def test_combined_normal_and_pseudo_element():
 
     assert node_props.get("content") == "Hi"
     assert class_props.get("content") == "Hi"
+
+
+def test_pseudo_element_inherits_normal_declarations():
+    css = "node { color: blue} ::after { content: 'Hi' }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    props = compiled_style_sheet.match(Node("node"))
+
+    assert props.get("::after")
+    assert props.get("::after").get("content") == "Hi"

--- a/gaphor/core/styling/tests/test_css.py
+++ b/gaphor/core/styling/tests/test_css.py
@@ -151,7 +151,7 @@ def test_compiled_style_sheet():
     """
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("mytype"))
+    props = compiled_style_sheet.compute_style(Node("mytype"))
 
     assert props.get("font-family") == "sans"
     assert props.get("font-size") == 42
@@ -183,7 +183,7 @@ def test_empty_compiled_style_sheet():
     css = ""
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("mytype"))
+    props = compiled_style_sheet.compute_style(Node("mytype"))
 
     assert filter_private(props) == {}
 
@@ -192,7 +192,7 @@ def test_color():
     css = "mytype { color: #00ff00 }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("mytype"))
+    props = compiled_style_sheet.compute_style(Node("mytype"))
 
     assert props.get("color") == (0, 1, 0, 1)
 
@@ -201,7 +201,7 @@ def test_color_typing_in_progress():
     css = "mytype { color: # }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("mytype"))
+    props = compiled_style_sheet.compute_style(Node("mytype"))
 
     assert props.get("color") is None
 
@@ -222,7 +222,7 @@ def test_line_style(css_value, result):
     css = f"mytype {{ line-style: {css_value} }}"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("mytype"))
+    props = compiled_style_sheet.compute_style(Node("mytype"))
 
     assert props.get("line-style") == result
 
@@ -242,7 +242,7 @@ def test_opacity(css_value, result):
     css = f"mytype {{ opacity: {css_value} }}"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("mytype"))
+    props = compiled_style_sheet.compute_style(Node("mytype"))
 
     assert props.get("opacity") == result
 
@@ -252,7 +252,7 @@ def test_broken_line_style():
     css = "diagram { line-style: sloppy * { }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("mytype"))
+    props = compiled_style_sheet.compute_style(Node("mytype"))
 
     assert props.get("line-style") is None
 
@@ -261,7 +261,7 @@ def test_variable():
     css = "diagram { --myvar: 12; line-width: var(--myvar) }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("diagram"))
+    props = compiled_style_sheet.compute_style(Node("diagram"))
 
     assert props.get("line-width") == 12
 
@@ -270,7 +270,7 @@ def test_variable_color():
     css = "* { --mycolor: #123456 } diagram { color: var(--mycolor) }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("diagram"))
+    props = compiled_style_sheet.compute_style(Node("diagram"))
 
     assert props.get("color") == pytest.approx(
         (0x12 / 255.0, 0x34 / 255.0, 0x56 / 255.0, 1.0)
@@ -281,7 +281,7 @@ def test_unknown_variable():
     css = "diagram { line-width: var(--myvar) }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("diagram"))
+    props = compiled_style_sheet.compute_style(Node("diagram"))
 
     assert props.get("line-width") is None
 
@@ -290,7 +290,7 @@ def test_unknown_variable_should_use_original_value():
     css = "* { line-width: 1.0 } diagram { line-width: var(--myvar) }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("diagram"))
+    props = compiled_style_sheet.compute_style(Node("diagram"))
 
     assert props.get("line-width") == pytest.approx(1.0)
 
@@ -299,7 +299,7 @@ def test_unknown_variable_resolve_original_value():
     css = "* { line-width: var(--lw); --lw: 1.0 } diagram { line-width: var(--myvar) }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("diagram"))
+    props = compiled_style_sheet.compute_style(Node("diagram"))
 
     assert props.get("line-width") == pytest.approx(1.0)
 
@@ -308,7 +308,7 @@ def test_variable_cannot_contain_a_variable():
     css = "* { line-width: var(--a); --a: var(--b); --b: 1.0 }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("diagram"))
+    props = compiled_style_sheet.compute_style(Node("diagram"))
 
     assert props.get("line-width") is None
 
@@ -317,7 +317,7 @@ def test_variable_with_property():
     css = "* { line-width: var(line-width); }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("diagram"))
+    props = compiled_style_sheet.compute_style(Node("diagram"))
 
     assert props.get("line-width") is None
 
@@ -334,9 +334,9 @@ def test_color_schemes():
     """
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    normal_props = compiled_style_sheet.match(Node("node"))
-    dark_props = compiled_style_sheet.match(Node("node", dark_mode=True))
-    light_props = compiled_style_sheet.match(Node("node", dark_mode=False))
+    normal_props = compiled_style_sheet.compute_style(Node("node"))
+    dark_props = compiled_style_sheet.compute_style(Node("node", dark_mode=True))
+    light_props = compiled_style_sheet.compute_style(Node("node", dark_mode=False))
 
     assert normal_props.get("line-width") == pytest.approx(1.0)
     assert dark_props.get("line-width") == pytest.approx(2.0)
@@ -355,7 +355,7 @@ def test_white_space_normal(white_space_value, result):
     css = f"* {{ white-space: {white_space_value} }}"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("node"))
+    props = compiled_style_sheet.compute_style(Node("node"))
 
     assert props.get("white-space") is result
 
@@ -364,7 +364,7 @@ def test_pseudo_element():
     css = "class::after { content: 'Hi' }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("class", pseudo="after"))
+    props = compiled_style_sheet.compute_style(Node("class", pseudo="after"))
 
     assert props.get("content") == "Hi"
 
@@ -373,7 +373,7 @@ def test_bare_pseudo_element():
     css = "::after { content: 'Hi' }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("node", pseudo="after"))
+    props = compiled_style_sheet.compute_style(Node("node", pseudo="after"))
 
     assert props.get("content") == "Hi"
 
@@ -382,8 +382,8 @@ def test_combined_normal_and_pseudo_element():
     css = "node, class::after { content: 'Hi' }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    node_props = compiled_style_sheet.match(Node("node"))
-    class_props = compiled_style_sheet.match(Node("class", pseudo="after"))
+    node_props = compiled_style_sheet.compute_style(Node("node"))
+    class_props = compiled_style_sheet.compute_style(Node("class", pseudo="after"))
 
     assert node_props.get("content") == "Hi"
     assert class_props.get("content") == "Hi"
@@ -393,7 +393,7 @@ def test_pseudo_element_inherits_normal_declarations():
     css = "node { color: blue} ::after { content: 'Hi' }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    props = compiled_style_sheet.match(Node("node"))
+    props = compiled_style_sheet.compute_style(Node("node"))
 
     assert props.get("::after")
     assert props.get("::after").get("content") == "Hi"

--- a/gaphor/core/styling/tests/test_css.py
+++ b/gaphor/core/styling/tests/test_css.py
@@ -354,3 +354,32 @@ def test_white_space_normal(white_space_value, result):
     props = compiled_style_sheet.match(Node("node"))
 
     assert props.get("white-space") is result
+
+
+def test_pseudo_element():
+    css = "class::after { content: 'Hi' }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    props = compiled_style_sheet.match(Node("class", pseudo="after"))
+
+    assert props.get("content") == "Hi"
+
+
+def test_bare_pseudo_element():
+    css = "::after { content: 'Hi' }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    props = compiled_style_sheet.match(Node("node", pseudo="after"))
+
+    assert props.get("content") == "Hi"
+
+
+def test_combined_normal_and_pseudo_element():
+    css = "node, class::after { content: 'Hi' }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    node_props = compiled_style_sheet.match(Node("node"))
+    class_props = compiled_style_sheet.match(Node("class", pseudo="after"))
+
+    assert node_props.get("content") == "Hi"
+    assert class_props.get("content") == "Hi"

--- a/gaphor/core/styling/tests/test_css.py
+++ b/gaphor/core/styling/tests/test_css.py
@@ -175,13 +175,17 @@ def test_faulty_font_size(font_size):
     assert props.get("font-size") is None
 
 
+def filter_private(props):
+    return {n: v for n, v in props.items() if not n.startswith("-gaphor-")}
+
+
 def test_empty_compiled_style_sheet():
     css = ""
 
     compiled_style_sheet = CompiledStyleSheet(css)
     props = compiled_style_sheet.match(Node("mytype"))
 
-    assert props == {}
+    assert filter_private(props) == {}
 
 
 def test_color():

--- a/gaphor/core/styling/tests/test_css.py
+++ b/gaphor/core/styling/tests/test_css.py
@@ -1,6 +1,10 @@
 import pytest
 
-from gaphor.core.styling import CompiledStyleSheet, compile_style_sheet
+from gaphor.core.styling import (
+    CompiledStyleSheet,
+    compile_style_sheet,
+    compute_pseudo_element_style,
+)
 from gaphor.core.styling.declarations import WhiteSpace
 from gaphor.core.styling.tests.test_compiler import Node
 
@@ -394,6 +398,7 @@ def test_pseudo_element_inherits_normal_declarations():
 
     compiled_style_sheet = CompiledStyleSheet(css)
     props = compiled_style_sheet.compute_style(Node("node"))
+    after = compute_pseudo_element_style(props, "after")
 
-    assert props.get("::after")
-    assert props.get("::after").get("content") == "Hi"
+    assert after
+    assert after.get("content") == "Hi"

--- a/gaphor/core/styling/tests/test_inherit.py
+++ b/gaphor/core/styling/tests/test_inherit.py
@@ -8,7 +8,7 @@ def test_inherit_from_parent_style():
     css = "node { font-size: 10 } node sub { content: 'Hi' }"
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    style = compiled_style_sheet.match(Node("node"))
+    style = compiled_style_sheet.compute_style(Node("node"))
     inherited = inherit_style(style, StyledChildElement("sub", None))
 
     assert inherited.get("font-size") == 10
@@ -23,7 +23,7 @@ def test_should_not_inherit_everything():
     """
 
     compiled_style_sheet = CompiledStyleSheet(css)
-    style = compiled_style_sheet.match(Node("node"))
+    style = compiled_style_sheet.compute_style(Node("node"))
     inherited = inherit_style(
         inherit_style(style, StyledChildElement("sub", None)),
         StyledChildElement("sub", None),

--- a/gaphor/core/styling/tests/test_inherit.py
+++ b/gaphor/core/styling/tests/test_inherit.py
@@ -1,0 +1,34 @@
+from gaphor.core.styling import CompiledStyleSheet
+from gaphor.core.styling.inherit import inherit_style
+from gaphor.core.styling.tests.test_compiler import Node
+from gaphor.diagram.shapes import StyledChildElement
+
+
+def test_inherit_from_parent_style():
+    css = "node { font-size: 10 } node sub { content: 'Hi' }"
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    style = compiled_style_sheet.match(Node("node"))
+    inherited = inherit_style(style, StyledChildElement("sub", None))
+
+    assert inherited.get("font-size") == 10
+    assert inherited.get("content") == "Hi"
+
+
+def test_should_not_inherit_everything():
+    css = """
+    node { background-color: blue }
+    node sub { content: 'Hi' }
+    node sub * { font-size: 10 }
+    """
+
+    compiled_style_sheet = CompiledStyleSheet(css)
+    style = compiled_style_sheet.match(Node("node"))
+    inherited = inherit_style(
+        inherit_style(style, StyledChildElement("sub", None)),
+        StyledChildElement("sub", None),
+    )
+
+    assert not inherited.get("background-color")
+    assert inherited.get("content") == "Hi"
+    assert inherited.get("font-size") == 10

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -55,6 +55,17 @@ executionspecification {
   background-color: var(--opaque-background-color);
 }
 
-* attribute {
+* attribute,
+* operation {
+  text-align: left;
+  white-space: nowrap;
+}
 
+* operation[isabstract] {
+  font-style: italic;
+}
+
+* attribute[isstatic],
+* operation[isstatic] {
+    text-decoration: underline;
 }

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -63,8 +63,7 @@ executionspecification {
   font-style: italic;
 }
 
-* attribute,
-* operation {
+* :is(attribute, operation) {
   text-align: left;
   white-space: nowrap;
 }
@@ -73,7 +72,6 @@ executionspecification {
   font-style: italic;
 }
 
-* attribute[isstatic],
-* operation[isstatic] {
+* :is(attribute, operation)[isstatic] {
     text-decoration: underline;
 }

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -63,7 +63,13 @@ executionspecification {
   font-style: italic;
 }
 
-* :is(attribute, operation) {
+* heading {
+  padding: 0 0 4 0;
+  font-size: x-small;
+  font-style: italic;
+}
+
+* :is(attribute, operation, slot) {
   text-align: left;
   white-space: nowrap;
 }

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -1,0 +1,60 @@
+/* Gaphor diagram style sheet */
+
+* {
+  --opaque-background-color: white;
+  background-color: transparent;
+  color: black;
+  font-size: 14;
+  line-width: 2;
+  padding: 0;
+}
+
+*:drop {
+  color: #1a5fb4;
+  line-width: 3;
+}
+
+*:disabled {
+  opacity: 0.5;
+}
+
+@media light-mode {
+  * {
+    --opaque-background-color: #fafafa;
+  }
+}
+
+@media dark-mode {
+  * {
+    --opaque-background-color: #242424;
+    color: white;
+  }
+
+  *:drop {
+    color: #62a0ea;
+  }
+}
+
+dependency,
+interfacerealization {
+  dash-style: 7 5;
+}
+
+dependency[on_folded_interface = true],
+interfacerealization[on_folded_interface = true] {
+  dash-style: 0;
+}
+
+controlflow {
+  dash-style: 9 3;
+}
+
+proxyport,
+activityparameternode,
+executionspecification {
+  background-color: var(--opaque-background-color);
+}
+
+* attribute {
+
+}

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -69,7 +69,7 @@ executionspecification {
   font-style: italic;
 }
 
-* :is(attribute, operation, enumeration, slot) {
+* :is(attribute, operation, enumeration, slot, part, reference, value) {
   text-align: left;
   white-space: nowrap;
 }

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -69,7 +69,7 @@ executionspecification {
   font-style: italic;
 }
 
-* :is(attribute, operation, slot) {
+* :is(attribute, operation, enumeration, slot) {
   text-align: left;
   white-space: nowrap;
 }

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -75,3 +75,19 @@ executionspecification {
 * :is(attribute, operation)[isstatic] {
     text-decoration: underline;
 }
+
+c4container {
+  text-align: left;
+}
+
+c4container[children = ""] {
+  text-align: center;
+}
+
+c4container technology {
+  font-size: x-small;
+}
+
+c4container description {
+  padding: 4 4 0 4;
+}

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -97,3 +97,7 @@ c4container technology {
 c4container description {
   padding: 4 4 0 4;
 }
+
+requirement {
+  justify-content: start;
+}

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -55,6 +55,14 @@ executionspecification {
   background-color: var(--opaque-background-color);
 }
 
+* name {
+  font-weight: bold;
+}
+
+* name[isabstract] {
+  font-style: italic;
+}
+
 * attribute,
 * operation {
   text-align: left;

--- a/gaphor/diagram/painter.py
+++ b/gaphor/diagram/painter.py
@@ -28,7 +28,7 @@ class ItemPainter:
         if not (diagram := item.diagram):
             return
 
-        style = diagram.style(StyledItem(item, selection, dark_mode=self.dark_mode))
+        style = diagram.style(StyledItem(item, selection, self.dark_mode))
 
         cr.save()
         try:

--- a/gaphor/diagram/painter.py
+++ b/gaphor/diagram/painter.py
@@ -28,7 +28,7 @@ class ItemPainter:
         if not (diagram := item.diagram):
             return
 
-        style = diagram.style(StyledItem(item, selection, self.dark_mode))
+        style = diagram.style(StyledItem(item, selection, dark_mode=self.dark_mode))
 
         cr.save()
         try:

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -15,7 +15,7 @@ from gaphor.core.modeling.event import AttributeUpdated, RevertibleEvent
 from gaphor.core.modeling.presentation import Presentation, S, literal_eval
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import Style, merge_styles
-from gaphor.diagram.shapes import stroke
+from gaphor.diagram.shapes import CssNode, Text, stroke
 from gaphor.diagram.text import TextAlign, middle_segment, text_point_at_line
 
 
@@ -29,6 +29,17 @@ class Valued:
 
 class Classified(Named):
     """Marker for Classifier presentations."""
+
+
+def text_name(item: Presentation):
+    """An item's `name` field."""
+    return CssNode(
+        "name",
+        item.subject,
+        Text(
+            text=lambda: item.subject and item.subject.name or "",
+        ),
+    )
 
 
 def from_package_str(item):

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -32,7 +32,7 @@ class Classified(Named):
 
 
 def text_name(item: Presentation):
-    """An item's `name` field."""
+    """An item subject's `name` field."""
     return CssNode(
         "name",
         item.subject,

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -36,9 +36,7 @@ def text_name(item: Presentation):
     return CssNode(
         "name",
         item.subject,
-        Text(
-            text=lambda: item.subject and item.subject.name or "",
-        ),
+        Text(text=lambda: item.subject and item.subject.name or ""),
     )
 
 

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -535,7 +535,7 @@ class Text:
 
 
 class StyledChildElement:
-    def __init__(self, name: str, element: Element):
+    def __init__(self, name: str, element: Element | None):
         self._name = name
         self._element = element
         self.pseudo: str | None = None
@@ -551,6 +551,8 @@ class StyledChildElement:
         return iter(())
 
     def attribute(self, name: str) -> str:
+        if not self._element:
+            return ""
         fields = name.split(".")
         return " ".join(map(attrstr, rgetattr(self._element, fields))).strip()
 
@@ -566,7 +568,7 @@ class CssNode:
     def __init__(
         self,
         name: str,
-        element: Element,
+        element: Element | None,
         child: Shape,
         style: Style | None = None,
     ):

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -545,7 +545,7 @@ class StyledChildElement:
         return self._name
 
     def parent(self) -> StyleNode | None:
-        return None
+        raise NotImplementedError()
 
     def children(self) -> Iterator[StyleNode]:
         return iter(())
@@ -557,7 +557,17 @@ class StyledChildElement:
         return " ".join(map(attrstr, rgetattr(self._element, fields))).strip()
 
     def state(self) -> Sequence[str]:
-        return ()
+        raise NotImplementedError()
+
+    def __hash__(self):
+        return hash((self.name, self._element))
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, StyledChildElement)
+            and self._name == other._name
+            and self._element == other._element
+        )
 
 
 class CssNode:

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -19,6 +19,7 @@ from gaphor.core.styling import (
     TextAlign,
     VerticalAlign,
     WhiteSpace,
+    compute_pseudo_element_style,
     merge_styles,
 )
 from gaphor.core.styling.inherit import inherit_style
@@ -488,7 +489,7 @@ class Text:
 
         if (
             style
-            and (after := style.get("::after"))
+            and (after := compute_pseudo_element_style(style, "after"))
             and (content := after.get("content"))
         ):
             return f"{t}{content}"

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -466,11 +466,15 @@ class Text:
         self._inline_style = style
         self._layout = Layout()
 
-    def text(self):
+    def text(self, style: Style):
         try:
-            return self._text()
+            t = self._text()
         except AttributeError:
-            return ""
+            t = ""
+
+        if (after := style.get("::after")) and (content := after.get("content")):
+            return f"{t}{content}"
+        return t
 
     def size(self, context: UpdateContext, bounding_box: Rectangle | None = None):
         style = merge_styles(context.style, self._inline_style)
@@ -481,7 +485,7 @@ class Text:
 
         layout = self._layout
         layout.set(
-            text=self.text(),
+            text=self.text(style),
             font=style,
             width=bounding_box.width
             if bounding_box and white_space == WhiteSpace.NORMAL

--- a/gaphor/diagram/tests/test_shapes.py
+++ b/gaphor/diagram/tests/test_shapes.py
@@ -279,3 +279,7 @@ def test_text_with_after_pseudo_element():
     text = Text("some")
 
     assert text.text(style) == "some text"
+
+
+def test_box_with_custom_css_name():
+    Box(Box(css_name="special"))

--- a/gaphor/diagram/tests/test_shapes.py
+++ b/gaphor/diagram/tests/test_shapes.py
@@ -279,7 +279,3 @@ def test_text_with_after_pseudo_element():
     text = Text("some")
 
     assert text.text(style) == "some text"
-
-
-def test_box_with_custom_css_name():
-    Box(Box(css_name="special"))

--- a/gaphor/diagram/tests/test_shapes.py
+++ b/gaphor/diagram/tests/test_shapes.py
@@ -3,7 +3,10 @@ import pytest
 from gaphas.geometry import Rectangle
 
 from gaphor.core.modeling.diagram import FALLBACK_STYLE
-from gaphor.core.styling import JustifyContent
+from gaphor.core.styling import (
+    CompiledStyleSheet,
+    JustifyContent,
+)
 from gaphor.diagram.shapes import (
     Box,
     DrawContext,
@@ -274,8 +277,16 @@ def test_text_width_min_height(update_context):
 
 
 def test_text_with_after_pseudo_element():
-    after_style = {"content": " text"}
-    style = {"color": (0, 0, 1, 1), "::after": after_style}
+    css = """
+    ::after { content: " text" }
+    """
+
+    class DummyStyleNode:
+        name = "text"
+        pseudo = None
+        dark_mode = False
+
+    style = CompiledStyleSheet(css).compute_style(DummyStyleNode)
     text = Text("some")
 
     assert text.text(style) == "some text"

--- a/gaphor/diagram/tests/test_shapes.py
+++ b/gaphor/diagram/tests/test_shapes.py
@@ -271,3 +271,11 @@ def test_text_width_min_height(update_context):
 
     _, h = text.size(update_context)
     assert h == 40
+
+
+def test_text_with_after_pseudo_element():
+    after_style = {"content": " text"}
+    style = {"color": (0, 0, 1, 1), "::after": after_style}
+    text = Text("some")
+
+    assert text.text(style) == "some text"


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

CSS can only be applied to elements (class, association). We can not write CSS that target specific parts in the element, e.g. attributes shown in a Class.

Issue Number: #2919 

### What is the new behavior?

* I added a new shape type: `CssNode`. With this shape we can tell Gaphor to update the style sheet for a specific element, such as an attribute owned by a class.
* Add support for the `::after` pseudo-element. This allows us to create custom tags (e.g. `{abstract}` to make it more clear a class/operation is abstract).
* Added more type annotations.
* Computed styles are cached
* Style names have been applied to names (at least the ones shown in bold) and compartments.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

### Other information

There's still some work ahead:

* Add `CssNode`s for all elements that makes sense.
* Move inline styling to a style sheet.
* Support for classes, so we can address styling for compartments in a Class item as `.compartment`. I think this makes more sense that referring to it as an element. 
* Currently the CSS model is rooted in the Element. E.i. an element that is contained by another element does not inherit any properties from its owner. Should this change too? (#2977)
* Add a way to figure out what CSS nodes are used in an item. (#2977)

!! NB. The caching is still a bit flaky. I disabled caching for now, but that may result in a lot more style computations.
