### PR TITLE
Fix #2736 & #3154: Cancelling the relationship connection

### DIFF
--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -75,6 +75,9 @@ class HandlePositionEvent(RevertibleEvent):
 
 
 class HandlePositionUpdate:
+
+    _lastHandleMoved = None
+
     def watch_handle(self, handle):
         handle.pos.add_handler(self._on_handle_position_update)
 
@@ -85,6 +88,7 @@ class HandlePositionUpdate:
         for handle in self.handles():  # type: ignore[attr-defined]
             if handle.pos is position:
                 self.handle(HandlePositionEvent(self, handle, old))  # type: ignore[attr-defined]
+                self._lastHandleMoved = handle
                 break
 
 
@@ -226,6 +230,8 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
 
         self.watch_handle(self.head)
         self.watch_handle(self.tail)
+
+        self._has_been_dropped = False
 
     head = property(lambda self: self._handles[0])
     tail = property(lambda self: self._handles[-1])

--- a/gaphor/diagram/tools/itemtool.py
+++ b/gaphor/diagram/tools/itemtool.py
@@ -2,6 +2,7 @@ from gaphas.tool import item_tool as _item_tool
 from gi.repository import Gtk
 
 from gaphor.diagram.event import DiagramSelectionChanged
+from gaphor.diagram.presentation import LinePresentation
 
 
 def item_tool(event_manager) -> Gtk.GestureDrag:
@@ -21,4 +22,8 @@ def on_drag_begin(gesture, _start_x, _start_y, event_manager):
 
 def on_drag_end(gesture, _offset_x, _offset_y):
     view = gesture.get_widget()
+    for i in view.selection.selected_items:
+        if isinstance(i, LinePresentation):
+            i._lastHandleMoved = None 
+            i._has_been_dropped = True
     view.selection.dropzone_item = None

--- a/gaphor/diagram/tools/tests/test_shortcut.py
+++ b/gaphor/diagram/tools/tests/test_shortcut.py
@@ -1,8 +1,24 @@
 from gaphas.selection import Selection
 
 from gaphor import UML
-from gaphor.diagram.tools.shortcut import delete_selected_items
+from gaphor.diagram.diagramtoolbox import new_item_factory
+from gaphor.diagram.tools import itemtool
+from gaphor.diagram.tools.shortcut import delete_selected_items, unselect 
 from gaphor.UML.diagramitems import PackageItem
+from gaphor.diagram.general import CommentItem, CommentLineItem
+from gaphor.core.modeling import Comment
+from gaphor.diagram.connectors import ItemDisconnected
+from gaphor.diagram.tests.fixtures import connect
+from gaphor.core import event_handler
+from gaphor.diagram.tools.placement import (
+    PlacementState,
+    on_drag_begin,
+    on_drag_end,
+    on_drag_update,
+    placement_tool,
+)
+from gaphor.diagram.tools.itemtool import item_tool, on_drag_end as item_tool
+
 
 
 class MockView:
@@ -30,3 +46,63 @@ def test_delete_selected_owner(create, diagram, event_manager):
 
     assert not diagram.ownedPresentation
     assert diagram.element is None
+
+
+def test_unselect_item_from_drop(create, event_manager, view):
+    comment = create(CommentItem, element_class=Comment)
+    tool =  itemtool.item_tool(event_manager)
+    line = create(CommentLineItem)
+    connect(line, line.handles()[0], comment)
+    view.selection.select_items(line)
+    view.add_controller(tool)
+
+    events = []
+
+    @event_handler(ItemDisconnected)
+    def handler(e):
+        events.append(e)
+
+    event_manager.subscribe(handler)
+
+    itemtool.on_drag_end(tool, 0, 0)
+
+    unselect(view, event_manager)
+
+    assert len(view.selection.selected_items) == 0
+    assert not events
+
+def test_cancel_line(create, event_manager, view):
+    comment = create(CommentItem, element_class=Comment)
+    factory = new_item_factory(CommentLineItem)
+    state = PlacementState(factory, event_manager, handle_index=-1)
+    tool_placement = placement_tool(factory, event_manager, handle_index=-1)
+    view.add_controller(tool_placement)
+
+    on_drag_begin(tool_placement, 2, 1, state)
+
+    tool = itemtool.item_tool(event_manager)
+    view.add_controller(tool)
+
+    line = next(iter(view.selection.selected_items))
+    connect(line, line.handles()[0], comment)
+
+
+    events = []
+
+    @event_handler(ItemDisconnected)
+    def handler(e):
+        events.append(e)
+
+    event_manager.subscribe(handler)
+
+    itemtool.on_drag_end(tool, 3, 2)
+
+    on_drag_update(tool_placement, 1,1,state)
+
+    on_drag_end(tool_placement, 0,0,state)
+
+
+    unselect(view, event_manager)
+
+    assert len(view.selection.selected_items) == 0
+    assert events


### PR DESCRIPTION
When pressing Esc while drawing a relationship caused an exception instead of cancelling the animation.

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
When the user presses Esc while connecting any 2 elements with a relationship the Pointer shortcut is invoked and nothing is done to handle the key pressed, so when we already have a relationship established and press Esc while disconnecting one of the handles nothing happens to the relationship and the handle continues to be red. 

Issue Number: 2736 & 3154

### What is the new behavior?
Now when we press Esc we invoke a handler that will check if the handle we were moving is connected or not, if it is not then we disconnect that handle and we unselect the connection, if it is connected or the selected object is not a connection we just unselect it. The key aspect is that this handle is called before we invoke the Pointer shortcut. 

### Does this PR introduce a breaking change?
- [ ] Yes
- [ x] No

