### PR TITLE
Fix undoing pasted items

### DIFF
--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -105,14 +105,7 @@ class Presentation(Matrices, Element, Generic[S]):
             self.parent.matrix_i2c.remove_handler(self._on_matrix_changed)
 
         if diagram := self._original_diagram:
-            connecting_items = [
-                cinfo.item
-                for cinfo in diagram.connections.get_connections(connected=self)
-            ]
-
             diagram.connections.remove_connections_to_item(self)
-            for item in connecting_items:
-                item.unlink()
             self._original_diagram = None
             super().inner_unlink(UnlinkEvent(self, diagram=diagram))
 

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -71,7 +71,15 @@ class BaseConnector:
     ) -> None:
         self.element = element
         self.line = line
-        self.diagram: Diagram = element.diagram
+
+        # Try to find the diagram. Any diagram can be None, when called while an element is unlinking
+        assert (
+            element.diagram is line.diagram
+            or element.diagram is None
+            or line.diagram is None
+        )
+        self.diagram: Diagram = element.diagram or line.diagram
+        assert self.diagram
 
     def get_connected(self, handle: Handle) -> Presentation[Element] | None:
         """Get item connected to a handle."""

--- a/gaphor/diagram/general/tests/test_comment.py
+++ b/gaphor/diagram/general/tests/test_comment.py
@@ -182,8 +182,8 @@ def test_commentline_element_unlink(create, diagram):
 
     assert clazz not in diagram.ownedPresentation
     assert not clazz.diagram
-    assert line not in diagram.ownedPresentation
-    assert not line.diagram
+    assert line in diagram.ownedPresentation
+    assert line.diagram
     assert not comment.subject.annotatedElement
     assert len(clazz_subject.comment) == 0
 

--- a/gaphor/diagram/tests/test_presentation.py
+++ b/gaphor/diagram/tests/test_presentation.py
@@ -150,5 +150,5 @@ def test_remove_connected_items_on_unlink(create, diagram):
     class_a_item.subject.unlink()
 
     assert class_a_item not in diagram.ownedPresentation
-    assert association_item not in diagram.ownedPresentation
+    assert association_item in diagram.ownedPresentation
     assert class_b_item in diagram.ownedPresentation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@
 from hypothesis import settings
 
 from gaphor.conftest import (
+    create,
+    diagram,
     element_factory,
     event_manager,
     modeling_language,

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -6,10 +6,12 @@ from gaphor import UML
 from gaphor.application import Application
 from gaphor.core import Transaction, event_handler
 from gaphor.core.modeling import AssociationUpdated, Diagram
+from gaphor.diagram.copypaste import copy_full, paste_full
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML.classes import (
     AssociationItem,
     ClassItem,
+    ContainmentItem,
     GeneralizationItem,
 )
 from gaphor.UML.interactions import MessageItem
@@ -376,6 +378,9 @@ def test_exception_raised_during_undo(event_manager, element_factory, undo_manag
 def test_exception_raised_during_undo_from_event_handler(
     event_manager, element_factory, undo_manager
 ):
+    class UndoRequested:
+        pass
+
     package: UML.Package = next(element_factory.select(UML.Package))
 
     with Transaction(event_manager):
@@ -405,5 +410,21 @@ def test_exception_raised_during_undo_from_event_handler(
     event_manager.handle()
 
 
-class UndoRequested:
-    pass
+def test_undo_paste_full(create, diagram, event_manager, undo_manager):
+    """Triggers an error when pasted data is undone.
+
+    Reproduce Hypothesis test found in https://github.com/gaphor/gaphor/issues/2895.
+    """
+
+    with Transaction(event_manager):
+        class_item = create(ClassItem, UML.Class)
+        containment_item = create(ContainmentItem)
+
+        connect(containment_item, containment_item.head, class_item)
+
+    copy_buffer = copy_full([containment_item, class_item])
+
+    with Transaction(event_manager):
+        paste_full(copy_buffer, diagram)
+
+    undo_manager.undo_transaction()

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -63,7 +63,7 @@ def test_class_association_undo_redo(event_manager, element_factory, undo_manage
     assert undo_manager.can_undo()
 
     for _i in range(3):
-        assert 8 == len(diagram.connections.solver.constraints)
+        assert 9 == len(diagram.connections.solver.constraints)
 
         undo_manager.undo_transaction()
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Create elements, copy and paste them, then hit undo. Bang!

Issue Number: fixes #2895

### What is the new behavior?

You can safely undo a paste action.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

Deleting items in a diagram behaves different.

### Other information

* Connecting items on a diagram are no longer automatically removed.
