### PR TITLE
Mark pt_BR, zh_Hans, and tr as mature translations

### DIFF
--- a/po/build-babel.py
+++ b/po/build-babel.py
@@ -37,7 +37,19 @@ def compile_mo_all():
 
 
 def compile_mo_release():
-    mature_translations = ["cs", "es", "de", "nl", "fi", "hr", "hu", "ru"]
+    mature_translations = [
+        "cs",
+        "es",
+        "de",
+        "nl",
+        "fi",
+        "hr",
+        "hu",
+        "pt_BR",
+        "ru",
+        "tr",
+        "zh_hans",
+    ]
     for path in (
         path
         for path in po_path.iterdir()


### PR DESCRIPTION
This PR enables 3 more translations since they are above 80% translated.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Gaphor is missing translations for Portuguese (Brazil), Chinese (Simplified), and Turkish.

Issue Number: N/A

### What is the new behavior?
Translations enabled

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
