### PR TITLE
Ellipsize long texts at the end

### DIFF
--- a/gaphor/ui/textfield.py
+++ b/gaphor/ui/textfield.py
@@ -14,6 +14,7 @@ _XML = """\
           <object class="GtkLabel">
             <property name="xalign">0</property>
             <property name="hexpand">yes</property>
+            <property name="ellipsize">end</property>
             <binding name="attributes">
               <lookup name="attributes">TextField</lookup>
             </binding>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Property editor becomes bigger if text is (too) long.

Issue Number: fixes #3235

### What is the new behavior?

Text ellipsizes at the end if it's too long to fit in the text box.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

<img width="319" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/4bc0bef8-408c-457a-95e7-30da8033996b">
