### PR TITLE
Add virus scan with VirusTotal to CI

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -390,6 +390,30 @@ jobs:
         run: type gaphor-self-test.txt
         shell: cmd
 
+  scan-for-viruses:
+    name: Virus Check
+    needs: check-windows-installer
+    runs-on: windows-latest
+    continue-on-error: true
+    timeout-minutes: 15
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+      - uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+        with:
+          name: ${{ needs.windows.outputs.installer }}
+          path: .
+      - name: VirusTotal Scan
+        uses: crazy-max/ghaction-virustotal@v4
+        with:
+          vt_api_key: ${{ secrets.VIRUSTOTAL_API_KEY }}
+          request_rate: 4
+          update_release_body: true
+          files: |
+            ${{ needs.windows.outputs.installer }}
+
   publish-to-pypi:
     name: Publish to PyPI (release only)
     needs: [ linux-wheel, linux-flatpak-devel, check-macos-app, check-windows-installer ]

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -392,7 +392,7 @@ jobs:
 
   scan-for-viruses:
     name: Virus Check
-    needs: check-windows-installer
+    needs: windows
     runs-on: windows-latest
     continue-on-error: true
     timeout-minutes: 15


### PR DESCRIPTION
Since we have been having a lot of problems with false positives with virus scanners, this PR adds a scan with Virus Total each time we build the Windows installer. If it is a release, it adds links to the scan results. 

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
