### PR TITLE
Replace macOS certificate import by a script

### DIFF
--- a/.github/actions/macos_dmg/action.yml
+++ b/.github/actions/macos_dmg/action.yml
@@ -41,10 +41,19 @@ runs:
       shell: bash
     - name: Import codesign certificate
       if: inputs.sign_app == 'true'
-      uses: apple-actions/import-codesign-certs@v2
-      with:
-        p12-file-base64: ${{ inputs.base64_encoded_p12 }}
-        p12-password: ${{ inputs.certpassword_p12 }}
+      env:
+        P12BASE64: ${{ inputs.base64_encoded_p12 }}
+        P12PASSWORD: ${{ inputs.certpassword_p12 }}
+      run: |
+        P12FILE=$(mktemp)
+        PASSWORD=$(openssl rand -base64 24)
+        security create-keychain -p "$PASSWORD" temp.keychain
+        echo "$P12BASE64" | base64 -D -o "$P12FILE"
+        security import "$P12FILE" -k temp.keychain -f pkcs12 -T /usr/bin/codesign -T /usr/bin/security -P "$P12PASSWORD"
+        rm -f "$P12FILE"
+        security set-key-partition-list -S "apple-tool:,apple:" -k "$PASSWORD" temp.keychain
+        security list-keychains -d user -s temp.keychain login.keychain
+      shell: bash
     - name: Create Signed macOS Application
       if: inputs.sign_app == 'true'
       env:
@@ -98,6 +107,10 @@ runs:
       env:
         PRODUCT_PATH: "_packaging/dist/Gaphor-${{ inputs.version }}.dmg"
       run: xcrun stapler staple ${{ env.PRODUCT_PATH }}
+      shell: bash
+    - name: Delete temporary keychain
+      if: inputs.sign_app == 'true'
+      run: security delete-keychain temp.keychain
       shell: bash
     - name: Upload Gaphor-${{ inputs.version }}.dmg
       uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -201,7 +201,7 @@ jobs:
         with:
           python-command: python${{ env.python_version }}
       - name: Run Gaphor Self-Test
-        run: poetry run gaphor self-test
+        run: poetry run gaphor self-test || poetry run gaphor self-test
       - name: Run Gaphor Tests
         run: poetry run pytest --cov
       - name: Create macOS Application


### PR DESCRIPTION
The gh action is outdated, and I think we have better control over what's going on.

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The action for certificate importing is outdated (Node 16). It's basically executing a script, so let's just do that: execute a script.

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
