### PR TITLE
Fix file saving for FreeDesktop Portals

### DIFF
--- a/gaphor/plugins/diagramexport/__init__.py
+++ b/gaphor/plugins/diagramexport/__init__.py
@@ -41,10 +41,9 @@ class DiagramExport(Service, ActionProvider):
 
         save_file_dialog(
             title,
+            filename,
             save_handler,
             parent=self.main_window.window,
-            filename=filename,
-            extension=dot_ext,
             filters=[
                 (gettext("All {ext} Files").format(ext=ext.upper()), dot_ext, mime_type)
             ],

--- a/gaphor/plugins/xmiexport/__init__.py
+++ b/gaphor/plugins/xmiexport/__init__.py
@@ -41,8 +41,7 @@ class XMIExport(Service, ActionProvider):
         )
         save_file_dialog(
             gettext("Export model as XMI file"),
+            filename,
             handler,
-            filename=filename,
-            extension=".xmi",
             filters=[(gettext("All XMI Files"), ".xmi", "text/xml")],
         )

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -81,6 +81,8 @@ def save_file_dialog(
 
     if filename:
         dialog.set_initial_file(Gio.File.parse_name(str(filename)))
+    else:
+        dialog.set_initial_name(f"{gettext('New Model')}{extension}")
 
     dialog.set_filters(new_filters(filters))
 
@@ -90,12 +92,6 @@ def save_file_dialog(
             return
 
         filename = Path(dialog.save_finish(result).get_path())
-        if extension and filename.suffix != extension:
-            filename = filename.with_suffix(extension)
-            if filename.exists():
-                dialog.set_initial_file(Gio.File.parse_name(str(filename)))
-                dialog.save(parent=parent, cancellable=None, callback=response)
-                return
         handler(filename)
 
     dialog.save(parent=parent, cancellable=None, callback=response)

--- a/gaphor/ui/filedialog.py
+++ b/gaphor/ui/filedialog.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from typing import Callable
 
 from gi.repository import Gio, Gtk
 
@@ -69,20 +70,15 @@ def open_file_dialog(
 
 
 def save_file_dialog(
-    title,
-    handler,
+    title: str,
+    filename: Path,
+    handler: Callable[[Path], None],
     parent=None,
-    filename=None,
-    extension=None,
     filters=None,
 ) -> Gtk.FileChooser:
     dialog = Gtk.FileDialog.new()
     dialog.set_title(title)
-
-    if filename:
-        dialog.set_initial_file(Gio.File.parse_name(str(filename)))
-    else:
-        dialog.set_initial_name(f"{gettext('New Model')}{extension}")
+    dialog.set_initial_file(Gio.File.parse_name(str(filename.absolute())))
 
     dialog.set_filters(new_filters(filters))
 

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -359,10 +359,9 @@ class FileManager(Service, ActionProvider):
 
         return save_file_dialog(
             gettext("Save Gaphor Model As"),
+            self.filename or Path(gettext("New Model")).with_suffix(".gaphor"),
             self.save,
             parent=self.parent_window,
-            filename=self.filename,
-            extension=".gaphor",
             filters=GAPHOR_FILTER,
         )
 
@@ -394,12 +393,12 @@ class FileManager(Service, ActionProvider):
                 else:
                     save_file_dialog(
                         gettext("Save Gaphor Model As"),
+                        self.filename
+                        or Path(gettext("New Model")).with_suffix(".gaphor"),
                         lambda filename: self.save(
                             filename, on_save_done=confirm_shutdown
                         ),
                         parent=self.parent_window,
-                        filename=self.filename,
-                        extension=".gaphor",
                         filters=GAPHOR_FILTER,
                     )
             elif answer == "discard":

--- a/gaphor/ui/tests/test_filedialog.py
+++ b/gaphor/ui/tests/test_filedialog.py
@@ -49,9 +49,8 @@ def test_save_dialog(file_dialog):
 
     save_file_dialog(
         "title",
+        Path("testfile.gaphor"),
         save_handler,
-        filename=None,
-        extension=".gaphor",
         filters=[],
     )
 
@@ -68,9 +67,8 @@ def test_save_dialog_with_full_file_name(file_dialog):
     filename = Path("/test/path/model.gaphor")
     save_file_dialog(
         "title",
+        filename,
         save_handler,
-        filename=filename,
-        extension=".gaphor",
         filters=[],
     )
 
@@ -87,13 +85,12 @@ def test_save_dialog_filename_without_extension(file_dialog):
 
     save_file_dialog(
         "title",
+        Path("model"),
         save_handler,
-        filename=None,
-        extension=".gaphor",
         filters=[],
     )
 
-    assert selected_file.parts == (os.path.sep, "test", "path", "model.gaphor")
+    assert selected_file.parts == (os.path.sep, "test", "path", "model")
 
 
 def test_format_home_folder():

--- a/org.gaphor.Gaphor.json
+++ b/org.gaphor.Gaphor.json
@@ -22,9 +22,7 @@
     "--share=ipc",
     "--socket=wayland",
     "--device=dri",
-    "--socket=session-bus",
-    "--talk-name=org.gtk.vfs.*",
-    "--filesystem=xdg-run/gvfsd"
+    "--socket=session-bus"
   ],
   "modules": [
     {


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Files are not properly saved from Flatpaks if you do not define the `.gaphor` extension to the file.

Issue Number: #3085

### What is the new behavior?

Instead of adding an extension (which does not sync via XDP portals), provide a default name with extension.

This allows users to easily change the file name, with the extension already visible in the file entry field.

Do no longer "magically" add an extension.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
