### PR TITLE
Fix issue when recovering from split and merged segments

### DIFF
--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -151,6 +151,7 @@ class MatrixUpdated(RevertibleEvent):
     def __init__(self, element, old_value):
         super().__init__(element)
         self.old_value = old_value
+        self.new_value = element.matrix.tuple()
 
     def revert(self, target):
         target.matrix.set(*self.old_value)

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -69,6 +69,7 @@ class HandlePositionEvent(RevertibleEvent):
         super().__init__(element)
         self.handle_index = element.handles().index(handle)
         self.old_value = old_value
+        self.new_value = handle.pos.tuple()
 
     def revert(self, target):
         target.handles()[self.handle_index].pos = self.old_value

--- a/gaphor/storage/recovery.py
+++ b/gaphor/storage/recovery.py
@@ -378,7 +378,7 @@ class Recorder:
 
     @event_handler(MatrixUpdated)
     def on_matrix_updated(self, event: MatrixUpdated):
-        self.events.append(("mu", event.element.id, tuple(event.element.matrix)))
+        self.events.append(("mu", event.element.id, event.new_value))
 
     @event_handler(HandlePositionEvent)
     def on_handle_position_event(self, event: HandlePositionEvent):

--- a/gaphor/storage/recovery.py
+++ b/gaphor/storage/recovery.py
@@ -382,9 +382,8 @@ class Recorder:
 
     @event_handler(HandlePositionEvent)
     def on_handle_position_event(self, event: HandlePositionEvent):
-        pos = event.element.handles()[event.handle_index].pos
         self.events.append(
-            ("hp", event.element.id, event.handle_index, (float(pos.x), float(pos.y)))
+            ("hp", event.element.id, event.handle_index, event.new_value)
         )
 
     @event_handler(ItemConnected)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Fix an issue I ran into when recovering an auto-layout model.

* Create a new model
* Add a line
* Split the line in a few segments
* move both ends
* Merge the line back to 1 segment
* Interrupt Gaphor (ctrl-C)
* Start gaphor again, see it crash

Issue Number: #2831

### What is the new behavior?

The Handle position event contains the new location, so we can record it, even if the handle has been removed in the mean time.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Now all recovery events are written with info from the event only. No lookups (except for id) need to be done on the element.