### PR TITLE
Element selected in Model Browser shows in Property Editor

### DIFF
--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -15,7 +15,11 @@ from gaphor.SysML.blocks.interfaceblock import InterfaceBlockItem
 from gaphor.SysML.blocks.property import PropertyItem
 from gaphor.SysML.blocks.proxyport import ProxyPortItem
 from gaphor.UML.classes.classespropertypages import OperationsPage, ShowOperationsPage
-from gaphor.UML.propertypages import TypedElementPropertyPage, list_of_classifiers
+from gaphor.UML.propertypages import (
+    ShowTypedElementPropertyPage,
+    TypedElementPropertyPage,
+    list_of_classifiers,
+)
 
 new_builder = new_resource_builder("gaphor.SysML")
 
@@ -76,8 +80,10 @@ PropertyPages.register(BlockItem)(ShowOperationsPage)
 PropertyPages.register(sysml.InterfaceBlock)(OperationsPage)
 PropertyPages.register(InterfaceBlockItem)(ShowOperationsPage)
 
-PropertyPages.register(PropertyItem)(TypedElementPropertyPage)
-PropertyPages.register(ProxyPortItem)(TypedElementPropertyPage)
+PropertyPages.register(UML.Property)(TypedElementPropertyPage)
+PropertyPages.register(PropertyItem)(ShowTypedElementPropertyPage)
+PropertyPages.register(sysml.ProxyPort)(TypedElementPropertyPage)
+PropertyPages.register(ProxyPortItem)(ShowTypedElementPropertyPage)
 
 
 @PropertyPages.register(BlockItem)

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -14,7 +14,7 @@ from gaphor.SysML.blocks.block import BlockItem
 from gaphor.SysML.blocks.interfaceblock import InterfaceBlockItem
 from gaphor.SysML.blocks.property import PropertyItem
 from gaphor.SysML.blocks.proxyport import ProxyPortItem
-from gaphor.UML.classes.classespropertypages import OperationsPage
+from gaphor.UML.classes.classespropertypages import OperationsPage, ShowOperationsPage
 from gaphor.UML.propertypages import TypedElementPropertyPage, list_of_classifiers
 
 new_builder = new_resource_builder("gaphor.SysML")
@@ -71,8 +71,10 @@ class RequirementPropertyPage(PropertyPageBase):
         )
 
 
-PropertyPages.register(BlockItem)(OperationsPage)
-PropertyPages.register(InterfaceBlockItem)(OperationsPage)
+PropertyPages.register(sysml.Block)(OperationsPage)
+PropertyPages.register(BlockItem)(ShowOperationsPage)
+PropertyPages.register(sysml.InterfaceBlock)(OperationsPage)
+PropertyPages.register(InterfaceBlockItem)(ShowOperationsPage)
 
 PropertyPages.register(PropertyItem)(TypedElementPropertyPage)
 PropertyPages.register(ProxyPortItem)(TypedElementPropertyPage)

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -14,7 +14,11 @@ from gaphor.SysML.blocks.block import BlockItem
 from gaphor.SysML.blocks.interfaceblock import InterfaceBlockItem
 from gaphor.SysML.blocks.property import PropertyItem
 from gaphor.SysML.blocks.proxyport import ProxyPortItem
-from gaphor.UML.classes.classespropertypages import OperationsPage, ShowOperationsPage
+from gaphor.UML.classes.classespropertypages import (
+    ATTRIBUTES_PAGE_CLASSIFIERS,
+    OPERATIONS_PAGE_CLASSIFIERS,
+    ShowOperationsPage,
+)
 from gaphor.UML.propertypages import (
     ShowTypedElementPropertyPage,
     TypedElementPropertyPage,
@@ -75,9 +79,9 @@ class RequirementPropertyPage(PropertyPageBase):
         )
 
 
-PropertyPages.register(sysml.Block)(OperationsPage)
+ATTRIBUTES_PAGE_CLASSIFIERS.extend([sysml.ValueType])
+OPERATIONS_PAGE_CLASSIFIERS.extend([sysml.Block, sysml.InterfaceBlock, sysml.ValueType])
 PropertyPages.register(BlockItem)(ShowOperationsPage)
-PropertyPages.register(sysml.InterfaceBlock)(OperationsPage)
 PropertyPages.register(InterfaceBlockItem)(ShowOperationsPage)
 
 PropertyPages.register(UML.Property)(TypedElementPropertyPage)

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -8,6 +8,9 @@ from gaphor.SysML.propertypages import (
     ItemFlowPropertyPage,
     PropertyAggregationPropertyPage,
     RequirementPropertyPage,
+)
+from gaphor.UML.propertypages import (
+    ShowTypedElementPropertyPage,
     TypedElementPropertyPage,
 )
 
@@ -48,12 +51,12 @@ def test_requirement_property_page_text(diagram, element_factory):
     assert subject.text == "test"
 
 
-def test_property_type_property_page_show_type(diagram, element_factory):
+def test_show_property_type_property_page_show_type(diagram, element_factory):
     item = diagram.create(
         SysML.blocks.ProxyPortItem,
         subject=element_factory.create(SysML.sysml.ProxyPort),
     )
-    property_page = TypedElementPropertyPage(item)
+    property_page = ShowTypedElementPropertyPage(item)
 
     widget = property_page.construct()
     show_parts = find(widget, "show-type")
@@ -121,15 +124,12 @@ def test_no_property_aggregation_page_for_ports(element_factory):
     assert not widget
 
 
-def test_property_type(diagram, element_factory):
-    item = diagram.create(
-        SysML.blocks.PropertyItem,
-        subject=element_factory.create(UML.Property),
-    )
+def test_property_type(element_factory):
+    subject = element_factory.create(UML.Property)
 
     type = element_factory.create(UML.Class)
     type.name = "Bar"
-    property_page = TypedElementPropertyPage(item)
+    property_page = TypedElementPropertyPage(subject)
 
     widget = property_page.construct()
     dropdown = find(widget, "element-type")
@@ -139,7 +139,7 @@ def test_property_type(diagram, element_factory):
     dropdown.set_selected(bar_index)
 
     assert dropdown.get_selected_item().label == "Bar"
-    assert item.subject.type is type
+    assert subject.type is type
 
 
 def test_association_item_flow(association):

--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -30,7 +30,7 @@ class ObjectNodePropertyPage(PropertyPageBase):
     def construct(self):
         subject = self.subject
 
-        if not subject:
+        if not subject or isinstance(subject, UML.ActivityParameterNode):
             return
 
         builder = new_builder(

--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -18,20 +18,17 @@ from gaphor.UML.actions.objectnode import ObjectNodeItem
 new_builder = new_resource_builder("gaphor.UML.actions")
 
 
-@PropertyPages.register(ObjectNodeItem)
+@PropertyPages.register(UML.ObjectNode)
 class ObjectNodePropertyPage(PropertyPageBase):
     order = 15
 
     ORDERING_VALUES = ["unordered", "ordered", "LIFO", "FIFO"]
 
-    subject: UML.ObjectNode
-    item: ObjectNodeItem
-
-    def __init__(self, item):
-        self.item = item
+    def __init__(self, subject: UML.ObjectNode):
+        self.subject = subject
 
     def construct(self):
-        subject = self.item.subject
+        subject = self.subject
 
         if not subject:
             return
@@ -41,7 +38,6 @@ class ObjectNodePropertyPage(PropertyPageBase):
             signals={
                 "upper-bound-changed": (self._on_upper_bound_change,),
                 "ordering-changed": (self._on_ordering_change,),
-                "show-ordering-changed": (self._on_ordering_show_change,),
             },
         )
 
@@ -51,20 +47,43 @@ class ObjectNodePropertyPage(PropertyPageBase):
         ordering = builder.get_object("ordering")
         ordering.set_selected(self.ORDERING_VALUES.index(subject.ordering))
 
-        show_ordering = builder.get_object("show-ordering")
-        show_ordering.set_active(self.item.show_ordering)
-
         return builder.get_object("object-node-editor")
 
     @transactional
     def _on_upper_bound_change(self, entry):
         value = entry.get_text().strip()
-        self.item.subject.upperBound = value
+        self.subject.upperBound = value
 
     @transactional
     def _on_ordering_change(self, dropdown, _pspec):
         value = self.ORDERING_VALUES[dropdown.get_selected()]
-        self.item.subject.ordering = value
+        self.subject.ordering = value
+
+
+@PropertyPages.register(ObjectNodeItem)
+class ShowObjectNodePropertyPage(PropertyPageBase):
+    order = 16
+
+    def __init__(self, item: ObjectNodeItem):
+        self.item = item
+
+    def construct(self):
+        subject = self.item.subject
+
+        if not subject:
+            return
+
+        builder = new_builder(
+            "show-object-node-editor",
+            signals={
+                "show-ordering-changed": (self._on_ordering_show_change,),
+            },
+        )
+
+        show_ordering = builder.get_object("show-ordering")
+        show_ordering.set_active(self.item.show_ordering)
+
+        return builder.get_object("show-object-node-editor")
 
     @transactional
     def _on_ordering_show_change(self, button, gparam):

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -19,6 +19,7 @@ from gaphor.diagram.propertypages import (
 )
 from gaphor.UML.actions.activity import ActivityParameterNodeItem
 from gaphor.UML.propertypages import (
+    ShowTypedElementPropertyPage,
     TypedElementPropertyPage,
     create_list_store,
     list_item_factory,
@@ -206,19 +207,55 @@ class ActivityParameterNodeNamePropertyPage(PropertyPageBase):
             self.subject.parameter.name = entry.get_text()
 
 
-@PropertyPages.register(ActivityParameterNodeItem)
+@PropertyPages.register(UML.ActivityParameterNode)
 class ActivityParameterNodeTypePropertyPage(TypedElementPropertyPage):
+    @property
+    def typed_element(self):
+        return self.subject.parameter
+
+
+@PropertyPages.register(ActivityParameterNodeItem)
+class ShowActivityParameterNodeTypePropertyPage(ShowTypedElementPropertyPage):
     @property
     def typed_element(self):
         return self.item.subject.parameter
 
 
-@PropertyPages.register(ActivityParameterNodeItem)
+@PropertyPages.register(UML.ActivityParameterNode)
 class ActivityParameterNodeDirectionPropertyPage(PropertyPageBase):
     DIRECTION = UML.Parameter.direction.values
     order = 40
 
-    def __init__(self, item):
+    def __init__(self, subject: UML.ActivityParameterNode):
+        super().__init__()
+        self.subject = subject
+
+    def construct(self):
+        if not (self.subject and self.subject.parameter):
+            return
+
+        builder = new_builder(
+            "parameter-direction-editor",
+            signals={
+                "parameter-direction-changed": (self._on_parameter_direction_changed,),
+            },
+        )
+
+        direction = builder.get_object("parameter-direction")
+        direction.set_selected(self.DIRECTION.index(self.subject.parameter.direction))
+
+        return builder.get_object("parameter-direction-editor")
+
+    @transactional
+    def _on_parameter_direction_changed(self, dropdown, _pspec):
+        self.subject.parameter.direction = self.DIRECTION[dropdown.get_selected()]
+
+
+@PropertyPages.register(ActivityParameterNodeItem)
+class ShowActivityParameterNodeDirectionPropertyPage(PropertyPageBase):
+    order = 40
+
+    def __init__(self, item: ActivityParameterNodeItem):
         super().__init__()
         self.item = item
 
@@ -227,26 +264,16 @@ class ActivityParameterNodeDirectionPropertyPage(PropertyPageBase):
             return
 
         builder = new_builder(
-            "parameter-direction-editor",
+            "show-parameter-direction-editor",
             signals={
-                "parameter-direction-changed": (self._on_parameter_direction_changed,),
                 "show-direction-changed": (self._on_show_direction_changed,),
             },
-        )
-
-        direction = builder.get_object("parameter-direction")
-        direction.set_selected(
-            self.DIRECTION.index(self.item.subject.parameter.direction)
         )
 
         show_direction = builder.get_object("show-direction")
         show_direction.set_active(self.item.show_direction)
 
-        return builder.get_object("parameter-direction-editor")
-
-    @transactional
-    def _on_parameter_direction_changed(self, dropdown, _pspec):
-        self.item.subject.parameter.direction = self.DIRECTION[dropdown.get_selected()]
+        return builder.get_object("show-parameter-direction-editor")
 
     @transactional
     def _on_show_direction_changed(self, button, _gspec):

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -17,7 +17,7 @@ from gaphor.diagram.propertypages import (
 from gaphor.diagram.propertypages import (
     new_builder as diagram_new_builder,
 )
-from gaphor.UML.actions.activity import ActivityItem, ActivityParameterNodeItem
+from gaphor.UML.actions.activity import ActivityParameterNodeItem
 from gaphor.UML.propertypages import (
     TypedElementPropertyPage,
     create_list_store,
@@ -98,16 +98,16 @@ def update_activity_parameter_node_model(
     )
 
 
-@PropertyPages.register(ActivityItem)
-class ActivityItemPage(PropertyPageBase):
+@PropertyPages.register(UML.Activity)
+class ActivityPage(PropertyPageBase):
     order = 40
 
-    def __init__(self, item: ActivityItem):
-        self.item = item
-        self.watcher = item.subject and item.subject.watcher()
+    def __init__(self, subject: UML.Activity):
+        self.subject = subject
+        self.watcher = subject and subject.watcher()
 
     def construct(self):
-        subject = self.item.subject
+        subject = self.subject
 
         if not subject:
             return
@@ -154,7 +154,7 @@ class ActivityItemPage(PropertyPageBase):
 
     @event_handler(AssociationUpdated)
     def on_nodes_changed(self, event):
-        update_activity_parameter_node_model(self.model, self.item.subject)
+        update_activity_parameter_node_model(self.model, self.subject)
 
     def on_parameters_info_clicked(self, image, event):
         self.info.set_visible(True)

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -141,20 +141,12 @@
       </object>
     </child>
     <child>
-      <object class="GtkBox">
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Show Ordering</property>
-            <property name="halign">start</property>
-            <property name="hexpand">yes</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSwitch" id="show-ordering">
-            <property name="focusable">1</property>
-            <signal name="notify::active" handler="show-ordering-changed" swapped="no" />
-          </object>
-        </child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Ordering</property>
+        <property name="xalign">0</property>
+        <style>
+          <class name="title" />
+        </style>
       </object>
     </child>
     <child>
@@ -170,6 +162,30 @@
           </object>
         </property>
         <signal name="notify::selected" handler="ordering-changed" swapped="no" />
+      </object>
+    </child>
+    <style>
+      <class name="propertypage" />
+    </style>
+  </object>
+
+  <object class="GtkBox" id="show-object-node-editor">
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show Ordering</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-ordering">
+            <property name="focusable">1</property>
+            <signal name="notify::active" handler="show-ordering-changed" swapped="no" />
+          </object>
+        </child>
       </object>
     </child>
     <style>

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -386,6 +386,15 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
   <object class="GtkBox" id="parameter-direction-editor">
     <property name="orientation">vertical</property>
     <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Direction</property>
+        <property name="xalign">0</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
+    <child>
       <object class="GtkDropDown" id="parameter-direction">
         <property name="model">
           <object class="GtkStringList">
@@ -400,6 +409,13 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <signal name="notify::selected" handler="parameter-direction-changed" swapped="no"/>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+  <object class="GtkBox" id="show-parameter-direction-editor">
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
         <child>

--- a/gaphor/UML/actions/tests/test_actionspropertypages.py
+++ b/gaphor/UML/actions/tests/test_actionspropertypages.py
@@ -6,6 +6,7 @@ from gaphor.UML.actions.actionspropertypages import (
     ForkNodePropertyPage,
     JoinNodePropertyPage,
     ObjectNodePropertyPage,
+    ShowObjectNodePropertyPage,
 )
 
 
@@ -13,7 +14,7 @@ def test_object_node_property_page_show_ordering(diagram, element_factory):
     item = diagram.create(
         UML.actions.ObjectNodeItem, subject=element_factory.create(UML.ObjectNode)
     )
-    property_page = ObjectNodePropertyPage(item)
+    property_page = ShowObjectNodePropertyPage(item)
 
     widget = property_page.construct()
     show_ordering = find(widget, "show-ordering")
@@ -23,30 +24,27 @@ def test_object_node_property_page_show_ordering(diagram, element_factory):
 
 
 def test_object_node_property_page_upper_bound(diagram, element_factory):
-    item = diagram.create(
-        UML.actions.ObjectNodeItem, subject=element_factory.create(UML.ObjectNode)
-    )
-    property_page = ObjectNodePropertyPage(item)
+    subject = element_factory.create(UML.ObjectNode)
+    property_page = ObjectNodePropertyPage(subject)
 
     widget = property_page.construct()
     upper_bound = find(widget, "upper-bound")
     upper_bound.set_text("test")
 
-    assert item.subject.upperBound == "test"
+    assert subject.upperBound == "test"
 
 
 def test_object_node_property_page_ordering(diagram, element_factory):
-    item = diagram.create(
-        UML.actions.ObjectNodeItem, subject=element_factory.create(UML.ObjectNode)
-    )
-    assert item.subject.ordering == "unordered"
-    property_page = ObjectNodePropertyPage(item)
+    subject = element_factory.create(UML.ObjectNode)
+
+    assert subject.ordering == "unordered"
+    property_page = ObjectNodePropertyPage(subject)
 
     widget = property_page.construct()
     ordering = find(widget, "ordering")
     ordering.set_selected(3)
 
-    assert item.subject.ordering == "FIFO"
+    assert subject.ordering == "FIFO"
 
 
 def test_decision_node_property_page_show_type(diagram, element_factory):

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -2,9 +2,9 @@ from gi.repository import Gdk
 
 from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
-from gaphor.UML.actions.activity import ActivityItem, ActivityParameterNodeItem
+from gaphor.UML.actions.activity import ActivityParameterNodeItem
 from gaphor.UML.actions.activitypropertypage import (
-    ActivityItemPage,
+    ActivityPage,
     ActivityParameterNodeDirectionPropertyPage,
     ActivityParameterNodeNamePropertyPage,
     ActivityParameterNodeTypePropertyPage,
@@ -69,13 +69,13 @@ def test_activity_parameter_node_add_new_parameter(element_factory):
     assert parameter.typeValue == "str"
 
 
-def test_update_model_when_new_parameter_added(create, element_factory):
-    activity_item = create(ActivityItem, UML.Activity)
+def test_update_model_when_new_parameter_added(element_factory):
+    subject = element_factory.create(UML.Activity)
 
-    property_page = ActivityItemPage(activity_item)
+    property_page = ActivityPage(subject)
     property_page.construct()
 
-    activity_item.subject.node = activity_parameter_node(element_factory, "one")
+    subject.node = activity_parameter_node(element_factory, "one")
 
     assert property_page.model.get_n_items() == 2  # one + empty row
 
@@ -92,10 +92,10 @@ def test_activity_parameter_node_name_editing(element_factory):
     assert subject.parameter.name == "A new name"
 
 
-def test_update_model_when_new_parameter_added_via_list_model(create, element_factory):
-    activity_item = create(ActivityItem, UML.Activity)
+def test_update_model_when_new_parameter_added_via_list_model(element_factory):
+    subject = element_factory.create(UML.Activity)
 
-    property_page = ActivityItemPage(activity_item)
+    property_page = ActivityPage(subject)
     property_page.construct()
 
     new_view = property_page.model.get_item(0)
@@ -106,61 +106,59 @@ def test_update_model_when_new_parameter_added_via_list_model(create, element_fa
     assert property_page.model.get_item(1).node is None
 
 
-def test_update_model_with_single_node_when_parameter_deleted(create, element_factory):
-    activity_item = create(ActivityItem, UML.Activity)
-    activity_item.subject.node = node = activity_parameter_node(element_factory, "one")
+def test_update_model_with_single_node_when_parameter_deleted(element_factory):
+    subject = element_factory.create(UML.Activity)
+    subject.node = node = activity_parameter_node(element_factory, "one")
 
-    property_page = ActivityItemPage(activity_item)
+    property_page = ActivityPage(subject)
     property_page.construct()
 
-    del activity_item.subject.node[node]
+    del subject.node[node]
 
-    assert not activity_item.subject.node
+    assert not subject.node
     assert property_page.model.get_n_items() == 1
     assert property_page.model.get_item(0).node is None
 
 
-def test_update_model_with_multiple_nodes_when_parameter_deleted(
-    create, element_factory
-):
-    activity_item = create(ActivityItem, UML.Activity)
-    activity_item.subject.node = node = activity_parameter_node(element_factory, "one")
-    activity_item.subject.node = activity_parameter_node(element_factory, "two")
+def test_update_model_with_multiple_nodes_when_parameter_deleted(element_factory):
+    subject = element_factory.create(UML.Activity)
+    subject.node = node = activity_parameter_node(element_factory, "one")
+    subject.node = activity_parameter_node(element_factory, "two")
 
-    property_page = ActivityItemPage(activity_item)
+    property_page = ActivityPage(subject)
     property_page.construct()
 
-    del activity_item.subject.node[node]
+    del subject.node[node]
 
     assert property_page.model.get_n_items() == 2
-    assert property_page.model.get_item(0).node in activity_item.subject.node
+    assert property_page.model.get_item(0).node in subject.node
     assert property_page.model.get_item(1).node is None
 
 
-def test_activity_parameter_node_reorder_down(create, element_factory):
-    activity_item = create(ActivityItem, UML.Activity)
-    activity_item.subject.node = activity_parameter_node(element_factory, "one")
-    activity_item.subject.node = activity_parameter_node(element_factory, "two")
-    node_one, node_two = activity_item.subject.node
+def test_activity_parameter_node_reorder_down(element_factory):
+    subject = element_factory.create(UML.Activity)
+    subject.node = activity_parameter_node(element_factory, "one")
+    subject.node = activity_parameter_node(element_factory, "two")
+    node_one, node_two = subject.node
 
-    property_page = ActivityItemPage(activity_item)
+    property_page = ActivityPage(subject)
     widget = property_page.construct()
 
     list_view = find(widget, "parameter-list")
 
     list_view_key_handler(ControllerStub(list_view), Gdk.KEY_plus, None, 0)
 
-    assert activity_item.subject.node[0] is node_two
-    assert activity_item.subject.node[1] is node_one
+    assert subject.node[0] is node_two
+    assert subject.node[1] is node_one
 
 
-def test_activity_parameter_node_reorder_up(create, element_factory):
-    activity_item = create(ActivityItem, UML.Activity)
-    activity_item.subject.node = activity_parameter_node(element_factory, "one")
-    activity_item.subject.node = activity_parameter_node(element_factory, "two")
-    node_one, node_two = activity_item.subject.node
+def test_activity_parameter_node_reorder_up(element_factory):
+    subject = element_factory.create(UML.Activity)
+    subject.node = activity_parameter_node(element_factory, "one")
+    subject.node = activity_parameter_node(element_factory, "two")
+    node_one, node_two = subject.node
 
-    property_page = ActivityItemPage(activity_item)
+    property_page = ActivityPage(subject)
     widget = property_page.construct()
 
     list_view = find(widget, "parameter-list")
@@ -169,31 +167,31 @@ def test_activity_parameter_node_reorder_up(create, element_factory):
 
     list_view_key_handler(ControllerStub(list_view), Gdk.KEY_minus, None, 0)
 
-    assert activity_item.subject.node[0] is node_two
-    assert activity_item.subject.node[1] is node_one
+    assert subject.node[0] is node_two
+    assert subject.node[1] is node_one
 
 
-def test_activity_parameter_node_reorder_first_node_up(create, element_factory):
-    activity_item = create(ActivityItem, UML.Activity)
-    activity_item.subject.node = activity_parameter_node(element_factory, "one")
-    activity_item.subject.node = activity_parameter_node(element_factory, "two")
-    node_one, node_two = activity_item.subject.node
+def test_activity_parameter_node_reorder_first_node_up(element_factory):
+    subject = element_factory.create(UML.Activity)
+    subject.node = activity_parameter_node(element_factory, "one")
+    subject.node = activity_parameter_node(element_factory, "two")
+    node_one, node_two = subject.node
 
-    property_page = ActivityItemPage(activity_item)
+    property_page = ActivityPage(subject)
     widget = property_page.construct()
 
     list_view = find(widget, "parameter-list")
 
     list_view_key_handler(ControllerStub(list_view), Gdk.KEY_minus, None, 0)
 
-    assert activity_item.subject.node[0] is node_one
-    assert activity_item.subject.node[1] is node_two
+    assert subject.node[0] is node_one
+    assert subject.node[1] is node_two
 
 
-def test_construct_activity_item_property_page(create):
-    activity_item = create(ActivityItem, UML.Activity)
+def test_construct_activity_item_property_page(element_factory):
+    subject = element_factory.create(UML.Activity)
 
-    property_page = ActivityItemPage(activity_item)
+    property_page = ActivityPage(subject)
     widget = property_page.construct()
 
     assert widget

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -2,7 +2,6 @@ from gi.repository import Gdk
 
 from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
-from gaphor.UML.actions.activity import ActivityParameterNodeItem
 from gaphor.UML.actions.activitypropertypage import (
     ActivityPage,
     ActivityParameterNodeDirectionPropertyPage,
@@ -197,39 +196,37 @@ def test_construct_activity_item_property_page(element_factory):
     assert widget
 
 
-def test_construct_activity_parameter_node_type_property_page(create, element_factory):
-    node_item = create(ActivityParameterNodeItem, UML.ActivityParameterNode)
-    node_item.subject.parameter = element_factory.create(UML.Parameter)
+def test_construct_activity_parameter_node_type_property_page(element_factory):
+    subject = element_factory.create(UML.ActivityParameterNode)
+    subject.parameter = element_factory.create(UML.Parameter)
 
-    property_page = ActivityParameterNodeTypePropertyPage(node_item)
+    property_page = ActivityParameterNodeTypePropertyPage(subject)
     widget = property_page.construct()
 
     assert widget
 
 
-def test_construct_activity_parameter_node_direction_property_page(
-    create, element_factory
-):
-    node_item = create(ActivityParameterNodeItem, UML.ActivityParameterNode)
-    node_item.subject.parameter = element_factory.create(UML.Parameter)
+def test_construct_activity_parameter_node_direction_property_page(element_factory):
+    subject = element_factory.create(UML.ActivityParameterNode)
+    subject.parameter = element_factory.create(UML.Parameter)
 
-    property_page = ActivityParameterNodeDirectionPropertyPage(node_item)
+    property_page = ActivityParameterNodeDirectionPropertyPage(subject)
     widget = property_page.construct()
 
     assert widget
 
 
-def test_construct_activity_parameter_node_direction_changed(create, element_factory):
-    node_item = create(ActivityParameterNodeItem, UML.ActivityParameterNode)
-    node_item.subject.parameter = element_factory.create(UML.Parameter)
+def test_construct_activity_parameter_node_direction_changed(element_factory):
+    subject = element_factory.create(UML.ActivityParameterNode)
+    subject.parameter = element_factory.create(UML.Parameter)
 
-    property_page = ActivityParameterNodeDirectionPropertyPage(node_item)
+    property_page = ActivityParameterNodeDirectionPropertyPage(subject)
     widget = property_page.construct()
 
     direction = find(widget, "parameter-direction")
     direction.set_selected(3)
 
-    assert node_item.subject.parameter.direction == "return"
+    assert subject.parameter.direction == "return"
 
 
 class ControllerStub:

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -66,7 +66,7 @@ class AssociationPropertyPage(PropertyPageBase):
         return name
 
     def construct(self):
-        if not self.subject:
+        if not self.subject or isinstance(self.subject, UML.Extension):
             return
 
         head_subject = self.subject.memberEnd[0]

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -16,24 +16,22 @@ from gaphor.UML.profiles.stereotypepropertypages import (
 )
 
 
-@PropertyPages.register(AssociationItem)
+@PropertyPages.register(UML.Association)
 class AssociationPropertyPage(PropertyPageBase):
     NAVIGABILITY = (None, False, True)
     AGGREGATION = UML.Property.aggregation.values
 
     order = 20
 
-    def __init__(self, item):
-        self.item = item
-        self.subject = item.subject
-        self.watcher = item.subject and self.subject.watcher()
+    def __init__(self, subject: UML.Association):
+        self.subject = subject
+        self.watcher = subject and subject.watcher()
         self.semaphore = 0
 
-    def construct_end(self, builder, end_name, end, stereotypes_model):
-        subject = end.subject
+    def construct_end(self, builder, end_name, subject, stereotypes_model):
         title = builder.get_object(f"{end_name}-title")
         if subject.type:
-            title.set_text(f"{end_name.title()} (: {subject.type.name})")
+            title.set_text(f"Member End (: {subject.type.name})")
 
         self.update_end_name(builder, end_name, subject)
 
@@ -69,28 +67,38 @@ class AssociationPropertyPage(PropertyPageBase):
 
     def construct(self):
         if not self.subject:
-            return None
+            return
 
-        head = self.item.head_end
-        tail = self.item.tail_end
+        head_subject = self.subject.memberEnd[0]
+        tail_subject = self.subject.memberEnd[1]
 
-        head_model = stereotype_model(head.subject)
-        tail_model = stereotype_model(tail.subject)
+        head_model = stereotype_model(head_subject)
+        tail_model = stereotype_model(tail_subject)
 
         builder = new_builder(
             "association-editor",
             "association-info",
             signals={
-                "show-direction-changed": (self._on_show_direction_change,),
-                "invert-direction-changed": (self._on_invert_direction_change,),
-                "head-name-changed": (self._on_end_name_change, head),
-                "head-navigation-changed": (self._on_end_navigability_change, head),
-                "head-aggregation-changed": (self._on_end_aggregation_change, head),
+                "head-name-changed": (self._on_end_name_change, head_subject),
+                "head-navigation-changed": (
+                    self._on_end_navigability_change,
+                    head_subject,
+                ),
+                "head-aggregation-changed": (
+                    self._on_end_aggregation_change,
+                    head_subject,
+                ),
                 "head-info-clicked": (self._on_association_info_clicked,),
                 "head-stereotype-key-pressed": (stereotype_key_handler,),
-                "tail-name-changed": (self._on_end_name_change, tail),
-                "tail-navigation-changed": (self._on_end_navigability_change, tail),
-                "tail-aggregation-changed": (self._on_end_aggregation_change, tail),
+                "tail-name-changed": (self._on_end_name_change, tail_subject),
+                "tail-navigation-changed": (
+                    self._on_end_navigability_change,
+                    tail_subject,
+                ),
+                "tail-aggregation-changed": (
+                    self._on_end_aggregation_change,
+                    tail_subject,
+                ),
                 "tail-info-clicked": (self._on_association_info_clicked,),
                 "tail-stereotype-key-pressed": (stereotype_key_handler,),
             },
@@ -100,34 +108,84 @@ class AssociationPropertyPage(PropertyPageBase):
         help_link(builder, "head-info-icon", "head-info")
         help_link(builder, "tail-info-icon", "tail-info")
 
-        show_direction = builder.get_object("show-direction")
-        show_direction.set_active(self.item.show_direction)
-
-        self.construct_end(builder, "head", head, head_model)
-        self.construct_end(builder, "tail", tail, tail_model)
+        self.construct_end(builder, "head", head_subject, head_model)
+        self.construct_end(builder, "tail", tail_subject, tail_model)
 
         def name_handler(event):
-            end_name = "head" if event.element is head.subject else "tail"
+            end_name = "head" if event.element is head_subject else "tail"
             self.update_end_name(builder, end_name, event.element)
 
         def restore_nav_handler(event):
-            for end_name, end in (("head", head), ("tail", tail)):
+            for end_name, end_subject in (
+                ("head", head_subject),
+                ("tail", tail_subject),
+            ):
                 combo = builder.get_object(f"{end_name}-navigation")
-                self._on_end_navigability_change(combo, None, end)
+                self._on_end_navigability_change(combo, None, end_subject)
 
         # Watch on association end:
-        self.watcher.watch("memberEnd[Property].name", name_handler).watch(
-            "memberEnd[Property].visibility", name_handler
-        ).watch("memberEnd[Property].lowerValue", name_handler).watch(
-            "memberEnd[Property].upperValue", name_handler
-        ).watch(
-            "memberEnd[Property].type",
-            restore_nav_handler,
-        )
+        if self.watcher:
+            self.watcher.watch("memberEnd[Property].name", name_handler).watch(
+                "memberEnd[Property].visibility", name_handler
+            ).watch("memberEnd[Property].lowerValue", name_handler).watch(
+                "memberEnd[Property].upperValue", name_handler
+            ).watch(
+                "memberEnd[Property].type",
+                restore_nav_handler,
+            )
 
         return unsubscribe_all_on_destroy(
             builder.get_object("association-editor"), self.watcher
         )
+
+    @transactional
+    def _on_end_name_change(self, entry, subject):
+        if not self.semaphore:
+            self.semaphore += 1
+            parse(subject, entry.get_text())
+            self.semaphore -= 1
+
+    @transactional
+    def _on_end_navigability_change(self, dropdown, _pspec, subject):
+        if subject and subject.opposite and subject.opposite.type:
+            UML.recipes.set_navigability(
+                subject.association,
+                subject,
+                self.NAVIGABILITY[dropdown.get_selected()],
+            )
+
+    @transactional
+    def _on_end_aggregation_change(self, dropdown, _pspec, subject):
+        subject.aggregation = self.AGGREGATION[dropdown.get_selected()]
+
+    def _on_association_info_clicked(self, widget, event):
+        self.info.set_relative_to(widget)
+        self.info.set_visible(True)
+
+
+@PropertyPages.register(AssociationItem)
+class AssociationDirectionPropertyPage(PropertyPageBase):
+    order = 20
+
+    def __init__(self, item: AssociationItem):
+        self.item = item
+
+    def construct(self):
+        if not self.item.subject:
+            return None
+
+        builder = new_builder(
+            "association-direction-editor",
+            signals={
+                "show-direction-changed": (self._on_show_direction_change,),
+                "invert-direction-changed": (self._on_invert_direction_change,),
+            },
+        )
+
+        show_direction = builder.get_object("show-direction")
+        show_direction.set_active(self.item.show_direction)
+
+        return builder.get_object("association-direction-editor")
 
     @transactional
     def _on_show_direction_change(self, button, gparam):
@@ -136,29 +194,3 @@ class AssociationPropertyPage(PropertyPageBase):
     @transactional
     def _on_invert_direction_change(self, button):
         self.item.invert_direction()
-
-    @transactional
-    def _on_end_name_change(self, entry, end):
-        if not self.semaphore:
-            self.semaphore += 1
-            parse(end.subject, entry.get_text())
-            self.semaphore -= 1
-
-    @transactional
-    def _on_end_navigability_change(self, dropdown, _pspec, end):
-        if end.subject and end.subject.opposite and end.subject.opposite.type:
-            UML.recipes.set_navigability(
-                end.subject.association,
-                end.subject,
-                self.NAVIGABILITY[dropdown.get_selected()],
-            )
-            # Call this again, or non-navigability will not be displayed
-            self.item.request_update()
-
-    @transactional
-    def _on_end_aggregation_change(self, dropdown, _pspec, end):
-        end.subject.aggregation = self.AGGREGATION[dropdown.get_selected()]
-
-    def _on_association_info_clicked(self, widget, event):
-        self.info.set_relative_to(widget)
-        self.info.set_visible(True)

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -28,7 +28,7 @@ class AssociationPropertyPage(PropertyPageBase):
         self.watcher = subject and subject.watcher()
         self.semaphore = 0
 
-    def construct_end(self, builder, end_name, subject, stereotypes_model):
+    def construct_end(self, builder, end_name, subject):
         title = builder.get_object(f"{end_name}-title")
         if subject.type:
             title.set_text(f"Member End (: {subject.type.name})")
@@ -41,7 +41,7 @@ class AssociationPropertyPage(PropertyPageBase):
         aggregation = builder.get_object(f"{end_name}-aggregation")
         aggregation.set_selected(self.AGGREGATION.index(subject.aggregation))
 
-        if stereotypes_model:
+        if stereotypes_model := stereotype_model(subject):
             stereotype_list = builder.get_object(f"{end_name}-stereotype-list")
             stereotype_set_model_with_interaction(stereotype_list, stereotypes_model)
         else:
@@ -71,9 +71,6 @@ class AssociationPropertyPage(PropertyPageBase):
 
         head_subject = self.subject.memberEnd[0]
         tail_subject = self.subject.memberEnd[1]
-
-        head_model = stereotype_model(head_subject)
-        tail_model = stereotype_model(tail_subject)
 
         builder = new_builder(
             "association-editor",
@@ -108,8 +105,8 @@ class AssociationPropertyPage(PropertyPageBase):
         help_link(builder, "head-info-icon", "head-info")
         help_link(builder, "tail-info-icon", "tail-info")
 
-        self.construct_end(builder, "head", head_subject, head_model)
-        self.construct_end(builder, "tail", tail_subject, tail_model)
+        self.construct_end(builder, "head", head_subject)
+        self.construct_end(builder, "tail", tail_subject)
 
         def name_handler(event):
             end_name = "head" if event.element is head_subject else "tail"

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -190,21 +190,19 @@ def update_attribute_model(store: Gio.ListStore, klass: UML.Class) -> None:
     )
 
 
-@PropertyPages.register(DataTypeItem)
-@PropertyPages.register(ClassItem)
-@PropertyPages.register(InterfaceItem)
+@PropertyPages.register(UML.DataType)
+@PropertyPages.register(UML.Class)
+@PropertyPages.register(UML.Interface)
 class AttributesPage(PropertyPageBase):
-    """An editor for attributes associated with classes and interfaces."""
-
     order = 20
 
-    def __init__(self, item):
+    def __init__(self, subject):
         super().__init__()
-        self.item = item
-        self.watcher = item.subject and item.subject.watcher()
+        self.subject = subject
+        self.watcher = subject and subject.watcher()
 
     def construct(self):
-        if not self.item.subject:
+        if not self.subject:
             return
 
         builder = new_builder(
@@ -213,15 +211,11 @@ class AttributesPage(PropertyPageBase):
             signals={
                 "attributes-activated": (list_view_activated,),
                 "attributes-key-pressed": (list_view_key_handler,),
-                "show-attributes-changed": (self.on_show_attributes_changed,),
                 "attributes-info-clicked": (self.on_attributes_info_clicked,),
             },
         )
         self.info = builder.get_object("attributes-info")
         help_link(builder, "attributes-info-icon", "attributes-info")
-
-        show_attributes = builder.get_object("show-attributes")
-        show_attributes.set_active(self.item.show_attributes)
 
         column_view: Gtk.ColumnView = builder.get_object("attributes-list")
 
@@ -245,7 +239,7 @@ class AttributesPage(PropertyPageBase):
         ):
             column.set_factory(factory)
 
-        self.model = attribute_model(self.item.subject)
+        self.model = attribute_model(self.subject)
         selection = Gtk.SingleSelection.new(self.model)
         column_view.set_model(selection)
 
@@ -256,16 +250,43 @@ class AttributesPage(PropertyPageBase):
             builder.get_object("attributes-editor"), self.watcher
         )
 
+    def on_attributes_changed(self, event):
+        update_attribute_model(self.model, self.subject)
+
+    def on_attributes_info_clicked(self, image, event):
+        self.info.set_visible(True)
+
+
+@PropertyPages.register(DataTypeItem)
+@PropertyPages.register(ClassItem)
+@PropertyPages.register(InterfaceItem)
+class ShowAttributesPage(PropertyPageBase):
+    order = 21
+
+    def __init__(self, item):
+        super().__init__()
+        self.item = item
+
+    def construct(self):
+        if not self.item.subject:
+            return
+
+        builder = new_builder(
+            "show-attributes-editor",
+            signals={
+                "show-attributes-changed": (self.on_show_attributes_changed,),
+            },
+        )
+
+        show_attributes = builder.get_object("show-attributes")
+        show_attributes.set_active(self.item.show_attributes)
+
+        return builder.get_object("show-attributes-editor")
+
     @transactional
     def on_show_attributes_changed(self, button, gparam):
         self.item.show_attributes = button.get_active()
         self.item.request_update()
-
-    def on_attributes_changed(self, event):
-        update_attribute_model(self.model, self.item.subject)
-
-    def on_attributes_info_clicked(self, image, event):
-        self.info.set_visible(True)
 
 
 class OperationView(GObject.Object):
@@ -347,21 +368,19 @@ def update_operation_model(store: Gio.ListStore, klass: UML.Class) -> None:
     )
 
 
-@PropertyPages.register(DataTypeItem)
-@PropertyPages.register(ClassItem)
-@PropertyPages.register(InterfaceItem)
+@PropertyPages.register(UML.DataType)
+@PropertyPages.register(UML.Class)
+@PropertyPages.register(UML.Interface)
 class OperationsPage(PropertyPageBase):
-    """An editor for operations associated with classes and interfaces."""
-
     order = 30
 
-    def __init__(self, item):
+    def __init__(self, subject):
         super().__init__()
-        self.item = item
-        self.watcher = item.subject and item.subject.watcher()
+        self.subject = subject
+        self.watcher = subject and subject.watcher()
 
     def construct(self):
-        if not self.item.subject:
+        if not self.subject:
             return
 
         builder = new_builder(
@@ -370,16 +389,12 @@ class OperationsPage(PropertyPageBase):
             signals={
                 "operations-activated": (list_view_activated,),
                 "operations-key-pressed": (list_view_key_handler,),
-                "show-operations-changed": (self.on_show_operations_changed,),
                 "operations-info-clicked": (self.on_operations_info_clicked,),
             },
         )
 
         self.info = builder.get_object("operations-info")
         help_link(builder, "operations-info-icon", "operations-info")
-
-        show_operations = builder.get_object("show-operations")
-        show_operations.set_active(self.item.show_operations)
 
         column_view: Gtk.ColumnView = builder.get_object("operations-list")
 
@@ -409,7 +424,7 @@ class OperationsPage(PropertyPageBase):
         ):
             column.set_factory(factory)
 
-        self.model = operation_model(self.item.subject)
+        self.model = operation_model(self.subject)
         selection = Gtk.SingleSelection.new(self.model)
         column_view.set_model(selection)
 
@@ -420,16 +435,43 @@ class OperationsPage(PropertyPageBase):
             builder.get_object("operations-editor"), self.watcher
         )
 
+    def on_operations_changed(self, event):
+        update_operation_model(self.model, self.subject)
+
+    def on_operations_info_clicked(self, image, event):
+        self.info.set_visible(True)
+
+
+@PropertyPages.register(DataTypeItem)
+@PropertyPages.register(ClassItem)
+@PropertyPages.register(InterfaceItem)
+class ShowOperationsPage(PropertyPageBase):
+    order = 31
+
+    def __init__(self, item):
+        super().__init__()
+        self.item = item
+
+    def construct(self):
+        if not self.item.subject:
+            return
+
+        builder = new_builder(
+            "show-operations-editor",
+            signals={
+                "show-operations-changed": (self.on_show_operations_changed,),
+            },
+        )
+
+        show_operations = builder.get_object("show-operations")
+        show_operations.set_active(self.item.show_operations)
+
+        return builder.get_object("show-operations-editor")
+
     @transactional
     def on_show_operations_changed(self, button, gparam):
         self.item.show_operations = button.get_active()
         self.item.request_update()
-
-    def on_operations_changed(self, event):
-        update_operation_model(self.model, self.item.subject)
-
-    def on_operations_info_clicked(self, image, event):
-        self.info.set_visible(True)
 
 
 @PropertyPages.register(UML.Component)

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -16,6 +16,7 @@ from gaphor.diagram.propertypages import (
     unsubscribe_all_on_destroy,
 )
 from gaphor.UML.classes.datatype import DataTypeItem
+from gaphor.UML.classes.enumeration import EnumerationItem
 from gaphor.UML.classes.interface import Folded, InterfaceItem
 from gaphor.UML.classes.klass import ClassItem
 from gaphor.UML.deployments.connector import ConnectorItem
@@ -190,6 +191,19 @@ def update_attribute_model(store: Gio.ListStore, klass: UML.Class) -> None:
     )
 
 
+# We need a type check here, or all Class subtypes will get this editor
+ATTRIBUTES_PAGE_CLASSIFIERS = [
+    UML.Class,
+    UML.DataType,
+    UML.Enumeration,
+    UML.Interface,
+    UML.PrimitiveType,
+    UML.Stereotype,
+]
+
+OPERATIONS_PAGE_CLASSIFIERS = list(ATTRIBUTES_PAGE_CLASSIFIERS)
+
+
 @PropertyPages.register(UML.DataType)
 @PropertyPages.register(UML.Class)
 @PropertyPages.register(UML.Interface)
@@ -202,7 +216,7 @@ class AttributesPage(PropertyPageBase):
         self.watcher = subject and subject.watcher()
 
     def construct(self):
-        if not self.subject:
+        if type(self.subject) not in ATTRIBUTES_PAGE_CLASSIFIERS:
             return
 
         builder = new_builder(
@@ -259,6 +273,7 @@ class AttributesPage(PropertyPageBase):
 
 @PropertyPages.register(DataTypeItem)
 @PropertyPages.register(ClassItem)
+@PropertyPages.register(EnumerationItem)
 @PropertyPages.register(InterfaceItem)
 class ShowAttributesPage(PropertyPageBase):
     order = 21
@@ -380,7 +395,7 @@ class OperationsPage(PropertyPageBase):
         self.watcher = subject and subject.watcher()
 
     def construct(self):
-        if not self.subject:
+        if type(self.subject) not in OPERATIONS_PAGE_CLASSIFIERS:
             return
 
         builder = new_builder(
@@ -443,6 +458,7 @@ class OperationsPage(PropertyPageBase):
 
 
 @PropertyPages.register(DataTypeItem)
+@PropertyPages.register(EnumerationItem)
 @PropertyPages.register(ClassItem)
 @PropertyPages.register(InterfaceItem)
 class ShowOperationsPage(PropertyPageBase):

--- a/gaphor/UML/classes/enumerationpropertypages.py
+++ b/gaphor/UML/classes/enumerationpropertypages.py
@@ -12,6 +12,8 @@ from gaphor.diagram.propertypages import (
 from gaphor.UML.classes.classespropertypages import (
     AttributesPage,
     OperationsPage,
+    ShowAttributesPage,
+    ShowOperationsPage,
     new_resource_builder,
 )
 from gaphor.UML.classes.enumeration import EnumerationItem
@@ -82,19 +84,19 @@ def update_enumeration_model(store: Gio.ListStore, enum: UML.Enumeration) -> Non
     )
 
 
-@PropertyPages.register(EnumerationItem)
+@PropertyPages.register(UML.Enumeration)
 class EnumerationPage(PropertyPageBase):
     """An editor for enumeration literals for an enumeration."""
 
-    order = 19
+    order = 18
 
-    def __init__(self, item):
+    def __init__(self, subject):
         super().__init__()
-        self.item = item
-        self.watcher = item.subject and item.subject.watcher()
+        self.subject = subject
+        self.watcher = subject and subject.watcher()
 
     def construct(self):
-        if not isinstance(self.item.subject, UML.Enumeration):
+        if not isinstance(self.subject, UML.Enumeration):
             return
 
         builder = new_builder(
@@ -103,16 +105,12 @@ class EnumerationPage(PropertyPageBase):
             signals={
                 "enumerations-activated": (list_view_activated,),
                 "enumerations-key-pressed": (list_view_key_handler,),
-                "show-enumerations-changed": (self.on_show_enumerations_changed,),
                 "enumerations-info-clicked": (self.on_enumerations_info_clicked,),
             },
         )
 
         self.info = builder.get_object("enumerations-info")
         help_link(builder, "enumerations-info-icon", "enumerations-info")
-
-        show_enumerations = builder.get_object("show-enumerations")
-        show_enumerations.set_active(self.item.show_enumerations)
 
         column_view: Gtk.ColumnView = builder.get_object("enumerations-list")
 
@@ -130,7 +128,7 @@ class EnumerationPage(PropertyPageBase):
         ):
             column.set_factory(factory)
 
-        self.model = enumeration_model(self.item.subject)
+        self.model = enumeration_model(self.subject)
         selection = Gtk.SingleSelection.new(self.model)
         column_view.set_model(selection)
 
@@ -141,17 +139,46 @@ class EnumerationPage(PropertyPageBase):
             builder.get_object("enumerations-editor"), self.watcher
         )
 
-    @transactional
-    def on_show_enumerations_changed(self, button, gparam):
-        self.item.show_enumerations = button.get_active()
-        self.item.request_update()
-
     def on_enumerations_changed(self, event):
-        update_enumeration_model(self.model, self.item.subject)
+        update_enumeration_model(self.model, self.subject)
 
     def on_enumerations_info_clicked(self, image, event):
         self.info.set_visible(True)
 
 
-PropertyPages.register(EnumerationItem)(AttributesPage)
-PropertyPages.register(EnumerationItem)(OperationsPage)
+@PropertyPages.register(EnumerationItem)
+class ShowEnumerationPage(PropertyPageBase):
+    """An editor for enumeration literals for an enumeration."""
+
+    order = 19
+
+    def __init__(self, item):
+        super().__init__()
+        self.item = item
+
+    def construct(self):
+        if not isinstance(self.item.subject, UML.Enumeration):
+            return
+
+        builder = new_builder(
+            "show-enumerations-editor",
+            signals={
+                "show-enumerations-changed": (self.on_show_enumerations_changed,),
+            },
+        )
+
+        show_enumerations = builder.get_object("show-enumerations")
+        show_enumerations.set_active(self.item.show_enumerations)
+
+        return builder.get_object("show-enumerations-editor")
+
+    @transactional
+    def on_show_enumerations_changed(self, button, gparam):
+        self.item.show_enumerations = button.get_active()
+        self.item.request_update()
+
+
+PropertyPages.register(UML.Enumeration)(AttributesPage)
+PropertyPages.register(EnumerationItem)(ShowAttributesPage)
+PropertyPages.register(UML.Enumeration)(OperationsPage)
+PropertyPages.register(EnumerationItem)(ShowOperationsPage)

--- a/gaphor/UML/classes/enumerationpropertypages.py
+++ b/gaphor/UML/classes/enumerationpropertypages.py
@@ -9,13 +9,7 @@ from gaphor.diagram.propertypages import (
     help_link,
     unsubscribe_all_on_destroy,
 )
-from gaphor.UML.classes.classespropertypages import (
-    AttributesPage,
-    OperationsPage,
-    ShowAttributesPage,
-    ShowOperationsPage,
-    new_resource_builder,
-)
+from gaphor.UML.classes.classespropertypages import new_resource_builder
 from gaphor.UML.classes.enumeration import EnumerationItem
 from gaphor.UML.propertypages import (
     create_list_store,
@@ -176,9 +170,3 @@ class ShowEnumerationPage(PropertyPageBase):
     def on_show_enumerations_changed(self, button, gparam):
         self.item.show_enumerations = button.get_active()
         self.item.request_update()
-
-
-PropertyPages.register(UML.Enumeration)(AttributesPage)
-PropertyPages.register(EnumerationItem)(ShowAttributesPage)
-PropertyPages.register(UML.Enumeration)(OperationsPage)
-PropertyPages.register(EnumerationItem)(ShowOperationsPage)

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -2,7 +2,7 @@
 <interface>
   <requires lib="gtk" version="4.0"/>
 
-  <object class="GtkBox" id="association-editor">
+  <object class="GtkBox" id="association-direction-editor">
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
@@ -40,6 +40,13 @@
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+  <object class="GtkBox" id="association-editor">
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
         <child>

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -348,6 +348,13 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         </property>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+  <object class="GtkBox" id="show-attributes-editor">
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
         <child>
@@ -550,6 +557,13 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         </property>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+  <object class="GtkBox" id="show-operations-editor">
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
         <child>
@@ -643,6 +657,13 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         </property>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+  <object class="GtkBox" id="show-enumerations-editor">
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
         <child>

--- a/gaphor/UML/classes/tests/test_associationpropertypages.py
+++ b/gaphor/UML/classes/tests/test_associationpropertypages.py
@@ -1,32 +1,23 @@
 from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
-from gaphor.UML.classes.associationpropertypages import AssociationPropertyPage
+from gaphor.UML.classes.associationpropertypages import (
+    AssociationDirectionPropertyPage,
+    AssociationPropertyPage,
+)
 
 
-def test_association_property_page(diagram, element_factory):
+def test_association_property_page(element_factory):
     end1 = element_factory.create(UML.Class)
     end2 = element_factory.create(UML.Class)
-    item = diagram.create(
-        UML.classes.AssociationItem, subject=UML.recipes.create_association(end1, end2)
-    )
-    item.head_subject = item.subject.memberEnd[0]
-    item.tail_subject = item.subject.memberEnd[1]
-    property_page = AssociationPropertyPage(item)
+    subject = UML.recipes.create_association(end1, end2)
+
+    property_page = AssociationPropertyPage(subject)
 
     widget = property_page.construct()
     head_name = find(widget, "head-name")
     head_name.set_text("head")
 
-    assert item.subject.memberEnd[0].name == "head"
-
-
-def test_association_property_page_with_no_subject(diagram, element_factory):
-    item = diagram.create(UML.classes.AssociationItem)
-    property_page = AssociationPropertyPage(item)
-
-    widget = property_page.construct()
-
-    assert widget is None
+    assert subject.memberEnd[0].name == "head"
 
 
 def test_association_property_page_invert_direction(diagram, element_factory):
@@ -37,7 +28,7 @@ def test_association_property_page_invert_direction(diagram, element_factory):
     )
     item.head_subject = item.subject.memberEnd[0]
     item.tail_subject = item.subject.memberEnd[1]
-    property_page = AssociationPropertyPage(item)
+    property_page = AssociationDirectionPropertyPage(item)
 
     property_page._on_invert_direction_change(None)
 
@@ -53,17 +44,13 @@ def metaclass_and_stereotype(element_factory):
     return metaclass, stereotype
 
 
-def test_association_property_with_stereotype(diagram, element_factory):
+def test_association_property_with_stereotype(element_factory):
     end1 = element_factory.create(UML.Class)
     end2 = element_factory.create(UML.Class)
-    item = diagram.create(
-        UML.classes.AssociationItem, subject=UML.recipes.create_association(end1, end2)
-    )
-    item.head_subject = item.subject.memberEnd[0]
-    item.tail_subject = item.subject.memberEnd[1]
-    metclass, stereotype = metaclass_and_stereotype(element_factory)
+    subject = UML.recipes.create_association(end1, end2)
+    metaclass_and_stereotype(element_factory)
 
-    property_page = AssociationPropertyPage(item)
+    property_page = AssociationPropertyPage(subject)
 
     widget = property_page.construct()
 

--- a/gaphor/UML/classes/tests/test_classespropertypages.py
+++ b/gaphor/UML/classes/tests/test_classespropertypages.py
@@ -9,6 +9,8 @@ from gaphor.UML.classes.classespropertypages import (
     InterfacePropertyPage,
     NamedElementPropertyPage,
     OperationsPage,
+    ShowAttributesPage,
+    ShowOperationsPage,
     attribute_model,
 )
 
@@ -70,11 +72,11 @@ def test_interface_property_page(diagram, element_factory):
     assert item.folded == Folded.PROVIDED
 
 
-def test_attributes_page(diagram, element_factory):
+def test_show_attributes_page(diagram, element_factory):
     item = diagram.create(
         UML.classes.InterfaceItem, subject=element_factory.create(UML.Interface)
     )
-    property_page = AttributesPage(item)
+    property_page = ShowAttributesPage(item)
 
     widget = property_page.construct()
     show_attributes = find(widget, "show-attributes")
@@ -84,44 +86,42 @@ def test_attributes_page(diagram, element_factory):
 
 
 def test_attributes_page_add_attribute(diagram, element_factory):
-    item = diagram.create(
-        UML.classes.InterfaceItem, subject=element_factory.create(UML.Interface)
-    )
-    property_page = AttributesPage(item)
+    subject = element_factory.create(UML.Interface)
+
+    property_page = AttributesPage(subject)
 
     property_page.construct()
     property_page.model.get_item(0).attribute = "+ attr: str"
 
-    assert item.subject.attribute[0].name == "attr"
-    assert item.subject.attribute[0].typeValue == "str"
+    assert subject.attribute[0].name == "attr"
+    assert subject.attribute[0].typeValue == "str"
 
 
-def test_attribute_create_model(diagram, element_factory):
-    class_item = diagram.create(
-        UML.classes.ClassItem, subject=element_factory.create(UML.Class)
-    )
+def test_attribute_create_model(element_factory):
+    subject = element_factory.create(UML.Class)
+
     attr1 = element_factory.create(UML.Property)
     attr1.name = "attr1"
-    class_item.subject.ownedAttribute = attr1
+    subject.ownedAttribute = attr1
     attr2 = element_factory.create(UML.Property)
     attr2.name = "attr2"
-    class_item.subject.ownedAttribute = attr2
+    subject.ownedAttribute = attr2
     attr3 = element_factory.create(UML.Property)
     attr3.name = "attr3"
-    class_item.subject.ownedAttribute = attr3
+    subject.ownedAttribute = attr3
 
-    list_store = attribute_model(class_item.subject)
+    list_store = attribute_model(subject)
 
     assert list_store[0].attr is attr1
     assert list_store[1].attr is attr2
     assert list_store[2].attr is attr3
 
 
-def test_operations_page(diagram, element_factory):
+def test_show_operations_page(diagram, element_factory):
     item = diagram.create(
         UML.classes.InterfaceItem, subject=element_factory.create(UML.Interface)
     )
-    property_page = OperationsPage(item)
+    property_page = ShowOperationsPage(item)
 
     widget = property_page.construct()
     show_operations = find(widget, "show-operations")
@@ -130,13 +130,12 @@ def test_operations_page(diagram, element_factory):
     assert not item.show_operations
 
 
-def test_operations_page_add_operation(diagram, element_factory):
-    item = diagram.create(
-        UML.classes.InterfaceItem, subject=element_factory.create(UML.Interface)
-    )
-    property_page = OperationsPage(item)
+def test_operations_page_add_operation(element_factory):
+    subject = element_factory.create(UML.Interface)
+
+    property_page = OperationsPage(subject)
 
     property_page.construct()
     property_page.model.get_item(0).operation = "+ oper()"
 
-    assert item.subject.ownedOperation[0].name == "oper"
+    assert subject.ownedOperation[0].name == "oper"

--- a/gaphor/UML/classes/tests/test_enumerationpropertypages.py
+++ b/gaphor/UML/classes/tests/test_enumerationpropertypages.py
@@ -1,11 +1,22 @@
 from gaphor import UML
-from gaphor.UML.classes.enumerationpropertypages import EnumerationPage
+from gaphor.UML.classes.enumerationpropertypages import (
+    EnumerationPage,
+    ShowEnumerationPage,
+)
 
 
 def test_enumeration_property_page(diagram, element_factory):
+    subject = element_factory.create(UML.Enumeration)
+
+    property_page = EnumerationPage(subject)
+
+    property_page.construct()
+
+
+def test_show_enumeration_property_page(diagram, element_factory):
     item = diagram.create(
         UML.classes.EnumerationItem, subject=element_factory.create(UML.Enumeration)
     )
-    property_page = EnumerationPage(item)
+    property_page = ShowEnumerationPage(item)
 
     property_page.construct()

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -67,6 +67,13 @@
         </property>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+  <object class="GtkBox" id="show-stereotypes-editor">
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
         <child>

--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -6,6 +6,16 @@
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkLabel">
+        <property name="halign">center</property>
+        <property name="hexpand">yes</property>
+        <property name="label" translatable="yes">Metaclass</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel">
         <property name="label" translatable="yes">Name</property>
         <property name="xalign">0</property>
         <style>

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -12,15 +12,15 @@ from gaphor.UML.profiles.metaclasspropertypage import new_builder
 from gaphor.UML.propertypages import text_field_handlers
 
 
-@PropertyPages.register(Presentation)
+@PropertyPages.register(Element)
 class StereotypePage(PropertyPageBase):
     order = 40
 
-    def __init__(self, item):
-        self.item = item
+    def __init__(self, subject):
+        self.subject = subject
 
     def construct(self):
-        subject = self.item.subject
+        subject = self.subject
         if not subject:
             return None
 
@@ -31,18 +31,10 @@ class StereotypePage(PropertyPageBase):
         builder = new_builder(
             "stereotypes-editor",
             signals={
-                "show-stereotypes-changed": (self._on_show_stereotypes_change,),
                 "stereotype-activated": (stereotype_activated,),
                 "stereotype-key-pressed": (stereotype_key_handler,),
             },
         )
-
-        show_stereotypes = builder.get_object("show-stereotypes")
-
-        if hasattr(self.item, "show_stereotypes"):
-            show_stereotypes.set_active(self.item.show_stereotypes)
-        else:
-            show_stereotypes.get_parent().unparent()
 
         stereotype_list = builder.get_object("stereotype-list")
         model = stereotype_model(subject)
@@ -50,6 +42,35 @@ class StereotypePage(PropertyPageBase):
         stereotype_set_model_with_interaction(stereotype_list, model)
 
         return builder.get_object("stereotypes-editor")
+
+
+@PropertyPages.register(Presentation)
+class ShowStereotypePage(PropertyPageBase):
+    order = 41
+
+    def __init__(self, item):
+        self.item = item
+
+    def construct(self):
+        subject = self.item.subject
+        if not subject or not hasattr(self.item, "show_stereotypes"):
+            return None
+
+        stereotypes = UML.recipes.get_stereotypes(subject)
+        if not stereotypes:
+            return None
+
+        builder = new_builder(
+            "show-stereotypes-editor",
+            signals={
+                "show-stereotypes-changed": (self._on_show_stereotypes_change,),
+            },
+        )
+
+        show_stereotypes = builder.get_object("show-stereotypes")
+        show_stereotypes.set_active(self.item.show_stereotypes)
+
+        return builder.get_object("show-stereotypes-editor")
 
     @transactional
     def _on_show_stereotypes_change(self, button, gparam):

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -5,14 +5,14 @@ from gi.repository import Gdk, Gio, GLib, GObject, Gtk
 
 from gaphor import UML
 from gaphor.core import transactional
-from gaphor.core.modeling.element import Element
+from gaphor.core.modeling import Element, Presentation
 from gaphor.diagram.propertypages import PropertyPageBase, PropertyPages
 from gaphor.i18n import gettext, translated_ui_string
 from gaphor.UML.profiles.metaclasspropertypage import new_builder
 from gaphor.UML.propertypages import text_field_handlers
 
 
-@PropertyPages.register(UML.Element)
+@PropertyPages.register(Presentation)
 class StereotypePage(PropertyPageBase):
     order = 40
 

--- a/gaphor/UML/profiles/tests/test_stereotypepage.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepage.py
@@ -1,33 +1,23 @@
 """Test Stereotype Property Page."""
 
-import pytest
 from gi.repository import Gtk
 
 from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
-from gaphor.UML.classes.klass import ClassItem
 from gaphor.UML.profiles.stereotypepropertypages import StereotypePage
 
 
-@pytest.fixture
-def class_(diagram, element_factory):
-    class_ = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
-    class_.subject.name = "Class"
-    yield class_
-    del class_
+def test_stereotype_page_with_no_stereotype(element_factory):
+    subject = element_factory.create(UML.Class)
 
-
-def test_stereotype_page_with_no_stereotype(class_):
-    """Test the Stereotype Property Page not created for a Class."""
-
-    editor = StereotypePage(class_)
+    editor = StereotypePage(subject)
     page = editor.construct()
 
     assert page is None
 
 
-def test_stereotype_page_with_stereotype(element_factory, class_):
-    """Test creation of a Stereotype Property Page."""
+def test_stereotype_page_with_stereotype(element_factory):
+    subject = element_factory.create(UML.Class)
 
     # Create a stereotype applicable to Class types:
     metaclass = element_factory.create(UML.Class)
@@ -38,7 +28,7 @@ def test_stereotype_page_with_stereotype(element_factory, class_):
     attr = element_factory.create(UML.Property)
     attr.name = "Property"
 
-    editor = StereotypePage(class_)
+    editor = StereotypePage(subject)
     page = editor.construct()
 
     stereotype_view = find(page, "stereotype-list")

--- a/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
@@ -1,15 +1,20 @@
 from gaphor import UML
 from gaphor.diagram.tests.fixtures import find
 from gaphor.UML.profiles.stereotypepropertypages import (
+    ShowStereotypePage,
     StereotypePage,
 )
 
 
 def create_property_page(diagram, element_factory) -> StereotypePage:
+    return StereotypePage(element_factory.create(UML.Class))
+
+
+def create_show_property_page(diagram, element_factory) -> ShowStereotypePage:
     item = diagram.create(
         UML.classes.ClassItem, subject=element_factory.create(UML.Class)
     )
-    return StereotypePage(item)
+    return ShowStereotypePage(item)
 
 
 def get_model(property_page: StereotypePage):
@@ -27,9 +32,9 @@ def metaclass_and_stereotype(element_factory):
     return metaclass, stereotype
 
 
-def test_stereotype_property_page_with_stereotype(diagram, element_factory):
+def test_show_stereotype_property_page_with_stereotype(diagram, element_factory):
     metaclass, stereotype = metaclass_and_stereotype(element_factory)
-    property_page = create_property_page(diagram, element_factory)
+    property_page = create_show_property_page(diagram, element_factory)
 
     widget = property_page.construct()
     show_stereotypes = find(widget, "show-stereotypes")
@@ -42,12 +47,12 @@ def test_stereotype_property_page_apply_stereotype(diagram, element_factory):
     _metaclass, stereotype = metaclass_and_stereotype(element_factory)
 
     property_page = create_property_page(diagram, element_factory)
-    item = property_page.item
+    subject = property_page.subject
     model = get_model(property_page)
     view = model[0]
     view.applied = True
 
-    assert stereotype in item.subject.appliedStereotype[0].classifier
+    assert stereotype in subject.appliedStereotype[0].classifier
 
 
 def test_stereotype_property_page_slot_value(diagram, element_factory):
@@ -59,11 +64,10 @@ def test_stereotype_property_page_slot_value(diagram, element_factory):
     UML.recipes.create_extension(metaclass, stereotype)
 
     property_page = create_property_page(diagram, element_factory)
-    item = property_page.item
     model = get_model(property_page)
     model[0].applied = True
     model[1].slot_value = "test"
-    applied_stereotype = item.subject.appliedStereotype[0]
+    applied_stereotype = property_page.subject.appliedStereotype[0]
     slot = applied_stereotype.slot[0]
 
     assert stereotype.ownedAttribute[0] is slot.definingFeature

--- a/gaphor/UML/propertypages.py
+++ b/gaphor/UML/propertypages.py
@@ -15,17 +15,17 @@ new_builder = new_resource_builder("gaphor.UML")
 class TypedElementPropertyPage(PropertyPageBase):
     order = 31
 
-    def __init__(self, item):
+    def __init__(self, subject):
         super().__init__()
-        self.item = item
+        self.subject = subject
 
-        assert (not item.subject) or isinstance(
+        assert (not subject) or isinstance(
             self.typed_element, UML.TypedElement
-        ), item.subject
+        ), subject
 
     @property
     def typed_element(self):
-        return self.item.subject
+        return self.subject
 
     def construct(self):
         if not self.typed_element:
@@ -33,12 +33,7 @@ class TypedElementPropertyPage(PropertyPageBase):
 
         typed_element = self.typed_element
 
-        builder = new_builder(
-            "typed-element-editor",
-            signals={
-                "show-type-changed": (self._on_show_type_change,),
-            },
-        )
+        builder = new_builder("typed-element-editor")
 
         dropdown = builder.get_object("element-type")
         model = list_of_classifiers(typed_element.model, UML.Classifier)
@@ -53,12 +48,6 @@ class TypedElementPropertyPage(PropertyPageBase):
 
         dropdown.connect("notify::selected", self._on_property_type_changed)
 
-        if hasattr(self.item, "show_type"):
-            show_type = builder.get_object("show-type")
-            show_type.set_active(self.item.show_type)
-        else:
-            builder.get_object("type-toggle-box").unparent()
-
         return builder.get_object("typed-element-editor")
 
     @transactional
@@ -70,6 +59,38 @@ class TypedElementPropertyPage(PropertyPageBase):
             typed_element.type = element
         else:
             del typed_element.type
+
+
+class ShowTypedElementPropertyPage(PropertyPageBase):
+    order = 32
+
+    def __init__(self, item):
+        super().__init__()
+        self.item = item
+
+        assert (not item.subject) or isinstance(
+            self.typed_element, UML.TypedElement
+        ), item.subject
+
+    @property
+    def typed_element(self):
+        return self.item.subject
+
+    def construct(self):
+        if not self.typed_element and hasattr(self.item, "show_type"):
+            return
+
+        builder = new_builder(
+            "show-typed-element-editor",
+            signals={
+                "show-type-changed": (self._on_show_type_change,),
+            },
+        )
+
+        show_type = builder.get_object("show-type")
+        show_type.set_active(self.item.show_type)
+
+        return builder.get_object("show-typed-element-editor")
 
     @transactional
     def _on_show_type_change(self, button, _gparam):

--- a/gaphor/UML/propertypages.ui
+++ b/gaphor/UML/propertypages.ui
@@ -21,6 +21,13 @@
         </property>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+  <object class="GtkBox" id="show-typed-element-editor">
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox" id="type-toggle-box">
         <child>

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -221,7 +221,7 @@ class DummyEventWatcher:
     def watch(self, path: str, handler: Handler | None = None) -> DummyEventWatcher:
         return self
 
-    def unsubscribe_all(self) -> None:
+    def unsubscribe_all(self, *_args) -> None:
         pass
 
 

--- a/gaphor/diagram/event.py
+++ b/gaphor/diagram/event.py
@@ -10,3 +10,10 @@ class DiagramItemPlaced(ToolCompleted):
 class DiagramOpened:
     def __init__(self, diagram):
         self.diagram = diagram
+
+
+class DiagramSelectionChanged:
+    def __init__(self, diagram_view, focused_item, selected_items):
+        self.diagram_view = diagram_view
+        self.focused_item = focused_item
+        self.selected_items = selected_items

--- a/gaphor/diagram/propertypages.ui
+++ b/gaphor/diagram/propertypages.ui
@@ -32,16 +32,12 @@
     <property name="orientation">vertical</property>
     <property name="baseline-position">top</property>
     <child>
-      <object class="GtkBox">
-        <child>
-          <object class="GtkLabel" id="type-label">
-            <property name="halign">center</property>
-            <property name="hexpand">yes</property>
-            <style>
-              <class name="title"/>
-            </style>
-          </object>
-        </child>
+      <object class="GtkLabel" id="type-label">
+        <property name="halign">center</property>
+        <property name="hexpand">yes</property>
+        <style>
+          <class name="title"/>
+        </style>
       </object>
     </child>
     <child>

--- a/gaphor/diagram/tools/__init__.py
+++ b/gaphor/diagram/tools/__init__.py
@@ -22,7 +22,9 @@ def apply_default_tool_set(view, modeling_language, event_manager, rubberband_st
     view.remove_all_controllers()
     view.add_controller(hover_tool())
     view.add_controller(*text_edit_tools(event_manager))
-    view.add_controller(*transactional_tool(item_tool(), event_manager=event_manager))
+    view.add_controller(
+        *transactional_tool(item_tool(event_manager), event_manager=event_manager)
+    )
     view.add_controller(rubberband_tool(rubberband_state))
     add_basic_tools(view, modeling_language, event_manager)
 

--- a/gaphor/diagram/tools/itemtool.py
+++ b/gaphor/diagram/tools/itemtool.py
@@ -1,11 +1,22 @@
 from gaphas.tool import item_tool as _item_tool
 from gi.repository import Gtk
 
+from gaphor.diagram.event import DiagramSelectionChanged
 
-def item_tool() -> Gtk.GestureDrag:
+
+def item_tool(event_manager) -> Gtk.GestureDrag:
     gesture = _item_tool()
+    gesture.connect_after("drag-begin", on_drag_begin, event_manager)
     gesture.connect_after("drag-end", on_drag_end)
     return gesture
+
+
+def on_drag_begin(gesture, _start_x, _start_y, event_manager):
+    view = gesture.get_widget()
+    selection = view.selection
+    event_manager.handle(
+        DiagramSelectionChanged(view, selection.focused_item, selection.selected_items)
+    )
 
 
 def on_drag_end(gesture, _offset_x, _offset_y):

--- a/gaphor/plugins/align/align.py
+++ b/gaphor/plugins/align/align.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import action, event_handler
+from gaphor.diagram.event import DiagramSelectionChanged
 from gaphor.diagram.presentation import ElementPresentation
 from gaphor.i18n import gettext
 from gaphor.transaction import Transaction
-from gaphor.ui.event import DiagramSelectionChanged
 
 
 class AlignService(Service, ActionProvider):

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -24,7 +24,7 @@ from gaphor.diagram.tools import (
     apply_placement_tool_set,
 )
 from gaphor.diagram.tools.magnet import MagnetPainter
-from gaphor.ui.event import DiagramClosed, DiagramSelectionChanged, ToolSelected
+from gaphor.ui.event import DiagramClosed, ToolSelected
 
 log = logging.getLogger(__name__)
 
@@ -121,8 +121,6 @@ class DiagramPage:
         self.style_manager.connect_object(
             "notify::dark", self._on_notify_dark, scrolled_window
         )
-
-        view.selection.add_handler(self._on_view_selection_changed)
 
         self.view = view
         self.widget = scrolled_window
@@ -266,17 +264,6 @@ class DiagramPage:
         )
 
         view.request_update(self.diagram.get_all_items())
-
-    def _on_view_selection_changed(self, item):
-        view = self.view
-        if not view:
-            return
-        selection = view.selection
-        self.event_manager.handle(
-            DiagramSelectionChanged(
-                view, selection.focused_item, selection.selected_items
-            )
-        )
 
 
 def context_menu_controller(context_menu, diagram):

--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -361,7 +361,8 @@ class Diagrams(UIComponent, ActionProvider):
     def _on_flush_model(self, event):
         """Close all tabs."""
         for page in self._notebook.get_pages():
-            self._notebook.close_page(page)
+            if page:
+                self._notebook.close_page(page)
         self._update_action_state()
 
     def _update_action_state(self):

--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -15,7 +15,7 @@ from gaphor.core.modeling import (
     StyleSheet,
 )
 from gaphor.diagram.drop import drop
-from gaphor.diagram.event import DiagramOpened
+from gaphor.diagram.event import DiagramOpened, DiagramSelectionChanged
 from gaphor.event import ActionEnabled
 from gaphor.i18n import translated_ui_string
 from gaphor.transaction import Transaction
@@ -24,7 +24,6 @@ from gaphor.ui.diagrampage import DiagramPage, GtkView
 from gaphor.ui.event import (
     CurrentDiagramChanged,
     DiagramClosed,
-    DiagramSelectionChanged,
     ElementOpened,
 )
 
@@ -280,13 +279,25 @@ class Diagrams(UIComponent, ActionProvider):
     def select_all(self):
         view = self.get_current_view()
         if view and view.has_focus():
-            view.selection.select_items(*view.model.get_all_items())
+            selection = view.selection
+            selection.select_items(*view.model.get_all_items())
+            self.event_manager.handle(
+                DiagramSelectionChanged(
+                    view, selection.focused_item, selection.selected_items
+                )
+            )
 
     @action(name="unselect-all", shortcut="<Primary><Shift>a")
     def unselect_all(self):
         view = self.get_current_view()
         if view and view.has_focus():
-            view.selection.unselect_all()
+            selection = view.selection
+            selection.unselect_all()
+            self.event_manager.handle(
+                DiagramSelectionChanged(
+                    view, selection.focused_item, selection.selected_items
+                )
+            )
 
     @event_handler(ElementOpened)
     def _on_show_element(self, event: ElementOpened):

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -19,6 +19,7 @@ from gaphor.core.modeling.event import (
     ModelReady,
 )
 from gaphor.core.styling import StyleNode
+from gaphor.diagram.event import DiagramSelectionChanged
 from gaphor.diagram.propertypages import PropertyPages, new_resource_builder
 from gaphor.event import ModelLoaded
 from gaphor.i18n import gettext, localedir
@@ -29,7 +30,7 @@ from gaphor.ui.csscompletion import (
     CssNamedColorProposals,
     CssPropertyProposals,
 )
-from gaphor.ui.event import DiagramSelectionChanged, ModelSelectionChanged
+from gaphor.ui.event import ModelSelectionChanged
 from gaphor.ui.modelmerge import ModelMerge
 
 log = logging.getLogger(__name__)
@@ -165,7 +166,6 @@ class EditorStack:
 
         self.vbox: Optional[Gtk.Box] = None
         self._current_item = None
-        self._last_focused_item = None
 
     def open(self, builder):
         """Display the ElementEditor pane."""
@@ -238,10 +238,6 @@ class EditorStack:
 
     @event_handler(DiagramSelectionChanged)
     def _diagram_selection_changed(self, event):
-        if self._last_focused_item is event.focused_item:
-            return
-
-        self._last_focused_item = event.focused_item
         self._selection_changed(event.focused_item)
 
     @event_handler(ModelSelectionChanged)

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -29,7 +29,7 @@ from gaphor.ui.csscompletion import (
     CssNamedColorProposals,
     CssPropertyProposals,
 )
-from gaphor.ui.event import DiagramSelectionChanged
+from gaphor.ui.event import DiagramSelectionChanged, ModelSelectionChanged
 from gaphor.ui.modelmerge import ModelMerge
 
 log = logging.getLogger(__name__)
@@ -171,15 +171,15 @@ class EditorStack:
         self.vbox = builder.get_object("editors")
 
         current_view = self.diagrams.get_current_view()
-        self._selection_changed(
-            focused_item=current_view and current_view.selection.focused_item
-        )
+        self._selection_changed(current_view and current_view.selection.focused_item)
 
-        self.event_manager.subscribe(self._selection_changed)
+        self.event_manager.subscribe(self._diagram_selection_changed)
+        self.event_manager.subscribe(self._model_selection_changed)
         self.event_manager.subscribe(self._element_changed)
 
     def close(self):
-        self.event_manager.unsubscribe(self._selection_changed)
+        self.event_manager.unsubscribe(self._diagram_selection_changed)
+        self.event_manager.unsubscribe(self._model_selection_changed)
         self.event_manager.unsubscribe(self._element_changed)
 
         self.vbox = None
@@ -218,14 +218,12 @@ class EditorStack:
         while page := self.vbox.get_first_child():
             self.vbox.remove(page)
 
-    @event_handler(DiagramSelectionChanged)
-    def _selection_changed(self, event=None, focused_item=None):
+    def _selection_changed(self, item):
         """Called when a diagram item receives focus.
 
         This reloads all tabs based on the current selection.
         """
         assert self.vbox
-        item = event and event.focused_item or focused_item
         if item is self._current_item and self.vbox.get_first_child():
             return
 
@@ -236,6 +234,14 @@ class EditorStack:
             self.create_pages(item)
         else:
             self.show_no_item_selected()
+
+    @event_handler(DiagramSelectionChanged)
+    def _diagram_selection_changed(self, event):
+        self._selection_changed(event.focused_item)
+
+    @event_handler(ModelSelectionChanged)
+    def _model_selection_changed(self, event):
+        self._selection_changed(event.focused_element)
 
     def show_no_item_selected(self):
         assert self.vbox
@@ -331,11 +337,11 @@ class PreferencesStack:
             language_model.append(language)
 
         current_view = self.diagrams.get_current_view()
-        self._selection_changed(
+        self._diagram_selection_changed(
             focused_item=current_view and current_view.selection.focused_item
         )
 
-        self.event_manager.subscribe(self._selection_changed)
+        self.event_manager.subscribe(self._diagram_selection_changed)
         self.event_manager.subscribe(self._model_ready)
         self.event_manager.subscribe(self._style_sheet_created)
         self.event_manager.subscribe(self._style_sheet_changed)
@@ -345,7 +351,7 @@ class PreferencesStack:
         self.update()
 
     def close(self):
-        self.event_manager.unsubscribe(self._selection_changed)
+        self.event_manager.unsubscribe(self._diagram_selection_changed)
         self.event_manager.unsubscribe(self._model_ready)
         self.event_manager.unsubscribe(self._style_sheet_changed)
         self.event_manager.unsubscribe(self._style_sheet_created)
@@ -399,7 +405,7 @@ class PreferencesStack:
             self.update()
 
     @event_handler(DiagramSelectionChanged)
-    def _selection_changed(self, event=None, focused_item=None):
+    def _diagram_selection_changed(self, event=None, focused_item=None):
         """Called when a diagram item receives focus.
 
         This rebuilds the CSS nodes view.

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -165,6 +165,7 @@ class EditorStack:
 
         self.vbox: Optional[Gtk.Box] = None
         self._current_item = None
+        self._last_focused_item = None
 
     def open(self, builder):
         """Display the ElementEditor pane."""
@@ -237,6 +238,10 @@ class EditorStack:
 
     @event_handler(DiagramSelectionChanged)
     def _diagram_selection_changed(self, event):
+        if self._last_focused_item is event.focused_item:
+            return
+
+        self._last_focused_item = event.focused_item
         self._selection_changed(event.focused_item)
 
     @event_handler(ModelSelectionChanged)

--- a/gaphor/ui/event.py
+++ b/gaphor/ui/event.py
@@ -22,13 +22,6 @@ class ModelSelectionChanged:
         self.focused_element = focused_element
 
 
-class DiagramSelectionChanged:
-    def __init__(self, diagram_view, focused_item, selected_items):
-        self.diagram_view = diagram_view
-        self.focused_item = focused_item
-        self.selected_items = selected_items
-
-
 class ToolSelected:
     def __init__(self, tool_name):
         self.tool_name = tool_name

--- a/gaphor/ui/event.py
+++ b/gaphor/ui/event.py
@@ -16,6 +16,12 @@ class CurrentDiagramChanged:
         self.diagram = diagram
 
 
+class ModelSelectionChanged:
+    def __init__(self, service, focused_element):
+        self.service = service
+        self.focused_element = focused_element
+
+
 class DiagramSelectionChanged:
     def __init__(self, diagram_view, focused_item, selected_items):
         self.diagram_view = diagram_view

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -27,7 +27,11 @@ from gaphor.i18n import gettext, translated_ui_string
 from gaphor.transaction import Transaction
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.actiongroup import create_action_group
-from gaphor.ui.event import DiagramSelectionChanged, ElementOpened
+from gaphor.ui.event import (
+    DiagramSelectionChanged,
+    ElementOpened,
+    ModelSelectionChanged,
+)
 from gaphor.ui.treemodel import (
     RelationshipItem,
     TreeItem,
@@ -80,6 +84,13 @@ class ModelBrowser(UIComponent, ActionProvider):
         )
         self.tree_view = Gtk.ListView.new(self.selection, factory)
         self.tree_view.set_vexpand(True)
+
+        def selection_changed(_selection, position, _n_items):
+            element = self.selection.get_item(position).get_item().element
+            if element:
+                self.event_manager.handle(ModelSelectionChanged(self, element))
+
+        self.selection.connect("selection-changed", selection_changed)
 
         def list_view_activate(list_view, position):
             element = self.selection.get_item(position).get_item().element

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -20,7 +20,7 @@ from gaphor.core.modeling import (
 )
 from gaphor.diagram.deletable import deletable
 from gaphor.diagram.diagramtoolbox import DiagramType
-from gaphor.diagram.event import DiagramOpened
+from gaphor.diagram.event import DiagramOpened, DiagramSelectionChanged
 from gaphor.diagram.group import change_owner
 from gaphor.diagram.tools.dnd import ElementDragData
 from gaphor.i18n import gettext, translated_ui_string
@@ -28,7 +28,6 @@ from gaphor.transaction import Transaction
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.actiongroup import create_action_group
 from gaphor.ui.event import (
-    DiagramSelectionChanged,
     ElementOpened,
     ModelSelectionChanged,
 )

--- a/tests/test_composite_association.py
+++ b/tests/test_composite_association.py
@@ -20,7 +20,7 @@ def test_connect_composite_association(create, diagram):
     a = create(AssociationItem)
     composite_association_config(a)
 
-    property_page = AssociationPropertyPage(a)
+    property_page = AssociationPropertyPage(a.subject)
     _widget = property_page.construct()
 
     connect(a, a.head, c1)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Only items selected in a diagram are shown in the Property Editor.

Issue Number: Fixes #2545 

### What is the new behavior?

When you select an element in the Model Browser, it will show in the Property Editor.

Property pages that contain both model and presentation settings (normally a _Show Something_ setting) have been split in two pages.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Still to do:

- [x] Attributes and Operations for Block, Requirement, etc.
- [x] Select Extension relation in model browser causes error
- [x] ActivityParameterNode also shows ObjectNode properties
