### PR TITLE
Find diagram in model browser

### DIFF
--- a/gaphor/diagram/instanteditors.py
+++ b/gaphor/diagram/instanteditors.py
@@ -104,6 +104,7 @@ def show_popover(widget, view, box, commit):
         if should_commit:
             commit()
         view.grab_focus()
+        popover.unparent()
 
     popover.connect("closed", on_closed)
 

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -225,6 +225,11 @@ class ModelBrowser(UIComponent, ActionProvider):
         if self.search_bar:
             self.search_bar.set_search_mode(True)
 
+    @action(name="win.show-in-model-browser")
+    def show_in_model_browser(self, id: str):
+        if element := self.element_factory.lookup(id):
+            self.select_element(element)
+
     @event_handler(ElementCreated)
     def on_element_created(self, event: ElementCreated):
         self.model.add_element(event.element)

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -438,16 +438,17 @@ def list_item_factory_setup(
             ),
         )
         element = list_item.get_item().get_item().element
-        if row.menu:
-            # Clean menu only when we want to create a new one.
-            row.menu.unparent()
-            row.menu = None
-        if element:
+        if not element:
+            return
+
+        if not row.menu:
             row.menu = Gtk.PopoverMenu.new_from_model(
                 popup_model(element, modeling_language)
             )
             row.menu.set_parent(row)
-            row.menu.popup()
+        else:
+            row.menu.set_menu_model(popup_model(element, modeling_language))
+        row.menu.popup()
 
     ctrl = Gtk.GestureClick.new()
     ctrl.set_button(Gdk.BUTTON_SECONDARY)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

It's hard to find the active diagram in the model browser.

Issue Number: Fixes #2597

### What is the new behavior?

Right-click in a diagram will show a popup menu. The popup menu contains an action to select the diagram or (hovered) item in the model browser.

<img width="1274" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/d05ba94e-7c1d-4c69-85c7-55708f0347f9">

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
