### PR TITLE
Use TypedElement.type for Lifeline and other types

### DIFF
--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -19,6 +19,7 @@ class PropertyItem(Named, ElementPresentation[UML.Property]):
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject[Property].name")
         self.watch("subject[Property].type.name")
+        self.watch("subject[Property].typeValue")
         self.watch("subject[Property].lowerValue")
         self.watch("subject[Property].upperValue")
         self.watch("subject[Property].aggregation", self.update_shapes)

--- a/gaphor/UML/actions/activity.py
+++ b/gaphor/UML/actions/activity.py
@@ -25,6 +25,9 @@ class ActivityItem(Classified, ElementPresentation):
             "subject[Activity].node[ActivityParameterNode].parameter.name",
             self.update_parameters,
         ).watch(
+            "subject[Activity].node[ActivityParameterNode].parameter.type.name",
+            self.update_parameters,
+        ).watch(
             "subject[Activity].node[ActivityParameterNode].parameter.typeValue",
             self.update_parameters,
         )

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -84,7 +84,9 @@ def attribute_watches(presentation, cast):
         f"subject[{cast}].ownedAttribute.upperValue"
     ).watch(f"subject[{cast}].ownedAttribute.defaultValue").watch(
         f"subject[{cast}].ownedAttribute.type"
-    ).watch(f"subject[{cast}].ownedAttribute.typeValue")
+    ).watch(f"subject[{cast}].ownedAttribute.type.name").watch(
+        f"subject[{cast}].ownedAttribute.typeValue"
+    )
 
 
 def operation_watches(presentation, cast):
@@ -97,8 +99,10 @@ def operation_watches(presentation, cast):
     ).watch(f"subject[{cast}].ownedOperation.visibility").watch(
         f"subject[{cast}].ownedOperation.ownedParameter.lowerValue"
     ).watch(f"subject[{cast}].ownedOperation.ownedParameter.upperValue").watch(
-        f"subject[{cast}].ownedOperation.ownedParameter.typeValue"
-    ).watch(f"subject[{cast}].ownedOperation.ownedParameter.defaultValue")
+        f"subject[{cast}].ownedOperation.ownedParameter.type.name"
+    ).watch(f"subject[{cast}].ownedOperation.ownedParameter.typeValue").watch(
+        f"subject[{cast}].ownedOperation.ownedParameter.defaultValue"
+    )
 
 
 def attributes_compartment(subject):

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -233,7 +233,7 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
             return ""
 
         if represents := self.subject.represents:
-            if represents.type:
+            if represents.type and represents.type.name:
                 return f"{represents.name or ''}: {represents.type.name or ''}"
             elif represents.typeValue:
                 return f"{represents.name or ''}: {represents.typeValue}"

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -177,6 +177,8 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
         self.watch("subject[NamedElement].name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[Lifeline].represents.name")
+        self.watch("subject[Lifeline].represents.type.name")
+        self.watch("subject[Lifeline].represents.typeValue")
         self.setup_constraints()
 
     is_destroyed: attribute[int] = attribute("is_destroyed", int, default=False)
@@ -230,10 +232,14 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
         if not self.subject:
             return ""
 
-        name = self.subject.name or ""
-        if self.subject.represents:
-            return f"{name}: {self.subject.represents.name or ''}"
-        return name
+        if represents := self.subject.represents:
+            if represents.type:
+                return f"{represents.name or ''}: {represents.type.name or ''}"
+            elif represents.typeValue:
+                return f"{represents.name or ''}: {represents.typeValue}"
+            return represents.name or ""
+
+        return self.subject.name or ""
 
     def draw_lifetime(self, box, context, bounding_box):
         """Draw lifeline time line.

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -52,10 +52,10 @@ def format_property(
         s.append(name)
 
     if type:
-        if el.typeValue:
-            s.append(f": {el.typeValue}")
-        elif el.type and el.type.name:
+        if el.type and el.type.name:
             s.append(f": {el.type.name}")
+        elif el.typeValue:
+            s.append(f": {el.typeValue}")
 
     if multiplicity:
         s.append(format_multiplicity(el))
@@ -163,7 +163,9 @@ def format_parameter(
 
     s.append(name or "")
 
-    if type and el.typeValue:
+    if el.type and el.type.name:
+        s.append(f": {el.type.name}")
+    elif type and el.typeValue:
         s.append(f": {el.typeValue}")
 
     if multiplicity:

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -163,10 +163,11 @@ def format_parameter(
 
     s.append(name or "")
 
-    if el.type and el.type.name:
-        s.append(f": {el.type.name}")
-    elif type and el.typeValue:
-        s.append(f": {el.typeValue}")
+    if type:
+        if el.type and el.type.name:
+            s.append(f": {el.type.name}")
+        elif el.typeValue:
+            s.append(f": {el.typeValue}")
 
     if multiplicity:
         s.append(format_multiplicity(el))


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Lifeline should show name of represented type (`ConnectableElement`)

Issue Number: Fixes #2514

### What is the new behavior?

Show represented name and type.

In addition I changed all cases where `TypedElement.typeValue` is used to also check for `TypedElement.type.name`. In all cases `type` takes precedence over `typeValue`, since type is actually linked to a model element and `typeValue` is something specifically added for Gaphor.

Also fixed messages: when attached to "life lines" without an actual lifeline, they act as a communication diagram.
In this case, lines so not need to be horizontal.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

It would be nice if the Property Editor also shows settings for elements selected in the Model Browser. E.g. now it's not possible to change the attribute type easily.
