### PR TITLE
Fix retain relations

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Workaround for errors while upgrading Python@3.12
-        run: brew uninstall --ignore-dependencies python@3.12
+        run: brew unlink python@3.12 && ls -l /usr/local/bin
       - name: Install macOS Dependencies
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Workaround for errors while upgrading Python@3.12
-        run: brew unlink python@3.12 && ls -l /usr/local/bin
+        run: sudo rm -f /usr/local/bin/2to3* /usr/local/bin/idle3* /usr/local/bin/pip3* /usr/local/bin/pydoc3* /usr/local/bin/python3* /usr/local/bin/wheel3*
       - name: Install macOS Dependencies
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -174,6 +174,8 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Workaround for linking error with Python@3.12
+        run: brew pin python@3.12
       - name: Install macOS Dependencies
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -174,8 +174,8 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Workaround for linking error with Python@3.12
-        run: brew pin python@3.12
+      - name: Workaround for errors while upgrading Python@3.12
+        run: brew uninstall --ignore-dependencies python@3.12
       - name: Install macOS Dependencies
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1

--- a/gaphor/SysML/blocks/tests/test_connectors.py
+++ b/gaphor/SysML/blocks/tests/test_connectors.py
@@ -132,6 +132,7 @@ def test_disconnect_connector_from_proxy_port(
     head_proxy_port_item: ProxyPortItem,
     tail_proxy_port_item: ProxyPortItem,
     element_factory,
+    sanitizer_service,
 ):
     connect(connector_item, connector_item.handles()[0], head_proxy_port_item)
     connect(connector_item, connector_item.handles()[1], tail_proxy_port_item)

--- a/gaphor/UML/actions/pinconnect.py
+++ b/gaphor/UML/actions/pinconnect.py
@@ -42,10 +42,8 @@ class ActionPinConnector:
     def disconnect(self, handle: Handle) -> None:
         pin = self.pin
         if pin.subject and pin.diagram:
-            subject = pin.subject
             del pin.subject
             pin.change_parent(None)
-            subject.unlink()
 
 
 @Connector.register(ValueSpecificationActionItem, PinItem)

--- a/gaphor/UML/actions/tests/test_flowconnect.py
+++ b/gaphor/UML/actions/tests/test_flowconnect.py
@@ -183,7 +183,7 @@ def test_object_flow_activity_is_set_on_input_pin(create):
     assert flow.subject.owner is activity.subject
 
 
-def test_object_flow_reconnect(create, element_factory):
+def test_object_flow_reconnect(create, element_factory, sanitizer_service):
     flow = create(ObjectFlowItem)
     a1 = create(ActionItem, UML.Action)
     o1 = create(ObjectNodeItem, UML.ObjectNode)
@@ -215,7 +215,7 @@ def test_object_flow_reconnect(create, element_factory):
     assert flow.subject.guard == "tguard"
 
 
-def test_control_flow_reconnection(create):
+def test_control_flow_reconnection(create, sanitizer_service):
     """Test control flow becoming object flow due to reconnection."""
     flow = create(ControlFlowItem)
     a1 = create(ActionItem, UML.Action)
@@ -284,7 +284,7 @@ def test_connect_to_action_item(create):
     assert flow.subject.target is a2.subject
 
 
-def test_disconnect_from_action_item(create):
+def test_disconnect_from_action_item(create, sanitizer_service):
     """Test flow item disconnection from action items."""
     flow = create(ControlFlowItem)
     a1 = create(ActionItem, UML.Action)
@@ -301,7 +301,7 @@ def test_disconnect_from_action_item(create):
     assert len(a2.subject.outgoing) == 0
 
 
-def test_reconnect(create, element_factory):
+def test_reconnect(create, element_factory, sanitizer_service):
     """Test flow item reconnection."""
     flow = create(ControlFlowItem)
     a1 = create(ActionItem, UML.Action)
@@ -333,7 +333,7 @@ def test_reconnect(create, element_factory):
     assert flow.subject.guard == "tguard"
 
 
-def test_object_flow_reconnection(create):
+def test_object_flow_reconnection(create, sanitizer_service):
     """Test object flow becoming control flow due to reconnection."""
     flow = create(ObjectFlowItem)
     a1 = create(ActionItem, UML.Action)
@@ -520,7 +520,14 @@ def test_combined_nodes_connection(
     [(ControlFlowItem, UML.ControlFlow), (ObjectFlowItem, UML.ObjectFlow)],
 )
 def test_combined_node_disconnection(
-    create, element_factory, item_cls, fork_node_cls, join_node_cls, flow_item, uml_flow
+    create,
+    element_factory,
+    item_cls,
+    fork_node_cls,
+    join_node_cls,
+    flow_item,
+    uml_flow,
+    sanitizer_service,
 ):
     """Test combined nodes disconnection.
 

--- a/gaphor/UML/classes/tests/test_associationconnect.py
+++ b/gaphor/UML/classes/tests/test_associationconnect.py
@@ -93,7 +93,9 @@ def test_association_item_reconnect_with_aggregation(connected_association, crea
     assert asc.tail_subject.aggregation == "composite"
 
 
-def test_disconnect_should_disconnect_model(connected_association, element_factory):
+def test_disconnect_should_disconnect_model(
+    connected_association, element_factory, sanitizer_service
+):
     asc, c1, c2 = connected_association
 
     disconnect(asc, asc.head)
@@ -108,7 +110,7 @@ def test_disconnect_should_disconnect_model(connected_association, element_facto
 
 
 def test_disconnect_of_second_association_should_leave_model_in_tact(
-    connected_association, clone
+    connected_association, clone, sanitizer_service
 ):
     asc, c1, c2 = connected_association
     new = clone(asc)
@@ -120,7 +122,7 @@ def test_disconnect_of_second_association_should_leave_model_in_tact(
 
 
 def test_disconnect_of_navigable_end_should_remove_owner_relationship(
-    connected_association, element_factory
+    connected_association, element_factory, sanitizer_service
 ):
     asc, c1, c2 = connected_association
 

--- a/gaphor/UML/classes/tests/test_dependencyconnect.py
+++ b/gaphor/UML/classes/tests/test_dependencyconnect.py
@@ -87,7 +87,7 @@ def test_dependency_reconnect_should_keep_attributes(create):
     assert dep.subject.name == "Name"
 
 
-def test_dependency_disconnect(create, element_factory):
+def test_dependency_disconnect(create, element_factory, sanitizer_service):
     actor1 = create(ActorItem, UML.Actor)
     actor2 = create(ActorItem, UML.Actor)
     dep = create(DependencyItem)
@@ -105,7 +105,7 @@ def test_dependency_disconnect(create, element_factory):
     assert dep_subj not in actor2.subject.clientDependency
 
 
-def test_dependency_reconnect_on_same(create):
+def test_dependency_reconnect_on_same(create, sanitizer_service):
     """Test dependency reconnection using two actor items."""
     actor1 = create(ActorItem, UML.Actor)
     actor2 = create(ActorItem, UML.Actor)

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -218,27 +218,21 @@ class LifelineExecutionSpecificationConnect(BaseConnector):
         if lifeline.interaction:
             exec_spec.enclosingInteraction = lifeline.interaction
 
-        diagram = self.diagram
         if self.line.parent is not self.element:
             self.line.change_parent(self.element)
 
-        for cinfo in diagram.connections.get_connections(connected=self.line):
+        for cinfo in self.diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).connect(cinfo.handle, cinfo.port)
         return True
 
     def disconnect(self, handle):
-        exec_spec: Optional[UML.ExecutionSpecification] = self.line.subject
         del self.line.subject
-        if exec_spec:
-            exec_spec.unlink()
-
-        diagram = self.diagram
 
         if self.line.parent is self.element:
             new_parent = self.element.parent
             self.line.change_parent(new_parent)
 
-        for cinfo in diagram.connections.get_connections(connected=self.line):
+        for cinfo in self.diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).disconnect(cinfo.handle)
 
 
@@ -264,10 +258,7 @@ class ExecutionSpecificationExecutionSpecificationConnect(BaseConnector):
         return True
 
     def disconnect(self, handle):
-        exec_spec: Optional[UML.ExecutionSpecification] = self.line.subject
         del self.line.subject
-        if exec_spec and not exec_spec.presentation:
-            exec_spec.unlink()
 
         for cinfo in self.diagram.connections.get_connections(connected=self.line):
             Connector(self.line, cinfo.item).disconnect(cinfo.handle)

--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -116,11 +116,8 @@ def disconnect_lifelines(line, send, received):
     # one is disconnected and one is about to be disconnected,
     # so destroy the message
     if not (subject.sendEvent or subject.receiveEvent):
-        # Both ends are disconnected:
-        message = line.subject
+        # Both ends are disconnected: remove subject
         del line.subject
-        if not message.presentation:
-            message.unlink()
 
 
 @Connector.register(LifelineItem, MessageItem)

--- a/gaphor/UML/interactions/tests/test_executionspecification.py
+++ b/gaphor/UML/interactions/tests/test_executionspecification.py
@@ -66,7 +66,9 @@ def test_connect_execution_specification_to_lifeline(diagram, element_factory):
     )
 
 
-def test_disconnect_execution_specification_from_lifeline(diagram, element_factory):
+def test_disconnect_execution_specification_from_lifeline(
+    diagram, element_factory, sanitizer_service
+):
     def elements_of_kind(type):
         return element_factory.lselect(type)
 
@@ -174,7 +176,7 @@ def test_connect_execution_specification_with_execution_specification_to_lifelin
 
 
 def test_disconnect_execution_specification_with_execution_specification_from_lifeline(
-    diagram, element_factory
+    diagram, element_factory, sanitizer_service
 ):
     def elements_of_kind(type):
         return element_factory.lselect(type)

--- a/gaphor/UML/interactions/tests/test_messageconnect.py
+++ b/gaphor/UML/interactions/tests/test_messageconnect.py
@@ -299,7 +299,9 @@ def test_message_connect_to_execution_specification_in_interaction(
     assert message.subject.interaction is interaction.subject
 
 
-def test_message_disconnect_from_execution_specification(diagram, element_factory):
+def test_message_disconnect_from_execution_specification(
+    diagram, element_factory, sanitizer_service
+):
     """Test gluing message on sequence diagram."""
 
     lifeline = diagram.create(

--- a/gaphor/UML/states/tests/test_transition_connect.py
+++ b/gaphor/UML/states/tests/test_transition_connect.py
@@ -34,7 +34,7 @@ def test_vertex_connect(create, select):
     assert t.subject.target == v2.subject
 
 
-def test_vertex_reconnect(create, select):
+def test_vertex_reconnect(create, select, sanitizer_service):
     v1 = create(StateItem, UML.State)
     v2 = create(StateItem, UML.State)
     v3 = create(StateItem, UML.State)

--- a/gaphor/conftest.py
+++ b/gaphor/conftest.py
@@ -26,6 +26,7 @@ from gaphor.core.modeling.modelinglanguage import (
 from gaphor.storage import storage
 from gaphor.SysML.modelinglanguage import SysMLModelingLanguage
 from gaphor.UML.modelinglanguage import UMLModelingLanguage
+from gaphor.UML.sanitizerservice import SanitizerService
 
 
 @pytest.fixture
@@ -47,6 +48,13 @@ def modeling_language():
     return MockModelingLanguage(
         CoreModelingLanguage(), UMLModelingLanguage(), SysMLModelingLanguage()
     )
+
+
+@pytest.fixture
+def sanitizer_service(event_manager):
+    sanitizer_service = SanitizerService(event_manager)
+    yield sanitizer_service
+    sanitizer_service.shutdown()
 
 
 @pytest.fixture

--- a/gaphor/conftest.py
+++ b/gaphor/conftest.py
@@ -15,6 +15,7 @@ import pytest
 # Load gaphor.ui first, so GTK library versions are set corrently
 import gaphor.ui  # noqa: F401
 
+import gaphor.services.properties
 from gaphor.core import Transaction
 from gaphor.core.eventmanager import EventManager
 from gaphor.core.modeling import Diagram, ElementFactory
@@ -118,3 +119,9 @@ def test_models():
 def models():
     """The folder where test models can be found."""
     return Path(__file__).parent.parent / "models"
+
+
+@pytest.fixture(autouse=True)
+def tmp_get_cache_config_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(gaphor.services.properties, "get_config_dir", lambda: tmp_path)
+    monkeypatch.setattr(gaphor.services.properties, "get_cache_dir", lambda: tmp_path)

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -298,16 +298,8 @@ class RelationshipConnect(BaseConnector):
         raise NotImplementedError("Implement connect_subject() in a subclass")
 
     def disconnect_subject(self, handle: Handle) -> None:
-        """Disconnect the diagram item from its model element.
-
-        If there are no more presentations(diagram items) connected to
-        the model element, unlink() it too.
-        """
-        line = self.line
-        old = line.subject
-        del line.subject
-        if old and len(old.presentation) == 0:
-            old.unlink()
+        """Disconnect the diagram item from its model element."""
+        del self.line.subject
 
     def connect(self, handle: Handle, port: Port) -> bool:
         """Connect the items to each other.

--- a/gaphor/diagram/general/tests/test_comment.py
+++ b/gaphor/diagram/general/tests/test_comment.py
@@ -109,7 +109,7 @@ def test_commentline_element_disconnect(create, diagram):
     assert not diagram.connections.get_connection(line.tail)
 
 
-def test_commentline_relationship_disconnect(create):
+def test_commentline_relationship_disconnect(create, sanitizer_service):
     """Test comment line to a relationship item connection and unlink.
 
     Demonstrates defect #103.
@@ -188,7 +188,7 @@ def test_commentline_element_unlink(create, diagram):
     assert len(clazz_subject.comment) == 0
 
 
-def test_commentline_relationship_unlink(create):
+def test_commentline_relationship_unlink(create, sanitizer_service):
     """Test comment line to a relationship item connection and unlink.
 
     Demonstrates defect #103.

--- a/gaphor/services/properties.py
+++ b/gaphor/services/properties.py
@@ -81,8 +81,6 @@ class Properties(Service):
         event_manager.subscribe(self.on_model_saved)
         event_manager.subscribe(self.on_model_flushed)
 
-        self.load()
-
     def shutdown(self):
         """Shutdown the properties service.
 

--- a/gaphor/services/tests/test_properties.py
+++ b/gaphor/services/tests/test_properties.py
@@ -4,13 +4,11 @@ import pytest
 
 import gaphor.services.properties
 from gaphor.event import ModelLoaded, ModelSaved
+from gaphor.services.properties import get_cache_dir, get_config_dir
 
 
 @pytest.fixture
-def properties(event_manager, tmpdir, monkeypatch):
-    monkeypatch.setattr(
-        gaphor.services.properties, "get_cache_dir", lambda: Path(tmpdir)
-    )
+def properties(event_manager):
     properties = gaphor.services.properties.Properties(event_manager)
     yield properties
     properties.shutdown()
@@ -47,10 +45,10 @@ def test_load_of_corrupted_properties(properties, event_manager, caplog):
 
 
 def test_config_dir():
-    config_dir = gaphor.services.properties.get_config_dir()
+    config_dir = get_config_dir()
     assert str(config_dir).endswith("gaphor")
 
 
 def test_cache_dir():
-    cache_dir = gaphor.services.properties.get_cache_dir()
+    cache_dir = get_cache_dir()
     assert str(cache_dir).endswith("gaphor")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from gaphor.conftest import (
     event_manager,
     modeling_language,
     test_models,
+    tmp_get_cache_config_dir,
 )
 
 settings.register_profile(

--- a/tests/test_remove_unused_elements.py
+++ b/tests/test_remove_unused_elements.py
@@ -1,0 +1,82 @@
+import pytest
+
+from gaphor import UML
+from gaphor.application import Session
+from gaphor.core import Transaction
+from gaphor.core.modeling import Diagram
+from gaphor.diagram.tests.fixtures import connect
+from gaphor.UML import diagramitems
+
+
+@pytest.fixture
+def session():
+    session = Session()
+
+    yield session
+    session.shutdown()
+
+
+@pytest.fixture
+def event_manager(session):
+    return session.get_service("event_manager")
+
+
+@pytest.fixture
+def element_factory(session):
+    return session.get_service("element_factory")
+
+
+@pytest.fixture
+def properties(session):
+    return session.get_service("properties")
+
+
+@pytest.fixture
+def diagram(event_manager, element_factory):
+    with Transaction(event_manager):
+        return element_factory.create(Diagram)
+
+
+@pytest.fixture
+def classes_and_association(diagram, event_manager, element_factory):
+    with Transaction(event_manager):
+        c1 = diagram.create(
+            diagramitems.ClassItem, subject=element_factory.create(UML.Class)
+        )
+        c2 = diagram.create(
+            diagramitems.ClassItem, subject=element_factory.create(UML.Class)
+        )
+
+        a = diagram.create(diagramitems.AssociationItem)
+        connect(a, a.handles()[0], c1)
+        connect(a, a.handles()[1], c2)
+
+    return c1.subject, c2.subject, a.subject
+
+
+@pytest.mark.parametrize(
+    ["remove_unused_elements", "comparator"],
+    [
+        [True, lambda a: not a],
+        [False, lambda a: a],
+    ],
+)
+def test_delete_diagram(
+    classes_and_association,
+    diagram,
+    event_manager,
+    element_factory,
+    properties,
+    remove_unused_elements,
+    comparator,
+):
+    properties.set("remove-unused-elements", remove_unused_elements)
+
+    c1, c2, a = classes_and_association
+
+    with Transaction(event_manager):
+        diagram.unlink()
+
+    assert comparator(c1 in element_factory)
+    assert comparator(c2 in element_factory)
+    assert comparator(a in element_factory)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

If you disable the "Remove Unused Elements" option, and remove a diagram, the relations in that diagram are removed anyway.

Issue Number: Fixes #2616 and #3047.

### What is the new behavior?

All unlinking is left to the _SanitizerService_. This service knows if the "Remove Unused Elements" option has been disabled and acts accordingly.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

Without a configured Sanitizer Service, relationships are no longer removed on model level when a relation is broken in a diagram.


### Other information

The change itself is quite simple: remove the unlink call from the connector. Fixing the tests took most of the time 😄 .

* Fixed Pin  interaction Messages and Execution Specification too.
* Use custom properties cache folder, so user settings are not intervening with tests.
* Added a hack to the macOS build, to allow Homebrew to upgrade Python 3.12.
