### PR TITLE
Change Dependabot to weekly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,17 +2,29 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+      github-action-updates:
+        patterns:
+          - "*"
     schedule:
-      interval: "daily"
+      interval: weekly
     labels: ["skip-changelog"]
 
   - package-ecosystem: "pip"
     directory: "/"
+    groups:
+      pip-updates:
+        patterns:
+          - "*"
     schedule:
-      interval: "daily"
+      interval: weekly
     labels: ["skip-changelog"]
 
   - package-ecosystem: docker
     directory: /.devcontainer
+    groups:
+      docker-updates:
+        patterns:
+          - "*"
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
Right now, Dependabot does daily updates and every dependency gets a separate PR. This PR reduces dependency merge overhead and CI/CD builds by grouping updates and reducing frequency to weekly.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Each dependency update gets a separate PR and dependencies are updated daily

Issue Number: N/A

### What is the new behavior?
Dependencies are in grouped PRs by package ecosystem and dependencies are updated weekly

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
