### PR TITLE
Remove use of pipx in CI

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -5,14 +5,16 @@ outputs:
     description: 'Build version with added dev reference for non-releases'
     value: ${{ steps.meta.outputs.version }}
 inputs:
-  python-version:
-    description: 'Python version. Can be a version python$V or $V depending on the platform.'
+  python-command:
+    description: 'Python command. Can be a version python$V or py -$V depending on the platform.'
     required: false
 runs:
   using: composite
   steps:
     - name: Install Poetry
-      run: pipx install --python ${{ inputs.python-version }} --pip-args=--constraint=.github/constraints.txt poetry
+      run: |
+        ${{ inputs.python-command }} -m ensurepip
+        ${{ inputs.python-command }} -m pip install --constraint=.github/constraints.txt poetry
       shell: bash
     - name: Configure Poetry
       run: poetry config virtualenvs.in-project true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
         path: ~/.cache/pip
         key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-22.04
     - name: Install Poetry
-      run: pipx install --python python${{ env.python_version }} --pip-args=--constraint=.github/constraints.txt poetry
+      run: python${{ env.python_version }} -m pip install --constraint=.github/constraints.txt poetry
     - name: Configure Poetry
       run: poetry config virtualenvs.in-project true
     - name: Install Python Dependencies

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -53,7 +53,7 @@ jobs:
         run: pip install babel && python po/check-babel.py
       - name: Check Poetry lock file integrity
         run: |
-          pipx install --python python${{ env.python_version }} --pip-args=--constraint=.github/constraints.txt poetry
+          python${{ env.python_version }} -m pip install --constraint=.github/constraints.txt poetry
           poetry config virtualenvs.in-project true
           poetry check
 
@@ -83,11 +83,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set ownership of checkout directory
         run: chown -R $(id -u):$(id -g) $PWD
-      - name: Install pipx
-        run: |
-          python${{ matrix.python_version }} -m ensurepip
-          py -${{ matrix.python_version }} -m pip install pipx
-          echo "/github/home/.local/bin" >> $GITHUB_PATH
       - name: Use Python Dependency Cache
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
@@ -97,7 +92,7 @@ jobs:
         id: install
         uses: ./.github/actions/install
         with:
-          python-version: ${{ matrix.python_version }}
+          python-command: python${{ matrix.python_version }}
       - name: Run Gaphor Tests
         run: xvfb-run poetry run pytest --cov
       - name: Upload Code Coverage to Code Climate
@@ -194,7 +189,7 @@ jobs:
         id: install
         uses: ./.github/actions/install
         with:
-          python-version: python${{ env.python_version }}
+          python-command: python${{ env.python_version }}
       - name: Run Gaphor Tests
         run: poetry run pytest --cov
       - name: Create macOS Application
@@ -334,10 +329,6 @@ jobs:
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: ${{ env.python_version }}
-      - name: Install pipx
-        run: |
-          python -m pip install pipx
-          pipx ensurepath
       - name: Use Python Dependency Cache
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
@@ -348,7 +339,7 @@ jobs:
         id: install
         uses: ./.github/actions/install
         with:
-          python-version: ${{ env.python_version }}
+          python-command: py -${{ env.python_version }}
       - name: Run Gaphor Tests
         run: poetry run pytest --cov
       - name: Create Windows Executables

--- a/.github/workflows/hypothesis-test.yml
+++ b/.github/workflows/hypothesis-test.yml
@@ -33,11 +33,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set ownership of checkout directory
         run: chown -R $(id -u):$(id -g) $PWD
-      - name: Install pipx
-        run: |
-          python${{ env.python_version }} -m ensurepip
-          py -${{ env.python_version }} -m pip install pipx
-          echo "/github/home/.local/bin" >> $GITHUB_PATH
       - name: Use Python Dependency Cache
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
@@ -52,7 +47,7 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install
         with:
-          python-version: ${{ env.python_version }}
+          python-command: python${{ env.python_version }}
       - name: Test with Hypothesis
         run: xvfb-run poetry run pytest -m hypothesis --hypothesis-profile=ci
         shell: bash


### PR DESCRIPTION
Currently, pipx is failing on CI due to a bug with version 1.4.1. This PR removes use of pipx to straight pip install poetry in the current environment.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
CI builds are failing due to a pipx not passing the correct path to Python.

Issue Number: N/A

### What is the new behavior?
CI builds are passing.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
