### PR TITLE
Session recovery (recovery 4/3)

### DIFF
--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -67,7 +67,7 @@ class SanitizerService(Service):
 
     @event_handler(TransactionBegin)
     def _begin_transaction(self, event):
-        self.in_undo_transaction = event.context in ("undo", "redo", "rollback")
+        self.in_undo_transaction = bool(event.context)
 
     @event_handler(TransactionCommit, TransactionRollback)
     def _end_transaction(self, _event):

--- a/gaphor/application.py
+++ b/gaphor/application.py
@@ -110,10 +110,12 @@ class Application(Service, ActionProvider):
             force=force,
         )
 
-    def recover_session(self, *, session_id):
+    def recover_session(self, *, session_id, filename=None, template=None):
         """Recover a (crashed) session."""
 
-        return self._spawn_session(session=Session(session_id=session_id))
+        return self._spawn_session(
+            session=Session(session_id=session_id), filename=filename, template=template
+        )
 
     def _spawn_session(
         self, session: Session, filename=None, template=None, force=False

--- a/gaphor/application.py
+++ b/gaphor/application.py
@@ -146,15 +146,6 @@ class Application(Service, ActionProvider):
 
         return session
 
-    def has_sessions(self):
-        return bool(self._sessions)
-
-    def has_session(self, filename):
-        filename = Path(filename)
-        return any(
-            session for session in self._sessions if session.filename == filename
-        )
-
     def shutdown_session(self, session):
         assert session
         session.shutdown()

--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -42,8 +42,8 @@ class SessionCreated(ServiceEvent):
         self,
         application: Service,
         session: Service,
-        filename: str | Path | None,
-        template: str | Path | None = None,
+        filename: Path | None,
+        template: Path | None = None,
         force: bool = False,
     ):
         super().__init__(application)

--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -43,7 +43,7 @@ class SessionCreated(ServiceEvent):
         application: Service,
         session: Service,
         filename: str | Path | None,
-        template: str | None = None,
+        template: str | Path | None = None,
         force: bool = False,
     ):
         super().__init__(application)

--- a/gaphor/main.py
+++ b/gaphor/main.py
@@ -113,7 +113,7 @@ def gui_parser():
             run_argv += ["--gapplication-service"]
         run_argv.extend(args.model)
 
-        return gaphor.ui.run(run_argv)
+        return gaphor.ui.run(run_argv, recover=True)
 
     parser = argparse.ArgumentParser(
         description="Launch the GUI.", parents=[version_parser()]

--- a/gaphor/storage/tests/test_recovery_eventlog.py
+++ b/gaphor/storage/tests/test_recovery_eventlog.py
@@ -12,7 +12,7 @@ def test_file(tmp_path):
 
 @pytest.fixture
 def event_log(test_file):
-    event_log = EventLog(test_file)
+    event_log = EventLog("_", test_file)
     return event_log
 
 

--- a/gaphor/storage/tests/test_recovery_eventlog.py
+++ b/gaphor/storage/tests/test_recovery_eventlog.py
@@ -83,7 +83,7 @@ def test_should_not_append_if_file_changed(event_log, test_file):
 def test_move_aside_event_log(event_log):
     event_log.write(["my", "line"])
 
-    event_log.move_aside("Because")
+    event_log.move_aside()
 
     assert not event_log.log_file.exists()
     assert event_log.log_file.with_suffix(".recovery.bak").exists()

--- a/gaphor/tests/test_main.py
+++ b/gaphor/tests/test_main.py
@@ -14,7 +14,7 @@ APP_NAME = sys.argv[0]
 def mock_gaphor_ui_run(monkeypatch):
     _argv = []
 
-    def run(argv):
+    def run(argv, recover=False):
         _argv[:] = argv
         return 0
 

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -81,7 +81,7 @@ def run(argv: list[str], *, launch_service="greeter", recover=False) -> int:
 
     def app_activate(gtk_app):
         assert application
-        if not application.has_sessions():
+        if not application.sessions:
             application.get_service(launch_service).open()
 
     def app_open(gtk_app, files, n_files, hint):

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -41,7 +41,7 @@ if sys.platform == "darwin":
         )
 
 
-def run(argv: list[str], launch_service="greeter") -> int:
+def run(argv: list[str], *, launch_service="greeter", recover=False) -> int:
     application: Application | None = None
 
     def app_startup(gtk_app):
@@ -72,7 +72,8 @@ def run(argv: list[str], launch_service="greeter") -> int:
             event_manager.subscribe(on_session_created)
             event_manager.subscribe(on_quit)
             application.get_service(launch_service).init(gtk_app)
-            recover_sessions(application)
+            if recover:
+                recover_sessions(application)
         except Exception:
             gtk_app.exit_code = 1
             gtk_app.quit()
@@ -81,7 +82,7 @@ def run(argv: list[str], launch_service="greeter") -> int:
     def app_activate(gtk_app):
         assert application
         if not application.has_sessions():
-            application.get_service("greeter").open()
+            application.get_service(launch_service).open()
 
     def app_open(gtk_app, files, n_files, hint):
         # appfilemanager should take care of this:

--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -22,6 +22,7 @@ from gaphor.application import Application, Session
 from gaphor.core import event_handler
 from gaphor.event import ActiveSessionChanged, ApplicationShutdown, SessionCreated
 from gaphor.settings import APPLICATION_ID, StyleVariant, settings
+from gaphor.storage.recovery import all_sessions
 from gaphor.ui.actiongroup import apply_application_actions
 
 Adw.init()
@@ -71,6 +72,7 @@ def run(argv: list[str], launch_service="greeter") -> int:
             event_manager.subscribe(on_session_created)
             event_manager.subscribe(on_quit)
             application.get_service(launch_service).init(gtk_app)
+            recover_sessions(application)
         except Exception:
             gtk_app.exit_code = 1
             gtk_app.quit()
@@ -112,6 +114,16 @@ def run(argv: list[str], launch_service="greeter") -> int:
     gtk_app.connect("open", app_open)
     gtk_app.run(argv)
     return gtk_app.exit_code
+
+
+def recover_sessions(application):
+    for session_id, filename, template in all_sessions():
+        if not any(
+            session.session_id == session_id for session in application.sessions
+        ):
+            application.recover_session(
+                session_id=session_id, filename=filename, template=template
+            )
 
 
 if __name__ == "__main__":

--- a/gaphor/ui/appfilemanager.py
+++ b/gaphor/ui/appfilemanager.py
@@ -31,7 +31,11 @@ class AppFileManager(Service, ActionProvider):
 
         def open_files(filenames):
             for filename in filenames:
-                if self.application.has_session(filename):
+                if any(
+                    session
+                    for session in self.application.sessions
+                    if session.filename == filename
+                ):
                     name = Path(filename).name
                     title = gettext("Switch to {name}?").format(name=name)
                     body = gettext(

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -111,6 +111,7 @@ class FileManager(Service, ActionProvider):
     def load_template(self, template):
         translated_model = translate_model(template)
         storage.load(translated_model, self.element_factory, self.modeling_language)
+        self.event_manager.handle(ModelReady(self))
 
     def load(self, filename: Path, on_load_done: Callable[[], None] | None = None):
         """Load the Gaphor model from the supplied file name.

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -13,6 +13,7 @@ from gi.repository import Adw, Gio, Gtk
 
 from gaphor import UML
 from gaphor.abc import ActionProvider, Service
+from gaphor.babel import translate_model
 from gaphor.core import action, event_handler, gettext
 from gaphor.core.changeset.compare import compare
 from gaphor.core.modeling import Diagram, ElementFactory, ModelReady, StyleSheet
@@ -108,7 +109,8 @@ class FileManager(Service, ActionProvider):
             self._update_monitor()
 
     def load_template(self, template):
-        storage.load(template, self.element_factory, self.modeling_language)
+        translated_model = translate_model(template)
+        storage.load(translated_model, self.element_factory, self.modeling_language)
 
     def load(self, filename: Path, on_load_done: Callable[[], None] | None = None):
         """Load the Gaphor model from the supplied file name.

--- a/gaphor/ui/greeter.py
+++ b/gaphor/ui/greeter.py
@@ -7,7 +7,6 @@ from gi.repository import Adw, GLib, Gtk
 from gaphor.abc import ActionProvider, Service
 from gaphor.action import action
 from gaphor.application import distribution
-from gaphor.babel import translate_model
 from gaphor.core import event_handler
 from gaphor.event import SessionCreated
 from gaphor.i18n import gettext, translated_ui_string
@@ -203,8 +202,7 @@ class Greeter(Service, ActionProvider):
             filename = (
                 importlib.resources.files("gaphor") / "templates" / child.filename
             )
-            translated_model = translate_model(filename)
-            session = self.application.new_session(template=translated_model)
+            session = self.application.new_session(template=filename)
             session.get_service("properties").set("modeling-language", child.lang)
             self.close()
 

--- a/gaphor/ui/selftest.py
+++ b/gaphor/ui/selftest.py
@@ -107,11 +107,6 @@ class SelfTest(Service):
 
     @test
     def test_new_session(self, status):
-        with (importlib.resources.files("gaphor") / "templates" / "uml.gaphor").open(
-            encoding="utf-8"
-        ) as f:
-            session = self.application.new_session(template=f)
-
         def check_new_session(session):
             main_window = session.get_service("main_window")
 
@@ -120,6 +115,8 @@ class SelfTest(Service):
                 return GLib.SOURCE_REMOVE
             return GLib.SOURCE_CONTINUE
 
+        template = importlib.resources.files("gaphor") / "templates" / "uml.gaphor"
+        session = self.application.new_session(template=template)
         GLib.idle_add(check_new_session, session, priority=GLib.PRIORITY_LOW)
 
     @test

--- a/tests/test_session_recovery.py
+++ b/tests/test_session_recovery.py
@@ -22,7 +22,9 @@ def test_recovery_when_reloading_file(application: Application, test_models):
 
     application.shutdown_session(session)
 
-    new_session = application.new_session(filename=model_file)
+    new_session = application.recover_session(
+        session_id=session.session_id, filename=model_file
+    )
     new_element_factory = new_session.get_service("element_factory")
 
     assert new_element_factory.lookup(diagram.id)
@@ -38,7 +40,9 @@ def test_recovery_when_change_is_rolled_back(application: Application, test_mode
 
     application.shutdown_session(session)
 
-    new_session = application.new_session(filename=model_file)
+    new_session = application.recover_session(
+        session_id=session.session_id, filename=model_file
+    )
     new_element_factory = new_session.get_service("element_factory")
 
     assert not new_element_factory.lookup(diagram.id)
@@ -57,7 +61,7 @@ def test_recovery_when_model_is_loaded_twice(application: Application, test_mode
     assert not new_element_factory.lookup(diagram.id)
 
 
-def test_no_recovery_for_new_file(application: Application):
+def test_no_recovery_for_new_session(application: Application):
     session = application.new_session()
     element_factory = session.get_service("element_factory")
     with Transaction(session.get_service("event_manager")):
@@ -84,7 +88,9 @@ def test_no_recovery_for_saved_file(application: Application, test_models, tmp_p
 
     application.shutdown_session(session)
 
-    new_session = application.new_session(filename=model_file)
+    new_session = application.recover_session(
+        session_id=session.session_id, filename=model_file
+    )
     new_element_factory = new_session.get_service("element_factory")
 
     assert not new_element_factory.lookup(diagram.id)
@@ -110,7 +116,9 @@ def test_no_recovey_when_model_changed(application: Application, test_models, tm
     with open(model_file, mode="a", encoding="utf-8") as f:
         f.write("\n")
 
-    new_session = application.new_session(filename=model_file)
+    new_session = application.recover_session(
+        session_id=session.session_id, filename=model_file
+    )
     new_element_factory = new_session.get_service("element_factory")
 
     assert not new_element_factory.lookup(diagram.id)
@@ -127,7 +135,9 @@ def test_no_recovery_for_properly_closed_session(application: Application, test_
 
     event_manager.handle(SessionShutdown(session))
 
-    new_session = application.new_session(filename=model_file)
+    new_session = application.recover_session(
+        session_id=session.session_id, filename=model_file
+    )
     new_element_factory = new_session.get_service("element_factory")
 
     assert not new_element_factory.lookup(diagram.id)
@@ -156,7 +166,9 @@ def test_broken_recovery_log(
     with log_file.open("a", encoding="utf-8") as f:
         f.write(errorous_line)
 
-    new_session = application.new_session(filename=model_file)
+    new_session = application.recover_session(
+        session_id=session.session_id, filename=model_file
+    )
     new_element_factory = new_session.get_service("element_factory")
 
     assert not new_element_factory.lookup(diagram.id)

--- a/tests/test_session_recovery.py
+++ b/tests/test_session_recovery.py
@@ -181,20 +181,21 @@ def test_recover_from_session_files(application: Application, test_models):
     session_id = "1234"
     class_id = "9876"
 
+    recovery_statements = [
+        {
+            "path": str(test_models / "all-elements.gaphor"),
+            "sha256": sha256sum(test_models / "all-elements.gaphor"),
+            "template": True,
+        },
+        [("c", "Class", class_id, None)],
+    ]
+
     with (sessions_dir() / f"{session_id}.recovery").open("w", encoding="utf-8") as f:
-        f.writelines(
-            [
-                f"{{'path': '{test_models}/all-elements.gaphor', 'sha256': '{sha256sum(test_models / 'all-elements.gaphor')}', 'template': True}}\n",
-                f"[('c', 'Class', '{class_id}', None)]\n",
-            ]
-        )
+        f.writelines(f"{repr(stmt)}\n" for stmt in recovery_statements)
 
     recover_sessions(application)
 
     session = next(s for s in application.sessions if s.session_id == session_id)
+    element_factory = session.get_service("element_factory")
 
-    assert session.session_id == session_id
-
-    # element_factory = session.get_service("element_factory")
-
-    # assert element_factory.lookup(class_id)
+    assert element_factory.lookup(class_id)

--- a/tests/test_session_recovery.py
+++ b/tests/test_session_recovery.py
@@ -177,7 +177,8 @@ def test_broken_recovery_log(
     assert "Could not recover model changes" in caplog.text
 
 
-def test_recover_from_session_files(application: Application, test_models):
+@pytest.mark.parametrize("template", [True, False])
+def test_recover_from_session_files(application: Application, test_models, template):
     session_id = "1234"
     class_id = "9876"
 
@@ -186,7 +187,7 @@ def test_recover_from_session_files(application: Application, test_models):
         {
             "path": str(test_models / "all-elements.gaphor"),
             "sha256": sha256sum(test_models / "all-elements.gaphor"),
-            "template": True,
+            "template": template,
         },
         [("c", "Class", class_id, None)],
     )


### PR DESCRIPTION
This is an attempt to perfect a way to recover work after Gaphor has crashed, or terminated. The idea is that a user doesn't loose his work in case of a failure.

I see three approaches at this point:

1. On application startup, show to-be recovered sessions in the Greeter window and allow users to recover them, or delete them 
2. When a model is loaded, any unsaved changes are automatically applied.
3. The application instantly opens with all user sessions, as if nothing happened.

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

In #3284, models are recovered by file name. This does not work if:

1. A model is opened multiple times: now, changes are just not tracked in the subsequently opened models
5. A model is opened by multiple processes: Only one event log will be saved.
6. No event log is generated for newly created model: a model needs a file name before Gaphor can create an event log

### What is the new behavior?

This PR is an attempt to improve session recording and recovery.

Sessions in the "sessions" folder are automatically restored on startup, also newly created (unsaved) models.

Each session will get a unique id. We can continue a session by providing it the id of a previously interrupted session.

This ensures that event logs are unique, since they're based of a session, instead of a model name. Also, we can record changes made to new models.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

* TODO: test if recovery and sanitizer service interfere
* TODO: test a lot with undo/redo
* TODO: deal with faulty headers (e.g. not a dict)
* TODO: Is a ModelSaved event emitted and handled when a user saves the model on quit?