### PR TITLE
Fix select association AssertionError

### DIFF
--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -26,7 +26,7 @@ class AssociationPropertyPage(PropertyPageBase):
     def __init__(self, subject: UML.Association):
         self.subject = subject
         self.watcher = subject and subject.watcher()
-        self.semaphore = 0
+        self.end_name_change_semaphore = 0
 
     def construct_end(self, builder, end_name, subject):
         title = builder.get_object(f"{end_name}-title")
@@ -59,10 +59,10 @@ class AssociationPropertyPage(PropertyPageBase):
             )
             or ""
         )
-        if not (name.is_focus() or self.semaphore):
-            self.semaphore += 1
+        if not (name.is_focus() or self.end_name_change_semaphore):
+            self.end_name_change_semaphore += 1
             name.set_text(new_name)
-            self.semaphore -= 1
+            self.end_name_change_semaphore -= 1
         return name
 
     def construct(self):
@@ -136,8 +136,8 @@ class AssociationPropertyPage(PropertyPageBase):
         )
 
     def _on_end_name_change(self, entry, subject):
-        if not self.semaphore:
-            self.semaphore += 1
+        if not self.end_name_change_semaphore:
+            self.end_name_change_semaphore += 1
 
             @transactional
             def do_in_tx():
@@ -145,7 +145,7 @@ class AssociationPropertyPage(PropertyPageBase):
 
             do_in_tx()
 
-            self.semaphore -= 1
+            self.end_name_change_semaphore -= 1
 
     @transactional
     def _on_end_navigability_change(self, dropdown, _pspec, subject):

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -135,11 +135,16 @@ class AssociationPropertyPage(PropertyPageBase):
             builder.get_object("association-editor"), self.watcher
         )
 
-    @transactional
     def _on_end_name_change(self, entry, subject):
         if not self.semaphore:
             self.semaphore += 1
-            parse(subject, entry.get_text())
+
+            @transactional
+            def do_in_tx():
+                parse(subject, entry.get_text())
+
+            do_in_tx()
+
             self.semaphore -= 1
 
     @transactional


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The problem is that Transaction handling has some caveats at the moment. this is because events are immediately forwarded to the undo manager when they happen, contrary to the "normal" behavior, which makes sures events are executed in order.

This gets a bit troublesome when a new transaction is started while there are still events in the queue. This PR fixes that for association end names by only starting a transaction if the change is not made twice.

Issue Number: Fixes #3348

### What is the new behavior?

Selecting an association with association ends filled in does no longer cause an exception.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

The real solution is fixing #3351.