### PR TITLE
Make all names stylable by CSS

### DIFF
--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -2,6 +2,7 @@ from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.presentation import AttachedPresentation, Named
 from gaphor.diagram.shapes import (
     Box,
+    CssNode,
     IconBox,
     Text,
     TextAlign,
@@ -36,7 +37,13 @@ class ProxyPortItem(Named, AttachedPresentation[sysml.ProxyPort]):
         self.shape = IconBox(
             Box(draw=draw_border),
             text_stereotypes(self, lambda: [self.diagram.gettext("proxy")]),
-            Text(text=self._format_name),
+            CssNode(
+                "name",
+                self.subject,
+                Text(
+                    text=self._format_name,
+                ),
+            ),
             style=text_position(self.connected_side()),
         )
 

--- a/gaphor/SysML/relationships.py
+++ b/gaphor/SysML/relationships.py
@@ -1,5 +1,5 @@
-from gaphor.diagram.presentation import LinePresentation, Named
-from gaphor.diagram.shapes import Box, Text, draw_arrow_head
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
+from gaphor.diagram.shapes import Box, draw_arrow_head
 from gaphor.UML.shapes import text_stereotypes
 
 
@@ -12,7 +12,7 @@ class DirectedRelationshipPropertyPathItem(Named, LinePresentation):
             id,
             shape_middle=Box(
                 text_stereotypes(self, lambda: [self.relation_type]),
-                Text(text=lambda: self.subject.name or ""),
+                text_name(self),
             ),
             style={"dash-style": (7.0, 5.0)},
         )

--- a/gaphor/UML/actions/action.py
+++ b/gaphor/UML/actions/action.py
@@ -2,7 +2,7 @@
 
 from gaphor import UML
 from gaphor.diagram.presentation import ElementPresentation, Named, Valued, text_name
-from gaphor.diagram.shapes import Box, Text, draw_border, stroke
+from gaphor.diagram.shapes import Box, CssNode, Text, draw_border, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 from gaphor.UML.umlfmt import format_call_behavior_action_name
@@ -35,12 +35,8 @@ class ValueSpecificationActionItem(Valued, ElementPresentation):
 
         self.width = 100
         self.shape = Box(
-            Text(
-                text=lambda: "«valueSpecification»",
-            ),
-            Text(
-                text=lambda: self.subject.value or "",
-            ),
+            text_stereotypes(self, lambda: ["valueSpecification"]),
+            CssNode("value", None, Text(text=lambda: self.subject.value or "")),
             style={
                 "padding": (4, 12, 4, 12),
                 "border-radius": 15,
@@ -58,8 +54,10 @@ class CallBehaviorActionItem(ActionItem):
 
         self.shape = Box(
             text_stereotypes(self),
-            Text(
-                text=lambda: format_call_behavior_action_name(self.subject),
+            CssNode(
+                "name",
+                None,
+                Text(text=lambda: format_call_behavior_action_name(self.subject)),
             ),
             style={
                 "padding": (4, 24, 4, 12),

--- a/gaphor/UML/actions/action.py
+++ b/gaphor/UML/actions/action.py
@@ -1,7 +1,7 @@
 """Action diagram item."""
 
 from gaphor import UML
-from gaphor.diagram.presentation import ElementPresentation, Named, Valued
+from gaphor.diagram.presentation import ElementPresentation, Named, Valued, text_name
 from gaphor.diagram.shapes import Box, Text, draw_border, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
@@ -16,9 +16,7 @@ class ActionItem(Named, ElementPresentation):
         self.width = 100
         self.shape = Box(
             text_stereotypes(self),
-            Text(
-                text=lambda: self.subject.name or "",
-            ),
+            text_name(self),
             style={
                 "padding": (4, 12, 4, 12),
                 "border-radius": 15,
@@ -109,7 +107,7 @@ class SendSignalActionItem(Named, ElementPresentation):
 
         self.shape = Box(
             text_stereotypes(self),
-            Text(text=lambda: self.subject.name or ""),
+            text_name(self),
             style={"padding": (4, 24, 4, 12)},
             draw=self.draw_border,
         )
@@ -138,7 +136,7 @@ class AcceptEventActionItem(Named, ElementPresentation):
 
         self.shape = Box(
             text_stereotypes(self),
-            Text(text=lambda: self.subject.name or ""),
+            text_name(self),
             style={"padding": (4, 12, 4, 24)},
             draw=self.draw_border,
         )

--- a/gaphor/UML/actions/activity.py
+++ b/gaphor/UML/actions/activity.py
@@ -7,7 +7,7 @@ from gaphor.diagram.presentation import (
     connect,
     text_name,
 )
-from gaphor.diagram.shapes import Box, JustifyContent, Text, draw_border
+from gaphor.diagram.shapes import Box, CssNode, JustifyContent, Text, draw_border
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 
@@ -78,8 +78,12 @@ class ActivityParameterNodeItem(AttachedPresentation[UML.ActivityParameterNode])
             diagram,
             id,
             shape=Box(
-                Text(
-                    text=self._format_name,
+                CssNode(
+                    "name",
+                    None,
+                    Text(
+                        text=self._format_name,
+                    ),
                 ),
                 style={"padding": (4, 12, 4, 12), "min-width": 120},
                 draw=draw_border,

--- a/gaphor/UML/actions/activity.py
+++ b/gaphor/UML/actions/activity.py
@@ -5,10 +5,10 @@ from gaphor.diagram.presentation import (
     Classified,
     ElementPresentation,
     connect,
+    text_name,
 )
-from gaphor.diagram.shapes import Box, JustifyContent, Text, TextAlign, draw_border
+from gaphor.diagram.shapes import Box, JustifyContent, Text, draw_border
 from gaphor.diagram.support import represents
-from gaphor.diagram.text import FontStyle
 from gaphor.UML.shapes import text_stereotypes
 
 
@@ -36,15 +36,7 @@ class ActivityItem(Classified, ElementPresentation):
     def update_shapes(self, event=None):
         self.shape = Box(
             text_stereotypes(self),
-            Text(
-                text=lambda: self.subject.name or "",
-                style={
-                    "text-align": TextAlign.LEFT,
-                    "font-style": FontStyle.ITALIC
-                    if self.subject and self.subject.isAbstract
-                    else FontStyle.NORMAL,
-                },
-            ),
+            text_name(self),
             style={
                 "padding": (4, 12, 4, 12),
                 "border-radius": 20,

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -15,6 +15,7 @@ from gaphor.diagram.presentation import (
     HandlePositionUpdate,
     Named,
     literal_eval,
+    text_name,
 )
 from gaphor.diagram.shapes import Box, IconBox, Text, ellipse, stroke
 from gaphor.diagram.support import represents
@@ -50,7 +51,7 @@ class InitialNodeItem(ActivityNodeItem, ElementPresentation):
             Box(draw=draw_initial_node),
             # Text should be left-top
             text_stereotypes(self),
-            Text(text=lambda: self.subject and self.subject.name or ""),
+            text_name(self),
         )
 
         self.watch("subject[NamedElement].name")
@@ -83,7 +84,7 @@ class ActivityFinalNodeItem(ActivityNodeItem, ElementPresentation):
             Box(draw=draw_activity_final_node),
             # Text should be right-bottom
             text_stereotypes(self),
-            Text(text=lambda: self.subject and self.subject.name or ""),
+            text_name(self),
         )
 
         self.watch("subject[NamedElement].name")
@@ -127,7 +128,7 @@ class FlowFinalNodeItem(ActivityNodeItem, ElementPresentation):
             Box(draw=draw_flow_final_node),
             # Text should be right-bottom
             text_stereotypes(self),
-            Text(text=lambda: self.subject and self.subject.name or ""),
+            text_name(self),
         )
 
         self.watch("subject[NamedElement].name")
@@ -162,7 +163,7 @@ class DecisionNodeItem(ActivityNodeItem, ElementPresentation):
             # Text should be left-top
             text_stereotypes(self),
             Text(text=self.node_type, style={"font-size": "small"}),
-            Text(text=lambda: self.subject and self.subject.name or ""),
+            text_name(self),
         )
 
         self.watch("show_underlying_type")
@@ -216,7 +217,7 @@ class ForkNodeItem(Named, Presentation[UML.ForkNode], HandlePositionUpdate):
         self._shape = IconBox(
             Box(draw=self.draw_fork_node),
             text_stereotypes(self),
-            Text(text=lambda: self.subject and self.subject.name or ""),
+            text_name(self),
             Text(
                 text=lambda: isinstance(self.subject, UML.JoinNode)
                 and self.subject.joinSpec not in (None, DEFAULT_JOIN_SPEC)

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -17,7 +17,7 @@ from gaphor.diagram.presentation import (
     literal_eval,
     text_name,
 )
-from gaphor.diagram.shapes import Box, IconBox, Text, ellipse, stroke
+from gaphor.diagram.shapes import Box, CssNode, IconBox, Text, ellipse, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 
@@ -162,7 +162,7 @@ class DecisionNodeItem(ActivityNodeItem, ElementPresentation):
             Box(draw=draw_decision_node),
             # Text should be left-top
             text_stereotypes(self),
-            Text(text=self.node_type, style={"font-size": "small"}),
+            CssNode("type", None, Text(text=self.node_type)),
             text_name(self),
         )
 
@@ -218,11 +218,15 @@ class ForkNodeItem(Named, Presentation[UML.ForkNode], HandlePositionUpdate):
             Box(draw=self.draw_fork_node),
             text_stereotypes(self),
             text_name(self),
-            Text(
-                text=lambda: isinstance(self.subject, UML.JoinNode)
-                and self.subject.joinSpec not in (None, DEFAULT_JOIN_SPEC)
-                and f"{{ joinSpec = {self.subject.joinSpec} }}"
-                or "",
+            CssNode(
+                "joinspec",
+                None,
+                Text(
+                    text=lambda: isinstance(self.subject, UML.JoinNode)
+                    and self.subject.joinSpec not in (None, DEFAULT_JOIN_SPEC)
+                    and f"{{ joinSpec = {self.subject.joinSpec} }}"
+                    or ""
+                ),
             ),
         )
 

--- a/gaphor/UML/actions/flow.py
+++ b/gaphor/UML/actions/flow.py
@@ -7,7 +7,7 @@ connectors.
 
 from gaphor import UML
 from gaphor.diagram.presentation import LinePresentation, Named, text_name
-from gaphor.diagram.shapes import Box, Text, draw_arrow_tail
+from gaphor.diagram.shapes import Box, CssNode, Text, draw_arrow_tail
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 
@@ -24,11 +24,15 @@ class ControlFlowItem(Named, LinePresentation):
         super().__init__(
             diagram,
             id,
-            shape_middle=Text(
-                text=lambda: self.subject
-                and self.subject.guard
-                and f"[{self.subject.guard}]"
-                or ""
+            shape_middle=CssNode(
+                "guard",
+                None,
+                Text(
+                    text=lambda: self.subject
+                    and self.subject.guard
+                    and f"[{self.subject.guard}]"
+                    or ""
+                ),
             ),
             shape_tail=Box(text_stereotypes(self), text_name(self)),
         )
@@ -53,11 +57,15 @@ class ObjectFlowItem(Named, LinePresentation):
         super().__init__(
             diagram,
             id,
-            shape_middle=Text(
-                text=lambda: self.subject
-                and self.subject.guard
-                and f"[{self.subject.guard}]"
-                or ""
+            shape_middle=CssNode(
+                "guard",
+                None,
+                Text(
+                    text=lambda: self.subject
+                    and self.subject.guard
+                    and f"[{self.subject.guard}]"
+                    or ""
+                ),
             ),
             shape_tail=Box(text_stereotypes(self), text_name(self)),
         )

--- a/gaphor/UML/actions/flow.py
+++ b/gaphor/UML/actions/flow.py
@@ -6,7 +6,7 @@ connectors.
 
 
 from gaphor import UML
-from gaphor.diagram.presentation import LinePresentation, Named
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
 from gaphor.diagram.shapes import Box, Text, draw_arrow_tail
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
@@ -30,10 +30,7 @@ class ControlFlowItem(Named, LinePresentation):
                 and f"[{self.subject.guard}]"
                 or ""
             ),
-            shape_tail=Box(
-                text_stereotypes(self),
-                Text(text=lambda: self.subject.name or ""),
-            ),
+            shape_tail=Box(text_stereotypes(self), text_name(self)),
         )
 
         self.watch("subject[NamedElement].name")
@@ -62,10 +59,7 @@ class ObjectFlowItem(Named, LinePresentation):
                 and f"[{self.subject.guard}]"
                 or ""
             ),
-            shape_tail=Box(
-                text_stereotypes(self),
-                Text(text=lambda: self.subject.name or ""),
-            ),
+            shape_tail=Box(text_stereotypes(self), text_name(self)),
         )
 
         self.watch("subject[NamedElement].name")

--- a/gaphor/UML/actions/objectnode.py
+++ b/gaphor/UML/actions/objectnode.py
@@ -2,7 +2,7 @@
 
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
-from gaphor.diagram.presentation import ElementPresentation, Named
+from gaphor.diagram.presentation import ElementPresentation, Named, text_name
 from gaphor.diagram.shapes import Box, IconBox, Text, draw_border
 from gaphor.diagram.support import represents
 from gaphor.i18n import i18nize
@@ -33,7 +33,7 @@ class ObjectNodeItem(Named, ElementPresentation):
             shape=IconBox(
                 Box(
                     text_stereotypes(self),
-                    Text(text=lambda: self.subject.name or ""),
+                    text_name(self),
                     style={
                         "padding": (4, 12, 4, 12),
                     },

--- a/gaphor/UML/actions/pin.py
+++ b/gaphor/UML/actions/pin.py
@@ -2,6 +2,7 @@ from gaphor import UML
 from gaphor.diagram.presentation import AttachedPresentation, Named
 from gaphor.diagram.shapes import (
     Box,
+    CssNode,
     IconBox,
     Text,
     TextAlign,
@@ -47,7 +48,7 @@ class PinItem(Named, AttachedPresentation[UML.Pin]):
         self.shape = IconBox(
             Box(draw=draw_border),
             text_stereotypes(self, lambda: [] if self.subject else [self.pin_type()]),
-            Text(text=lambda: format_pin(self.subject)),
+            CssNode("name", self.subject, Text(text=lambda: format_pin(self.subject))),
             style=text_position(self.connected_side()),
         )
 

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -16,10 +16,14 @@ from gaphas.geometry import Rectangle, distance_rectangle_point
 from gaphor import UML
 from gaphor.core.modeling.properties import association, attribute, enumeration
 from gaphor.core.styling import Style, merge_styles
-from gaphor.diagram.presentation import LinePresentation, Named, get_center_pos
+from gaphor.diagram.presentation import (
+    LinePresentation,
+    Named,
+    get_center_pos,
+    text_name,
+)
 from gaphor.diagram.shapes import (
     Box,
-    Text,
     cairo_state,
     draw_default_head,
     draw_default_tail,
@@ -53,7 +57,7 @@ class AssociationItem(Named, LinePresentation[UML.Association]):
             id,
             shape_middle=Box(
                 text_stereotypes(self),
-                Text(text=lambda: self.subject.name or ""),
+                text_name(self),
                 *shape_information_flow(self, "abstraction"),
             ),
         )

--- a/gaphor/UML/classes/dependency.py
+++ b/gaphor/UML/classes/dependency.py
@@ -16,8 +16,8 @@ the type of dependency in an automatic way.
 
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
-from gaphor.diagram.presentation import LinePresentation, Named
-from gaphor.diagram.shapes import Box, Text, stroke
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
+from gaphor.diagram.shapes import Box, stroke
 from gaphor.diagram.support import represents
 from gaphor.i18n import i18nize
 from gaphor.UML.classes.interface import Folded, InterfacePort
@@ -58,7 +58,7 @@ class DependencyItem(Named, LinePresentation):
                         for s in additional_stereotype.get(self._dependency_type, ())
                     ],
                 ),
-                Text(text=lambda: self.subject.name or ""),
+                text_name(self),
             ),
         )
 

--- a/gaphor/UML/classes/interfacerealization.py
+++ b/gaphor/UML/classes/interfacerealization.py
@@ -3,8 +3,8 @@
 
 from gaphor import UML
 from gaphor.core.styling import Style
-from gaphor.diagram.presentation import LinePresentation, Named
-from gaphor.diagram.shapes import Box, Text, stroke
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
+from gaphor.diagram.shapes import Box, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.interface import Folded, InterfacePort
 from gaphor.UML.shapes import text_stereotypes
@@ -22,7 +22,7 @@ class InterfaceRealizationItem(Named, LinePresentation):
             id,
             shape_middle=Box(
                 text_stereotypes(self),
-                Text(text=lambda: self.subject.name or ""),
+                text_name(self),
             ),
         )
 

--- a/gaphor/UML/deployments/connector.py
+++ b/gaphor/UML/deployments/connector.py
@@ -100,8 +100,8 @@ interfaces are connectable elements.
 """
 
 from gaphor import UML
-from gaphor.diagram.presentation import LinePresentation, Named
-from gaphor.diagram.shapes import Box, Text
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
+from gaphor.diagram.shapes import Box
 from gaphor.diagram.support import represents
 from gaphor.UML.informationflow import (
     draw_information_flow,
@@ -132,7 +132,7 @@ class ConnectorItem(Named, LinePresentation[UML.Connector]):
             id,
             shape_middle=Box(
                 text_stereotypes(self),
-                Text(text=lambda: self.subject.name or ""),
+                text_name(self),
                 *shape_information_flow(self, "informationFlow"),
             ),
         )

--- a/gaphor/UML/interactions/interaction.py
+++ b/gaphor/UML/interactions/interaction.py
@@ -1,9 +1,9 @@
 """Interaction diagram item."""
 
 from gaphor import UML
-from gaphor.core.styling import JustifyContent, TextAlign
-from gaphor.diagram.presentation import ElementPresentation, Named
-from gaphor.diagram.shapes import Box, Text, stroke
+from gaphor.core.styling import JustifyContent
+from gaphor.diagram.presentation import ElementPresentation, Named, text_name
+from gaphor.diagram.shapes import Box, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 
@@ -16,10 +16,7 @@ class InteractionItem(Named, ElementPresentation):
         self.shape = Box(
             Box(
                 text_stereotypes(self),
-                Text(
-                    text=lambda: self.subject.name or "",
-                    style={"text-align": TextAlign.LEFT},
-                ),
+                text_name(self),
                 style={
                     "padding": (4, 4, 4, 4),
                     "justify-content": JustifyContent.START,

--- a/gaphor/UML/interactions/message.py
+++ b/gaphor/UML/interactions/message.py
@@ -51,8 +51,13 @@ from gaphas.connector import Handle
 from gaphas.constraint import constraint
 
 from gaphor import UML
-from gaphor.diagram.presentation import LinePresentation, Named, get_center_pos
-from gaphor.diagram.shapes import Box, Text, cairo_state, stroke
+from gaphor.diagram.presentation import (
+    LinePresentation,
+    Named,
+    get_center_pos,
+    text_name,
+)
+from gaphor.diagram.shapes import Box, cairo_state, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.interactions.lifeline import LifelineItem
 from gaphor.UML.shapes import text_stereotypes
@@ -82,7 +87,7 @@ class MessageItem(Named, LinePresentation[UML.Message]):
             id,
             shape_middle=Box(
                 text_stereotypes(self),
-                Text(text=lambda: self.subject.name or ""),
+                text_name(self),
             ),
         )
         self.handles()[1].pos = (40, 0)

--- a/gaphor/UML/profiles/extension.py
+++ b/gaphor/UML/profiles/extension.py
@@ -3,8 +3,8 @@ ExtensionItem -- Graphical representation of an association.
 """
 
 from gaphor import UML
-from gaphor.diagram.presentation import LinePresentation, Named
-from gaphor.diagram.shapes import Box, Text
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
+from gaphor.diagram.shapes import Box
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 
@@ -23,7 +23,7 @@ class ExtensionItem(Named, LinePresentation):
             id,
             shape_middle=Box(
                 text_stereotypes(self),
-                Text(text=lambda: self.subject.name or ""),
+                text_name(self),
             ),
         )
 

--- a/gaphor/UML/states/finalstate.py
+++ b/gaphor/UML/states/finalstate.py
@@ -1,8 +1,8 @@
 """Final state diagram item."""
 
 from gaphor import UML
-from gaphor.diagram.presentation import ElementPresentation, Named
-from gaphor.diagram.shapes import Box, IconBox, Text, ellipse, stroke
+from gaphor.diagram.presentation import ElementPresentation, Named, text_name
+from gaphor.diagram.shapes import Box, IconBox, ellipse, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 
@@ -17,7 +17,7 @@ class FinalStateItem(ElementPresentation, Named):
         self.shape = IconBox(
             Box(draw=draw_final_state),
             text_stereotypes(self),
-            Text(text=lambda: self.subject and self.subject.name or ""),
+            text_name(self),
         )
 
         self.watch("subject[NamedElement].name")

--- a/gaphor/UML/states/pseudostates.py
+++ b/gaphor/UML/states/pseudostates.py
@@ -7,8 +7,8 @@ from gaphas.item import SE
 
 from gaphor import UML
 from gaphor.core.modeling.properties import relation_one
-from gaphor.diagram.presentation import ElementPresentation, Named
-from gaphor.diagram.shapes import Box, IconBox, Text, ellipse, stroke
+from gaphor.diagram.presentation import ElementPresentation, Named, text_name
+from gaphor.diagram.shapes import Box, IconBox, ellipse, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 
@@ -48,7 +48,7 @@ class PseudostateItem(ElementPresentation, Named):
         self.shape = IconBox(
             Box(draw=draw),
             text_stereotypes(self),
-            Text(text=lambda: self.subject.name or ""),
+            text_name(self),
         )
 
 

--- a/gaphor/UML/states/region.py
+++ b/gaphor/UML/states/region.py
@@ -1,5 +1,4 @@
-from gaphor.core.styling import JustifyContent, TextAlign
-from gaphor.diagram.shapes import BoundedBox, Text, draw_top_separator
+from gaphor.diagram.shapes import BoundedBox, Box, CssNode, Text, draw_top_separator
 
 
 def region_compartment(subject):
@@ -12,15 +11,14 @@ def region_compartment(subject):
 
 def _create_region_compartment(region, index):
     return BoundedBox(
-        Text(
-            text=lambda: region.name or "",
-            style={"text-align": TextAlign.LEFT},
-        ),
-        style={
-            "padding": (4, 4, 4, 4),
-            "min-height": 100,
-            "justify-content": JustifyContent.START,
-            "dash-style": (7, 3) if index > 0 else (),
-        },
-        draw=draw_top_separator,
+        CssNode(
+            "region",
+            region,
+            Box(
+                Text(
+                    text=lambda: region.name or "",
+                ),
+                draw=draw_top_separator,
+            ),
+        )
     )

--- a/gaphor/UML/states/state.py
+++ b/gaphor/UML/states/state.py
@@ -7,9 +7,9 @@ from gaphas.types import Pos
 from gaphor import UML
 from gaphor.core.modeling.element import Element
 from gaphor.core.modeling.properties import attribute
-from gaphor.core.styling import JustifyContent, TextAlign
+from gaphor.core.styling import JustifyContent
 from gaphor.diagram.presentation import ElementPresentation, Named, text_name
-from gaphor.diagram.shapes import Box, Text, draw_top_separator, stroke
+from gaphor.diagram.shapes import Box, CssNode, Text, draw_top_separator, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 from gaphor.UML.states.region import region_compartment
@@ -40,21 +40,17 @@ class StateItem(ElementPresentation[UML.State], Named):
                 text=lambda: self.subject.entry.name
                 and f"entry / {self.subject.entry.name}"
                 or "",
-                style={"text-align": TextAlign.LEFT},
             ),
             Text(
                 text=lambda: self.subject.exit.name
                 and f"exit / {self.subject.exit.name}"
                 or "",
-                style={"text-align": TextAlign.LEFT},
             ),
             Text(
                 text=lambda: self.subject.doActivity.name
                 and f"do / {self.subject.doActivity.name}"
                 or "",
-                style={"text-align": TextAlign.LEFT},
             ),
-            style={"padding": (4, 4, 4, 4), "justify-content": JustifyContent.START},
             draw=draw_top_separator,
         )
         if not any(t.text() for t in compartment.children):  # type: ignore[attr-defined]
@@ -66,7 +62,7 @@ class StateItem(ElementPresentation[UML.State], Named):
                 text_name(self),
                 style={"padding": (4, 4, 4, 4)},
             ),
-            compartment,
+            CssNode("compartment", self.subject, compartment),
             Box(
                 *(self._region_boxes),
                 style={"justify-content": JustifyContent.STRETCH},

--- a/gaphor/UML/states/state.py
+++ b/gaphor/UML/states/state.py
@@ -8,7 +8,7 @@ from gaphor import UML
 from gaphor.core.modeling.element import Element
 from gaphor.core.modeling.properties import attribute
 from gaphor.core.styling import JustifyContent, TextAlign
-from gaphor.diagram.presentation import ElementPresentation, Named
+from gaphor.diagram.presentation import ElementPresentation, Named, text_name
 from gaphor.diagram.shapes import Box, Text, draw_top_separator, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
@@ -63,7 +63,7 @@ class StateItem(ElementPresentation[UML.State], Named):
         self.shape = Box(
             Box(
                 text_stereotypes(self),
-                Text(text=lambda: self.subject.name or ""),
+                text_name(self),
                 style={"padding": (4, 4, 4, 4)},
             ),
             compartment,

--- a/gaphor/UML/states/transition.py
+++ b/gaphor/UML/states/transition.py
@@ -2,7 +2,7 @@
 
 from gaphor import UML
 from gaphor.diagram.presentation import LinePresentation, Named, text_name
-from gaphor.diagram.shapes import Box, Text, draw_arrow_tail
+from gaphor.diagram.shapes import Box, CssNode, Text, draw_arrow_tail
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 
@@ -15,12 +15,16 @@ class TransitionItem(Named, LinePresentation[UML.Transition]):
         super().__init__(
             diagram,
             id,
-            shape_middle=Text(
-                text=lambda: self.subject
-                and self.subject.guard
-                and self.subject.guard.specification
-                and f"[{self.subject.guard.specification}]"
-                or ""
+            shape_middle=CssNode(
+                "guard",
+                None,
+                Text(
+                    text=lambda: self.subject
+                    and self.subject.guard
+                    and self.subject.guard.specification
+                    and f"[{self.subject.guard.specification}]"
+                    or ""
+                ),
             ),
             shape_tail=Box(
                 text_stereotypes(self),

--- a/gaphor/UML/states/transition.py
+++ b/gaphor/UML/states/transition.py
@@ -1,7 +1,7 @@
 """State transition implementation."""
 
 from gaphor import UML
-from gaphor.diagram.presentation import LinePresentation, Named
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
 from gaphor.diagram.shapes import Box, Text, draw_arrow_tail
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
@@ -24,7 +24,7 @@ class TransitionItem(Named, LinePresentation[UML.Transition]):
             ),
             shape_tail=Box(
                 text_stereotypes(self),
-                Text(text=lambda: self.subject.name or ""),
+                text_name(self),
             ),
         )
 

--- a/gaphor/UML/usecases/extend.py
+++ b/gaphor/UML/usecases/extend.py
@@ -1,8 +1,8 @@
 """Use case extension relationship."""
 
 from gaphor import UML
-from gaphor.diagram.presentation import LinePresentation, Named
-from gaphor.diagram.shapes import Box, Text, draw_arrow_head
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
+from gaphor.diagram.shapes import Box, draw_arrow_head
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 
@@ -17,7 +17,7 @@ class ExtendItem(Named, LinePresentation):
             id,
             shape_middle=Box(
                 text_stereotypes(self, lambda: [self.diagram.gettext("extend")]),
-                Text(text=lambda: self.subject.name or ""),
+                text_name(self),
             ),
         )
 

--- a/gaphor/UML/usecases/include.py
+++ b/gaphor/UML/usecases/include.py
@@ -1,8 +1,8 @@
 """Use case inclusion relationship."""
 
 from gaphor import UML
-from gaphor.diagram.presentation import LinePresentation, Named
-from gaphor.diagram.shapes import Box, Text, draw_arrow_head
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
+from gaphor.diagram.shapes import Box, draw_arrow_head
 from gaphor.diagram.support import represents
 from gaphor.UML.shapes import text_stereotypes
 
@@ -17,7 +17,7 @@ class IncludeItem(Named, LinePresentation):
             id,
             shape_middle=Box(
                 text_stereotypes(self, lambda: [self.diagram.gettext("include")]),
-                Text(text=lambda: self.subject.name or ""),
+                text_name(self),
             ),
         )
 

--- a/gaphor/core/styling/compiler.py
+++ b/gaphor/core/styling/compiler.py
@@ -154,6 +154,22 @@ def descendants(el):
         yield from descendants(c)
 
 
+def previous(el):
+    p = el.parent()
+    if p is None:
+        return None
+    children = list(p.children())
+    try:
+        i = children.index(el)
+    except ValueError:
+        return None
+
+    if i == 0:
+        return None
+
+    return children[i - 1]
+
+
 @compile_node.register
 def compile_combined_selector(selector: selectors.CombinedSelector):
     left_inside = compile_node(selector.left)
@@ -166,6 +182,12 @@ def compile_combined_selector(selector: selectors.CombinedSelector):
 
         def left(el):
             p = el.parent()
+            return p is not None and left_inside(p)
+
+    elif selector.combinator == "+":
+
+        def left(el):
+            p = previous(el)
             return p is not None and left_inside(p)
 
     else:

--- a/gaphor/core/styling/compiler.py
+++ b/gaphor/core/styling/compiler.py
@@ -164,10 +164,7 @@ def previous(el):
     except ValueError:
         return None
 
-    if i == 0:
-        return None
-
-    return children[i - 1]
+    return None if i == 0 else children[i - 1]
 
 
 @compile_node.register

--- a/gaphor/core/styling/tests/test_compiler.py
+++ b/gaphor/core/styling/tests/test_compiler.py
@@ -115,6 +115,21 @@ def test_select_parent_combinator():
     assert not selector(Node("classitem"))
 
 
+def test_select_sibling_combinator():
+    css = "previous + sibling {}"
+
+    selector, _declarations = next(compile_style_sheet(css))
+
+    assert selector(Node("sibling", parent=Node("parent", children=[Node("previous")])))
+    assert not selector(
+        Node("sibling", parent=Node("parent", children=[Node("other")]))
+    )
+    assert not selector(
+        Node("other", parent=Node("parent", children=[Node("previous")]))
+    )
+    assert not selector(Node("sibling"))
+
+
 def test_attributes():
     css = "classitem[subject] {}"
 

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -73,6 +73,10 @@ diagram type {
   font-weight: bold;
 }
 
+decisionnode type {
+  font-size: small;
+}
+
 proxyport,
 activityparameternode,
 executionspecification {
@@ -102,7 +106,23 @@ swimlane {
 compartment {
   padding: 4 4 4 4;
   min-height: 8;
+  text-align: left;
   justify-content: start;
+}
+
+statemachine {
+  justify-content: start;
+}
+
+region {
+  padding: 4;
+  min-height: 100;
+  justify-content: start;
+  text-align: left;
+}
+
+region + region {
+  dash-style: 7 3;
 }
 
 and name,

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -105,7 +105,44 @@ compartment {
   justify-content: start;
 }
 
-* name {
+and name,
+xor name,
+intermediateevent name,
+dormantevent name,
+basicevent name,
+houseevent name,
+topevent name,
+inhibit name,
+conditionalevent name,
+zeroevent name,
+or name,
+not name,
+transferin name,
+transferout name,
+undevelopedevent name,
+seq name,
+majorityvote name,
+unsafecontrolaction name,
+operationalsituation name,
+controlaction name,
+interfaceblock name,
+block name,
+property name,
+requirement name,
+c4person name,
+c4database name,
+c4container name,
+package name,
+enumeration name,
+interface name,
+class name,
+datatype name,
+component name,
+statemachine name,
+usecase name,
+actor name,
+artifact name,
+node name {
   font-weight: bold;
 }
 

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -154,8 +154,8 @@ node name {
   font-size: x-small;
 }
 
-:is(activity, interaction) stereotypes {
-  text-align: left;
+:is(activity, interaction) :is(name, stereotypes) {
+    text-align: left;
 }
 
 * heading {

--- a/gaphor/diagram/general/comment.py
+++ b/gaphor/diagram/general/comment.py
@@ -17,7 +17,7 @@ class CommentItem(ElementPresentation):
         self.shape = Box(
             CssNode(
                 "body",
-                self.subject,
+                None,
                 Text(
                     text=lambda: self.subject.body or "",
                 ),

--- a/gaphor/diagram/general/diagramitem.py
+++ b/gaphor/diagram/general/diagramitem.py
@@ -3,7 +3,7 @@ An item representing a diagram.
 """
 
 from gaphor.core.modeling.diagram import Diagram
-from gaphor.diagram.presentation import ElementPresentation, Named
+from gaphor.diagram.presentation import ElementPresentation, Named, text_name
 from gaphor.diagram.shapes import Box, CssNode, IconBox, Text, draw_border, stroke
 from gaphor.diagram.support import represents
 
@@ -27,7 +27,7 @@ class DiagramItem(ElementPresentation, Named):
                     text=lambda: self.subject and self.subject.diagramType or "",
                 ),
             ),
-            Text(text=lambda: self.subject and self.subject.name or ""),
+            text_name(self),
         )
 
         self.watch("subject[Diagram].name")

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -643,9 +643,9 @@ class StyledCssNode:
         return (node.style_node(self) for node in traverse_css_nodes(self._shape))
 
     def attribute(self, name: str) -> str | None:
-        if not self._shape._element:
-            return None
-        return lookup_attribute(self._shape._element, name)
+        if self._shape._element:
+            return lookup_attribute(self._shape._element, name)
+        return self._parent.attribute(name) if self._parent else None
 
     def state(self) -> Sequence[str]:
         return ()


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Only "bold" names are stylable.

Issue Number: #3023

### What is the new behavior?

All name entries can be styled.

Added sibling (`region. region`) combinator to support State machine regions.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
