### PR TITLE
Give the diagram a default "view" background

### DIFF
--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -115,6 +115,7 @@ class DiagramPage:
         scrolled_window = Gtk.ScrolledWindow()
         scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scrolled_window.set_child(view)
+        scrolled_window.add_css_class("view")
         self.style_manager.connect_object(
             "notify::dark", self._on_notify_dark, scrolled_window
         )


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The contrast between the diagram and the side bar is a bit off, since both use the same background color.

### What is the new behavior?

Use Adwaita's default "view" style as background for diagrams.

<img width="1246" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/c96d6950-93a4-4596-9f5b-e1a086d60653">


### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
