### PR TITLE
Cleanup some encoding warnings

### DIFF
--- a/gaphor/ui/tests/test_filemanager.py
+++ b/gaphor/ui/tests/test_filemanager.py
@@ -89,7 +89,7 @@ def test_notify_changes(
     notified = False
     event_manager.subscribe(on_changed_on_disk)
 
-    out_file.write_text("a")
+    out_file.write_text("a", encoding="utf-8")
     iteration(lambda: notified)
 
     assert notified

--- a/gaphor/ui/tests/test_modelchanged.py
+++ b/gaphor/ui/tests/test_modelchanged.py
@@ -20,13 +20,13 @@ def test_create_ui(event_manager):
 
 def test_monitor_file_changed(event_manager, tmp_path):
     new_file = tmp_path / "new_file"
-    new_file.write_text("a")
+    new_file.write_text("a", encoding="utf-8")
 
     model_changed = ModelChanged(event_manager)
     widget = model_changed.open()
     event_manager.handle(ModelChangedOnDisk(model_changed, new_file))
 
-    new_file.write_text("b")
+    new_file.write_text("b", encoding="utf-8")
     iteration()
 
     assert widget.get_revealed()


### PR DESCRIPTION
Fixes a few encoding warnings recently introduced in the tests. There is a ruff rule for this called [PLW1514](https://docs.astral.sh/ruff/rules/unspecified-encoding/), but it is only available if preview rules are enabled.


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
