### PR TITLE
Fix no matching distribution right after publish

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -436,6 +436,8 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Wait for PyPI to sync after version update
+        run: sleep 30s
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2.1.2
         with:


### PR DESCRIPTION
I noticed during the last two releases, that the dispatch action is failing to update the flatpak due to a no matching distribution error. When I restart the workflow it immediately passes, so I think PyPI needs a little time to sync the publish operation. This PR adds a wait time before running the workflow.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Dispatch workflow is failing, see https://github.com/flathub/org.gaphor.Gaphor/actions/runs/7521064978/attempts/1

Issue Number: N/A

### What is the new behavior?
Dispatch should pass

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
