### PR TITLE
More fixes for broken updates

### DIFF
--- a/gaphor/UML/actions/partitionpage.py
+++ b/gaphor/UML/actions/partitionpage.py
@@ -123,4 +123,5 @@ class PartitionPropertyPage(PropertyPageBase):
             last_child = self.partitions.get_last_child()
             self.partitions.remove(last_child)
 
-        self.item.diagram.update(self.item.diagram.ownedPresentation)
+        diagram = self.item.diagram
+        diagram.update(diagram.ownedPresentation)

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -301,7 +301,6 @@ class ShowAttributesPage(PropertyPageBase):
     @transactional
     def on_show_attributes_changed(self, button, gparam):
         self.item.show_attributes = button.get_active()
-        self.item.request_update()
 
 
 class OperationView(GObject.Object):
@@ -487,7 +486,6 @@ class ShowOperationsPage(PropertyPageBase):
     @transactional
     def on_show_operations_changed(self, button, gparam):
         self.item.show_operations = button.get_active()
-        self.item.request_update()
 
 
 @PropertyPages.register(UML.Component)

--- a/gaphor/UML/classes/enumerationpropertypages.py
+++ b/gaphor/UML/classes/enumerationpropertypages.py
@@ -169,4 +169,3 @@ class ShowEnumerationPage(PropertyPageBase):
     @transactional
     def on_show_enumerations_changed(self, button, gparam):
         self.item.show_enumerations = button.get_active()
-        self.item.request_update()

--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -39,14 +39,14 @@ class SanitizerService(Service):
         self.undo_manager = undo_manager
 
         event_manager.subscribe(self._unlink_on_subject_delete)
-        event_manager.subscribe(self.update_annotated_element_link)
+        event_manager.subscribe(self._update_annotated_element_link)
         event_manager.subscribe(self._unlink_on_extension_delete)
         event_manager.subscribe(self._redraw_diagram_on_move)
 
     def shutdown(self):
         event_manager = self.event_manager
         event_manager.unsubscribe(self._unlink_on_subject_delete)
-        event_manager.unsubscribe(self.update_annotated_element_link)
+        event_manager.unsubscribe(self._update_annotated_element_link)
         event_manager.unsubscribe(self._unlink_on_extension_delete)
         event_manager.unsubscribe(self._redraw_diagram_on_move)
 
@@ -78,7 +78,7 @@ class SanitizerService(Service):
 
     @event_handler(AssociationSet)
     @undo_guard
-    def update_annotated_element_link(self, event):
+    def _update_annotated_element_link(self, event):
         """Link comment and element if a comment line is present, but comment
         and element subject are not connected yet."""
         if event.property is not Presentation.subject:  # type: ignore[misc]

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -26,7 +26,11 @@ from gaphor.core.modeling.element import (
     generate_id,
     self_and_owners,
 )
-from gaphor.core.modeling.event import AssociationAdded, AssociationDeleted
+from gaphor.core.modeling.event import (
+    AssociationAdded,
+    AssociationDeleted,
+    DiagramUpdateRequested,
+)
 from gaphor.core.modeling.presentation import Presentation
 from gaphor.core.modeling.properties import (
     association,
@@ -469,6 +473,7 @@ class Diagram(Element):
         """
         if item in self.ownedPresentation:
             self._update_dirty_items(dirty_items={item})
+        self.handle(DiagramUpdateRequested(self))
 
     def update_now(self, _dirty_items: Collection[Presentation]) -> None:
         pass
@@ -486,6 +491,7 @@ class Diagram(Element):
         if removed_items:
             self._dirty_items.difference_update(removed_items)
 
+        # We can directly request updates on the view, since those happen asynchronously
         for v in self._registered_views:
             v.request_update(dirty_items, removed_items)
 

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -250,3 +250,13 @@ class ModelFlushed(ServiceEvent):
         the factory.
         """
         super().__init__(service)
+
+
+class DiagramUpdateRequested:
+    """Event fired when a diagram needs updating.
+
+    Instead of updating directly, this event is emited so
+    diagrams can be updated in bulk."""
+
+    def __init__(self, diagram):
+        self.diagram = diagram

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -36,9 +36,8 @@ class Presentation(Matrices, Element, Generic[S]):
         self.diagram = diagram
         self._original_diagram: Diagram | None = diagram
 
-        def update(event):
-            if self.diagram:
-                self.diagram.update({self})
+        def update(_event):
+            self.request_update()
 
         self._watcher = self.watcher(default_handler=update)
         self.watch("subject")

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -217,13 +217,13 @@ class LineStylePage(PropertyPageBase):
             line_segment.split_segment(0)
         active = button.get_active()
         self.item.orthogonal = active
-        self.item.diagram.update({self.item})
+        self.item.request_update()
         self.horizontal_button.set_sensitive(active)
 
     @transactional
     def _on_horizontal_change(self, button, gparam):
         self.item.horizontal = button.get_active()
-        self.item.diagram.update({self.item})
+        self.item.request_update()
 
 
 @PropertyPages.register(Element)

--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -197,8 +197,7 @@ class DiagramPage:
         ):
             self.update_drawing_style()
 
-            diagram = self.diagram
-            diagram.update(diagram.ownedPresentation)
+            self.diagram.update(self.diagram.ownedPresentation)
         elif event.property is Diagram.name and self.view:
             self.view.update_back_buffer()
 

--- a/gaphor/ui/diagrams.py
+++ b/gaphor/ui/diagrams.py
@@ -10,13 +10,14 @@ from gaphor.core import action, event_handler
 from gaphor.core.modeling import (
     AttributeUpdated,
     Diagram,
+    DiagramUpdateRequested,
     ModelFlushed,
     ModelReady,
     StyleSheet,
 )
 from gaphor.diagram.drop import drop
 from gaphor.diagram.event import DiagramOpened, DiagramSelectionChanged
-from gaphor.event import ActionEnabled
+from gaphor.event import ActionEnabled, TransactionCommit
 from gaphor.i18n import translated_ui_string
 from gaphor.transaction import Transaction
 from gaphor.ui.abc import UIComponent
@@ -47,6 +48,7 @@ class Diagrams(UIComponent, ActionProvider):
         self.toolbox = toolbox
         self._notebook: Gtk.Widget = None
         self._page_handler_ids: list[int] = []
+        self._to_be_updated_diagrams = set()
 
     def open(self):
         """Open the diagrams component."""
@@ -74,12 +76,16 @@ class Diagrams(UIComponent, ActionProvider):
         self.event_manager.subscribe(self._on_name_change)
         self.event_manager.subscribe(self._on_flush_model)
         self.event_manager.subscribe(self._on_model_ready)
+        self.event_manager.subscribe(self._diagram_update_requested)
+        self.event_manager.subscribe(self._on_update_diagrams)
 
         self._on_model_ready()
         return self._stack
 
     def close(self):
         """Close the diagrams component."""
+        self.event_manager.unsubscribe(self._on_update_diagrams)
+        self.event_manager.unsubscribe(self._diagram_update_requested)
         self.event_manager.unsubscribe(self._on_model_ready)
         self.event_manager.unsubscribe(self._on_flush_model)
         self.event_manager.unsubscribe(self._on_name_change)
@@ -393,6 +399,16 @@ class Diagrams(UIComponent, ActionProvider):
                 if widget is self._notebook.get_selected_page():
                     self.event_manager.handle(CurrentDiagramChanged(event.element))
                 return
+
+    @event_handler(DiagramUpdateRequested)
+    def _diagram_update_requested(self, event: DiagramUpdateRequested):
+        self._to_be_updated_diagrams.add(event.diagram)
+
+    @event_handler(TransactionCommit)
+    def _on_update_diagrams(self, event):
+        for diagram in self._to_be_updated_diagrams:
+            diagram.update()
+        self._to_be_updated_diagrams.clear()
 
 
 def apply_tool_select_controller(widget, toolbox):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The new update model is still not fool proof. Mostly updates coming from changes in the model are not always reflected in the diagrams.

The main issue is that I'd like to batch updates, but those update do have to happen within the context of the current transaction. Ergo, they can not happen completely asynchronous (as was the case previously).

Just requesting an update is not enough.

This is now solved by updating directly after an update request is done. This has the possible risk of doing double work. However, it's our only guarantee at the moment to make sure the diagrams are up to date.


Issue Number: N/A

### What is the new behavior?

The `request_update()` methods still schedule a diagram item for an update. The update now happens when a transaction is committed.

To ensure that the transaction is not closed directly, the Undo Manager schedules a new event to close the commit.

This only works when working with diagrams interactively. If diagrams are changed programmatically, `Diagram.update()` needs to be called explictly.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

 * Removed some redundant update requests.