### PR TITLE
Workaround: Install GTK 4.14.0 on macOS untill 4.14.4 is available

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -200,6 +200,8 @@ jobs:
         uses: ./.github/actions/install
         with:
           python-command: python${{ env.python_version }}
+      - name: Run Gaphor Self-Test
+        run: poetry run gaphor self-test
       - name: Run Gaphor Tests
         run: poetry run pytest --cov
       - name: Create macOS Application

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -181,8 +181,10 @@ jobs:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: >
-          brew update && brew install gtk4 gtksourceview5 libadwaita
+          brew update && brew install gtksourceview5 libadwaita
           adwaita-icon-theme gobject-introspection graphviz create-dmg upx
+      - name: Workaround - Install GTK 4.14.0
+        run: brew unlink gtk4 && brew install ./_packaging/gtk4.rb
       - name: Set up Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:

--- a/_packaging/gtk4.rb
+++ b/_packaging/gtk4.rb
@@ -1,0 +1,102 @@
+class Gtk4 < Formula
+  desc "Toolkit for creating graphical user interfaces"
+  homepage "https://gtk.org/"
+  url "https://download.gnome.org/sources/gtk/4.14/gtk-4.14.0.tar.xz"
+  sha256 "3821124067258d4a1f0ab581a56df68768036e66f072eec7e12867949ad0f810"
+  license "LGPL-2.1-or-later"
+
+  livecheck do
+    url :stable
+    regex(/gtk[._-](4\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+  end
+
+  bottle do
+    sha256 arm64_sonoma:   "c498379f925597b656bd23459e46e58f03857807435e931e2f9e8269d39643ba"
+    sha256 arm64_ventura:  "5c323936423d6175afdc9c9f0fd693abd1eabfea0f44365e39f78a49cf1ba385"
+    sha256 arm64_monterey: "396fc89951460159010b12311354a6f12dda670c6a04663b510dd6375cf8b08c"
+    sha256 sonoma:         "6e078bc3fdc8c80d415fd1941841139c13ec8c6a2ab9b9201a305b191fa3656c"
+    sha256 ventura:        "3685e2cf9d78a5815f95e1cb217c0620b9c16d7e32aa6ddffafa617a0e23d76f"
+    sha256 monterey:       "882689aafd65d003a55b41ee836948d909759d0cee285f3a3e60ea42f4635fce"
+    sha256 x86_64_linux:   "71ae2c6217f1b1bb4f8f8c675e62c36f53589b8f08fbe0d56516e48c85303d87"
+  end
+
+  depends_on "docbook" => :build
+  depends_on "docbook-xsl" => :build
+  depends_on "docutils" => :build
+  depends_on "gobject-introspection" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => [:build, :test]
+  depends_on "sassc" => :build
+  depends_on "gdk-pixbuf"
+  depends_on "glib"
+  depends_on "graphene"
+  depends_on "hicolor-icon-theme"
+  depends_on "jpeg-turbo"
+  depends_on "libepoxy"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "pango"
+
+  uses_from_macos "libxslt" => :build # for xsltproc
+  uses_from_macos "cups"
+
+  on_linux do
+    depends_on "libxcursor"
+    depends_on "libxkbcommon"
+  end
+
+  def install
+    args = %w[
+      -Dgtk_doc=false
+      -Dman-pages=true
+      -Dintrospection=enabled
+      -Dbuild-examples=false
+      -Dbuild-tests=false
+      -Dmedia-gstreamer=disabled
+      -Dvulkan=disabled
+    ]
+
+    if OS.mac?
+      args << "-Dx11-backend=false"
+      args << "-Dmacos-backend=true"
+      args << "-Dprint-cups=disabled" if MacOS.version <= :mojave
+    end
+
+    # ensure that we don't run the meson post install script
+    ENV["DESTDIR"] = "/"
+
+    # Find our docbook catalog
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+
+    # Disable asserts and cast checks explicitly
+    ENV.append "CPPFLAGS", "-DG_DISABLE_ASSERT -DG_DISABLE_CAST_CHECKS"
+
+    system "meson", *std_meson_args, "build", *args
+    system "meson", "compile", "-C", "build", "-v"
+    system "meson", "install", "-C", "build"
+  end
+
+  def post_install
+    system "#{Formula["glib"].opt_bin}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
+    system bin/"gtk4-update-icon-cache", "-f", "-t", "#{HOMEBREW_PREFIX}/share/icons/hicolor"
+    system "#{Formula["glib"].opt_bin}/gio-querymodules", "#{HOMEBREW_PREFIX}/lib/gtk-4.0/4.0.0/printbackends"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <gtk/gtk.h>
+
+      int main(int argc, char *argv[]) {
+        gtk_disable_setlocale();
+        return 0;
+      }
+    EOS
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["jpeg-turbo"].opt_lib/"pkgconfig"
+    flags = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs gtk4").strip.split
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+    # include a version check for the pkg-config files
+    assert_match version.to_s, shell_output("cat #{lib}/pkgconfig/gtk4.pc").strip
+  end
+end


### PR DESCRIPTION
4.14.0 does not have the delay in screen updates.
This workaround should be reverted as soon as 4.14.4 is available.
