### PR TITLE
Show element details

### DIFF
--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -797,7 +797,7 @@ NamedElement.clientDependency = association("clientDependency", Dependency, comp
 NamedElement.namespace = derivedunion("namespace", Namespace, upper=1)
 # 68: override NamedElement.qualifiedName: derived[list[str]]
 
-from gaphor.core.modeling.diagram import qualifiedName
+from gaphor.core.modeling import qualifiedName
 
 NamedElement.qualifiedName = derived(
     "qualifiedName",

--- a/gaphor/core/modeling/__init__.py
+++ b/gaphor/core/modeling/__init__.py
@@ -8,7 +8,12 @@ from gaphor.core.modeling.coremodel import (
     RefChange,
     ValueChange,
 )
-from gaphor.core.modeling.diagram import Diagram, DrawContext, UpdateContext
+from gaphor.core.modeling.diagram import (
+    Diagram,
+    DrawContext,
+    UpdateContext,
+    qualifiedName,
+)
 from gaphor.core.modeling.element import Element, self_and_owners
 from gaphor.core.modeling.elementfactory import ElementFactory
 from gaphor.core.modeling.event import *

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -292,7 +292,7 @@ class InternalsPropertyPage(PropertyPageBase):
             presentation_text = textwrap.dedent(
                 f"""\
                 {gettext('Presentation')}:
-                  {gettext('class')}: {type(subject).__module__}.{type(subject).__name__}
+                  {gettext('class')}: {presentation_class(subject)}
                   {gettext('id')}: {subject.id}"""
             )
             element = subject.subject
@@ -304,7 +304,7 @@ class InternalsPropertyPage(PropertyPageBase):
             textwrap.dedent(
                 f"""\
                 {gettext('Model Element')}:
-                  {gettext('class')}: {type(element).__module__}.{type(element).__name__}
+                  {gettext('class')}: {model_element_class(element)}
                   {gettext('id')}: {element.id}"""
             )
             if element
@@ -317,3 +317,21 @@ class InternalsPropertyPage(PropertyPageBase):
             internals.set_label(presentation_text or element_text)
 
         return builder.get_object("internals-editor")
+
+
+def presentation_class(subject):
+    t = type(subject)
+    if t.__module__.startswith("gaphor.UML."):
+        return f"gaphor.UML.diagramitems.{t.__name__}"
+    elif t.__module__.startswith("gaphor.SysML."):
+        return f"gaphor.SysML.diagramitems.{t.__name__}"
+    elif t.__module__.startswith("gaphor.RAAML."):
+        return f"gaphor.RAAML.diagramitems.{t.__name__}"
+    return f"{t.__module__}.{t.__name__}"
+
+
+def model_element_class(subject):
+    t = type(subject)
+    if t.__module__ == "gaphor.UML.uml":
+        return f"gaphor.UML.{t.__name__}"
+    return f"{t.__module__}.{t.__name__}"

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -15,7 +15,7 @@ from gaphas.segment import Segment
 from gi.repository import GObject, Gtk
 
 from gaphor.core import transactional
-from gaphor.core.modeling import Diagram, Element, Presentation
+from gaphor.core.modeling import Diagram, Element, Presentation, qualifiedName
 from gaphor.i18n import gettext, translated_ui_string
 
 
@@ -304,6 +304,7 @@ class InternalsPropertyPage(PropertyPageBase):
             textwrap.dedent(
                 f"""\
                 {gettext('Model Element')}:
+                  {gettext('qname')}: {'.'.join(qualifiedName(element))}
                   {gettext('class')}: {model_element_class(element)}
                   {gettext('id')}: {element.id}"""
             )

--- a/gaphor/diagram/propertypages.ui
+++ b/gaphor/diagram/propertypages.ui
@@ -141,9 +141,6 @@
     </style>
   </object>
 
-
-
-
   <object class="GtkBox" id="metadata-editor">
     <property name="orientation">vertical</property>
     <child>
@@ -272,6 +269,45 @@
       <object class="GtkButton">
         <property name="label" translatable="yes">Set default size</property>
         <signal name="clicked" handler="set-default-size" swapped="no"/>
+      </object>
+    </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+  <object class="GtkBox" id="internals-editor">
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">Internals of focused item</property>
+        <property name="xalign">0</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkFrame">
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="vscrollbar-policy">never</property>
+            <property name="child">
+              <object class="GtkLabel" id="internals">
+                <property name="use-markup">1</property>
+                <property name="wrap">0</property>
+                <property name="selectable">1</property>
+                <property name="label" translatable="yes">No focused item.</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
+                <style>
+                  <class name="mono" />
+                  <class name="internals-label" />
+                </style>
+              </object>
+            </property>
+          </object>
+        </child>
       </object>
     </child>
     <style>

--- a/gaphor/diagram/tests/test_propertypages.py
+++ b/gaphor/diagram/tests/test_propertypages.py
@@ -1,6 +1,7 @@
 from gaphor.core.modeling import Comment, Diagram
 from gaphor.diagram.general import CommentItem, Line
 from gaphor.diagram.propertypages import (
+    InternalsPropertyPage,
     LineStylePage,
     NamePropertyPage,
     NotePropertyPage,
@@ -67,3 +68,15 @@ def test_note_page_with_subject(element_factory):
     note.get_buffer().set_text("A new note")
 
     assert comment.note == "A new note"
+
+
+def test_internals_page_for_presentation(create):
+    subject = create(CommentItem, Comment)
+    property_page = InternalsPropertyPage(subject)
+    widget = property_page.construct()
+
+    internals = find(widget, "internals")
+    text = internals.get_label()
+
+    assert "CommentItem" in text
+    assert "gaphor.core.modeling.coremodel.Comment" in text

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -65,6 +65,7 @@ flowboxchild {
   margin-top: 6px;
 }
 
+frame .internals-label,
 frame > textview {
   padding: 6px;
 }

--- a/models/UML.override
+++ b/models/UML.override
@@ -67,7 +67,7 @@ Constraint.context = derivedunion('context', Namespace, 0, 1)
 %%
 override NamedElement.qualifiedName: derived[list[str]]
 
-from gaphor.core.modeling.diagram import qualifiedName
+from gaphor.core.modeling import qualifiedName
 
 NamedElement.qualifiedName = derived(
     "qualifiedName",


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Issue Number: Fixes #2750 

### What is the new behavior?

A section at the bottom of the property editor shows some details about the selected item:

<img width="1274" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/3ce15d9a-0831-489c-a395-f6c00708d38a">
