### PR TITLE
Display diagram type in model browser

### DIFF
--- a/gaphor/core/format.py
+++ b/gaphor/core/format.py
@@ -23,6 +23,8 @@ def parse(el: Element, text: str) -> None:
 
 @format.register(Diagram)
 def format_diagram(el, **kwargs) -> str:
+    if el.diagramType:
+        return f"[{el.diagramType}] {el.name}"
     return el.name or ""
 
 


### PR DESCRIPTION
Fixes #2587

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the new behavior?

Diagram type is shown in model browser:

<img width="1040" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/caf63c53-270a-456c-a7df-a744965aea19">

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
