### PR TITLE
Build our own Gaphor bootloader

### DIFF
--- a/.github/actions/windows_executables/action.yml
+++ b/.github/actions/windows_executables/action.yml
@@ -24,6 +24,19 @@ runs:
         poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\PyGObject*.whl)
         poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\pycairo*.whl)
       shell: pwsh
+    - name: Build PyInstaller Bootloader
+      run: |
+        # The pre-compiled bootloader is often flagged by virus scanners as a false positive, build our own
+        poetry shell
+        $env:PYINSTALLER_VER=$(poetry run py -c "from importlib.metadata import version; print(version('pyinstaller'))")
+        git clone --depth 1 --branch v$env:PYINSTALLER_VER https://github.com/pyinstaller/pyinstaller.git
+        cd .\pyinstaller\bootloader
+        py .\waf all --target-arch=64bit
+        cd ..
+        poetry run py -m pip install .
+        cd ..
+        rm -r -fo .\pyinstaller
+      shell: pwsh
     - name: Create Windows Installers
       run: |
         poetry build

--- a/.github/actions/windows_executables/action.yml
+++ b/.github/actions/windows_executables/action.yml
@@ -32,9 +32,8 @@ runs:
         git clone --depth 1 --branch v$env:PYINSTALLER_VER https://github.com/pyinstaller/pyinstaller.git
         cd .\pyinstaller\bootloader
         py .\waf all --target-arch=64bit
-        cd ..
-        poetry run py -m pip install .
-        cd ..
+        cd ..\..
+        py -m pip install .\pyinstaller
         rm -r -fo .\pyinstaller
       shell: pwsh
     - name: Create Windows Installers

--- a/.github/actions/windows_executables/action.yml
+++ b/.github/actions/windows_executables/action.yml
@@ -33,7 +33,7 @@ runs:
         cd .\pyinstaller\bootloader
         py .\waf all --gcc --target-arch=64bit
         cd ..\..
-        py -m pip install .\pyinstaller
+        py -m pip --disable-pip-version-check install .\pyinstaller
         rm -r -fo .\pyinstaller
       shell: pwsh
     - name: Create Windows Installers

--- a/.github/actions/windows_executables/action.yml
+++ b/.github/actions/windows_executables/action.yml
@@ -31,7 +31,7 @@ runs:
         $env:PYINSTALLER_VER=$(poetry run py -c "from importlib.metadata import version; print(version('pyinstaller'))")
         git clone --depth 1 --branch v$env:PYINSTALLER_VER https://github.com/pyinstaller/pyinstaller.git
         cd .\pyinstaller\bootloader
-        py .\waf all --target-arch=64bit
+        py .\waf all --gcc --target-arch=64bit
         cd ..\..
         py -m pip install .\pyinstaller
         rm -r -fo .\pyinstaller

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -290,9 +290,10 @@ jobs:
         id: output
         run: Write-Output "cachekey=${{ runner.os }}-gvsbuild-${{ env.gvsbuild_update }}-${{ env.gvsbuild_version }}" >> $env:GITHUB_OUTPUT
       - name: Upload libraries
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: windows-build-gtk
+          name: gtk-build
           path: C:\gtk-build\gtk\x64\release
 
   windows:

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -289,6 +289,11 @@ jobs:
       - name: GTK binaries output cache key
         id: output
         run: Write-Output "cachekey=${{ runner.os }}-gvsbuild-${{ env.gvsbuild_update }}-${{ env.gvsbuild_version }}" >> $env:GITHUB_OUTPUT
+      - name: Upload libraries
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        with:
+          name: windows-build-gtk
+          path: C:\gtk-build\gtk\x64\release
 
   windows:
     name: Windows


### PR DESCRIPTION
The PyInstaller bootloader is often flagged by virus scanners as a virus or trojan. This PR builds our own bootloader on CI on Windows which should have a different virus scanner signature than ones pre-built.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Avast, Windows Defender, AVG, Google Smartscanner, and others were detecting that Gaphor was a Trojan.

Issue Number: N/A

### What is the new behavior?
All detect as clean.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
