### PR TITLE
Fix conditional must use context for env variables

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -396,7 +396,7 @@ jobs:
     runs-on: windows-latest
     continue-on-error: true
     timeout-minutes: 15
-    if: env.mainline_build == 'true'
+    if: ${{ env.mainline_build == 'true' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0


### PR DESCRIPTION
In #3138, the syntax wasn't correct and now we are getting a failure `The workflow is not valid. .github/workflows/full-build.yml (Line: 399, Col: 9): Unrecognized named-value: 'env'. Located at position 1 within expression: env.mainline_build == 'true'`.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
We are getting a build error.

Issue Number: N/A

### What is the new behavior?
Build error resolved.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
