### PR TITLE
Fix CSS tree test

### DIFF
--- a/gaphor/ui/tests/test_elementeditor.py
+++ b/gaphor/ui/tests/test_elementeditor.py
@@ -67,9 +67,10 @@ def test_dump_css_tree(element_factory, create):
     assert text == textwrap.dedent(
         """\
         class
-         ├╴stereotypes
-         ├╴name
-         ├╴from
+         ├╴compartment
+         │  ├╴stereotypes
+         │  ├╴name
+         │  ╰╴from
          ├╴compartment
          │  ╰╴attribute
          ╰╴compartment


### PR DESCRIPTION
This broke because #3021 and #3040 branches were merged.