### PR TITLE
Windows: Download GTK instead of building

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -31,8 +31,8 @@ runs:
     - name: Windows specific overrides
       if: runner.os == 'Windows'
       run: |
-        poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\PyGObject*.whl)
-        poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\pycairo*.whl)
+        poetry run pip install --force-reinstall (Resolve-Path C:\gtk\wheels\PyGObject*.whl)
+        poetry run pip install --force-reinstall (Resolve-Path C:\gtk\wheels\pycairo*.whl)
       shell: pwsh
     - name: Install settings schemas
       run: poetry run gaphor install-schemas

--- a/.github/actions/windows_executables/action.yml
+++ b/.github/actions/windows_executables/action.yml
@@ -21,8 +21,8 @@ runs:
       shell: bash
     - name: Windows specific overrides
       run: |
-        poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\PyGObject*.whl)
-        poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\gtk\x64\release\pycairo*.whl)
+        poetry run pip install --force-reinstall (Resolve-Path C:\gtk\wheels\PyGObject*.whl)
+        poetry run pip install --force-reinstall (Resolve-Path C:\gtk\wheels\pycairo*.whl)
       shell: pwsh
     - name: Build PyInstaller Bootloader
       run: |

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -251,23 +251,12 @@ jobs:
       - name: Download Gvsbuild
         if: steps.cache.outputs.cache-hit != 'true'
         env:
-          REPO: "wingtk/gvsbuild"
-          MATCH: "^GTK4_Gvsbuild_.+_x64.zip$"
-          RENAME: "Gvsbuild.zip"
-        shell: bash
+          GH_TOKEN: ${{ github.token }}
+          HASH: c5cd0079f47124190d9c66d3661da018eccc1dfc3dd31b5c01531df7f88006e5
         run: |
-          curl -sL --fail \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ github.token }}" \
-              "https://api.github.com/repos/${REPO}/releases/tags/${{ env.gvsbuild_version }}" \
-              | jq -r ".assets | .[] | select(.name | test(\"${MATCH}\")) | .url" \
-              | tee asset.url
-          curl -sL --fail \
-            -H "Accept: application/octet-stream" \
-            -H "Authorization: Bearer ${{ github.token }}" \
-              -o "${RENAME}" \
-              "$(cat asset.url)"
-          7z x Gvsbuild.zip -oC:\gtk -y
+          gh release download --repo wingtk/gvsbuild ${{ env.gvsbuild_version }} -p 'GTK4_Gvsbuild_${{ env.gvsbuild_version }}_x64.zip'
+          (Get-FileHash GTK4_Gvsbuild_${{ env.gvsbuild_version }}_x64.zip).Hash -eq $HASH
+          7z x GTK4_Gvsbuild_${{ env.gvsbuild_version }}_x64.zip -oC:\gtk -y
       - name: Set up env
         run: |
           Write-Output "PKG_CONFIG=C:\gtk\bin\pkgconf.exe" >> $env:GITHUB_ENV

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -237,14 +237,10 @@ jobs:
           # Retry if first test fails
           Gaphor.app/Contents/MacOS/gaphor self-test || Gaphor.app/Contents/MacOS/gaphor self-test
 
-  windows-build-gtk:
+  windows-download-gtk:
     name: Windows (Build GTK)
     runs-on: windows-latest
-    timeout-minutes: 60
-    env:
-      gvsbuild_version: 2024.4.1
-      # Bump this number if you want to force a rebuild of gvsbuild with the same version
-      gvsbuild_update: 1
+    timeout-minutes: 15
     outputs:
       cachekey: ${{ steps.output.outputs.cachekey }}
     steps:
@@ -254,49 +250,50 @@ jobs:
           egress-policy: audit
 
       - name: GTK binaries create dir
-        run: mkdir C:\gtk-build\gtk\x64\release
+        run: mkdir C:\gtk
       - name: GTK binaries get from cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         id: cache
         with:
-          path: C:\gtk-build\gtk\x64\release\**
-          key: ${{ runner.os }}-gvsbuild-${{ env.gvsbuild_update }}-${{ env.gvsbuild_version }}
+          path: C:\gtk\**
+          key: ${{ runner.os }}-gvsbuild-${{ env.gvsbuild_version }}
       - name: Set up Python
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: ${{ env.python_version }}
-      - name: Install gvsbuild
+      - name: Download Gvsbuild
         if: steps.cache.outputs.cache-hit != 'true'
-        run: python -m pip install gvsbuild==${{ env.gvsbuild_version }}
-        # j2 option resolves out of memory issues while linking on GitHub Actions runners
-      - name: GTK binaries run gvsbuild
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: >
-          gvsbuild build --ninja-opts -j2 --enable-gi --py-wheel gobject-introspection
-          gtk4 libadwaita gtksourceview5 pycairo pygobject adwaita-icon-theme hicolor-icon-theme
-      - name: Copy wheels to cached directory
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: >
-          Get-ChildItem C:\gtk-build\build\x64\release\*\dist\*.whl |
-          ForEach-Object -process { cp $_ C:\gtk-build\gtk\x64\release\ }
+        env:
+          REPO: "wingtk/gvsbuild"
+          VERSION: "2024.5.0"
+          MATCH: "^GTK4_Gvsbuild_.+_x64.zip$"
+          RENAME: "Gvsbuild.zip"
+        shell: bash
+        run: |
+          curl -sL --fail \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+              "https://api.github.com/repos/${REPO}/releases/tags/${VERSION}" \
+              | jq -r ".assets | .[] | select(.name | test(\"${MATCH}\")) | .url" \
+              | tee asset.url
+          curl -sL --fail \
+            -H "Accept: application/octet-stream" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+              -o "${RENAME}" \
+              "$(cat asset.url)"
+          7z x Gvsbuild.zip -oC:\gtk -y
       - name: GTK binaries output cache key
         id: output
-        run: Write-Output "cachekey=${{ runner.os }}-gvsbuild-${{ env.gvsbuild_update }}-${{ env.gvsbuild_version }}" >> $env:GITHUB_OUTPUT
-      - name: Upload libraries
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        with:
-          name: gtk-build
-          path: C:\gtk-build\gtk\x64\release
+        run: Write-Output "cachekey=${{ runner.os }}-gvsbuild-${{ env.gvsbuild_version }}" >> $env:GITHUB_OUTPUT
 
   windows:
     name: Windows
-    needs: [lint, windows-build-gtk]
+    needs: [lint, windows-download-gtk]
     runs-on: windows-latest
     env:
-      INCLUDE: C:\gtk-build\gtk\x64\release\include;C:\gtk-build\gtk\x64\release\include\cairo;C:\gtk-build\gtk\x64\release\include\glib-2.0;C:\gtk-build\gtk\x64\release\include\gobject-introspection-1.0;C:\gtk-build\gtk\x64\release\lib\glib-2.0\include;
-      LIB: C:\gtk-build\gtk\x64\release\lib
+      INCLUDE: C:\gtk\include;C:\gtk\include\cairo;C:\gtk\include\glib-2.0;C:\gtk\include\gobject-introspection-1.0;C:\gtk\lib\glib-2.0\include;
+      LIB: C:\gtk\lib
     permissions:
       contents: write
     timeout-minutes: 45
@@ -310,13 +307,13 @@ jobs:
           egress-policy: audit
 
       - name: Create GTK binaries dir
-        run: mkdir C:\gtk-build\gtk\x64\release
+        run: mkdir C:\gtk
       - name: Get GTK binaries from cache
         uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         id: cache
         with:
-          path: C:\gtk-build\gtk\x64\release\**
-          key: ${{ needs.windows-build-gtk.outputs.cachekey }}
+          path: C:\gtk\**
+          key: ${{ needs.windows-download-gtk.outputs.cachekey }}
       - name: Check cache hit
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
@@ -324,9 +321,9 @@ jobs:
           exit 1
       - name: Set up env
         run: |
-          Write-Output "PKG_CONFIG=C:\gtk-build\gtk\x64\release\bin\pkgconf.exe" >> $env:GITHUB_ENV
+          Write-Output "PKG_CONFIG=C:\gtk\bin\pkgconf.exe" >> $env:GITHUB_ENV
           Write-Output "XDG_DATA_HOME=$HOME\.local\share" >> $env:GITHUB_ENV
-          Write-Output "C:\gtk-build\gtk\x64\release\bin" >> $env:GITHUB_PATH
+          Write-Output "C:\gtk\bin" >> $env:GITHUB_PATH
           choco install graphviz -y
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -166,11 +166,6 @@ jobs:
       LDFLAGS: -L/usr/local/opt/python@${python_version}/lib
       PKG_CONFIG_PATH: /usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/python@${python_version}/lib/pkgconfig:${PKG_CONFIG_PATH:-}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -220,11 +215,6 @@ jobs:
     runs-on: macos-12
     timeout-minutes: 10
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
-        with:
-          egress-policy: audit
-
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         id: download
         with:
@@ -238,17 +228,12 @@ jobs:
           Gaphor.app/Contents/MacOS/gaphor self-test || Gaphor.app/Contents/MacOS/gaphor self-test
 
   windows-download-gtk:
-    name: Windows (Build GTK)
+    name: Windows (Download GTK)
     runs-on: windows-latest
     timeout-minutes: 15
     outputs:
       cachekey: ${{ steps.output.outputs.cachekey }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
-        with:
-          egress-policy: audit
-
       - name: GTK binaries create dir
         run: mkdir C:\gtk
       - name: GTK binaries get from cache
@@ -301,11 +286,6 @@ jobs:
       installer: gaphor-${{ steps.install.outputs.version }}-installer.exe
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
-        with:
-          egress-policy: audit
-
       - name: Create GTK binaries dir
         run: mkdir C:\gtk
       - name: Get GTK binaries from cache
@@ -359,11 +339,6 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
-        with:
-          egress-policy: audit
-
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{ needs.windows.outputs.installer }}
@@ -388,10 +363,6 @@ jobs:
     continue-on-error: true
     timeout-minutes: 15
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
-        with:
-          egress-policy: audit
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{ needs.windows.outputs.installer }}

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -227,31 +227,31 @@ jobs:
           # Retry if first test fails
           Gaphor.app/Contents/MacOS/gaphor self-test || Gaphor.app/Contents/MacOS/gaphor self-test
 
-  windows-download-gtk:
-    name: Windows (Download GTK)
+  windows:
+    name: Windows
+    needs: lint
     runs-on: windows-latest
-    timeout-minutes: 15
+    env:
+      INCLUDE: C:\gtk\include;C:\gtk\include\cairo;C:\gtk\include\glib-2.0;C:\gtk\include\gobject-introspection-1.0;C:\gtk\lib\glib-2.0\include;
+      LIB: C:\gtk\lib
+      gvsbuild_version: 2024.5.0
+    permissions:
+      contents: write
+    timeout-minutes: 45
     outputs:
-      cachekey: ${{ steps.output.outputs.cachekey }}
+      installer: gaphor-${{ steps.install.outputs.version }}-installer.exe
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
-      - name: GTK binaries create dir
-        run: mkdir C:\gtk
       - name: GTK binaries get from cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         id: cache
         with:
           path: C:\gtk\**
           key: ${{ runner.os }}-gvsbuild-${{ env.gvsbuild_version }}
-      - name: Set up Python
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
-        with:
-          python-version: ${{ env.python_version }}
       - name: Download Gvsbuild
         if: steps.cache.outputs.cache-hit != 'true'
         env:
           REPO: "wingtk/gvsbuild"
-          VERSION: "2024.5.0"
           MATCH: "^GTK4_Gvsbuild_.+_x64.zip$"
           RENAME: "Gvsbuild.zip"
         shell: bash
@@ -259,7 +259,7 @@ jobs:
           curl -sL --fail \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer ${{ github.token }}" \
-              "https://api.github.com/repos/${REPO}/releases/tags/${VERSION}" \
+              "https://api.github.com/repos/${REPO}/releases/tags/${{ env.gvsbuild_version }}" \
               | jq -r ".assets | .[] | select(.name | test(\"${MATCH}\")) | .url" \
               | tee asset.url
           curl -sL --fail \
@@ -268,37 +268,6 @@ jobs:
               -o "${RENAME}" \
               "$(cat asset.url)"
           7z x Gvsbuild.zip -oC:\gtk -y
-      - name: GTK binaries output cache key
-        id: output
-        run: Write-Output "cachekey=${{ runner.os }}-gvsbuild-${{ env.gvsbuild_version }}" >> $env:GITHUB_OUTPUT
-
-  windows:
-    name: Windows
-    needs: [lint, windows-download-gtk]
-    runs-on: windows-latest
-    env:
-      INCLUDE: C:\gtk\include;C:\gtk\include\cairo;C:\gtk\include\glib-2.0;C:\gtk\include\gobject-introspection-1.0;C:\gtk\lib\glib-2.0\include;
-      LIB: C:\gtk\lib
-    permissions:
-      contents: write
-    timeout-minutes: 45
-    outputs:
-      installer: gaphor-${{ steps.install.outputs.version }}-installer.exe
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
-    steps:
-      - name: Create GTK binaries dir
-        run: mkdir C:\gtk
-      - name: Get GTK binaries from cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        id: cache
-        with:
-          path: C:\gtk\**
-          key: ${{ needs.windows-download-gtk.outputs.cachekey }}
-      - name: Check cache hit
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          echo "No GTK binaries cache"
-          exit 1
       - name: Set up env
         run: |
           Write-Output "PKG_CONFIG=C:\gtk\bin\pkgconf.exe" >> $env:GITHUB_ENV

--- a/.github/workflows/hypothesis-test.yml
+++ b/.github/workflows/hypothesis-test.yml
@@ -17,11 +17,6 @@ jobs:
     container: fedora:39
     timeout-minutes: 60
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
-        with:
-          egress-policy: audit
-
       - name: Install Linux Dependencies
         run: >
           dnf install -y gcc git graphviz pkg-config python-launcher upx

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -39,34 +39,10 @@ To set up a development environment in Windows first install
 choco install git
 ```
 
-### MSYS2
+### GTK and Python with Gvsbuild
 
-The development environment in the next step needs MSYS2 installed to provide
-some Linux command line tools in Windows.
-
-Keep PowerShell open as administrator and install [MSYS2](http://www.msys2.org/):
-
-```PowerShell
-choco install msys2
-```
-
-### GTK and Python with gvsbuild
-
-gvsbuild provides a Python script helps you build the GTK library stack for
-Windows using Visual Studio. By compiling GTK with Visual Studio, we can then
-use a standard Python development environment in Windows.
-
-First we will install the gvsbuild dependencies:
-1. Visual C++ build tools workload for Visual Studio 2022 Build Tools
-2. Python
-
-#### Install Visual Studio 2022
-
-With your admin PowerShell terminal:
-
-```PowerShell
-choco install visualstudio2022-workload-vctools
-```
+Gvsbuild provides pre-built GTK libraries for Windows. We will install
+these libraries and Python.
 
 #### Install the Latest Python
 
@@ -83,7 +59,7 @@ The default installation options should be fine for use with Gaphor.
 2. Open a PowerShell terminal as a normal user and check the python version:
 
    ```PowerShell
-   py -3.11 --version
+   py -3.12 --version
    ```
 
 #### Install Graphviz
@@ -107,26 +83,20 @@ Graphviz is used by Gaphor for automatic diagram formatting.
 
 From the regular user PowerShell terminal execute:
 ```PowerShell
-py -3.11 -m pip install --user pipx
-py -3.11 -m pipx ensurepath
+py -3.12 -m pip install --user pipx
+py -3.12 -m pipx ensurepath
 ```
 
-#### Install gvsbuild
+#### Download GTK
 
-From the regular user PowerShell terminal execute:
+Download the latest release asset at https://github.com/wingtk/gvsbuild/releases. The file will be
+called GTK4_Gvsbuild_VERSION_x64.zip, where VERSION is the latest released version.
+
+Unzip the GTK4_Gvsbuild_VERSION_x64.zip file to C:\gtk. For example with 7Zip:
 
 ```PowerShell
-pipx install gvsbuild
+7z x GTK4_Gvsbuild_*.zip  -oC:\gtk -y
 ```
-
-#### Build GTK
-
-In the same PowerShell terminal, execute:
-
-```PowerShell
-gvsbuild build --enable-gi --py-wheel gobject-introspection gtk4 libadwaita gtksourceview5 pygobject pycairo adwaita-icon-theme hicolor-icon-theme
-```
-Grab a coffee, the build will take a few minutes to complete.
 
 ### Setup Gaphor
 
@@ -144,9 +114,9 @@ pipx install poetry
 
 Add GTK to your environmental variables:
 ```PowerShell
-$env:Path = $env:Path + ";C:\gtk-build\gtk\x64\release\bin"
-$env:LIB = "C:\gtk-build\gtk\x64\release\lib"
-$env:INCLUDE = "C:\gtk-build\gtk\x64\release\include;C:\gtk-build\gtk\x64\release\include\cairo;C:\gtk-build\gtk\x64\release\include\glib-2.0;C:\gtk-build\gtk\x64\release\include\gobject-introspection-1.0;C:\gtk-build\gtk\x64\release\lib\glib-2.0\include;"
+$env:Path = $env:Path + ";C:\gtk\bin"
+$env:LIB = "C:\gtk\lib"
+$env:INCLUDE = "C:\gtk\include;C:\gtk\include\cairo;C:\gtk\include\glib-2.0;C:\gtk\include\gobject-introspection-1.0;C:\gtk\lib\glib-2.0\include;"
 $env:XDG_DATA_HOME = "$HOME\.local\share"
 ```
 
@@ -165,8 +135,8 @@ poetry run pre-commit install
 
 Reinstall PyGObject and pycairo using gvsbuild wheels
 ```PowerShell
-poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\build\x64\release\pygobject\dist\PyGObject*.whl)
-poetry run pip install --force-reinstall (Resolve-Path C:\gtk-build\build\x64\release\pycairo\dist\pycairo*.whl)
+poetry run pip install --force-reinstall (Resolve-Path C:\gtk\wheels\PyGObject*.whl)
+poetry run pip install --force-reinstall (Resolve-Path C:\gtk\wheels\pycairo*.whl)
 ```
 
 Launch Gaphor!
@@ -183,7 +153,7 @@ cd (to the location you put gaphor)
 
 Ensure that path environment variable is set:
 ```PowerShell
-$env:Path = "C:\gtk-build\gtk\x64\release\bin;" + $env:Path
+$env:Path = "C:\gtk\bin;" + $env:Path
 ```
 
 Start Visual Studio Code:

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -90,9 +90,9 @@ py -3.12 -m pipx ensurepath
 #### Download GTK
 
 Download the latest release asset at https://github.com/wingtk/gvsbuild/releases. The file will be
-called GTK4_Gvsbuild_VERSION_x64.zip, where VERSION is the latest released version.
+called `GTK4_Gvsbuild_VERSION_x64.zip`, where `VERSION` is the latest released version.
 
-Unzip the GTK4_Gvsbuild_VERSION_x64.zip file to C:\gtk. For example with 7Zip:
+Unzip the `GTK4_Gvsbuild_VERSION_x64.zip` file to `C:\gtk`. For example with 7Zip:
 
 ```PowerShell
 7z x GTK4_Gvsbuild_*.zip  -oC:\gtk -y


### PR DESCRIPTION
This PR updates the CI/CD pipeline and dev environment instructions to directly download a pre-built version of GTK, rather than building it from source ourselves. The release of Gvsbuild today is the first one that distributed GTK as a release asset.

Also Step Security's Harden Runners only work with Ubuntu VMs, so I removed them for the Windows, macOS, and Fedora workflows.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
We have to rebuild GTK ourselves for Gaphor on Windows

Issue Number: N/A

### What is the new behavior?
We download GTK and use it

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
