### PR TITLE
Clean up property pages

### DIFF
--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -2,11 +2,12 @@
 <interface>
   <requires lib="gtk" version="4.0" />
 
-  <object class="GtkExpander" id="item-flow-editor">
-    <property name="expanded">1</property>
-    <child type="label">
+  <object class="GtkBox" id="item-flow-editor">
+    <property name="orientation">vertical</property>
+    <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Item Flow</property>
+        <property name="halign">start</property>
         <style>
           <class name="title"/>
         </style>
@@ -14,71 +15,63 @@
     </child>
     <child>
       <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkBox">
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Enable Item Flow</property>
-                <property name="halign">start</property>
-                <property name="hexpand">yes</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="use-item-flow">
-                <signal name="notify::active" handler="item-flow-active" swapped="no" />
-              </object>
-            </child>
-          </object>
-        </child>
         <child>
           <object class="GtkLabel">
-            <property name="label" translatable="yes">Item Property</property>
-            <property name="xalign">0</property>
+            <property name="label" translatable="yes">Enable Item Flow</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
-          <object class="GtkBox">
+          <object class="GtkSwitch" id="use-item-flow">
+            <signal name="notify::active" handler="item-flow-active" swapped="no" />
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Item Property</property>
+        <property name="xalign">0</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkEntry" id="item-flow-name">
+            <signal name="changed" handler="item-flow-name-changed" swapped="no" />
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="item-flow-invert">
+            <property name="tooltip-text" translatable="yes">Invert direction</property>
+            <signal name="clicked" handler="invert-direction-changed" swapped="no" />
             <child>
-              <object class="GtkEntry" id="item-flow-name">
-                <signal name="changed" handler="item-flow-name-changed" swapped="no" />
-                <property name="halign">start</property>
-                <property name="hexpand">yes</property>
+              <object class="GtkImage">
+                <property name="icon-name">object-flip-horizontal-symbolic</property>
               </object>
             </child>
-            <child>
-              <object class="GtkButton" id="item-flow-invert">
-                <property name="tooltip-text" translatable="yes">Invert direction</property>
-                <signal name="clicked" handler="invert-direction-changed" swapped="no" />
-                <child>
-                  <object class="GtkImage">
-                    <property name="icon-name">object-flip-horizontal-symbolic</property>
-                  </object>
-                </child>
-                <style>
-                  <class name="flat" />
-                </style>
-              </object>
-            </child>
+            <style>
+              <class name="flat" />
+            </style>
           </object>
         </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Allocated Type</property>
-            <property name="xalign">0</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkDropDown" id="item-flow-type">
-            <property name="enable-search">1</property>
-            <property name="expression">
-              <lookup type="LabelValue" name="label" />
-            </property>
-          </object>
-        </child>
-        <style>
-          <class name="propertypage"/>
-        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Allocated Type</property>
+        <property name="halign">start</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="item-flow-type">
+        <property name="enable-search">1</property>
+        <property name="expression">
+          <lookup type="LabelValue" name="label" />
+        </property>
       </object>
     </child>
     <style>
@@ -86,11 +79,12 @@
     </style>
   </object>
 
-  <object class="GtkExpander" id="compartment-editor">
-    <property name="expanded">1</property>
-    <child type="label">
+  <object class="GtkBox" id="compartment-editor">
+    <property name="orientation">vertical</property>
+    <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Compartments</property>
+        <property name="halign">start</property>
         <style>
           <class name="title"/>
         </style>
@@ -98,58 +92,50 @@
     </child>
     <child>
       <object class="GtkBox">
-        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Show Parts</property>
-                <property name="halign">start</property>
-                <property name="hexpand">yes</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="show-parts">
-                <signal name="notify::active" handler="show-parts-changed" swapped="no"/>
-              </object>
-            </child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Parts</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
-          <object class="GtkBox">
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Show References</property>
-                <property name="halign">start</property>
-                <property name="hexpand">yes</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="show-references">
-                <signal name="notify::active" handler="show-references-changed" swapped="no" />
-              </object>
-            </child>
+          <object class="GtkSwitch" id="show-parts">
+            <signal name="notify::active" handler="show-parts-changed" swapped="no"/>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show References</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
-          <object class="GtkBox">
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Show Values</property>
-                <property name="halign">start</property>
-                <property name="hexpand">yes</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="show-values">
-                <signal name="notify::active" handler="show-values-changed" swapped="no" />
-              </object>
-            </child>
+          <object class="GtkSwitch" id="show-references">
+            <signal name="notify::active" handler="show-references-changed" swapped="no" />
           </object>
         </child>
-        <style>
-          <class name="propertypage"/>
-        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Values</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-values">
+            <signal name="notify::active" handler="show-values-changed" swapped="no" />
+          </object>
+        </child>
       </object>
     </child>
     <style>
@@ -157,11 +143,12 @@
     </style>
   </object>
 
-  <object class="GtkExpander" id="interfaceblock-editor">
-    <property name="expanded">1</property>
-    <child type="label">
+  <object class="GtkBox" id="interfaceblock-editor">
+    <property name="orientation">vertical</property>
+    <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Compartments</property>
+        <property name="halign">start</property>
         <style>
           <class name="title"/>
         </style>
@@ -169,26 +156,18 @@
     </child>
     <child>
       <object class="GtkBox">
-        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Show Values</property>
-                <property name="halign">start</property>
-                <property name="hexpand">yes</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="show-values">
-                <signal name="notify::active" handler="show-values-changed" swapped="no" />
-              </object>
-            </child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Values</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
-        <style>
-          <class name="propertypage"/>
-        </style>
+        <child>
+          <object class="GtkSwitch" id="show-values">
+            <signal name="notify::active" handler="show-values-changed" swapped="no" />
+          </object>
+        </child>
       </object>
     </child>
     <style>

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -287,56 +287,53 @@
     </style>
   </object>
 
-  <object class="GtkExpander" id="activity-editor">
-    <property name="focusable">1</property>
-    <property name="expanded">1</property>
-    <child type="label">
+  <object class="GtkBox" id="activity-editor">
+    <property name="orientation">vertical</property>
+    <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Parameter Nodes</property>
+        <property name="halign">start</property>
         <style>
           <class name="title" />
         </style>
       </object>
     </child>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkFrame">
-            <property name="child">
-              <object class="GtkColumnView" id="parameter-list">
-                <style>
-                  <class name="data-table" />
-                </style>
-                <property name="height-request">112</property>
-                <property name="focusable">1</property>
-                <child>
-                  <object class="GtkColumnViewColumn">
-                    <property name="title" translatable="yes">Parameter Nodes</property>
-                    <property name="expand">1</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkEventControllerKey">
-                    <signal name="key-pressed" handler="parameter-key-pressed" />
-                  </object>
-                </child>
-                <signal name="activate" handler="parameter-activated" />
-              </object>
-            </property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="parameters-info-icon">
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">ⓘ Help</property>
+      <object class="GtkFrame">
+        <property name="child">
+          <object class="GtkColumnView" id="parameter-list">
+            <style>
+              <class name="data-table" />
+            </style>
+            <property name="height-request">112</property>
+            <property name="focusable">1</property>
             <child>
-              <object class="GtkPopover" id="parameters-info">
-                <property name="visible">0</property>
-                <property name="position">top</property>
-                <property name="child">
-                  <object class="GtkLabel">
-                    <property name="label" translatable="yes">Add and edit class activity according to UML syntax.
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Parameter Nodes</property>
+                <property name="expand">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkEventControllerKey">
+                <signal name="key-pressed" handler="parameter-key-pressed" />
+              </object>
+            </child>
+            <signal name="activate" handler="parameter-activated" />
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel" id="parameters-info-icon">
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">ⓘ Help</property>
+        <child>
+          <object class="GtkPopover" id="parameters-info">
+            <property name="visible">0</property>
+            <property name="position">top</property>
+            <property name="child">
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Add and edit class activity according to UML syntax.
 
   • &lt;tt&gt;attr&lt;/tt&gt; (name, defaults to public visibility)
   • &lt;tt&gt;+ attr: int&lt;/tt&gt; (public with type)
@@ -346,19 +343,17 @@
 
 Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                    <property name="use-markup">1</property>
-                    <style>
-                      <class name="info-popover" />
-                    </style>
-                  </object>
-                </property>
+                <property name="use-markup">1</property>
+                <style>
+                  <class name="info-popover" />
+                </style>
               </object>
-            </child>
-            <style>
-              <class name="info" />
-            </style>
+            </property>
           </object>
         </child>
+        <style>
+          <class name="info" />
+        </style>
       </object>
     </child>
     <style>

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -290,12 +290,51 @@
   <object class="GtkBox" id="activity-editor">
     <property name="orientation">vertical</property>
     <child>
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Parameter Nodes</property>
-        <property name="halign">start</property>
-        <style>
-          <class name="title" />
-        </style>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Parameter Nodes</property>
+            <property name="xalign">0</property>
+            <property name="hexpand">1</property>
+            <style>
+              <class name="title" />
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="parameters-info-icon">
+            <property name="halign">end</property>
+            <property name="valign">end</property>
+            <property name="label" translatable="yes">ⓘ Help</property>
+            <child>
+              <object class="GtkPopover" id="parameters-info">
+                <property name="visible">0</property>
+                <property name="position">top</property>
+                <property name="child">
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">Add and edit class activity according to UML syntax.
+
+  • &lt;tt&gt;attr&lt;/tt&gt; (name, defaults to public visibility)
+  • &lt;tt&gt;+ attr: int&lt;/tt&gt; (public with type)
+  • &lt;tt&gt;+ attr: int[0..1]&lt;/tt&gt; (public, type, and multiplicity)
+  • &lt;tt&gt;+ attr: int | bool&lt;/tt&gt; (public, union type)
+  • &lt;tt&gt;# /attr: int # a note&lt;/tt&gt; (protected, derived, with remark)
+
+Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
+Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
+                    <property name="use-markup">1</property>
+                    <style>
+                      <class name="info-popover" />
+                    </style>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <style>
+              <class name="info" />
+            </style>
+          </object>
+        </child>
       </object>
     </child>
     <child>
@@ -321,39 +360,6 @@
             <signal name="activate" handler="parameter-activated" />
           </object>
         </property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkLabel" id="parameters-info-icon">
-        <property name="halign">end</property>
-        <property name="label" translatable="yes">ⓘ Help</property>
-        <child>
-          <object class="GtkPopover" id="parameters-info">
-            <property name="visible">0</property>
-            <property name="position">top</property>
-            <property name="child">
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Add and edit class activity according to UML syntax.
-
-  • &lt;tt&gt;attr&lt;/tt&gt; (name, defaults to public visibility)
-  • &lt;tt&gt;+ attr: int&lt;/tt&gt; (public with type)
-  • &lt;tt&gt;+ attr: int[0..1]&lt;/tt&gt; (public, type, and multiplicity)
-  • &lt;tt&gt;+ attr: int | bool&lt;/tt&gt; (public, union type)
-  • &lt;tt&gt;# /attr: int # a note&lt;/tt&gt; (protected, derived, with remark)
-
-Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
-Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                <property name="use-markup">1</property>
-                <style>
-                  <class name="info-popover" />
-                </style>
-              </object>
-            </property>
-          </object>
-        </child>
-        <style>
-          <class name="info" />
-        </style>
       </object>
     </child>
     <style>

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -45,7 +45,8 @@
         <child>
           <object class="GtkLabel" id="head-title">
             <property name="label" translatable="yes">Head:</property>
-            <property name="halign">start</property>
+            <property name="xalign">0</property>
+            <property name="hexpand">1</property>
             <style>
               <class name="title"/>
             </style>
@@ -54,6 +55,7 @@
         <child>
           <object class="GtkLabel" id="head-info-icon">
             <property name="halign">end</property>
+            <property name="valign">end</property>
             <property name="label" translatable="yes">ⓘ Help</property>
             <child>
               <object class="GtkPopover" id="head-info">
@@ -154,7 +156,8 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <child>
           <object class="GtkLabel" id="tail-title">
             <property name="label" translatable="yes">Tail:</property>
-            <property name="halign">start</property>
+            <property name="xalign">0</property>
+            <property name="hexpand">1</property>
             <style>
               <class name="title"/>
             </style>
@@ -163,6 +166,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <child>
           <object class="GtkLabel" id="tail-info-icon">
             <property name="halign">end</property>
+            <property name="valign">end</property>
             <property name="label" translatable="yes">ⓘ Help</property>
             <child>
               <object class="GtkPopover" id="tail-info">
@@ -266,12 +270,52 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
   <object class="GtkBox" id="attributes-editor">
     <property name="orientation">vertical</property>
     <child>
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Attributes</property>
-        <property name="halign">start</property>
-        <style>
-          <class name="title"/>
-        </style>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Attributes</property>
+            <property name="xalign">0</property>
+            <property name="hexpand">1</property>
+            <style>
+              <class name="title"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="attributes-info-icon">
+            <property name="halign">end</property>
+            <property name="valign">end</property>
+            <property name="label" translatable="yes">ⓘ Help</property>
+
+            <child>
+              <object class="GtkPopover" id="attributes-info">
+                <property name="visible">0</property>
+                <property name="position">top</property>
+                <property name="child">
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">Add and edit class attributes according to UML syntax.
+
+  • &lt;tt&gt;attr&lt;/tt&gt; (name, defaults to public visibility)
+  • &lt;tt&gt;+ attr: int&lt;/tt&gt; (public with type)
+  • &lt;tt&gt;+ attr: int[0..1]&lt;/tt&gt; (public, type, and multiplicity)
+  • &lt;tt&gt;+ attr: int | bool&lt;/tt&gt; (public, union type)
+  • &lt;tt&gt;# /attr: int # a note&lt;/tt&gt; (protected, derived, with remark)
+
+Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
+Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
+                    <property name="use-markup">1</property>
+                    <style>
+                      <class name="info-popover"/>
+                    </style>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <style>
+              <class name="info"/>
+            </style>
+          </object>
+        </child>
       </object>
     </child>
     <child>
@@ -319,40 +363,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <signal name="activate" handler="attributes-activated" />
           </object>
         </property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkLabel" id="attributes-info-icon">
-        <property name="halign">end</property>
-        <property name="label" translatable="yes">ⓘ Help</property>
-
-        <child>
-          <object class="GtkPopover" id="attributes-info">
-            <property name="visible">0</property>
-            <property name="position">top</property>
-            <property name="child">
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Add and edit class attributes according to UML syntax.
-
-  • &lt;tt&gt;attr&lt;/tt&gt; (name, defaults to public visibility)
-  • &lt;tt&gt;+ attr: int&lt;/tt&gt; (public with type)
-  • &lt;tt&gt;+ attr: int[0..1]&lt;/tt&gt; (public, type, and multiplicity)
-  • &lt;tt&gt;+ attr: int | bool&lt;/tt&gt; (public, union type)
-  • &lt;tt&gt;# /attr: int # a note&lt;/tt&gt; (protected, derived, with remark)
-
-Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
-Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                <property name="use-markup">1</property>
-                <style>
-                  <class name="info-popover"/>
-                </style>
-              </object>
-            </property>
-          </object>
-        </child>
-        <style>
-          <class name="info"/>
-        </style>
       </object>
     </child>
     <style>
@@ -460,12 +470,49 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
   <object class="GtkBox" id="operations-editor">
     <property name="orientation">vertical</property>
     <child>
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Operations</property>
-        <property name="halign">start</property>
-        <style>
-          <class name="title"/>
-        </style>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Operations</property>
+            <property name="xalign">0</property>
+            <property name="hexpand">1</property>
+            <style>
+              <class name="title"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="operations-info-icon">
+            <property name="halign">end</property>
+            <property name="valign">end</property>
+            <property name="label" translatable="yes">ⓘ Help</property>
+            <child>
+              <object class="GtkPopover" id="operations-info">
+                <property name="visible">0</property>
+                <property name="position">top</property>
+                <property name="child">
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">Add and edit class operations according to UML syntax.
+
+  • &lt;tt&gt;call()&lt;/tt&gt;
+  • &lt;tt&gt;+ call(a: int[*], b: str): bool&lt;/tt&gt; (public, parameters)
+  • &lt;tt&gt;# call(a: int, b: str) # a note&lt;/tt&gt; (protected, with remark)
+
+Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
+Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
+                    <property name="use-markup">1</property>
+                    <style>
+                      <class name="info-popover"/>
+                    </style>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <style>
+              <class name="info"/>
+            </style>
+          </object>
+        </child>
       </object>
     </child>
     <child>
@@ -520,38 +567,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         </property>
       </object>
     </child>
-    <child>
-      <object class="GtkLabel" id="operations-info-icon">
-        <property name="visible">1</property>
-        <property name="halign">end</property>
-        <property name="label" translatable="yes">ⓘ Help</property>
-        <child>
-          <object class="GtkPopover" id="operations-info">
-            <property name="visible">0</property>
-            <property name="position">top</property>
-            <property name="child">
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Add and edit class operations according to UML syntax.
-
-  • &lt;tt&gt;call()&lt;/tt&gt;
-  • &lt;tt&gt;+ call(a: int[*], b: str): bool&lt;/tt&gt; (public, parameters)
-  • &lt;tt&gt;# call(a: int, b: str) # a note&lt;/tt&gt; (protected, with remark)
-
-Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
-Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                <property name="use-markup">1</property>
-                <style>
-                  <class name="info-popover"/>
-                </style>
-              </object>
-            </property>
-          </object>
-        </child>
-        <style>
-          <class name="info"/>
-        </style>
-      </object>
-    </child>
     <style>
       <class name="propertypage"/>
     </style>
@@ -560,12 +575,47 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
   <object class="GtkBox" id="enumerations-editor">
     <property name="orientation">vertical</property>
     <child>
-      <object class="GtkLabel">
-        <property name="label" translatable="yes">Enumeration Literals</property>
-        <property name="halign">start</property>
-        <style>
-          <class name="title"/>
-        </style>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Enumeration Literals</property>
+            <property name="xalign">0</property>
+            <property name="hexpand">1</property>
+            <style>
+              <class name="title"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="enumerations-info-icon">
+            <property name="halign">end</property>
+            <property name="valign">end</property>
+            <property name="label" translatable="yes">ⓘ Help</property>
+
+            <child>
+              <object class="GtkPopover" id="enumerations-info">
+                <property name="position">top</property>
+                <property name="child">
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">Add and edit enumeration literals according to UML syntax.
+
+  • &lt;tt&gt;enum&lt;/tt&gt;
+
+Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
+Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
+                    <property name="use-markup">1</property>
+                    <style>
+                      <class name="info-popover"/>
+                    </style>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <style>
+              <class name="info"/>
+            </style>
+          </object>
+        </child>
       </object>
     </child>
     <child>
@@ -609,37 +659,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <signal name="activate" handler="enumerations-activated" />
           </object>
         </property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkLabel" id="enumerations-info-icon">
-        <property name="visible">1</property>
-        <property name="halign">end</property>
-        <property name="label" translatable="yes">ⓘ Help</property>
-
-        <child>
-          <object class="GtkPopover" id="enumerations-info">
-            <property name="position">top</property>
-            <property name="child">
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Add and edit enumeration literals according to UML syntax.
-
-  • &lt;tt&gt;enum&lt;/tt&gt;
-
-Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
-Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                <property name="use-markup">1</property>
-                <style>
-                  <class name="info-popover"/>
-                </style>
-              </object>
-            </property>
-          </object>
-        </child>
-
-        <style>
-          <class name="info"/>
-        </style>
       </object>
     </child>
     <style>

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -41,31 +41,27 @@
       </object>
     </child>
     <child>
-      <object class="GtkLabel" id="head-title">
-        <property name="label" translatable="yes">Head:</property>
-        <property name="halign">start</property>
-        <style>
-          <class name="title"/>
-        </style>
-      </object>
-    </child>
-    <child>
-      <object class="GtkEntry" id="head-name">
-        <property name="focusable">1</property>
-        <signal name="changed" handler="head-name-changed" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkLabel" id="head-info-icon">
-        <property name="halign">end</property>
-        <property name="label" translatable="yes">ⓘ Help</property>
+      <object class="GtkBox">
         <child>
-          <object class="GtkPopover" id="head-info">
-            <property name="visible">0</property>
-            <property name="position">top</property>
-            <property name="child">
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Add and edit association ends according to UML syntax.
+          <object class="GtkLabel" id="head-title">
+            <property name="label" translatable="yes">Head:</property>
+            <property name="halign">start</property>
+            <style>
+              <class name="title"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="head-info-icon">
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">ⓘ Help</property>
+            <child>
+              <object class="GtkPopover" id="head-info">
+                <property name="visible">0</property>
+                <property name="position">top</property>
+                <property name="child">
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">Add and edit association ends according to UML syntax.
 
   • &lt;tt&gt;+ name&lt;/tt&gt;
   • &lt;tt&gt;+ name[1]&lt;/tt&gt;
@@ -75,17 +71,25 @@
 
 Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                <property name="use-markup">1</property>
-                <style>
-                  <class name="info-popover"/>
-                </style>
+                    <property name="use-markup">1</property>
+                    <style>
+                      <class name="info-popover"/>
+                    </style>
+                  </object>
+                </property>
               </object>
-            </property>
+            </child>
+            <style>
+              <class name="info"/>
+            </style>
           </object>
         </child>
-        <style>
-          <class name="info"/>
-        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkEntry" id="head-name">
+        <property name="focusable">1</property>
+        <signal name="changed" handler="head-name-changed" swapped="no"/>
       </object>
     </child>
     <child>
@@ -146,31 +150,27 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
       </object>
     </child>
     <child>
-      <object class="GtkLabel" id="tail-title">
-        <property name="label" translatable="yes">Tail:</property>
-        <property name="halign">start</property>
-        <style>
-          <class name="title"/>
-        </style>
-      </object>
-    </child>
-    <child>
-      <object class="GtkEntry" id="tail-name">
-        <property name="focusable">1</property>
-        <signal name="changed" handler="tail-name-changed" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkLabel" id="tail-info-icon">
-        <property name="halign">end</property>
-        <property name="label" translatable="yes">ⓘ Help</property>
+      <object class="GtkBox">
         <child>
-          <object class="GtkPopover" id="tail-info">
-            <property name="visible">0</property>
-            <property name="position">top</property>
-            <property name="child">
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Add and edit association ends according to UML syntax.
+          <object class="GtkLabel" id="tail-title">
+            <property name="label" translatable="yes">Tail:</property>
+            <property name="halign">start</property>
+            <style>
+              <class name="title"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="tail-info-icon">
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">ⓘ Help</property>
+            <child>
+              <object class="GtkPopover" id="tail-info">
+                <property name="visible">0</property>
+                <property name="position">top</property>
+                <property name="child">
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">Add and edit association ends according to UML syntax.
 
   • &lt;tt&gt;+ name&lt;/tt&gt;
   • &lt;tt&gt;+ name[1]&lt;/tt&gt;
@@ -180,17 +180,25 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
 
 Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                <property name="use-markup">1</property>
-                <style>
-                  <class name="info-popover"/>
-                </style>
+                    <property name="use-markup">1</property>
+                    <style>
+                      <class name="info-popover"/>
+                    </style>
+                  </object>
+                </property>
               </object>
-            </property>
+            </child>
+            <style>
+              <class name="info"/>
+            </style>
           </object>
         </child>
-        <style>
-          <class name="info"/>
-        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkEntry" id="tail-name">
+        <property name="focusable">1</property>
+        <signal name="changed" handler="tail-name-changed" swapped="no"/>
       </object>
     </child>
     <child>

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -41,155 +41,31 @@
       </object>
     </child>
     <child>
-      <object class="GtkExpander">
-        <property name="focusable">1</property>
-        <property name="expanded">1</property>
-        <child type="label">
-          <object class="GtkLabel" id="head-title">
-            <property name="label" translatable="yes">Head:</property>
-            <style>
-              <class name="title"/>
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkEntry" id="head-name">
-                <property name="focusable">1</property>
-                <signal name="changed" handler="head-name-changed" swapped="no"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="head-info-icon">
-                <property name="halign">end</property>
-                <property name="label" translatable="yes">ⓘ Help</property>
-                <child>
-                  <object class="GtkPopover" id="head-info">
-                    <property name="visible">0</property>
-                    <property name="position">top</property>
-                    <property name="child">
-                      <object class="GtkLabel">
-                        <property name="label" translatable="yes">Add and edit association ends according to UML syntax.
-
-  • &lt;tt&gt;+ name&lt;/tt&gt;
-  • &lt;tt&gt;+ name[1]&lt;/tt&gt;
-  • &lt;tt&gt;- name[1..2]&lt;/tt&gt;
-  • &lt;tt&gt;1..2&lt;/tt&gt;
-  • &lt;tt&gt;- [1..2]&lt;/tt&gt;
-
-Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
-Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                        <property name="use-markup">1</property>
-                        <style>
-                          <class name="info-popover"/>
-                        </style>
-                      </object>
-                    </property>
-                  </object>
-                </child>
-                <style>
-                  <class name="info"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkDropDown" id="head-navigation">
-                <property name="model">
-                  <object class="GtkStringList">
-                    <items>
-                      <item translatable="yes">Unknown navigation</item>
-                      <item translatable="yes">Not navigable</item>
-                      <item translatable="yes">Navigable</item>
-                    </items>
-                  </object>
-                </property>
-                <signal name="notify::selected" handler="head-navigation-changed" swapped="no"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkDropDown" id="head-aggregation">
-                <property name="model">
-                  <object class="GtkStringList">
-                    <items>
-                      <item translatable="yes">No aggregation</item>
-                      <item translatable="yes">Shared</item>
-                      <item translatable="yes">Composite</item>
-                    </items>
-                  </object>
-                </property>
-                <signal name="notify::selected" handler="head-aggregation-changed" swapped="no"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFrame" id="head-stereotype-frame">
-                <property name="child">
-                  <object class="GtkColumnView" id="head-stereotype-list">
-                    <property name="height-request">112</property>
-                    <property name="focusable">1</property>
-                    <style>
-                      <class name="data-table"/>
-                    </style>
-                    <child>
-                      <object class="GtkColumnViewColumn">
-                        <property name="title" translatable="yes">Stereotypes</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkColumnViewColumn">
-                        <property name="title" translatable="yes">Values</property>
-                        <property name="expand">1</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkEventControllerKey">
-                        <signal name="key-pressed" handler="head-stereotype-key-pressed" />
-                      </object>
-                    </child>
-                  </object>
-                </property>
-              </object>
-            </child>
-            <style>
-              <class name="propertypage"/>
-            </style>
-          </object>
-        </child>
+      <object class="GtkLabel" id="head-title">
+        <property name="label" translatable="yes">Head:</property>
+        <property name="halign">start</property>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>
-      <object class="GtkExpander">
+      <object class="GtkEntry" id="head-name">
         <property name="focusable">1</property>
-        <property name="expanded">1</property>
-        <child type="label">
-          <object class="GtkLabel" id="tail-title">
-            <property name="label" translatable="yes">Tail:</property>
-            <style>
-              <class name="title"/>
-            </style>
-          </object>
-        </child>
+        <signal name="changed" handler="head-name-changed" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel" id="head-info-icon">
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">ⓘ Help</property>
         <child>
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkEntry" id="tail-name">
-                <property name="focusable">1</property>
-                <signal name="changed" handler="tail-name-changed" swapped="no"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="tail-info-icon">
-                <property name="halign">end</property>
-                <property name="label" translatable="yes">ⓘ Help</property>
-                <child>
-                  <object class="GtkPopover" id="tail-info">
-                    <property name="visible">0</property>
-                    <property name="position">top</property>
-                    <property name="child">
-                      <object class="GtkLabel">
-                        <property name="label" translatable="yes">Add and edit association ends according to UML syntax.
+          <object class="GtkPopover" id="head-info">
+            <property name="visible">0</property>
+            <property name="position">top</property>
+            <property name="child">
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Add and edit association ends according to UML syntax.
 
   • &lt;tt&gt;+ name&lt;/tt&gt;
   • &lt;tt&gt;+ name[1]&lt;/tt&gt;
@@ -199,81 +75,179 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
 
 Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                        <property name="use-markup">1</property>
-                        <style>
-                          <class name="info-popover"/>
-                        </style>
-                      </object>
-                    </property>
-                  </object>
-                </child>
+                <property name="use-markup">1</property>
                 <style>
-                  <class name="info"/>
+                  <class name="info-popover"/>
                 </style>
               </object>
-            </child>
-            <child>
-              <object class="GtkDropDown" id="tail-navigation">
-                <property name="model">
-                  <object class="GtkStringList">
-                    <items>
-                      <item translatable="yes">Unknown navigation</item>
-                      <item translatable="yes">Not navigable</item>
-                      <item translatable="yes">Navigable</item>
-                    </items>
-                  </object>
-                </property>
-                <signal name="notify::selected" handler="tail-navigation-changed" swapped="no"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkDropDown" id="tail-aggregation">
-                <property name="model">
-                  <object class="GtkStringList">
-                    <items>
-                      <item translatable="yes">No aggregation</item>
-                      <item translatable="yes">Shared</item>
-                      <item translatable="yes">Composite</item>
-                    </items>
-                  </object>
-                </property>
-                <signal name="notify::selected" handler="tail-aggregation-changed" swapped="no"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFrame" id="tail-stereotype-frame">
-                <property name="child">
-                  <object class="GtkColumnView" id="tail-stereotype-list">
-                    <property name="height-request">112</property>
-                    <property name="focusable">1</property>
-                    <style>
-                      <class name="data-table"/>
-                    </style>
-                    <child>
-                      <object class="GtkColumnViewColumn">
-                        <property name="title" translatable="yes">Stereotypes</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkColumnViewColumn">
-                        <property name="title" translatable="yes">Values</property>
-                        <property name="expand">1</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkEventControllerKey">
-                        <signal name="key-pressed" handler="tail-stereotype-key-pressed" />
-                      </object>
-                    </child>
-                  </object>
-                </property>
-              </object>
-            </child>
-            <style>
-              <class name="propertypage"/>
-            </style>
+            </property>
           </object>
         </child>
+        <style>
+          <class name="info"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="head-navigation">
+        <property name="model">
+          <object class="GtkStringList">
+            <items>
+              <item translatable="yes">Unknown navigation</item>
+              <item translatable="yes">Not navigable</item>
+              <item translatable="yes">Navigable</item>
+            </items>
+          </object>
+        </property>
+        <signal name="notify::selected" handler="head-navigation-changed" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="head-aggregation">
+        <property name="model">
+          <object class="GtkStringList">
+            <items>
+              <item translatable="yes">No aggregation</item>
+              <item translatable="yes">Shared</item>
+              <item translatable="yes">Composite</item>
+            </items>
+          </object>
+        </property>
+        <signal name="notify::selected" handler="head-aggregation-changed" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkFrame" id="head-stereotype-frame">
+        <property name="child">
+          <object class="GtkColumnView" id="head-stereotype-list">
+            <property name="height-request">112</property>
+            <property name="focusable">1</property>
+            <style>
+              <class name="data-table"/>
+            </style>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Stereotypes</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Values</property>
+                <property name="expand">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkEventControllerKey">
+                <signal name="key-pressed" handler="head-stereotype-key-pressed" />
+              </object>
+            </child>
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel" id="tail-title">
+        <property name="label" translatable="yes">Tail:</property>
+        <property name="halign">start</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkEntry" id="tail-name">
+        <property name="focusable">1</property>
+        <signal name="changed" handler="tail-name-changed" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel" id="tail-info-icon">
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">ⓘ Help</property>
+        <child>
+          <object class="GtkPopover" id="tail-info">
+            <property name="visible">0</property>
+            <property name="position">top</property>
+            <property name="child">
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Add and edit association ends according to UML syntax.
+
+  • &lt;tt&gt;+ name&lt;/tt&gt;
+  • &lt;tt&gt;+ name[1]&lt;/tt&gt;
+  • &lt;tt&gt;- name[1..2]&lt;/tt&gt;
+  • &lt;tt&gt;1..2&lt;/tt&gt;
+  • &lt;tt&gt;- [1..2]&lt;/tt&gt;
+
+Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
+Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
+                <property name="use-markup">1</property>
+                <style>
+                  <class name="info-popover"/>
+                </style>
+              </object>
+            </property>
+          </object>
+        </child>
+        <style>
+          <class name="info"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="tail-navigation">
+        <property name="model">
+          <object class="GtkStringList">
+            <items>
+              <item translatable="yes">Unknown navigation</item>
+              <item translatable="yes">Not navigable</item>
+              <item translatable="yes">Navigable</item>
+            </items>
+          </object>
+        </property>
+        <signal name="notify::selected" handler="tail-navigation-changed" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="tail-aggregation">
+        <property name="model">
+          <object class="GtkStringList">
+            <items>
+              <item translatable="yes">No aggregation</item>
+              <item translatable="yes">Shared</item>
+              <item translatable="yes">Composite</item>
+            </items>
+          </object>
+        </property>
+        <signal name="notify::selected" handler="tail-aggregation-changed" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkFrame" id="tail-stereotype-frame">
+        <property name="child">
+          <object class="GtkColumnView" id="tail-stereotype-list">
+            <property name="height-request">112</property>
+            <property name="focusable">1</property>
+            <style>
+              <class name="data-table"/>
+            </style>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Stereotypes</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Values</property>
+                <property name="expand">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkEventControllerKey">
+                <signal name="key-pressed" handler="tail-stereotype-key-pressed" />
+              </object>
+            </child>
+          </object>
+        </property>
       </object>
     </child>
     <style>
@@ -281,12 +255,12 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
     </style>
   </object>
 
-  <object class="GtkExpander" id="attributes-editor">
-    <property name="focusable">1</property>
-    <property name="expanded">1</property>
-    <child type="label">
+  <object class="GtkBox" id="attributes-editor">
+    <property name="orientation">vertical</property>
+    <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Attributes</property>
+        <property name="halign">start</property>
         <style>
           <class name="title"/>
         </style>
@@ -294,66 +268,63 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
     </child>
     <child>
       <object class="GtkBox">
-        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Show Attributes</property>
-                <property name="halign">start</property>
-                <property name="hexpand">yes</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="show-attributes">
-                <property name="focusable">1</property>
-                <signal name="notify::active" handler="show-attributes-changed" swapped="no"/>
-              </object>
-            </child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Attributes</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
-          <object class="GtkFrame">
-            <property name="child">
-              <object class="GtkColumnView" id="attributes-list">
-                <property name="height-request">112</property>
-                <property name="focusable">1</property>
-                <style>
-                  <class name="data-table"/>
-                </style>
-                <child>
-                  <object class="GtkColumnViewColumn">
-                    <property name="title" translatable="yes">Attributes</property>
-                    <property name="expand">1</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkColumnViewColumn">
-                    <property name="title" translatable="yes">Static</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkEventControllerKey">
-                    <signal name="key-pressed" handler="attributes-key-pressed" />
-                  </object>
-                </child>
-                <signal name="activate" handler="attributes-activated" />
-              </object>
-            </property>
+          <object class="GtkSwitch" id="show-attributes">
+            <property name="focusable">1</property>
+            <signal name="notify::active" handler="show-attributes-changed" swapped="no"/>
           </object>
         </child>
-        <child>
-          <object class="GtkLabel" id="attributes-info-icon">
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">ⓘ Help</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkFrame">
+        <property name="child">
+          <object class="GtkColumnView" id="attributes-list">
+            <property name="height-request">112</property>
+            <property name="focusable">1</property>
+            <style>
+              <class name="data-table"/>
+            </style>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Attributes</property>
+                <property name="expand">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Static</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkEventControllerKey">
+                <signal name="key-pressed" handler="attributes-key-pressed" />
+              </object>
+            </child>
+            <signal name="activate" handler="attributes-activated" />
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel" id="attributes-info-icon">
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">ⓘ Help</property>
 
-            <child>
-              <object class="GtkPopover" id="attributes-info">
-                <property name="visible">0</property>
-                <property name="position">top</property>
-                <property name="child">
-                  <object class="GtkLabel">
-                    <property name="label" translatable="yes">Add and edit class attributes according to UML syntax.
+        <child>
+          <object class="GtkPopover" id="attributes-info">
+            <property name="visible">0</property>
+            <property name="position">top</property>
+            <property name="child">
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Add and edit class attributes according to UML syntax.
 
   • &lt;tt&gt;attr&lt;/tt&gt; (name, defaults to public visibility)
   • &lt;tt&gt;+ attr: int&lt;/tt&gt; (public with type)
@@ -363,21 +334,16 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
 
 Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                    <property name="use-markup">1</property>
-                    <style>
-                      <class name="info-popover"/>
-                    </style>
-                  </object>
-                </property>
+                <property name="use-markup">1</property>
+                <style>
+                  <class name="info-popover"/>
+                </style>
               </object>
-            </child>
-            <style>
-              <class name="info"/>
-            </style>
+            </property>
           </object>
         </child>
         <style>
-          <class name="propertypage"/>
+          <class name="info"/>
         </style>
       </object>
     </child>
@@ -483,12 +449,12 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
     </style>
   </object>
 
-  <object class="GtkExpander" id="operations-editor">
-    <property name="focusable">1</property>
-    <property name="expanded">1</property>
-    <child type="label">
+  <object class="GtkBox" id="operations-editor">
+    <property name="orientation">vertical</property>
+    <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Operations</property>
+        <property name="halign">start</property>
         <style>
           <class name="title"/>
         </style>
@@ -496,71 +462,68 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
     </child>
     <child>
       <object class="GtkBox">
-        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Show Operations</property>
-                <property name="halign">start</property>
-                <property name="hexpand">yes</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="show-operations">
-                <property name="focusable">1</property>
-                <signal name="notify::active" handler="show-operations-changed" swapped="no"/>
-              </object>
-            </child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Operations</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
-          <object class="GtkFrame">
+          <object class="GtkSwitch" id="show-operations">
+            <property name="focusable">1</property>
+            <signal name="notify::active" handler="show-operations-changed" swapped="no"/>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkFrame">
+        <property name="child">
+          <object class="GtkColumnView" id="operations-list">
+            <property name="height-request">112</property>
+            <property name="focusable">1</property>
+            <style>
+              <class name="data-table"/>
+            </style>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Operations</property>
+                <property name="expand">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Abstract</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Static</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkEventControllerKey">
+                <signal name="key-pressed" handler="operations-key-pressed" />
+              </object>
+            </child>
+            <signal name="activate" handler="operations-activated" />
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel" id="operations-info-icon">
+        <property name="visible">1</property>
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">ⓘ Help</property>
+        <child>
+          <object class="GtkPopover" id="operations-info">
+            <property name="visible">0</property>
+            <property name="position">top</property>
             <property name="child">
-              <object class="GtkColumnView" id="operations-list">
-                <property name="height-request">112</property>
-                <property name="focusable">1</property>
-                <style>
-                  <class name="data-table"/>
-                </style>
-                <child>
-                  <object class="GtkColumnViewColumn">
-                    <property name="title" translatable="yes">Operations</property>
-                    <property name="expand">1</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkColumnViewColumn">
-                    <property name="title" translatable="yes">Abstract</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkColumnViewColumn">
-                    <property name="title" translatable="yes">Static</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkEventControllerKey">
-                    <signal name="key-pressed" handler="operations-key-pressed" />
-                  </object>
-                </child>
-                <signal name="activate" handler="operations-activated" />
-              </object>
-            </property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="operations-info-icon">
-            <property name="visible">1</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">ⓘ Help</property>
-            <child>
-              <object class="GtkPopover" id="operations-info">
-                <property name="visible">0</property>
-                <property name="position">top</property>
-                <property name="child">
-                  <object class="GtkLabel">
-                    <property name="label" translatable="yes">Add and edit class operations according to UML syntax.
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Add and edit class operations according to UML syntax.
 
   • &lt;tt&gt;call()&lt;/tt&gt;
   • &lt;tt&gt;+ call(a: int[*], b: str): bool&lt;/tt&gt; (public, parameters)
@@ -568,21 +531,16 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
 
 Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                    <property name="use-markup">1</property>
-                    <style>
-                      <class name="info-popover"/>
-                    </style>
-                  </object>
-                </property>
+                <property name="use-markup">1</property>
+                <style>
+                  <class name="info-popover"/>
+                </style>
               </object>
-            </child>
-            <style>
-              <class name="info"/>
-            </style>
+            </property>
           </object>
         </child>
         <style>
-          <class name="propertypage"/>
+          <class name="info"/>
         </style>
       </object>
     </child>
@@ -591,12 +549,12 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
     </style>
   </object>
 
-  <object class="GtkExpander" id="enumerations-editor">
-    <property name="focusable">1</property>
-    <property name="expanded">1</property>
-    <child type="label">
+  <object class="GtkBox" id="enumerations-editor">
+    <property name="orientation">vertical</property>
+    <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Enumeration Literals</property>
+        <property name="halign">start</property>
         <style>
           <class name="title"/>
         </style>
@@ -604,83 +562,75 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
     </child>
     <child>
       <object class="GtkBox">
-        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Show Enumeration Literals</property>
-                <property name="hexpand">yes</property>
-                <property name="halign">start</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="show-enumerations">
-                <property name="halign">center</property>
-                <property name="focusable">1</property>
-                <signal name="notify::active" handler="show-enumerations-changed" swapped="no"/>
-              </object>
-            </child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Enumeration Literals</property>
+            <property name="hexpand">yes</property>
+            <property name="halign">start</property>
           </object>
         </child>
         <child>
-          <object class="GtkFrame">
-            <property name="child">
-              <object class="GtkColumnView" id="enumerations-list">
-                <property name="height-request">112</property>
-                <property name="focusable">1</property>
-                <style>
-                  <class name="data-table"/>
-                </style>
-                <child>
-                  <object class="GtkColumnViewColumn">
-                    <property name="title" translatable="yes">Enumeration Literals</property>
-                    <property name="expand">1</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkEventControllerKey">
-                    <signal name="key-pressed" handler="enumerations-key-pressed" />
-                  </object>
-                </child>
-                <signal name="activate" handler="enumerations-activated" />
-              </object>
-            </property>
+          <object class="GtkSwitch" id="show-enumerations">
+            <property name="halign">center</property>
+            <property name="focusable">1</property>
+            <signal name="notify::active" handler="show-enumerations-changed" swapped="no"/>
           </object>
         </child>
-        <child>
-          <object class="GtkLabel" id="enumerations-info-icon">
-            <property name="visible">1</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">ⓘ Help</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkFrame">
+        <property name="child">
+          <object class="GtkColumnView" id="enumerations-list">
+            <property name="height-request">112</property>
+            <property name="focusable">1</property>
+            <style>
+              <class name="data-table"/>
+            </style>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Enumeration Literals</property>
+                <property name="expand">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkEventControllerKey">
+                <signal name="key-pressed" handler="enumerations-key-pressed" />
+              </object>
+            </child>
+            <signal name="activate" handler="enumerations-activated" />
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel" id="enumerations-info-icon">
+        <property name="visible">1</property>
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">ⓘ Help</property>
 
-            <child>
-              <object class="GtkPopover" id="enumerations-info">
-                <property name="position">top</property>
-                <property name="child">
-                  <object class="GtkLabel">
-                    <property name="label" translatable="yes">Add and edit enumeration literals according to UML syntax.
+        <child>
+          <object class="GtkPopover" id="enumerations-info">
+            <property name="position">top</property>
+            <property name="child">
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Add and edit enumeration literals according to UML syntax.
 
   • &lt;tt&gt;enum&lt;/tt&gt;
 
 Press &lt;b&gt;Enter&lt;/b&gt; to edit, &lt;b&gt;Backspace&lt;/b&gt;/&lt;b&gt;Delete&lt;/b&gt; to remove items.
 Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</property>
-                    <property name="use-markup">1</property>
-                    <style>
-                      <class name="info-popover"/>
-                    </style>
-                  </object>
-                </property>
+                <property name="use-markup">1</property>
+                <style>
+                  <class name="info-popover"/>
+                </style>
               </object>
-            </child>
-
-            <style>
-              <class name="info"/>
-            </style>
+            </property>
           </object>
         </child>
+
         <style>
-          <class name="propertypage"/>
+          <class name="info"/>
         </style>
       </object>
     </child>

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -319,23 +319,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
       </object>
     </child>
     <child>
-      <object class="GtkBox">
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Show Attributes</property>
-            <property name="halign">start</property>
-            <property name="hexpand">yes</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSwitch" id="show-attributes">
-            <property name="focusable">1</property>
-            <signal name="notify::active" handler="show-attributes-changed" swapped="no"/>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
       <object class="GtkFrame">
         <property name="child">
           <object class="GtkColumnView" id="attributes-list">
@@ -363,6 +346,23 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <signal name="activate" handler="attributes-activated" />
           </object>
         </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Attributes</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-attributes">
+            <property name="focusable">1</property>
+            <signal name="notify::active" handler="show-attributes-changed" swapped="no"/>
+          </object>
+        </child>
       </object>
     </child>
     <style>
@@ -516,23 +516,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
       </object>
     </child>
     <child>
-      <object class="GtkBox">
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Show Operations</property>
-            <property name="halign">start</property>
-            <property name="hexpand">yes</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSwitch" id="show-operations">
-            <property name="focusable">1</property>
-            <signal name="notify::active" handler="show-operations-changed" swapped="no"/>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
       <object class="GtkFrame">
         <property name="child">
           <object class="GtkColumnView" id="operations-list">
@@ -565,6 +548,23 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <signal name="activate" handler="operations-activated" />
           </object>
         </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Operations</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-operations">
+            <property name="focusable">1</property>
+            <signal name="notify::active" handler="show-operations-changed" swapped="no"/>
+          </object>
+        </child>
       </object>
     </child>
     <style>
@@ -619,24 +619,6 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
       </object>
     </child>
     <child>
-      <object class="GtkBox">
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Show Enumeration Literals</property>
-            <property name="hexpand">yes</property>
-            <property name="halign">start</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSwitch" id="show-enumerations">
-            <property name="halign">center</property>
-            <property name="focusable">1</property>
-            <signal name="notify::active" handler="show-enumerations-changed" swapped="no"/>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
       <object class="GtkFrame">
         <property name="child">
           <object class="GtkColumnView" id="enumerations-list">
@@ -659,6 +641,24 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <signal name="activate" handler="enumerations-activated" />
           </object>
         </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Enumeration Literals</property>
+            <property name="hexpand">yes</property>
+            <property name="halign">start</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-enumerations">
+            <property name="halign">center</property>
+            <property name="focusable">1</property>
+            <signal name="notify::active" handler="show-enumerations-changed" swapped="no"/>
+          </object>
+        </child>
       </object>
     </child>
     <style>

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -26,11 +26,12 @@
     </style>
   </object>
 
-  <object class="GtkExpander" id="stereotypes-editor">
-    <property name="expanded">1</property>
+  <object class="GtkBox" id="stereotypes-editor">
+    <property name="orientation">vertical</property>
     <child type="label">
       <object class="GtkLabel">
         <property name="label" translatable="yes">Stereotypes</property>
+        <property name="halign">start</property>
         <style>
           <class name="title"/>
         </style>
@@ -38,56 +39,48 @@
     </child>
     <child>
       <object class="GtkBox">
-        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Show Stereotypes</property>
-                <property name="halign">start</property>
-                <property name="hexpand">yes</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="show-stereotypes">
-                <signal name="notify::active" handler="show-stereotypes-changed" swapped="no"/>
-              </object>
-            </child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Stereotypes</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
           </object>
         </child>
         <child>
-          <object class="GtkFrame">
-            <property name="child">
-              <object class="GtkColumnView" id="stereotype-list">
-                <property name="height-request">112</property>
-                <property name="focusable">1</property>
-                <style>
-                  <class name="data-table"/>
-                </style>
-                <child>
-                  <object class="GtkColumnViewColumn">
-                    <property name="title" translatable="yes">Stereotypes</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkColumnViewColumn">
-                    <property name="title" translatable="yes">Values</property>
-                    <property name="expand">1</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkEventControllerKey">
-                    <signal name="key-pressed" handler="stereotype-key-pressed" />
-                  </object>
-                </child>
-                <signal name="activate" handler="stereotype-activated" />
-              </object>
-            </property>
+          <object class="GtkSwitch" id="show-stereotypes">
+            <signal name="notify::active" handler="show-stereotypes-changed" swapped="no"/>
           </object>
         </child>
-        <style>
-          <class name="propertypage"/>
-        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkFrame">
+        <property name="child">
+          <object class="GtkColumnView" id="stereotype-list">
+            <property name="height-request">112</property>
+            <property name="focusable">1</property>
+            <style>
+              <class name="data-table"/>
+            </style>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Stereotypes</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">Values</property>
+                <property name="expand">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkEventControllerKey">
+                <signal name="key-pressed" handler="stereotype-key-pressed" />
+              </object>
+            </child>
+            <signal name="activate" handler="stereotype-activated" />
+          </object>
+        </property>
       </object>
     </child>
     <style>

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -38,22 +38,6 @@
       </object>
     </child>
     <child>
-      <object class="GtkBox">
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Show Stereotypes</property>
-            <property name="halign">start</property>
-            <property name="hexpand">yes</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSwitch" id="show-stereotypes">
-            <signal name="notify::active" handler="show-stereotypes-changed" swapped="no"/>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
       <object class="GtkFrame">
         <property name="child">
           <object class="GtkColumnView" id="stereotype-list">
@@ -81,6 +65,22 @@
             <signal name="activate" handler="stereotype-activated" />
           </object>
         </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Stereotypes</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-stereotypes">
+            <signal name="notify::active" handler="show-stereotypes-changed" swapped="no"/>
+          </object>
+        </child>
       </object>
     </child>
     <style>

--- a/gaphor/UML/states/propertypages.ui
+++ b/gaphor/UML/states/propertypages.ui
@@ -2,73 +2,66 @@
 <interface>
   <requires lib="gtk" version="4.0"/>
 
-  <object class="GtkExpander" id="state-editor">
-    <property name="expanded">1</property>
+  <object class="GtkBox" id="state-editor">
+    <property name="orientation">vertical</property>
     <child type="label">
       <object class="GtkLabel">
         <property name="label" translatable="yes">Activities</property>
+        <property name="halign">start</property>
         <style>
           <class name="title"/>
         </style>
       </object>
     </child>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Entry</property>
-            <property name="xalign">0</property>
-            <style>
-              <class name="title" />
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkDropDown" id="entry">
-            <property name="enable-search">1</property>
-            <property name="expression">
-              <lookup type="LabelValue" name="label" />
-            </property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Exit</property>
-            <property name="xalign">0</property>
-            <style>
-              <class name="title" />
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkDropDown" id="exit">
-            <property name="enable-search">1</property>
-            <property name="expression">
-              <lookup type="LabelValue" name="label" />
-            </property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Do activity</property>
-            <property name="xalign">0</property>
-            <style>
-              <class name="title" />
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkDropDown" id="do-activity">
-            <property name="enable-search">1</property>
-            <property name="expression">
-              <lookup type="LabelValue" name="label" />
-            </property>
-          </object>
-        </child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Entry</property>
+        <property name="xalign">0</property>
         <style>
-          <class name="propertypage"/>
+          <class name="title" />
         </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="entry">
+        <property name="enable-search">1</property>
+        <property name="expression">
+          <lookup type="LabelValue" name="label" />
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Exit</property>
+        <property name="halign">start</property>
+        <style>
+          <class name="title" />
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="exit">
+        <property name="enable-search">1</property>
+        <property name="expression">
+          <lookup type="LabelValue" name="label" />
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Do activity</property>
+        <property name="xalign">0</property>
+        <style>
+          <class name="title" />
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkDropDown" id="do-activity">
+        <property name="enable-search">1</property>
+        <property name="expression">
+          <lookup type="LabelValue" name="label" />
+        </property>
       </object>
     </child>
     <style>
@@ -81,7 +74,7 @@
     <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Guard</property>
-        <property name="xalign">0</property>
+        <property name="halign">start</property>
         <style>
           <class name="title"/>
         </style>
@@ -101,56 +94,52 @@
     <property name="page-increment">10</property>
   </object>
 
-  <object class="GtkExpander" id="region-editor">
-    <property name="margin-top">12</property>
-    <child type="label">
+  <object class="GtkBox" id="region-editor">
+        <property name="orientation">vertical</property>
+    <child>
       <object class="GtkLabel" id="titlelabel">
         <property name="label" translatable="yes">Regions</property>
-        <attributes>
-          <attribute name="weight" value="bold"></attribute>
-        </attributes>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox" id="childbox">
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkBox">
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Show Regions</property>
-                <property name="halign">start</property>
-                <property name="hexpand">1</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="show-regions">
-                <signal name="notify::active" handler="show-regions-changed" swapped="no"/>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Regions</property>
-                <property name="halign">start</property>
-                <property name="hexpand">1</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSpinButton" id="num-regions">
-                <property name="adjustment">num-regions-adjustment</property>
-                <signal name="value-changed" handler="regions-changed" swapped="no"/>
-              </object>
-            </child>
-          </object>
-        </child>
+        <property name="halign">start</property>
         <style>
-          <class name="propertypage"/>
+          <class name="title"/>
         </style>
       </object>
     </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Regions</property>
+            <property name="halign">start</property>
+            <property name="hexpand">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-regions">
+            <signal name="notify::active" handler="show-regions-changed" swapped="no"/>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Regions</property>
+            <property name="halign">start</property>
+            <property name="hexpand">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="num-regions">
+            <property name="adjustment">num-regions-adjustment</property>
+            <signal name="value-changed" handler="regions-changed" swapped="no"/>
+          </object>
+        </child>
+      </object>
+    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
   </object>
 </interface>

--- a/gaphor/UML/states/propertypages.ui
+++ b/gaphor/UML/states/propertypages.ui
@@ -109,22 +109,6 @@
       <object class="GtkBox">
         <child>
           <object class="GtkLabel">
-            <property name="label" translatable="yes">Show Regions</property>
-            <property name="halign">start</property>
-            <property name="hexpand">1</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSwitch" id="show-regions">
-            <signal name="notify::active" handler="show-regions-changed" swapped="no"/>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <child>
-          <object class="GtkLabel">
             <property name="label" translatable="yes">Regions</property>
             <property name="halign">start</property>
             <property name="hexpand">1</property>
@@ -134,6 +118,22 @@
           <object class="GtkSpinButton" id="num-regions">
             <property name="adjustment">num-regions-adjustment</property>
             <signal name="value-changed" handler="regions-changed" swapped="no"/>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Regions</property>
+            <property name="halign">start</property>
+            <property name="hexpand">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-regions">
+            <signal name="notify::active" handler="show-regions-changed" swapped="no"/>
           </object>
         </child>
       </object>

--- a/gaphor/diagram/propertypages.ui
+++ b/gaphor/diagram/propertypages.ui
@@ -63,11 +63,12 @@
     </style>
   </object>
 
-  <object class="GtkExpander" id="line-editor">
-    <property name="expanded">1</property>
+  <object class="GtkBox" id="line-editor">
+    <property name="orientation">vertical</property>
     <child type="label">
       <object class="GtkLabel">
         <property name="label" translatable="yes">Style</property>
+        <property name="xalign">0</property>
         <style>
           <class name="title"/>
         </style>
@@ -75,45 +76,40 @@
     </child>
     <child>
       <object class="GtkBox">
-        <property name="orientation">vertical</property>
+        <property name="margin_top">6</property>
+        <property name="margin_bottom">6</property>
         <child>
-          <object class="GtkBox">
-            <property name="margin_top">6</property>
-            <property name="margin_bottom">6</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Rectilinear</property>
-                <property name="halign">start</property>
-                <property name="hexpand">1</property>
-                <property name="hexpand-set">1</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="line-rectilinear">
-                <property name="halign">end</property>
-                <signal name="notify::active" handler="rectilinear-changed" swapped="no"/>
-              </object>
-            </child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Rectilinear</property>
+            <property name="halign">start</property>
+            <property name="hexpand">1</property>
+            <property name="hexpand-set">1</property>
           </object>
         </child>
         <child>
-          <object class="GtkBox">
-            <property name="margin_top">6</property>
-            <property name="margin_bottom">6</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Flip orientation</property>
-                <property name="halign">start</property>
-                <property name="hexpand">1</property>
-                <property name="hexpand-set">1</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="flip-orientation">
-                <property name="halign">end</property>
-                <signal name="notify::active" handler="orientation-changed" swapped="no"/>
-              </object>
-            </child>
+          <object class="GtkSwitch" id="line-rectilinear">
+            <property name="halign">end</property>
+            <signal name="notify::active" handler="rectilinear-changed" swapped="no"/>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="margin_top">6</property>
+        <property name="margin_bottom">6</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Flip orientation</property>
+            <property name="halign">start</property>
+            <property name="hexpand">1</property>
+            <property name="hexpand-set">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="flip-orientation">
+            <property name="halign">end</property>
+            <signal name="notify::active" handler="orientation-changed" swapped="no"/>
           </object>
         </child>
       </object>
@@ -123,9 +119,9 @@
     </style>
   </object>
 
-  <object class="GtkExpander" id="note-editor">
-    <property name="expanded">1</property>
-    <child type="label">
+  <object class="GtkBox" id="note-editor">
+    <property name="orientation">vertical</property>
+    <child>
       <object class="GtkLabel">
         <property name="label" translatable="yes">Note</property>
         <property name="xalign">0</property>
@@ -135,21 +131,13 @@
       </object>
     </child>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkFrame">
-            <property name="child">
-              <object class="GtkTextView" id="note">
-                <property name="wrap-mode">word</property>
-                <property name="height-request">96</property>
-              </object>
-            </property>
+      <object class="GtkFrame">
+        <property name="child">
+          <object class="GtkTextView" id="note">
+            <property name="wrap-mode">word</property>
+            <property name="height-request">96</property>
           </object>
-        </child>
-        <style>
-          <class name="propertypage"/>
-        </style>
+        </property>
       </object>
     </child>
     <style>

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -165,7 +165,6 @@ class EditorStack:
 
         self.vbox: Optional[Gtk.Box] = None
         self._current_item = None
-        self._expanded_pages = {}
 
     def open(self, builder):
         """Display the ElementEditor pane."""
@@ -207,9 +206,6 @@ class EditorStack:
                 page = adapter.construct()
                 if not page:
                     continue
-                elif isinstance(page, Gtk.Expander):
-                    page.set_expanded(self._expanded_pages.get(name, True))
-                    page.connect_after("activate", self.on_expand, name)
                 self.vbox.append(page)
             except Exception:
                 log.error(
@@ -221,9 +217,6 @@ class EditorStack:
         assert self.vbox
         while page := self.vbox.get_first_child():
             self.vbox.remove(page)
-
-    def on_expand(self, widget, name):
-        self._expanded_pages[name] = widget.get_expanded()
 
     @event_handler(DiagramSelectionChanged)
     def _selection_changed(self, event=None, focused_item=None):

--- a/gaphor/ui/help/shortcuts.ui
+++ b/gaphor/ui/help/shortcuts.ui
@@ -5,19 +5,16 @@
 
     <child>
       <object class="GtkShortcutsSection">
-        <property name="visible">1</property>
         <property name="section-name">shortcuts</property>
         <property name="max-height">18</property>
 
         <!-- General shortcuts -->
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="visible">1</property>
             <property name="title" translatable="yes">General</property>
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">F2</property>
                 <property name="title" translatable="yes">Rename</property>
               </object>
@@ -25,7 +22,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;f</property>
                 <property name="title" translatable="yes">Search</property>
               </object>
@@ -33,7 +29,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">F9</property>
                 <property name="title" translatable="yes">Toggle Property Editor</property>
               </object>
@@ -41,7 +36,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;w</property>
                 <property name="title" translatable="yes">Close Diagram</property>
               </object>
@@ -49,7 +43,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;comma</property>
                 <property name="title" translatable="yes">Preferences</property>
               </object>
@@ -57,7 +50,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">F11</property>
                 <property name="title" translatable="yes">Toggle Fullscreen</property>
               </object>
@@ -65,7 +57,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;q</property>
                 <property name="title" translatable="yes">Quit Gaphor</property>
               </object>
@@ -77,12 +68,10 @@
         <!-- File shortcuts -->
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="visible">1</property>
             <property name="title" translatable="yes">Files</property>
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;n</property>
                 <property name="title" translatable="yes">New Model…</property>
               </object>
@@ -90,7 +79,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;o</property>
                 <property name="title" translatable="yes">Open a Model…</property>
               </object>
@@ -98,7 +86,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;s</property>
                 <property name="title" translatable="yes">Save</property>
               </object>
@@ -106,7 +93,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;s</property>
                 <property name="title" translatable="yes">Save As…</property>
               </object>
@@ -119,12 +105,10 @@
         <!-- Undo shortcuts -->
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="visible">1</property>
             <property name="title" translatable="yes">Undo and Redo</property>
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;z</property>
                 <property name="title" translatable="yes">Undo</property>
               </object>
@@ -132,7 +116,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;z</property>
                 <property name="title" translatable="yes">Redo</property>
               </object>
@@ -144,12 +127,10 @@
         <!-- Zoom shortcuts -->
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="visible">1</property>
             <property name="title" translatable="yes">Zoom</property>
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;equal</property>
                 <property name="title" translatable="yes">Zoom In</property>
               </object>
@@ -157,7 +138,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;minus</property>
                 <property name="title" translatable="yes">Zoom Out</property>
               </object>
@@ -165,7 +145,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;0</property>
                 <property name="title" translatable="yes">Reset Zoom</property>
               </object>
@@ -176,12 +155,10 @@
         <!-- Selections shortcuts -->
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="visible">1</property>
             <property name="title" translatable="yes">Selections</property>
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;a</property>
                 <property name="title" translatable="yes">Select All</property>
               </object>
@@ -189,7 +166,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;a</property>
                 <property name="title" translatable="yes">Deselect All</property>
               </object>
@@ -201,12 +177,10 @@
         <!-- Copy shortcuts -->
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="visible">1</property>
             <property name="title" translatable="yes">Copy and Paste</property>
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;c</property>
                 <property name="title" translatable="yes">Copy</property>
               </object>
@@ -214,7 +188,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;x</property>
                 <property name="title" translatable="yes">Cut</property>
               </object>
@@ -222,7 +195,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;v</property>
                 <property name="title" translatable="yes">Paste (link defining elements)</property>
               </object>
@@ -230,7 +202,6 @@
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">1</property>
                 <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;v</property>
                 <property name="title" translatable="yes">Paste (copy defining elements)</property>
               </object>

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -60,16 +60,17 @@ flowboxchild {
   margin-top: 12px;
 }
 
-box.propertypage > * {
+.propertypage {
   margin-top: 6px;
-}
-
-expander-widget.propertypage {
-  margin-top: 12px;
+  border-spacing: 6px;
 }
 
 .propertypage box.horizontal:not(.linked) {
   border-spacing: 6px;
+}
+
+.propertypage .title {
+  margin-top: 6px;
 }
 
 .propertypage .info {

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -73,10 +73,6 @@ flowboxchild {
   margin-top: 6px;
 }
 
-/* .propertypage .info {
-  margin: 3px 2px 0 2px;
-} */
-
 frame > textview {
   padding: 6px;
 }
@@ -110,7 +106,7 @@ textfield text selection {
 .info {
   border-radius: 16px;
   font-size: small;
-  /* padding: 1px 6px; */
+  padding: 2px 6px;
 }
 
 .info:hover {

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -73,9 +73,9 @@ flowboxchild {
   margin-top: 6px;
 }
 
-.propertypage .info {
+/* .propertypage .info {
   margin: 3px 2px 0 2px;
-}
+} */
 
 frame > textview {
   padding: 6px;
@@ -110,7 +110,7 @@ textfield text selection {
 .info {
   border-radius: 16px;
   font-size: small;
-  padding: 1px 6px;
+  /* padding: 1px 6px; */
 }
 
 .info:hover {


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Property editors are often (but not always) encapsulated in a `GtkExpander`. There's little need for that, since the number of editors is not *that* long.

Issue Number: N/A

### What is the new behavior?

Simplify property editors. 

* Info/help boxes are now placed on a more logical place.
* Expanders have been removed.
* _Show Xxx_ switches are placed after data entry.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

This will make it easier to split model and view based properties in the future. In the end we want to be able to use the property editor for elements selected in the Model Browser.

<img width="1274" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/3330290a-1843-49c9-a967-9c4def5ae5da">

