### PR TITLE
Windows: Fix couldn't load MyriadPro font warning

### DIFF
--- a/gaphor/ui/icons/hicolor/scalable/emblems/SysML.svg
+++ b/gaphor/ui/icons/hicolor/scalable/emblems/SysML.svg
@@ -60,7 +60,7 @@
        style="fill:#3d247c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.0352778"
        id="path369" />
     <text
-       style="font-variant:normal;font-weight:normal;font-size:7.65393px;font-family:MyriadPro;-inkscape-font-specification:MyriadPro-Regular;writing-mode:lr-tb;fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.159459"
+       style="font-variant:normal;font-weight:normal;font-size:7.65393px;font-family:sans-serif;-inkscape-font-specification:sans-serif;writing-mode:lr-tb;fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.159459"
        id="text379"
        x="138.66797"
        y="85.377327"


### PR DESCRIPTION
Launching Gaphor on Windows gives the following error: `(gaphor:18052): Pango-WARNING **: 12:50:04.556: couldn't load font "MyriadPro Not-Rotated 7.654", falling back to "Sans Not-Rotated 7.654", expect ugly output.`

I realized that the MyriadPro font was being used in the SysML logo. This PR updates the SysML logo to use a Sans font directly.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
