### PR TITLE
Control visibility of requirements

### DIFF
--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -78,7 +78,7 @@ class RequirementPropertyPage(PropertyPageBase):
         self.subject.externalId = entry.get_text()
 
     @transactional
-    def _on_show_text_change(self, button, gparam):
+    def _on_show_text_change(self, button):
         self.item.show_text = button.get_active()
 
     @transactional

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -36,10 +36,14 @@ class RequirementPropertyPage(PropertyPageBase):
     def __init__(self, item):
         super().__init__()
         self.item = item
-        self.subject = item.subject
-        self.watcher = item.subject.watcher()
 
     def construct(self):
+        if not self.item.subject:
+            return
+
+        subject = self.item.subject
+        watcher = subject.watcher()
+
         builder = new_builder(
             "requirement-editor",
             "requirement-text-buffer",
@@ -48,10 +52,8 @@ class RequirementPropertyPage(PropertyPageBase):
                 "requirement-id-changed": (self._on_id_changed,),
             },
         )
-        subject = self.subject
-
         entry = builder.get_object("requirement-id")
-        entry.set_text(subject.externalId or "")
+        entry.set_text(self.item.subject.externalId or "")
 
         text_view = builder.get_object("requirement-text")
 
@@ -67,15 +69,15 @@ class RequirementPropertyPage(PropertyPageBase):
             if not text_view.props.has_focus:
                 buffer.set_text(event.new_value)
 
-        self.watcher.watch("text", text_handler)
+        watcher.watch("text", text_handler)
 
         return unsubscribe_all_on_destroy(
-            builder.get_object("requirement-editor"), self.watcher
+            builder.get_object("requirement-editor"), watcher
         )
 
     @transactional
     def _on_id_changed(self, entry):
-        self.subject.externalId = entry.get_text()
+        self.item.subject.externalId = entry.get_text()
 
     @transactional
     def _on_show_text_change(self, button, gparam):
@@ -83,7 +85,7 @@ class RequirementPropertyPage(PropertyPageBase):
 
     @transactional
     def _on_text_changed(self, buffer):
-        self.subject.text = buffer.get_text(
+        self.item.subject.text = buffer.get_text(
             buffer.get_start_iter(), buffer.get_end_iter(), False
         )
 

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -43,6 +43,7 @@ class RequirementPropertyPage(PropertyPageBase):
             "requirement-editor",
             "requirement-text-buffer",
             signals={
+                "show-requirement-text-changed": (self._on_show_text_change,),
                 "requirement-id-changed": (self._on_id_changed,),
             },
         )
@@ -56,6 +57,9 @@ class RequirementPropertyPage(PropertyPageBase):
         buffer = builder.get_object("requirement-text-buffer")
         if subject.text:
             buffer.set_text(subject.text)
+
+        show_requirement_text = builder.get_object("show-requirement-text")
+        show_requirement_text.set_active(self.subject.showText)
 
         @handler_blocking(buffer, "changed", self._on_text_changed)
         def text_handler(event):
@@ -71,6 +75,10 @@ class RequirementPropertyPage(PropertyPageBase):
     @transactional
     def _on_id_changed(self, entry):
         self.subject.externalId = entry.get_text()
+
+    @transactional
+    def _on_show_text_change(self, button, gparam):
+        self.subject.showText = button.get_active()
 
     @transactional
     def _on_text_changed(self, buffer):

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -14,6 +14,7 @@ from gaphor.SysML.blocks.block import BlockItem
 from gaphor.SysML.blocks.interfaceblock import InterfaceBlockItem
 from gaphor.SysML.blocks.property import PropertyItem
 from gaphor.SysML.blocks.proxyport import ProxyPortItem
+from gaphor.SysML.requirements import RequirementItem
 from gaphor.UML.classes.classespropertypages import (
     ATTRIBUTES_PAGE_CLASSIFIERS,
     OPERATIONS_PAGE_CLASSIFIERS,
@@ -28,15 +29,15 @@ from gaphor.UML.propertypages import (
 new_builder = new_resource_builder("gaphor.SysML")
 
 
-@PropertyPages.register(sysml.Requirement)
+@PropertyPages.register(RequirementItem)
 class RequirementPropertyPage(PropertyPageBase):
     order = 15
 
-    def __init__(self, subject: sysml.Requirement):
+    def __init__(self, item):
         super().__init__()
-        assert subject
-        self.subject = subject
-        self.watcher = subject.watcher()
+        self.item = item
+        self.subject = item.subject
+        self.watcher = item.subject.watcher()
 
     def construct(self):
         builder = new_builder(
@@ -59,7 +60,7 @@ class RequirementPropertyPage(PropertyPageBase):
             buffer.set_text(subject.text)
 
         show_requirement_text = builder.get_object("show-requirement-text")
-        show_requirement_text.set_active(self.subject.showText)
+        show_requirement_text.set_active(self.item.show_text)
 
         @handler_blocking(buffer, "changed", self._on_text_changed)
         def text_handler(event):
@@ -78,7 +79,7 @@ class RequirementPropertyPage(PropertyPageBase):
 
     @transactional
     def _on_show_text_change(self, button, gparam):
-        self.subject.showText = button.get_active()
+        self.item.show_text = button.get_active()
 
     @transactional
     def _on_text_changed(self, buffer):

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -78,7 +78,7 @@ class RequirementPropertyPage(PropertyPageBase):
         self.subject.externalId = entry.get_text()
 
     @transactional
-    def _on_show_text_change(self, button):
+    def _on_show_text_change(self, button, gparam):
         self.item.show_text = button.get_active()
 
     @transactional

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -244,6 +244,22 @@
         </child>
       </object>
     </child>
+    <child>
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Show text</property>
+            <property name="halign">start</property>
+            <property name="hexpand">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show-requirement-text">
+            <signal name="notify::active" handler="show-requirement-text-changed" swapped="no"/>
+          </object>
+        </child>
+      </object>
+    </child>
     <style>
       <class name="propertypage"/>
     </style>

--- a/gaphor/SysML/propertypages.ui
+++ b/gaphor/SysML/propertypages.ui
@@ -244,6 +244,13 @@
         </child>
       </object>
     </child>
+    <style>
+      <class name="propertypage"/>
+    </style>
+  </object>
+
+  <object class="GtkBox" id="requirement-item-editor">
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
         <child>

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -1,5 +1,6 @@
 from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.presentation import (
+    RESET_HEIGHT,
     Classified,
     ElementPresentation,
 )
@@ -47,6 +48,8 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
     show_operations: attribute[int] = attribute("show_operations", int, default=False)
 
     def update_shapes(self, event=None):
+        # reset height so requirement block is reduced to minimum required height
+        self.height = RESET_HEIGHT
         self.shape = Box(
             name_compartment(self, lambda: [self.diagram.gettext("requirement")]),
             *(

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -28,18 +28,20 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("show_stereotypes", self.update_shapes).watch(
-            "show_attributes", self.update_shapes
-        ).watch("show_operations", self.update_shapes).watch(
-            "subject[NamedElement].name"
-        ).watch("subject[NamedElement].namespace.name").watch(
-            "subject[Classifier].isAbstract", self.update_shapes
-        ).watch("subject[AbstractRequirement].externalId", self.update_shapes).watch(
-            "subject[AbstractRequirement].text", self.update_shapes
-        ).watch("subject[AbstractRequirement].showText", self.update_shapes)
+        self.watch("show_text", self.update_shapes).watch(
+            "show_stereotypes", self.update_shapes
+        ).watch("show_attributes", self.update_shapes).watch(
+            "show_operations", self.update_shapes
+        ).watch("subject[NamedElement].name").watch(
+            "subject[NamedElement].namespace.name"
+        ).watch("subject[Classifier].isAbstract", self.update_shapes).watch(
+            "subject[AbstractRequirement].externalId", self.update_shapes
+        ).watch("subject[AbstractRequirement].text", self.update_shapes)
         attribute_watches(self, "Requirement")
         operation_watches(self, "Requirement")
         stereotype_watches(self)
+
+    show_text: attribute[int] = attribute("show_text", int, default=True)
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)
 
@@ -71,7 +73,7 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
 
     def id_and_text_compartment(self):
         subject = self.subject
-        if subject and (subject.externalId or (subject.text and subject.showText)):
+        if subject and (subject.externalId or (subject.text and self.show_text)):
             return CssNode(
                 "compartment",
                 self.subject,
@@ -93,7 +95,7 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
                                 "text", None, Text(text=lambda: f"Text: {subject.text}")
                             )
                         ]
-                        if subject and subject.text and subject.showText
+                        if subject and subject.text and self.show_text
                         else []
                     ),
                     draw=draw_top_separator,

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -35,7 +35,7 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
             "subject[Classifier].isAbstract", self.update_shapes
         ).watch("subject[AbstractRequirement].externalId", self.update_shapes).watch(
             "subject[AbstractRequirement].text", self.update_shapes
-        )
+        ).watch("subject[AbstractRequirement].showText", self.update_shapes)
         attribute_watches(self, "Requirement")
         operation_watches(self, "Requirement")
         stereotype_watches(self)
@@ -68,7 +68,7 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
 
     def id_and_text_compartment(self):
         subject = self.subject
-        if subject and (subject.externalId or subject.text):
+        if subject and (subject.externalId or (subject.text and subject.showText)):
             return CssNode(
                 "compartment",
                 self.subject,
@@ -90,7 +90,7 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
                                 "text", None, Text(text=lambda: f"Text: {subject.text}")
                             )
                         ]
-                        if subject and subject.text
+                        if subject and subject.text and subject.showText
                         else []
                     ),
                     draw=draw_top_separator,

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -1,6 +1,6 @@
 from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.presentation import (
-    RESET_HEIGHT,
+    DEFAULT_HEIGHT,
     Classified,
     ElementPresentation,
 )
@@ -51,7 +51,7 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
 
     def update_shapes(self, event=None):
         # reset height so requirement block is reduced to minimum required height
-        self.height = RESET_HEIGHT
+        self.height = DEFAULT_HEIGHT
         self.shape = Box(
             name_compartment(self, lambda: [self.diagram.gettext("requirement")]),
             *(

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -32,6 +32,7 @@ class AbstractRequirement(NamedElement):
     master: derived[AbstractRequirement]
     refinedBy: derived[NamedElement]
     satisfiedBy: derived[NamedElement]
+    showText: _attribute[int] = _attribute("showText", int, 1)
     text: _attribute[str] = _attribute("text", str)
     tracedTo: derived[NamedElement]
     verifiedBy: derived[NamedElement]

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -32,7 +32,6 @@ class AbstractRequirement(NamedElement):
     master: derived[AbstractRequirement]
     refinedBy: derived[NamedElement]
     satisfiedBy: derived[NamedElement]
-    showText: _attribute[int] = _attribute("showText", int, 1)
     text: _attribute[str] = _attribute("text", str)
     tracedTo: derived[NamedElement]
     verifiedBy: derived[NamedElement]

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -1,6 +1,7 @@
 import pytest
 
 from gaphor import UML, SysML
+from gaphor.diagram.presentation import RESET_HEIGHT
 from gaphor.diagram.propertypages import PropertyPages
 from gaphor.diagram.tests.fixtures import find
 from gaphor.SysML.propertypages import (
@@ -55,6 +56,33 @@ def test_requirement_property_page_text(diagram, element_factory):
     requirement_text.get_buffer().set_text("test")
 
     assert item.subject.text == "test"
+
+
+def test_requirement_property_page_show_text(diagram, element_factory):
+    item = diagram.create(
+        SysML.requirements.RequirementItem,
+        subject=element_factory.create(SysML.sysml.Requirement),
+    )
+    property_page = RequirementPropertyPage(item)
+
+    widget = property_page.construct()
+    show_requirement_text = find(widget, "show-requirement-text")
+
+    assert item.show_text
+    show_requirement_text.set_active(False)
+    assert ~item.show_text
+
+
+def test_requirement_height_reset(diagram, element_factory):
+    item = diagram.create(
+        SysML.requirements.RequirementItem,
+        subject=element_factory.create(SysML.sysml.Requirement),
+    )
+    item.height = 500
+    assert item.height == 500
+
+    item.subject.text = "test"
+    assert item.height == RESET_HEIGHT
 
 
 def test_show_property_type_property_page_show_type(diagram, element_factory):

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -8,6 +8,7 @@ from gaphor.SysML.propertypages import (
     CompartmentPage,
     ItemFlowPropertyPage,
     PropertyAggregationPropertyPage,
+    RequirementItemPropertyPage,
     RequirementPropertyPage,
 )
 from gaphor.UML.propertypages import (
@@ -30,32 +31,26 @@ def connector(element_factory):
     return UML.recipes.create_connector(prop_a, prop_b)
 
 
-def test_requirement_property_page_id(diagram, element_factory):
-    item = diagram.create(
-        SysML.requirements.RequirementItem,
-        subject=element_factory.create(SysML.sysml.Requirement),
-    )
-    property_page = RequirementPropertyPage(item)
+def test_requirement_property_page_id(element_factory):
+    subject = element_factory.create(SysML.sysml.Requirement)
+    property_page = RequirementPropertyPage(subject)
 
     widget = property_page.construct()
     requirement_id = find(widget, "requirement-id")
     requirement_id.set_text("test")
 
-    assert item.subject.externalId == "test"
+    assert subject.externalId == "test"
 
 
-def test_requirement_property_page_text(diagram, element_factory):
-    item = diagram.create(
-        SysML.requirements.RequirementItem,
-        subject=element_factory.create(SysML.sysml.Requirement),
-    )
-    property_page = RequirementPropertyPage(item)
+def test_requirement_property_page_text(element_factory):
+    subject = element_factory.create(SysML.sysml.Requirement)
+    property_page = RequirementPropertyPage(subject)
 
     widget = property_page.construct()
     requirement_text = find(widget, "requirement-text")
     requirement_text.get_buffer().set_text("test")
 
-    assert item.subject.text == "test"
+    assert subject.text == "test"
 
 
 def test_requirement_property_page_show_text(diagram, element_factory):
@@ -63,7 +58,7 @@ def test_requirement_property_page_show_text(diagram, element_factory):
         SysML.requirements.RequirementItem,
         subject=element_factory.create(SysML.sysml.Requirement),
     )
-    property_page = RequirementPropertyPage(item)
+    property_page = RequirementItemPropertyPage(item)
 
     widget = property_page.construct()
     show_requirement_text = find(widget, "show-requirement-text")

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -1,7 +1,7 @@
 import pytest
 
 from gaphor import UML, SysML
-from gaphor.diagram.presentation import RESET_HEIGHT
+from gaphor.diagram.presentation import DEFAULT_HEIGHT
 from gaphor.diagram.propertypages import PropertyPages
 from gaphor.diagram.tests.fixtures import find
 from gaphor.SysML.propertypages import (
@@ -77,7 +77,7 @@ def test_requirement_height_reset(diagram, element_factory):
     assert item.height == 500
 
     item.subject.text = "test"
-    assert item.height == RESET_HEIGHT
+    assert item.height == DEFAULT_HEIGHT
 
 
 def test_show_property_type_property_page_show_type(diagram, element_factory):

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -29,26 +29,32 @@ def connector(element_factory):
     return UML.recipes.create_connector(prop_a, prop_b)
 
 
-def test_requirement_property_page_id(element_factory):
-    subject = element_factory.create(SysML.sysml.Requirement)
-    property_page = RequirementPropertyPage(subject)
+def test_requirement_property_page_id(diagram, element_factory):
+    item = diagram.create(
+        SysML.requirements.RequirementItem,
+        subject=element_factory.create(SysML.sysml.Requirement),
+    )
+    property_page = RequirementPropertyPage(item)
 
     widget = property_page.construct()
     requirement_id = find(widget, "requirement-id")
     requirement_id.set_text("test")
 
-    assert subject.externalId == "test"
+    assert item.subject.externalId == "test"
 
 
 def test_requirement_property_page_text(diagram, element_factory):
-    subject = element_factory.create(SysML.sysml.Requirement)
-    property_page = RequirementPropertyPage(subject)
+    item = diagram.create(
+        SysML.requirements.RequirementItem,
+        subject=element_factory.create(SysML.sysml.Requirement),
+    )
+    property_page = RequirementPropertyPage(item)
 
     widget = property_page.construct()
     requirement_text = find(widget, "requirement-text")
     requirement_text.get_buffer().set_text("test")
 
-    assert subject.text == "test"
+    assert item.subject.text == "test"
 
 
 def test_show_property_type_property_page_show_type(diagram, element_factory):

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -18,6 +18,9 @@ from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.shapes import CssNode, Shape, Text, stroke, traverse_css_nodes
 from gaphor.diagram.text import TextAlign, middle_segment, text_point_at_line
 
+RESET_HEIGHT = 50
+RESET_WIDTH = 100
+
 
 class Named:
     """Marker for any NamedElement presentations."""
@@ -106,8 +109,8 @@ class ElementPresentation(gaphas.Element, HandlePositionUpdate, Presentation[S])
         diagram: Diagram,
         id: Id | None = None,
         shape: Shape | None = None,
-        width=100,
-        height=50,
+        width=RESET_WIDTH,
+        height=RESET_HEIGHT,
     ):
         super().__init__(
             connections=diagram.connections,

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -18,8 +18,8 @@ from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.shapes import CssNode, Shape, Text, stroke, traverse_css_nodes
 from gaphor.diagram.text import TextAlign, middle_segment, text_point_at_line
 
-RESET_HEIGHT = 50
-RESET_WIDTH = 100
+DEFAULT_HEIGHT = 50
+DEFAULT_WIDTH = 100
 
 
 class Named:
@@ -109,8 +109,8 @@ class ElementPresentation(gaphas.Element, HandlePositionUpdate, Presentation[S])
         diagram: Diagram,
         id: Id | None = None,
         shape: Shape | None = None,
-        width=RESET_WIDTH,
-        height=RESET_HEIGHT,
+        width=DEFAULT_WIDTH,
+        height=DEFAULT_HEIGHT,
     ):
         super().__init__(
             connections=diagram.connections,


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->
PR that addresses feature request to support controlling visibility of requirement's text

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

Additionally:
- [x] I have added unit tests around new feature

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- requirement text is always visible on diagram
- requirement box (on diagram) automatically expands in height when more text is added, but does not reduce in height when text is removed

Issue Number: #2967

### What is the new behavior?
- requirement is added to diagram as item (similar to blocks)
- Whether requirement text is shown on diagram can be toggled in property window of requirements
- Upon a change in text the height is automatically cropped to the minimum required.

### Does this PR introduce a breaking change?
hopefully not, but would love to hear your verdict :)
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
