### PR TITLE
Show CSS nodes below style sheet editor

### DIFF
--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -343,6 +343,27 @@
                         <property name="xalign">0</property>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="margin_top">6</property>
+                        <property name="label" translatable="yes">CSS Nodes of focused item</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"></attribute>
+                        </attributes>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="css-nodes">
+                        <property name="wrap">0</property>
+                        <property name="selectable">1</property>
+                        <property name="label" translatable="yes">No focused item.</property>
+                        <property name="xalign">0</property>
+                        <style>
+                          <class name="mono" />
+                        </style>
+                      </object>
+                    </child>
                   </object>
                 </property>
               </object>

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -337,16 +337,8 @@
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="label" translatable="yes">🔗 &lt;a href=&quot;https://docs.gaphor.org/en/latest/style_sheets.html&quot;&gt;Style sheets in Gaphor&lt;/a&gt;</property>
-                        <property name="use_markup">1</property>
-                        <property name="wrap">1</property>
-                        <property name="xalign">0</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
                         <property name="margin_top">6</property>
-                        <property name="label" translatable="yes">CSS Nodes of focused item</property>
+                        <property name="label" translatable="yes">CSS nodes of focused item</property>
                         <property name="xalign">0</property>
                         <attributes>
                           <attribute name="weight" value="bold"></attribute>
@@ -354,14 +346,27 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="css-nodes">
-                        <property name="wrap">0</property>
-                        <property name="selectable">1</property>
-                        <property name="label" translatable="yes">No focused item.</property>
+                      <object class="GtkFrame">
+                        <child>
+                          <object class="GtkLabel" id="css-nodes">
+                            <property name="use-markup">1</property>
+                            <property name="wrap">0</property>
+                            <property name="selectable">1</property>
+                            <property name="label" translatable="yes">No focused item.</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="mono" />
+                            </style>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">🔗 &lt;a href=&quot;https://docs.gaphor.org/en/latest/style_sheets.html&quot;&gt;Style sheets in Gaphor&lt;/a&gt;</property>
+                        <property name="use_markup">1</property>
+                        <property name="wrap">1</property>
                         <property name="xalign">0</property>
-                        <style>
-                          <class name="mono" />
-                        </style>
                       </object>
                     </child>
                   </object>

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -173,3 +173,7 @@ flowboxchild:hover {
 flowboxchild:active {
   background-color: alpha(@shade_color, 2);
 }
+
+.mono {
+  font-family: monospace;
+}

--- a/gaphor/ui/tests/test_elementeditor.py
+++ b/gaphor/ui/tests/test_elementeditor.py
@@ -1,10 +1,13 @@
+import textwrap
+
 import pytest
 
 import gaphor.UML.classes.classespropertypages  # noqa
 from gaphor import UML
+from gaphor.core.modeling.diagram import StyledItem
 from gaphor.diagram.tests.fixtures import find
-from gaphor.ui.elementeditor import ElementEditor
-from gaphor.UML.diagramitems import PackageItem
+from gaphor.ui.elementeditor import ElementEditor, dump_css_tree
+from gaphor.UML.diagramitems import ClassItem, PackageItem
 
 
 class DiagramsStub:
@@ -51,3 +54,24 @@ def test_create_pages(
     editor.editors.clear_pages()
 
     assert not find(editor.editors.vbox, "name-editor")
+
+
+def test_dump_css_tree(element_factory, create):
+    class_item = create(ClassItem, UML.Class)
+
+    class_item.subject.ownedAttribute = element_factory.create(UML.Property)
+    class_item.subject.ownedOperation = element_factory.create(UML.Operation)
+
+    text = dump_css_tree(StyledItem(class_item))
+
+    assert text == textwrap.dedent(
+        """\
+        class
+         ├╴stereotypes
+         ├╴name
+         ├╴from
+         ├╴compartment
+         │  ╰╴attribute
+         ╰╴compartment
+            ╰╴operation"""
+    )


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

It's hard to guess what CSS nodes are part of an item in a diagram.

Issue Number: #3023

### What is the new behavior?

Below the style editor, a node layout is given for the currently selected element.

<img width="1413" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/3c30386b-3263-4f7d-8f3c-f300c8d42b0e">
