### PR TITLE
Use Python 3.12 with readthedocs, bump dependencies

### DIFF
--- a/.github/constraints.txt
+++ b/.github/constraints.txt
@@ -1,3 +1,3 @@
-poetry==1.8.2
-reuse==3.0.1
-Babel==2.14.0
+poetry==1.8.3
+reuse==3.0.2
+Babel==2.15.0

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
   apt_packages:
   - libgirepository1.0-dev
   - gir1.2-pango-1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2.25.2
+------
+
 2.25.1
 ------
 - macOS: fix screen update delays


### PR DESCRIPTION
Moves from Python 3.11 to Python 3.12 with readthedocs.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
