### PR TITLE
pydot: clean line continuations with windows line endings

### DIFF
--- a/gaphor/plugins/autolayout/pydot.py
+++ b/gaphor/plugins/autolayout/pydot.py
@@ -371,7 +371,11 @@ def parse_bb(bb, height: float | None = None) -> Rect:
 
 
 def strip_quotes(s):
-    return s.replace('"', "").replace("\\\n", "")
+    """Replace quotes and line continuations (backslash + newline).
+
+    Basically cleaning up some stuff that Pydot leaves in.
+    """
+    return s.replace('"', "").replace("\\\n", "").replace("\\\r\n", "")
 
 
 # Do not auto-layout sequence diagrams

--- a/gaphor/plugins/autolayout/tests/test_pydot.py
+++ b/gaphor/plugins/autolayout/tests/test_pydot.py
@@ -3,7 +3,7 @@ import pytest
 from gaphor import UML
 from gaphor.core.modeling import Comment
 from gaphor.diagram.tests.fixtures import connect
-from gaphor.plugins.autolayout.pydot import AutoLayout, parse_edge_pos
+from gaphor.plugins.autolayout.pydot import AutoLayout, parse_edge_pos, strip_quotes
 from gaphor.UML.diagramitems import (
     ActionItem,
     AssociationItem,
@@ -107,3 +107,9 @@ def test_parse_pos():
 def test_parse_pos_invalid_number_of_points():
     with pytest.raises(IndexError):
         parse_edge_pos('"1.0,2.0 3.0,4 5.0,6.0"', 10)
+
+
+def test_strip_line_endings():
+    assert strip_quotes("\\\n807.5") == "807.5"
+    assert strip_quotes("\\\r\n807.5") == "807.5"
+    assert strip_quotes('\\\r\n"807.5"') == "807.5"


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3328

### What is the new behavior?

Windows line breaks are also handled.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
