### PR TITLE
Fix models failing to load for collection not hashable TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 2.23.2
 ------
-(Unreleased)
+- Fix models failing to load for collection not hashable TypeError
 
 2.23.1
 ------

--- a/gaphor/core/modeling/collection.py
+++ b/gaphor/core/modeling/collection.py
@@ -60,6 +60,9 @@ class collection(Generic[T]):
             isinstance(other, collection) and self.items == other.items
         )
 
+    def __hash__(self):
+        return hash(str(self))
+
     def index(self, key: T) -> int:
         """Given an object, return the position of that object in the
         collection."""

--- a/gaphor/core/modeling/tests/test_style_attributes.py
+++ b/gaphor/core/modeling/tests/test_style_attributes.py
@@ -1,5 +1,6 @@
 from gaphor import UML
-from gaphor.core.modeling.diagram import Diagram, StyledItem, lookup_attribute
+from gaphor.core.modeling.collection import collection
+from gaphor.core.modeling.diagram import Diagram, StyledItem, attrname, lookup_attribute
 from gaphor.UML.classes import ClassItem
 
 
@@ -114,3 +115,13 @@ def test_non_extsant_nested_attribute():
 
     assert lookup_attribute(diagram, "ownedDiagram.name") is None
     assert lookup_attribute(diagram, "ownedDiagram.doesnotexist") is None
+
+
+def test_attrname_diagram_subject():
+    diagram = Diagram()
+    assert attrname(diagram, "subject") == "subject"
+
+
+def test_attrname_collection_subject(diagram):
+    collection1 = collection(None, None, int)
+    assert attrname(collection1, "subject") == "subject"

--- a/gaphor/core/modeling/tests/test_style_attributes.py
+++ b/gaphor/core/modeling/tests/test_style_attributes.py
@@ -96,7 +96,7 @@ def test_get_existing_attribute():
     assert lookup_attribute(diagram, "owner") == ""
 
 
-def test_non_existant_attribute():
+def test_non_existent_attribute():
     diagram = Diagram()
 
     assert lookup_attribute(diagram, "doesnotexist") is None
@@ -110,7 +110,7 @@ def test_nested_attribute():
     assert lookup_attribute(diagram, "ownedDiagram.doesnotexist") is None
 
 
-def test_non_extsant_nested_attribute():
+def test_non_existent_nested_attribute():
     diagram = Diagram()
 
     assert lookup_attribute(diagram, "ownedDiagram.name") is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gaphor"
-version = "2.23.1"
+version = "2.23.2"
 description = "Gaphor is the simple modeling tool written in Python."
 authors = [
     "Arjan Molenaar <gaphor@gmail.com>",


### PR DESCRIPTION
This PR fixes a TypeError when trying to look up an attribute for a collection type caused by the class missing a `__hash__` definition. This was causing some models to fail to load. I also added two tests, one to test a passing example of a `attrname` lookup, and a 2nd that was failing with a collection object and is now passing.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Some models are failing to load

Issue Number: #2995

### What is the new behavior?
Models successfully load

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
