### PR TITLE
Update minimal Python version to 3.11

### DIFF
--- a/gaphor/core/tests/test_eventmanager.py
+++ b/gaphor/core/tests/test_eventmanager.py
@@ -1,5 +1,4 @@
 import pytest
-from exceptiongroup import ExceptionGroup
 
 from gaphor.core.eventmanager import event_handler
 

--- a/gaphor/plugins/errorreports/errorreports.py
+++ b/gaphor/plugins/errorreports/errorreports.py
@@ -8,7 +8,6 @@ import time
 from types import TracebackType
 
 import better_exceptions
-from exceptiongroup import BaseExceptionGroup
 from gi.repository import Gtk
 
 from gaphor.abc import ActionProvider

--- a/gaphor/plugins/errorreports/tests/test_errorreport.py
+++ b/gaphor/plugins/errorreports/tests/test_errorreport.py
@@ -1,7 +1,6 @@
 import sys
 
 import pytest
-from exceptiongroup import ExceptionGroup
 
 from gaphor.plugins.errorreports.errorreports import ErrorReports
 

--- a/gaphor/tests/raises.py
+++ b/gaphor/tests/raises.py
@@ -1,6 +1,3 @@
-from exceptiongroup import ExceptionGroup
-
-
 class raises_exception_group:
     def __init__(
         self,

--- a/gaphor/tests/test_raises.py
+++ b/gaphor/tests/test_raises.py
@@ -1,5 +1,4 @@
 import pytest
-from exceptiongroup import ExceptionGroup
 
 from gaphor.tests.raises import raises_exception_group
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -417,9 +417,6 @@ files = [
     {file = "coverage-7.4.0.tar.gz", hash = "sha256:707c0f58cb1712b8809ece32b68996ee1e609f71bd14615bd8f87a1293cb610e"},
 ]
 
-[package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
-
 [package.extras]
 toml = ["tomli"]
 
@@ -688,7 +685,6 @@ files = [
 
 [package.dependencies]
 attrs = ">=22.2.0"
-exceptiongroup = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
@@ -820,7 +816,6 @@ files = [
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 decorator = "*"
-exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 jedi = ">=0.16"
 matplotlib-inline = "*"
 pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
@@ -1783,11 +1778,9 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -2754,5 +2747,5 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10,<3.13"
-content-hash = "fe4c6eca7221af7f047d908cd9627c1731b00ce7fe45f6e95ec25d59060c4cae"
+python-versions = ">=3.11,<3.13"
+content-hash = "21bd89f089ade378b83a5d46b8ef07cf243672cb8c2c912426659789597afb5e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ include = ["gaphor/locale/*/LC_MESSAGES/*"]
 exclude = ["**/tests", "gaphor/conftest.py" ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.11,<3.13"
 pycairo = "^1.22.0"
 PyGObject = "^3.30"
 gaphas = ">3.9.0,<5.0"
@@ -219,7 +219,7 @@ addopts = [
 junit_family = "xunit1"
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 warn_redundant_casts = true

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -1,7 +1,6 @@
 import logging
 
 import pytest
-from exceptiongroup import ExceptionGroup
 
 from gaphor import UML
 from gaphor.application import Application


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

We're building and testing Python 3.11 and 3.12. However, the project suggests it works with Python 3.10 as well.

Issue Number: N/A

### What is the new behavior?

Update minimal Python version to 3.11.

Remove uses of exceptiongroup module. 3.11 has native support for those.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
