### PR TITLE
Get rid of ModelLoaded event (recovery 1/3)

### DIFF
--- a/gaphor/application.py
+++ b/gaphor/application.py
@@ -20,7 +20,6 @@ from gaphor.entrypoint import initialize
 from gaphor.event import (
     ActiveSessionChanged,
     ApplicationShutdown,
-    ModelLoaded,
     ModelSaved,
     ServiceInitializedEvent,
     ServiceShutdownEvent,
@@ -239,6 +238,6 @@ class Session(Service):
         self.component_registry.unregister(srv)
         srv.shutdown()
 
-    @event_handler(SessionCreated, ModelLoaded, ModelSaved)
+    @event_handler(SessionCreated, ModelSaved)
     def on_filename_changed(self, event):
         self._filename = event.filename

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -23,7 +23,6 @@ from gaphor.core.modeling.event import (
     ElementCreated,
     ElementDeleted,
     ModelFlushed,
-    ModelReady,
 )
 from gaphor.core.modeling.presentation import Presentation
 
@@ -200,11 +199,6 @@ class ElementFactory(Service):
                 element.unlink()
 
         self.handle(ModelFlushed(self))
-
-    def model_ready(self) -> None:
-        """Send notification that a new model has been loaded by means of the
-        ModelReady event from gaphor.core.modeling.event."""
-        self.handle(ModelReady(self))
 
     @contextmanager
     def block_events(self, new_event_manager: EventHandler | None = None):

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -230,12 +230,13 @@ class ElementDeleted(ServiceEvent):
 class ModelReady(ServiceEvent):
     """A generic element factory event."""
 
-    def __init__(self, service):
+    def __init__(self, service, modified=False):
         """Constructor.
 
         The service parameter is the service the emitted the event.
         """
         super().__init__(service)
+        self.modified = modified
 
 
 class ModelFlushed(ServiceEvent):

--- a/gaphor/core/modeling/tests/test_elementfactory.py
+++ b/gaphor/core/modeling/tests/test_elementfactory.py
@@ -8,7 +8,6 @@ from gaphor.core.modeling.event import (
     ElementCreated,
     ElementDeleted,
     ModelFlushed,
-    ModelReady,
     ServiceEvent,
 )
 from gaphor.core.modeling.presentation import Presentation
@@ -131,11 +130,6 @@ def test_remove_event(element_factory):
     clear_events()
     p.unlink()
     assert isinstance(last_event, ElementDeleted)
-
-
-def test_model_event(element_factory):
-    element_factory.model_ready()
-    assert isinstance(last_event, ModelReady)
 
 
 def test_flush_event(element_factory):

--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -43,7 +43,7 @@ class SessionCreated(ServiceEvent):
         application: Service,
         session: Service,
         filename: str | Path | None,
-        template: str | None,
+        template: str | None = None,
     ):
         super().__init__(application)
         self.application = application
@@ -65,13 +65,6 @@ class SessionShutdownRequested(ServiceEvent):
 
 class SessionShutdown(ServiceEvent):
     """The session is emitting this event when it's ready to shut down."""
-
-
-class ModelLoaded:
-    def __init__(self, service, filename: Path | None = None, modified: bool = False):
-        self.service = service
-        self.filename = filename
-        self.modified = modified
 
 
 class ModelSaved:

--- a/gaphor/services/properties.py
+++ b/gaphor/services/properties.py
@@ -17,7 +17,7 @@ from gi.repository import GLib
 from gaphor.abc import Service
 from gaphor.core import event_handler
 from gaphor.core.modeling.event import ModelFlushed
-from gaphor.event import ModelLoaded, ModelSaved, SessionCreated
+from gaphor.event import ModelSaved, SessionCreated
 
 log = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ class Properties(Service):
         self.event_manager.unsubscribe(self.on_model_saved)
         self.event_manager.unsubscribe(self.on_model_flushed)
 
-    @event_handler(ModelLoaded, SessionCreated)
+    @event_handler(SessionCreated)
     def on_model_loaded(self, event):
         self.filename = get_cache_dir() / file_hash(event.filename or "")
         self.load()

--- a/gaphor/services/tests/test_properties.py
+++ b/gaphor/services/tests/test_properties.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 import gaphor.services.properties
-from gaphor.event import ModelLoaded, ModelSaved
+from gaphor.event import ModelSaved, SessionCreated
 from gaphor.services.properties import get_cache_dir, get_config_dir
 
 
@@ -15,7 +15,7 @@ def properties(event_manager):
 
 
 def test_set_property(properties):
-    properties.on_model_loaded(ModelLoaded(None, "some_file_name"))
+    properties.on_model_loaded(SessionCreated(None, None, filename="some_file_name"))
 
     properties.set("test", 1)
 
@@ -27,7 +27,7 @@ def test_load_properties(properties, event_manager):
     properties.on_model_saved(ModelSaved(None, "test_load_properties"))
 
     new_properties = gaphor.services.properties.Properties(event_manager)
-    new_properties.on_model_loaded(ModelLoaded(None, "test_load_properties"))
+    new_properties.on_model_loaded(SessionCreated(None, None, "test_load_properties"))
 
     assert new_properties.get("test") == 1
 
@@ -38,7 +38,7 @@ def test_load_of_corrupted_properties(properties, event_manager, caplog):
     Path(properties.filename).write_text("{ invalid content }", encoding="utf-8")
 
     new_properties = gaphor.services.properties.Properties(event_manager)
-    new_properties.on_model_loaded(ModelLoaded(None, "test_load_properties"))
+    new_properties.on_model_loaded(SessionCreated(None, None, "test_load_properties"))
 
     assert new_properties.get("test", "not set") == "not set"
     assert "Invalid syntax in property file" in caplog.text

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -163,7 +163,8 @@ class UndoManager(Service, ActionProvider):
     def reset(self, event=None):
         self.clear_redo_stack()
         self.clear_undo_stack()
-        self._action_executed()
+        self.event_manager.handle(ActionEnabled("win.edit-undo", False))
+        self.event_manager.handle(ActionEnabled("win.edit-redo", False))
 
     @event_handler(TransactionBegin)
     def begin_transaction(self, event=None):

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -317,7 +317,6 @@ def load_generator(
                 yield percentage
 
     yield 100
-    element_factory.model_ready()
 
 
 def version_lower_than(gaphor_version, version):

--- a/gaphor/tests/test_application.py
+++ b/gaphor/tests/test_application.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from gaphor.application import Application
-from gaphor.event import ModelLoaded, ModelSaved
+from gaphor.event import ModelSaved, SessionCreated
 
 
 @pytest.fixture
@@ -29,7 +29,9 @@ def test_service_load(application):
 
 def test_model_loaded(application):
     session = application.new_session()
-    session.event_manager.handle(ModelLoaded(None, Path("some_file_name")))
+    session.event_manager.handle(
+        SessionCreated(None, session, filename=Path("some_file_name"))
+    )
 
     assert session.filename == Path("some_file_name")
 

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -21,7 +21,6 @@ from gaphor.core.modeling.event import (
 from gaphor.core.styling import StyleNode
 from gaphor.diagram.event import DiagramSelectionChanged
 from gaphor.diagram.propertypages import PropertyPages, new_resource_builder
-from gaphor.event import ModelLoaded
 from gaphor.i18n import gettext, localedir
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.csscompletion import (
@@ -87,15 +86,15 @@ class ElementEditor(UIComponent, ActionProvider):
         self.editor_stack = builder.get_object("editor-stack")
 
         resolve = builder.get_object("modelmerge-resolve")
-        resolve.connect_after("clicked", self.on_model_loaded)
+        resolve.connect_after("clicked", self.on_model_ready)
 
         self.editors.open(builder)
         self.preferences.open(builder)
         self.modelmerge.open(builder)
 
-        self.event_manager.subscribe(self.on_model_loaded)
+        self.event_manager.subscribe(self.on_model_ready)
 
-        self.on_model_loaded(None)
+        self.on_model_ready(None)
 
         return builder.get_object("elementeditor")
 
@@ -106,7 +105,7 @@ class ElementEditor(UIComponent, ActionProvider):
         idempotent if set.
         """
 
-        self.event_manager.unsubscribe(self.on_model_loaded)
+        self.event_manager.unsubscribe(self.on_model_ready)
 
         self.editors.close()
         self.preferences.close()
@@ -114,8 +113,8 @@ class ElementEditor(UIComponent, ActionProvider):
 
         return True
 
-    @event_handler(ModelLoaded)
-    def on_model_loaded(self, event):
+    @event_handler(ModelReady)
+    def on_model_ready(self, _event):
         if editor_stack := self.editor_stack:
             editor_stack.set_visible_child_name(
                 "modelmerge" if self.modelmerge.needs_merge else "editors"
@@ -386,16 +385,16 @@ class PreferencesStack:
         self._in_update = 0
 
     @event_handler(ModelReady)
-    def _model_ready(self, event):
+    def _model_ready(self, _event):
         self.update()
 
     @event_handler(ElementCreated)
-    def _style_sheet_created(self, event):
+    def _style_sheet_created(self, event: ElementCreated):
         if isinstance(event.element, StyleSheet):
             self.update()
 
     @event_handler(AttributeUpdated)
-    def _style_sheet_changed(self, event):
+    def _style_sheet_changed(self, event: AttributeUpdated):
         if event.property is StyleSheet.styleSheet:
             self.update()
 

--- a/gaphor/ui/modelchanged.py
+++ b/gaphor/ui/modelchanged.py
@@ -2,7 +2,8 @@ from gi.repository import Gtk
 
 from gaphor.abc import ActionProvider
 from gaphor.core import event_handler
-from gaphor.event import ModelChangedOnDisk, ModelLoaded, ModelSaved
+from gaphor.core.modeling import ModelReady
+from gaphor.event import ModelChangedOnDisk, ModelSaved
 from gaphor.i18n import translated_ui_string
 from gaphor.ui.abc import UIComponent
 
@@ -41,7 +42,7 @@ class ModelChanged(UIComponent, ActionProvider):
         if self._banner:
             self._banner.set_revealed(True)
 
-    @event_handler(ModelLoaded, ModelSaved)
+    @event_handler(ModelReady, ModelSaved)
     def _on_model_reset(self, _event):
         if self._banner:
             self._banner.set_revealed(False)

--- a/gaphor/ui/modelmerge/editor.py
+++ b/gaphor/ui/modelmerge/editor.py
@@ -5,9 +5,8 @@ from gi.repository import Gio, Gtk
 
 from gaphor.core import event_handler
 from gaphor.core.changeset.apply import applicable, apply_change
-from gaphor.core.modeling import PendingChange
+from gaphor.core.modeling import ModelReady, PendingChange
 from gaphor.event import (
-    ModelLoaded,
     TransactionBegin,
     TransactionCommit,
     TransactionRollback,
@@ -91,7 +90,7 @@ class ModelMerge:
                 change.unlink()
         self.close()
 
-    @event_handler(ModelLoaded)
+    @event_handler(ModelReady)
     def on_model_loaded(self, event):
         self.event_manager.subscribe(self.on_model_updated)
         self.refresh_model()

--- a/gaphor/ui/recentfiles.py
+++ b/gaphor/ui/recentfiles.py
@@ -4,7 +4,7 @@ from gi.repository import GLib, Gtk
 
 from gaphor.abc import Service
 from gaphor.core import event_handler
-from gaphor.event import ModelLoaded, ModelSaved
+from gaphor.event import ModelSaved, SessionCreated
 from gaphor.ui import APPLICATION_ID
 
 
@@ -18,7 +18,7 @@ class RecentFiles(Service):
     def shutdown(self):
         self.event_manager.unsubscribe(self._on_filename_changed)
 
-    @event_handler(ModelLoaded, ModelSaved)
+    @event_handler(SessionCreated, ModelSaved)
     def _on_filename_changed(self, event):
         filename = event.filename
         if not filename:

--- a/gaphor/ui/tests/test_modelbrowser.py
+++ b/gaphor/ui/tests/test_modelbrowser.py
@@ -1,7 +1,7 @@
 import pytest
 
 from gaphor import UML
-from gaphor.core.modeling import Diagram
+from gaphor.core.modeling import Diagram, ModelReady
 from gaphor.ui.modelbrowser import (
     ElementDragData,
     ModelBrowser,
@@ -163,7 +163,7 @@ def test_model_browser_model_ready(event_manager, element_factory, modeling_lang
     model_browser.open()
     tree_model = model_browser.model
 
-    element_factory.model_ready()
+    event_manager.handle(ModelReady(element_factory))
 
     assert tree_model.tree_item_for_element(package) is not None
     assert tree_model.tree_item_for_element(class_) is None

--- a/gaphor/ui/tests/test_recentfiles.py
+++ b/gaphor/ui/tests/test_recentfiles.py
@@ -2,7 +2,7 @@ import pathlib
 
 from gi.repository import GLib
 
-from gaphor.event import ModelLoaded
+from gaphor.event import SessionCreated
 from gaphor.ui.recentfiles import RecentFiles
 
 
@@ -21,7 +21,7 @@ def test_add_new_recent_file(event_manager):
     recent_manager = RecentManagerStub()
     RecentFiles(event_manager, recent_manager)
 
-    event_manager.handle(ModelLoaded(None, "testfile.gaphor"))
+    event_manager.handle(SessionCreated(None, None, "testfile.gaphor"))
 
     assert len(recent_manager.items) == 1
     assert recent_manager.items[0].startswith("file:///"), recent_manager.items[0]

--- a/tests/run_with_merge_conflict.py
+++ b/tests/run_with_merge_conflict.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

Issue:  #2831

### What is the current behavior?

We had three events: SessionCreated, ModelLoaded, and ModelReady.

SessionCreated is emitted when a new session is launched. A session may be based on an existing model (`filename` is set).

ModelLoaded is emitted when a model is loaded, and it also contains the file name

ModelReady is emitted when a model is loaded.

### What is the new behavior?

Cleaned up event structure.

There's some overlap in those events. Back in the day we had the option to load a model in an existing session. We do not allow that anymore. Therefore the ModelLoaded event is a redundant and has been removed.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

I ran into this while implementing #3284.