### PR TITLE
Make self-test a command, instead of an option

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -233,7 +233,7 @@ jobs:
           hdiutil attach ${{ needs.macos.outputs.artifact }}
           cd /Volumes/Gaphor*
           # Retry if first test fails
-          Gaphor.app/Contents/MacOS/gaphor --self-test || Gaphor.app/Contents/MacOS/gaphor --self-test
+          Gaphor.app/Contents/MacOS/gaphor self-test || Gaphor.app/Contents/MacOS/gaphor self-test
 
   windows-build-gtk:
     name: Windows (Build GTK)
@@ -385,7 +385,7 @@ jobs:
         shell: cmd
       - name: Perform self-test
         timeout-minutes: 5
-        run: start "" /WAIT "C:\Program Files\Gaphor\gaphor.exe" --self-test
+        run: start "" /WAIT "C:\Program Files\Gaphor\gaphor.exe" self-test
         shell: cmd
       - name: Test output
         if: always()

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -109,8 +109,6 @@ def gui_parser():
 
         # Recreate a command line for our GTK gui
         run_argv = [sys.argv[0]]
-        if args.self_test:
-            run_argv += ["--self-test"]
         if args.gapplication_service:
             run_argv += ["--gapplication-service"]
         run_argv.extend(args.model)
@@ -122,11 +120,26 @@ def gui_parser():
     )
 
     group = parser.add_argument_group("options (no command provided)")
-    group.add_argument(
-        "--self-test", help="run self test and exit", action="store_true"
-    )
     group.add_argument("--gapplication-service", action="store_true")
     group.add_argument("model", nargs="*", help="model file(s) to load")
+    parser.set_defaults(command=run)
+    return parser
+
+
+def self_test_parser():
+    def run(args) -> int:
+        # Only now import the UI module
+        import gaphor.ui
+
+        # Recreate a command line for our GTK gui
+        run_argv = [sys.argv[0]]
+
+        return gaphor.ui.run(run_argv, launch_service="self_test")
+
+    parser = argparse.ArgumentParser(
+        description="Perform a self test and exit", parents=[version_parser()]
+    )
+
     parser.set_defaults(command=run)
     return parser
 

--- a/gaphor/tests/test_main.py
+++ b/gaphor/tests/test_main.py
@@ -47,12 +47,6 @@ def test_quiet_logging():
     assert logging.getLogger("root").getEffectiveLevel() == logging.WARNING
 
 
-def test_self_test(mock_gaphor_ui_run):
-    main([APP_NAME, "--self-test"])
-
-    assert mock_gaphor_ui_run == [APP_NAME, "--self-test"]
-
-
 def test_gapplication_service(mock_gaphor_ui_run):
     main([APP_NAME, "--gapplication-service"])
 

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -39,7 +39,7 @@ if sys.platform == "darwin":
         )
 
 
-def run(argv: list[str]) -> int:
+def run(argv: list[str], launch_service="greeter") -> int:
     application: Application | None = None
 
     def app_startup(gtk_app):
@@ -69,9 +69,7 @@ def run(argv: list[str]) -> int:
             event_manager = application.get_service("event_manager")
             event_manager.subscribe(on_session_created)
             event_manager.subscribe(on_quit)
-            application.get_service(
-                "self_test" if "--self-test" in argv else "greeter"
-            ).init(gtk_app)
+            application.get_service(launch_service).init(gtk_app)
         except Exception:
             gtk_app.exit_code = 1
             gtk_app.quit()
@@ -108,24 +106,11 @@ def run(argv: list[str]) -> int:
 
     settings.style_variant_changed(update_color_scheme)
     gtk_app.exit_code = 0
-    add_main_options(gtk_app)
     gtk_app.connect("startup", app_startup)
     gtk_app.connect("activate", app_activate)
     gtk_app.connect("open", app_open)
     gtk_app.run(argv)
     return gtk_app.exit_code
-
-
-def add_main_options(gtk_app):
-    """These parameters are handled in `gaphor.ui.run()`."""
-    gtk_app.add_main_option(
-        "self-test",
-        0,
-        GLib.OptionFlags.NONE,
-        GLib.OptionArg.NONE,
-        "Run self test and exit",
-        None,
-    )
 
 
 if __name__ == "__main__":

--- a/gaphor/ui/tests/test_selftest.py
+++ b/gaphor/ui/tests/test_selftest.py
@@ -5,6 +5,6 @@ from gaphor.ui import run
 
 def test_self_test(caplog):
     caplog.set_level(logging.DEBUG)
-    exit_code = run(["--self-test"])
+    exit_code = run(argv=[], launch_service="self_test")
 
     assert exit_code == 0

--- a/org.gaphor.Gaphor.json
+++ b/org.gaphor.Gaphor.json
@@ -74,7 +74,7 @@
       ],
       "run-tests": true,
       "test-commands": [
-        "gaphor --self-test"
+        "gaphor self-test"
       ]
     }
   ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ gaphor = "gaphor.main:main"
 
 [tool.poetry.plugins."gaphor.argparsers"]
 gui = "gaphor.main:gui_parser"
+self-test = "gaphor.main:self_test_parser"
 exec = "gaphor.main:exec_parser"
 export = "gaphor.plugins.diagramexport.exportcli:export_parser"
 install-schemas = "gaphor.ui.installschemas:install_schemas_parser"


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Self test is an option. This is from the time we did not have commands.

Issue Number: N/A

### What is the new behavior?

Now you can self-test by calling `gaphor self-test`.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
