### PR TITLE
Fix env variables aren't accessible within job.if

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -396,7 +396,6 @@ jobs:
     runs-on: windows-latest
     continue-on-error: true
     timeout-minutes: 15
-    if: ${{ env.mainline_build == 'true' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -408,6 +407,7 @@ jobs:
           path: .
       - name: VirusTotal Scan
         uses: crazy-max/ghaction-virustotal@v4
+        if: env.mainline_build == 'true'
         with:
           vt_api_key: ${{ secrets.VIRUSTOTAL_API_KEY }}
           request_rate: 4


### PR DESCRIPTION
Apparently https://github.com/gaphor/gaphor/pull/3146 didn't fix the build issue with the conditional, my fault. This is due to the fact that environmental variables aren't available in the context of job.if, and only in job.step.if as shown here: https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Unrecognized named-value: 'env'

Issue Number: N/A

### What is the new behavior?
No error

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
