### PR TITLE
Do not perform diagram updates outside of a transaction

### DIFF
--- a/.github/workflows/hypothesis-test.yml
+++ b/.github/workflows/hypothesis-test.yml
@@ -53,7 +53,7 @@ jobs:
           XDG_RUNTIME_DIR: /tmp
         run: |
           eval $(dbus-launch --auto-syntax)
-          mutter --wayland --no-x11 --sm-disable --headless -- poetry run pytest --cov
+          mutter --wayland --no-x11 --sm-disable --headless -- poetry run pytest -m hypothesis --hypothesis-profile=ci
       - name: Create Issue on Failure
         uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
         if: failure()

--- a/gaphor/SysML/blocks/tests/test_proxy_port.py
+++ b/gaphor/SysML/blocks/tests/test_proxy_port.py
@@ -23,7 +23,7 @@ def test_proxy_port_item_point(diagram):
 def test_ports(diagram):
     proxy_port = diagram.create(ProxyPortItem)
 
-    diagram.update_now({proxy_port})
+    diagram.update({proxy_port})
 
     top, right, bottom, left = proxy_port.ports()
 

--- a/gaphor/UML/actions/partitionpage.py
+++ b/gaphor/UML/actions/partitionpage.py
@@ -123,4 +123,4 @@ class PartitionPropertyPage(PropertyPageBase):
             last_child = self.partitions.get_last_child()
             self.partitions.remove(last_child)
 
-        self.item.diagram.update_now(self.item.diagram.ownedPresentation)
+        self.item.diagram.update(self.item.diagram.ownedPresentation)

--- a/gaphor/UML/actions/tests/test_flow.py
+++ b/gaphor/UML/actions/tests/test_flow.py
@@ -50,5 +50,5 @@ def test_draw(create, diagram):
         selected=True,
         dropzone=False,
     )
-    diagram.update_now((flow,))
+    diagram.update({flow})
     flow.draw(context)

--- a/gaphor/UML/actions/tests/test_forknode.py
+++ b/gaphor/UML/actions/tests/test_forknode.py
@@ -15,7 +15,7 @@ def saver():
 
 def test_forknode_save_default_height(diagram, saver):
     fork: ForkNodeItem = diagram.create(ForkNodeItem)
-    diagram.update_now({fork})
+    diagram.update({fork})
 
     fork.save(saver)
 
@@ -28,7 +28,7 @@ def test_forknode_save_height_0(diagram, saver):
 
     fork.handles()[0].pos.y = -100
     fork.handles()[1].pos.y = 0
-    diagram.update_now({fork})
+    diagram.update({fork})
 
     fork.save(saver)
 
@@ -41,7 +41,7 @@ def test_forknode_save_height_1(diagram, saver):
 
     fork.handles()[0].pos.y = 0
     fork.handles()[1].pos.y = 100
-    diagram.update_now({fork})
+    diagram.update({fork})
 
     fork.save(saver)
 

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -182,8 +182,8 @@ class AssociationItem(Named, LinePresentation[UML.Association]):
         self.request_update()
 
     def update(self, _context: UpdateContext | None = None):
-        for end in (self._head_end, self._tail_end):
-            end.set_text()
+        self._head_end.update_text()
+        self._tail_end.update_text()
 
     def point(self, x, y):
         """Returns the distance from the Association to the (mouse) cursor."""
@@ -351,10 +351,11 @@ class AssociationEnd:
     def subject(self) -> Optional[UML.Property]:
         return getattr(self.owner, f"{self._end}_subject")  # type:ignore[no-any-return]
 
-    def request_update(self):
-        self._owner.request_update()
+    @property
+    def name(self):
+        return self._name
 
-    def set_text(self):
+    def update_text(self):
         """Set the text on the association end."""
         if self.subject:
             try:
@@ -366,13 +367,6 @@ class AssociationEnd:
             else:
                 self._name = n
                 self._mult = m
-                self.request_update()
-
-    def get_name(self):
-        return self._name
-
-    def get_mult(self):
-        return self._mult
 
     def update_position(self, context: UpdateContext, p1, p2):
         """Update label placement for association's name and multiplicity

--- a/gaphor/UML/classes/tests/test_association.py
+++ b/gaphor/UML/classes/tests/test_association.py
@@ -85,7 +85,7 @@ def test_association_end_updates(create, diagram):
     assert a.subject.memberEnd[0].name is None
 
     a.subject.memberEnd[0].name = "blah"
-    diagram.update_now((a,))
+    diagram.update({a})
 
     assert a.head_end.name == "+ blah", a.head_end.name
 

--- a/gaphor/UML/classes/tests/test_association.py
+++ b/gaphor/UML/classes/tests/test_association.py
@@ -87,7 +87,7 @@ def test_association_end_updates(create, diagram):
     a.subject.memberEnd[0].name = "blah"
     diagram.update_now((a,))
 
-    assert a.head_end._name == "+ blah", a.head_end.get_name()
+    assert a.head_end.name == "+ blah", a.head_end.name
 
 
 def test_association_end_owner_handles(items):

--- a/gaphor/UML/classes/tests/test_class.py
+++ b/gaphor/UML/classes/tests/test_class.py
@@ -23,7 +23,7 @@ def test_compartments(element_factory):
     assert 0 == len(compartments(klass)[0].child.children)
     assert 0 == len(compartments(klass)[1].child.children)
 
-    diagram.update_now((klass,))
+    diagram.update({klass})
 
     assert 50 == float(klass.min_height)
     assert 100 == float(klass.min_width)
@@ -32,7 +32,7 @@ def test_compartments(element_factory):
     attr.name = 4 * "x"  # about 44 pixels
     klass.subject.ownedAttribute = attr
 
-    diagram.update_now((klass,))
+    diagram.update({klass})
 
     assert 1 == len(compartments(klass)[0].child.children)
     assert compartments(klass)[0].size(context()) >= (40, 15)
@@ -45,7 +45,7 @@ def test_compartments(element_factory):
     oper.name = 6 * "x"  # about 66 pixels
     klass.subject.ownedOperation = oper
 
-    diagram.update_now((klass,))
+    diagram.update({klass})
     assert 2 == len(compartments(klass)[1].child.children)
     assert compartments(klass)[1].size(context()) > (60.0, 34.0)
 
@@ -53,7 +53,7 @@ def test_compartments(element_factory):
 def test_attribute_removal(element_factory):
     diagram = element_factory.create(Diagram)
     klass = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
-    diagram.update_now((klass,))
+    diagram.update({klass})
 
     attr = element_factory.create(UML.Property)
     attr.name = "blah1"
@@ -79,7 +79,7 @@ def test_compartment_resizing(element_factory):
     klass = diagram.create(ClassItem, subject=element_factory.create(UML.Class))
     klass.subject.name = "Class1"
 
-    diagram.update_now((klass,))
+    diagram.update({klass})
 
     attr = element_factory.create(UML.Property)
     attr.name = "blah"
@@ -93,7 +93,7 @@ def test_compartment_resizing(element_factory):
 
     attr.name = "x" * 25
 
-    diagram.update_now((klass,))
+    diagram.update({klass})
 
     width = klass.width
     assert width >= 170.0

--- a/gaphor/UML/classes/tests/test_interfaceconnect.py
+++ b/gaphor/UML/classes/tests/test_interfaceconnect.py
@@ -26,7 +26,7 @@ def test_interface_realization_folded_interface_connection(element_factory, diag
     impl = diagram.create(InterfaceRealizationItem)
 
     connect(impl, impl.head, iface)
-    diagram.update_now((iface, impl))
+    diagram.update({iface, impl})
 
     style = diagram.style(StyledItem(impl))
     assert not style["dash-style"]
@@ -66,7 +66,7 @@ def test_dependency_folded_interface_connection(element_factory, diagram):
     connect(dep, dep.head, iface)
     connect(dep, dep.tail, clazz)
     iface.update_shapes()
-    diagram.update_now((clazz, iface, dep))
+    diagram.update({clazz, iface, dep})
     style = diagram.style(StyledItem(dep))
 
     assert dep.subject

--- a/gaphor/UML/deployments/tests/test_connect.py
+++ b/gaphor/UML/deployments/tests/test_connect.py
@@ -132,7 +132,7 @@ def test_simple_connection(create, diagram):
     connect(line, line.head, iface)
     connect(line, line.tail, comp)
     iface.update_shapes()
-    diagram.update_now((iface, comp, line))
+    diagram.update((iface, comp, line))
 
     # interface goes into assembly mode
     assert iface.folded == Folded.PROVIDED

--- a/gaphor/UML/deployments/tests/test_connect.py
+++ b/gaphor/UML/deployments/tests/test_connect.py
@@ -132,7 +132,7 @@ def test_simple_connection(create, diagram):
     connect(line, line.head, iface)
     connect(line, line.tail, comp)
     iface.update_shapes()
-    diagram.update((iface, comp, line))
+    diagram.update({iface, comp, line})
 
     # interface goes into assembly mode
     assert iface.folded == Folded.PROVIDED

--- a/gaphor/UML/interactions/interaction.py
+++ b/gaphor/UML/interactions/interaction.py
@@ -33,6 +33,8 @@ def draw_interaction(box, context, bounding_box):
     cr.rectangle(0, 0, bounding_box.width, bounding_box.height)
     stroke(context, fill=True)
     # draw pentagon
+    if not box.sizes:
+        box.size(context, bounding_box)
     w, h = box.sizes[0]
     h2 = h / 2.0
     cr.move_to(0, h)

--- a/gaphor/UML/interactions/tests/test_executionspecification.py
+++ b/gaphor/UML/interactions/tests/test_executionspecification.py
@@ -216,7 +216,7 @@ def test_save_and_load(diagram, element_factory, saver, loader):
         diagram, element_factory
     )
 
-    diagram.update_now((lifeline, exec_spec))
+    diagram.update({lifeline, exec_spec})
 
     saved_data = saver()
 

--- a/gaphor/UML/interactions/tests/test_message.py
+++ b/gaphor/UML/interactions/tests/test_message.py
@@ -52,7 +52,7 @@ def test_message_connected_to_lifeline(diagram, element_factory, saver, loader):
     )
     lifeline.lifetime.length = 100
     message = diagram.create(MessageItem, subject=element_factory.create(UML.Message))
-    diagram.update_now({lifeline, message})
+    diagram.update({lifeline, message})
     message.head.pos.x = lifeline.handles()[SE].pos.x
     message.head.pos.y = lifeline.handles()[-1].pos.y
 

--- a/gaphor/UML/interactions/tests/test_message.py
+++ b/gaphor/UML/interactions/tests/test_message.py
@@ -71,5 +71,5 @@ def test_message_connected_to_lifeline(diagram, element_factory, saver, loader):
     new_port = new_diagram.connections.get_connection(new_message.head).port
 
     assert new_lifeline.lifetime.visible
-    assert new_lifeline.lifetime.length == 50
+    assert new_lifeline.lifetime.length == 100
     assert new_port is new_lifeline.lifetime.port

--- a/gaphor/UML/usecases/tests/test_actor.py
+++ b/gaphor/UML/usecases/tests/test_actor.py
@@ -9,7 +9,7 @@ def test_create_actor(create, diagram):
     actor_item = create(ActorItem, UML.Actor)
     actor_item.subject.name = "Actor"
 
-    diagram.update_now({actor_item})
+    diagram.update({actor_item})
 
 
 def test_connect_to_lower_port(create, diagram):
@@ -20,7 +20,7 @@ def test_connect_to_lower_port(create, diagram):
     line_head.pos = (50, 100)
     line_tail.pos = (50, 100)
 
-    diagram.update_now({actor_item, line_item})
+    diagram.update({actor_item, line_item})
 
     connect(line_item, line_head, actor_item)
 
@@ -36,11 +36,11 @@ def test_save_and_load(create, diagram, element_factory, saver, loader):
     line_head.pos = (50, 100)
     line_tail.pos = (50, 100)
 
-    diagram.update_now({actor_item, line_item})
+    diagram.update({actor_item, line_item})
 
     connect(line_item, line_head, actor_item)
 
-    diagram.update_now({actor_item, line_item})
+    diagram.update({actor_item, line_item})
 
     data = saver()
     loader(data)

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -448,8 +448,12 @@ class Diagram(Element):
         self,
         dirty_items: Sequence[Presentation],
     ) -> None:
-        """Update the diagram canvas."""
+        self.update(dirty_items)
 
+    def update(
+        self,
+        dirty_items: Iterable[Presentation],
+    ) -> None:
         # Clear our (cached) style sheet first
         self._compiled_style_sheet = None
 

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -5,14 +5,11 @@ Diagrams can be visualized and edited.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable, Collection, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import (
-    Callable,
-    Iterable,
-    Iterator,
     Protocol,
-    Sequence,
     TypeVar,
     overload,
     runtime_checkable,
@@ -279,6 +276,7 @@ class Diagram(Element):
 
         self._compiled_style_sheet: CompiledStyleSheet | None = None
         self._registered_views: set[gaphas.model.View] = set()
+        self._dirty_items: set[gaphas.Item] = set()
 
         self._watcher = self.watcher()
         self._watcher.watch("ownedPresentation", self._owned_presentation_changed)
@@ -295,7 +293,7 @@ class Diagram(Element):
 
     def _owned_presentation_changed(self, event):
         if isinstance(event, AssociationDeleted) and event.old_value:
-            self._update_views(removed_items=(event.old_value,))
+            self._update_dirty_items(removed_items={event.old_value})
         elif isinstance(event, AssociationAdded):
             self._order_owned_presentation()
 
@@ -376,7 +374,7 @@ class Diagram(Element):
             item.subject = subject
         if parent:
             item.parent = parent
-        self.request_update(item)
+        self.update({item})
         return item
 
     def lookup(self, id: Id) -> Presentation | None:
@@ -436,29 +434,32 @@ class Diagram(Element):
 
     def request_update(self, item: gaphas.item.Item) -> None:
         if item in self.ownedPresentation:
-            self._update_views(dirty_items=(item,))
+            self._update_dirty_items(dirty_items={item})
 
-    def _update_views(self, dirty_items=(), removed_items=()):
+    def _update_dirty_items(self, dirty_items=(), removed_items=()):
         """Send an update notification to all registered views."""
+        if dirty_items:
+            self._dirty_items.update(dirty_items)
+        if removed_items:
+            self._dirty_items.difference_update(removed_items)
+
         for v in self._registered_views:
             v.request_update(dirty_items, removed_items)
 
-    @gaphas.decorators.nonrecursive
-    def update_now(
-        self,
-        dirty_items: Sequence[Presentation],
-    ) -> None:
-        self.update(dirty_items)
+    def update_now(self, _dirty_items: Collection[Presentation]) -> None:
+        pass
 
     def update(
         self,
-        dirty_items: Iterable[Presentation],
+        dirty_items: Collection[Presentation] = (),
     ) -> None:
+        self._update_dirty_items(dirty_items)
+
         # Clear our (cached) style sheet first
         self._compiled_style_sheet = None
 
         def dirty_items_with_ancestors():
-            for item in set(dirty_items):
+            for item in self._dirty_items:
                 yield item
                 yield from gaphas.canvas.ancestors(self, item)
 
@@ -468,6 +469,8 @@ class Diagram(Element):
 
         self._connections.solve()
 
+        self._dirty_items.clear()
+
     def _on_constraint_solved(self, cinfo: gaphas.connections.Connection) -> None:
         dirty_items = set()
         if cinfo.item:
@@ -475,7 +478,7 @@ class Diagram(Element):
         if cinfo.connected:
             dirty_items.add(cinfo.connected)
         if dirty_items:
-            self._update_views(dirty_items)
+            self._update_dirty_items(dirty_items)
 
     def register_view(self, view: gaphas.model.View[Presentation]) -> None:
         self._registered_views.add(view)

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -38,7 +38,7 @@ class Presentation(Matrices, Element, Generic[S]):
 
         def update(event):
             if self.diagram:
-                self.diagram.request_update(self)
+                self.diagram.update({self})
 
         self._watcher = self.watcher(default_handler=update)
         self.watch("subject")

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -201,7 +201,7 @@ def _paste_presentation(copy_data: PresentationCopy, _diagram, lookup):
     for name, ser in data.items():
         for value in deserialize(ser, lookup):
             item.load(name, value)
-    diagram.update_now((item,))
+    diagram.update({item})
 
 
 def _paste(copy_data: Opaque, diagram: Diagram, full: bool) -> set[Presentation]:

--- a/gaphor/diagram/export.py
+++ b/gaphor/diagram/export.py
@@ -15,7 +15,7 @@ def escape_filename(diagram_name):
 
 
 def render(diagram, new_surface, padding=8, write_to_png=None) -> None:
-    diagram.update_now(diagram.get_all_items())
+    diagram.update(set(diagram.get_all_items()))
 
     painter = new_painter(diagram)
 

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -146,10 +146,10 @@ class ElementPresentation(gaphas.Element, HandlePositionUpdate, Presentation[S])
         be drawn or when styling changes."""
 
     def update(self, context):
-        if not self.shape:
+        if not self._shape:
             self.update_shapes()
-        if self.shape:
-            self.min_width, self.min_height = self.shape.size(
+        if self._shape:
+            self.min_width, self.min_height = self._shape.size(
                 context, bounding_box=Rectangle(0, 0, self.width, self.height)
             )
 

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -54,7 +54,7 @@ def postload_connect(item: gaphas.Item, handle: gaphas.Handle, target: gaphas.It
     This function finds a suitable spot on the `target` item to connect the `handle` to.
     """
     target.postload()
-    item.diagram.update_now({item, target})
+    item.diagram.update({item, target})
     connector = ConnectorAspect(item, handle, item.diagram.connections)
     sink = ConnectionSink(target, distance=float("inf"))
     connector.glue(sink)

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -216,13 +216,13 @@ class LineStylePage(PropertyPageBase):
             line_segment.split_segment(0)
         active = button.get_active()
         self.item.orthogonal = active
-        self.item.diagram.update_now((self.item,))
+        self.item.diagram.update({self.item})
         self.horizontal_button.set_sensitive(active)
 
     @transactional
     def _on_horizontal_change(self, button, gparam):
         self.item.horizontal = button.get_active()
-        self.item.diagram.update_now((self.item,))
+        self.item.diagram.update({self.item})
 
 
 @PropertyPages.register(Element)

--- a/gaphor/diagram/tests/test_presentation.py
+++ b/gaphor/diagram/tests/test_presentation.py
@@ -7,7 +7,7 @@ from gaphor.UML import diagramitems
 
 
 class DummyVisualComponent:
-    def size(self, ctx):
+    def size(self, ctx, bounding_box=None):
         return 0, 0
 
     def draw(self, ctx, bounding_box):

--- a/gaphor/diagram/tests/test_presentation.py
+++ b/gaphor/diagram/tests/test_presentation.py
@@ -71,13 +71,13 @@ def test_element_loading(element_factory, diagram):
     p = diagram.create(StubElement)
 
     p.load("matrix", "(2.0, 0.0, 0.0, 2.0, 0.0, 0.0)")
-    p.load("width", "20")
-    p.load("height", "25")
+    p.load("width", "200")
+    p.load("height", "225")
     p.load("subject", subject)
 
     assert tuple(p.matrix) == (2.0, 0.0, 0.0, 2.0, 0.0, 0.0)
-    assert p.width == 20
-    assert p.height == 25
+    assert p.width == 200
+    assert p.height == 225
     assert p.subject is subject
 
 

--- a/gaphor/diagram/tools/itemtool.py
+++ b/gaphor/diagram/tools/itemtool.py
@@ -7,6 +7,7 @@ from gaphor.diagram.event import DiagramSelectionChanged
 def item_tool(event_manager) -> Gtk.GestureDrag:
     gesture = _item_tool()
     gesture.connect_after("drag-begin", on_drag_begin, event_manager)
+    gesture.connect_after("drag-update", on_drag_update)
     gesture.connect_after("drag-end", on_drag_end)
     return gesture
 
@@ -19,6 +20,12 @@ def on_drag_begin(gesture, _start_x, _start_y, event_manager):
     )
 
 
+def on_drag_update(gesture, _offset_x, _offset_y):
+    view = gesture.get_widget()
+    view.model.update()
+
+
 def on_drag_end(gesture, _offset_x, _offset_y):
     view = gesture.get_widget()
     view.selection.dropzone_item = None
+    view.model.update()

--- a/gaphor/diagram/tools/magnet.py
+++ b/gaphor/diagram/tools/magnet.py
@@ -76,6 +76,7 @@ def on_drag_update(gesture, offset_x, offset_y, drag_state):
         moving.move((x, y))
 
     view.magnet = (drag_state.direction, x, y)
+    view.model.update()
     view.update_back_buffer()
 
 
@@ -92,6 +93,7 @@ def on_drag_end(gesture, offset_x, offset_y, drag_state):
     for moving in drag_state.moving_items:
         moving.stop_move((x + offset_x, y + offset_y))
     drag_state.reset()
+    view.model.update()
     view.update_back_buffer()
     drag_state.event_manager.handle(ToolCompleted())
     with contextlib.suppress(AttributeError):

--- a/gaphor/diagram/tools/placement.py
+++ b/gaphor/diagram/tools/placement.py
@@ -55,6 +55,7 @@ def on_drag_begin(gesture, start_x, start_y, placement_state: PlacementState):
         placement_state.event_manager.handle(DiagramItemPlaced(item))
 
     view.selection.dropzone_item = None
+    view.model.update({item})
 
 
 def create_item(view, factory, event_manager, x, y):
@@ -92,13 +93,13 @@ def connect_opposite_handle(view, new_item, x, y, handle_index):
                 handle_move.connect(vpos)
 
 
-def on_drag_update(gesture, offset_x, offset_y, placement_state):
+def on_drag_update(gesture, offset_x, offset_y, placement_state: PlacementState):
     if placement_state.moving:
         _, x, y = gesture.get_start_point()
         placement_state.moving.move((x + offset_x, y + offset_y))
 
 
-def on_drag_end(gesture, offset_x, offset_y, placement_state):
+def on_drag_end(gesture, offset_x, offset_y, placement_state: PlacementState):
     if placement_state.moving:
         view = gesture.get_widget()
         _, x, y = gesture.get_start_point()
@@ -107,7 +108,7 @@ def on_drag_end(gesture, offset_x, offset_y, placement_state):
         connect_opposite_handle(view, item, x, y, placement_state.handle_index)
         placement_state.event_manager.handle(DiagramItemPlaced(item))
         view.selection.dropzone_item = None
-        view.model.request_update(item)
+        view.model.update({item})
         open_editor(item, view, placement_state.event_manager)
 
 

--- a/gaphor/diagram/tools/placement.py
+++ b/gaphor/diagram/tools/placement.py
@@ -63,7 +63,7 @@ def create_item(view, factory, event_manager, x, y):
     item = factory(view.model, parent)
     x, y = view.get_matrix_v2i(item).transform_point(x, y)
     item.matrix.translate(x, y)
-    view.model.update_now({item})
+    view.model.update({item})
     maybe_group(parent, item)
     selection.unselect_all()
     selection.focused_item = item

--- a/gaphor/plugins/align/align.py
+++ b/gaphor/plugins/align/align.py
@@ -67,7 +67,7 @@ class AlignService(Service, ActionProvider):
 
                 with Transaction(self.event_manager):
                     f(elements)
-                    current_diagram.update_now(current_diagram.get_all_items())
+                    current_diagram.update(set(current_diagram.get_all_items()))
 
 
 def _align_elements_left(elements: set[ElementPresentation]):

--- a/gaphor/plugins/autolayout/pydot.py
+++ b/gaphor/plugins/autolayout/pydot.py
@@ -74,6 +74,7 @@ class AutoLayout:
         graph = diagram_as_pydot(diagram, splines=splines)
         rendered_graph = self.render(graph)
         self.apply_layout(diagram, rendered_graph)
+        diagram.update(set(diagram.get_all_items()))
 
     def render(self, graph: pydot.Dot):
         if self.dump_gv:

--- a/gaphor/plugins/autolayout/pydot.py
+++ b/gaphor/plugins/autolayout/pydot.py
@@ -70,7 +70,7 @@ class AutoLayout:
         self.dump_gv = dump_gv
 
     def layout(self, diagram: Diagram, splines="polyline") -> None:
-        diagram.update_now(diagram.get_all_items())
+        diagram.update(set(diagram.get_all_items()))
         graph = diagram_as_pydot(diagram, splines=splines)
         rendered_graph = self.render(graph)
         self.apply_layout(diagram, rendered_graph)

--- a/gaphor/storage/tests/test_storage.py
+++ b/gaphor/storage/tests/test_storage.py
@@ -182,7 +182,7 @@ def test_save_and_load_of_association_with_two_connected_classes(
     c2 = create(ClassItem, UML.Class)
     c2.matrix.translate(200, 200)
     diagram.request_update(c2)
-    diagram.update_now((c1, c2))
+    diagram.update({c1, c2})
     assert tuple(c2.matrix_i2c) == (1, 0, 0, 1, 200, 200)
 
     a = create(AssociationItem)
@@ -190,7 +190,7 @@ def test_save_and_load_of_association_with_two_connected_classes(
     connect(a, a.head, c1)
     connect(a, a.tail, c2)
 
-    diagram.update_now((c1, c2, a))
+    diagram.update({c1, c2, a})
 
     assert a.head.pos.y == 0, a.head.pos
     assert a.tail.pos.x == 200, a.tail.pos

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -181,7 +181,7 @@ def system_information():
         Pango version:          {Pango.version_string()}
         PyGObject version:      {gi.__version__}
         Pycairo version:        {cairo.version}
-        pygit2/libgit2 version: {"pygit2" in globals() and f"{pygit2.__version__}  / {pygit2.LIBGIT2_VERSION}" or "-NONE-"}
+        pygit2/libgit2 version: {"pygit2" in globals() and f"{pygit2.__version__} / {pygit2.LIBGIT2_VERSION}" or "-NONE-"}
         """
     )
 

--- a/tests/test_auto_layouting.py
+++ b/tests/test_auto_layouting.py
@@ -24,7 +24,7 @@ from hypothesis.strategies import data, integers, sampled_from
 from gaphor.application import Session
 from gaphor.C4Model.toolbox import c4
 from gaphor.core import Transaction
-from gaphor.core.modeling import Diagram, ElementFactory
+from gaphor.core.modeling import Diagram, ElementFactory, Presentation
 from gaphor.core.modeling.element import Element, generate_id, uuid_generator
 from gaphor.diagram.group import can_group, change_owner
 from gaphor.diagram.presentation import LinePresentation
@@ -132,9 +132,9 @@ class AutoLayouting(RuleBasedStateMachine):
     )
     def add_item_to_diagram(self, tooldef, data, x, y):
         with self.transaction:
-            item = tooldef.item_factory(self.diagram)
+            item: Presentation = tooldef.item_factory(self.diagram)
             item.matrix.translate(x, y)
-            self.diagram.update_now({item})
+            self.diagram.update({item})
 
         # Do best effort to connect a line, no problem if it fails
         if isinstance(item, LinePresentation):

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -162,7 +162,7 @@ class ModelConsistency(RuleBasedStateMachine):
         with self.transaction:
             item = tooldef.item_factory(diagram)
             item.matrix.translate(x, y)
-            diagram.update_now({item})
+            diagram.update({item})
 
         # Do best effort to connect a line, no problem if it fails
         if isinstance(item, LinePresentation):

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -348,7 +348,7 @@ def test_reconnect_on_same_element(event_manager, element_factory, undo_manager)
     assert original_handle_pos != new_handle_pos
 
     undo_manager.undo_transaction()
-    diagram.update_now(diagram.ownedPresentation)
+    diagram.update(diagram.ownedPresentation)
 
     assert original_handle_pos == copy_pos(association.head.pos)
 

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -328,11 +328,10 @@ def test_delete_item_with_subject_owning_diagram(
     undo_manager.undo_transaction()
 
 
-def copy_pos(pos):
-    return tuple(map(float, pos))
-
-
 def test_reconnect_on_same_element(event_manager, element_factory, undo_manager):
+    def copy_pos(pos):
+        return tuple(map(float, pos))
+
     with Transaction(event_manager):
         diagram: Diagram = element_factory.create(Diagram)
         klass = element_factory.create(UML.Class)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Spontaneous errors could occur if a diagram was updated. This was because the update happened from within the idle handler of the diagram-view widget.

Some items on a diagram did updates that caused handle positions or the position (matrix) to change.

Issue Number: Fixes #3203. It may also be a fix for #3069.

### What is the new behavior?

Updates do no longer happen from the view. Instead, the application should in time update the diagram state.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

* Take care that updates happen in time, as they do no longer happen automagically.

### Other information

* Association ends are now updated by model changes, no longer in the update method
* Also fixes the hypothesis test command. This was broken when we changed from Xvfb to Mutter.