### PR TITLE
Fix title style for Property Editor

### DIFF
--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -241,7 +241,9 @@ class MainWindow(Service, ActionProvider):
             element_editor.set_reveal_child(active)
         self.properties.set("show-editors", active)
 
-    @action("fullscreen", shortcut="F11", state=False)
+    @action(
+        "fullscreen", shortcut="F11", state=lambda self: self.window.is_fullscreen()
+    )
     def toggle_fullscreen(self, active):
         if not self.window:
             return

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -139,6 +139,10 @@ textfield text selection {
   border-left: 1px solid @unfocused_borders;
 }
 
+#element_editor .title {
+  font-weight: bold;
+}
+
 .toolbar {
   padding-top: 0;
 }


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

With #3183 the title style for the Property Editor is gone.

This PR fixes that.

Also sets the full screen state properly.
