### PR TITLE
Remove both owner and memberNamespace in model browser

### DIFF
--- a/gaphor/ui/tests/test_modelbrowser.py
+++ b/gaphor/ui/tests/test_modelbrowser.py
@@ -9,6 +9,7 @@ from gaphor.ui.modelbrowser import (
     get_first_selected_item,
     list_item_drop_drop,
 )
+from gaphor.UML import recipes
 
 
 @pytest.fixture
@@ -311,6 +312,25 @@ def test_unlink_element_should_not_collapse_branch(
     assert row0.get_item().element is package
     assert row0.get_expanded()
     assert model_browser.selection.get_item(1).get_item().element is class_b
+
+
+def test_stereotype_base_class_should_not_end_up_in_root(
+    model_browser, element_factory
+):
+    profile = element_factory.create(UML.Profile)
+    profile.name = "profile"
+    metaclass = element_factory.create(UML.Class)
+    metaclass.package = profile
+    metaclass.name = "Metaclass"
+    stereotype = element_factory.create(UML.Stereotype)
+    stereotype.package = profile
+    stereotype.name = "Stereotype"
+
+    relation = recipes.create_extension(metaclass, stereotype)
+    relation.package = profile
+
+    row0 = model_browser.selection.get_item(0)
+    assert row0.get_item().element is profile  # not property
 
 
 class MockRowItem:

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -237,17 +237,27 @@ class TreeModel:
                 self.remove_element(child)
 
         # Deal with member relation, but exclude namespace, since it also relates to the owner
-        if (
-            former_owner is None
-            and isinstance(element, UML.NamedElement)
-            and element.memberNamespace
-            and element.memberNamespace is not element.namespace
-        ):
-            former_owner = element.memberNamespace
+        former_namespace = (
+            element.memberNamespace
+            if (
+                former_owner is None
+                and isinstance(element, UML.NamedElement)
+                and element.memberNamespace
+                and element.memberNamespace is not element.namespace
+            )
+            else None
+        )
 
         if (
-            owner_branch := self.owner_branch_for_element(
-                element, former_owner=former_owner
+            owner_branch := (
+                self.owner_branch_for_element(element, former_owner=former_owner)
+                or (
+                    former_namespace
+                    and self.owner_branch_for_element(
+                        element, former_owner=former_namespace
+                    )
+                    or None
+                )
             )
         ) is not None:
             owner_branch.remove(element)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When creating a stereotype, a ghost/rogue element appears at the root of the model browser.

Issue Number: #2987

### What is the new behavior?

When removing an element, remove it both from the `owner` and from the `memberNamespace` branches in the model browser.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
