### PR TITLE
Update Gvsbuild to version 2024.3.0

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -240,7 +240,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
     env:
-      gvsbuild_version: 2024.1.0
+      gvsbuild_version: 2024.3.0
       # Bump this number if you want to force a rebuild of gvsbuild with the same version
       gvsbuild_update: 0
     outputs:
@@ -264,11 +264,6 @@ jobs:
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: ${{ env.python_version }}
-      - name: GTK binaries move git binary
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          move "C:\Program Files\Git\usr\bin" "C:\Program Files\Git\usr\notbin"
-          move "C:\Program Files\Git\bin" "C:\Program Files\Git\notbin"
       - name: Install gvsbuild
         if: steps.cache.outputs.cache-hit != 'true'
         run: python -m pip install gvsbuild==${{ env.gvsbuild_version }}
@@ -283,11 +278,6 @@ jobs:
         run: >
           Get-ChildItem C:\gtk-build\build\x64\release\*\dist\*.whl |
           ForEach-Object -process { cp $_ C:\gtk-build\gtk\x64\release\ }
-      - name: GTK binaries restore git binary
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          move "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
-          move "C:\Program Files\Git\notbin" "C:\Program Files\Git\bin"
       - name: GTK binaries output cache key
         id: output
         run: Write-Output "cachekey=${{ runner.os }}-gvsbuild-${{ env.gvsbuild_update }}-${{ env.gvsbuild_version }}" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
Updates Gvsbuild. I also fixed the libpng errors we use to get my having Git in the path, so no need to move the Git binary out of the way.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
