### PR TITLE
Only run virus scan on mainline builds

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -396,6 +396,7 @@ jobs:
     runs-on: windows-latest
     continue-on-error: true
     timeout-minutes: 15
+    if: env.mainline_build == 'true'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0


### PR DESCRIPTION
Dependabot and other builds are failing for the virus scan because they don't have access to the API key. This PR updates this build to only do virus scans when it is a mainline build.


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
External PRs are failing because they don't have access to secrets.

Issue Number: N/A

### What is the new behavior?
All PRs are passing.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
