### PR TITLE
Property Pages can now wire up services

### DIFF
--- a/docs/locale/cs/LC_MESSAGES/docs.po
+++ b/docs/locale/cs/LC_MESSAGES/docs.po
@@ -3622,7 +3622,7 @@ msgid "Overview of Transactions"
 msgstr ""
 
 #: ../undo.md:9
-msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction` and a decorator called `@transactional`."
+msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction`."
 msgstr ""
 
 #: ../undo.md:16

--- a/docs/locale/de/LC_MESSAGES/docs.po
+++ b/docs/locale/de/LC_MESSAGES/docs.po
@@ -3419,7 +3419,7 @@ msgid "Overview of Transactions"
 msgstr ""
 
 #: ../undo.md:9
-msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction` and a decorator called `@transactional`."
+msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction`."
 msgstr ""
 
 #: ../undo.md:16

--- a/docs/locale/docs.pot
+++ b/docs/locale/docs.pot
@@ -6794,7 +6794,7 @@ msgid "Overview of Transactions"
 msgstr ""
 
 #: ../undo.md:9
-msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction` and a decorator called `@transactional`."
+msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction`."
 msgstr ""
 
 #: ../undo.md:16

--- a/docs/locale/es/LC_MESSAGES/docs.po
+++ b/docs/locale/es/LC_MESSAGES/docs.po
@@ -4326,14 +4326,14 @@ msgid "Overview of Transactions"
 msgstr "Resumen de las transacciones"
 
 #: ../undo.md:9
-msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction` and a decorator called `@transactional`."
+msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction`."
 msgstr ""
 "La grabación y reproducción de cambios en Gaphor se gestiona mediante el "
 "Gestor de deshacer. El Gestor de deshacer funciona transaccionalmente. Una "
 "transacción debe tener éxito o fallar como una unidad completa. Si la "
 "transacción falla en el medio, es revertida. En Gaphor esto se consigue "
 "mediante el módulo `transaction`, que proporciona un gestor de contexto "
-"`Transaction` y un decorador llamado `@transactional`."
+"`Transaction`."
 
 #: ../undo.md:16
 msgid "When transactions take place, they emit event notifications on the key transaction milestones so that other services can make use of the events. The event notifications are for the begin of the transaction, and the commit of the transaction if it is successful or the rollback of the transaction if it fails."

--- a/docs/locale/hr/LC_MESSAGES/docs.po
+++ b/docs/locale/hr/LC_MESSAGES/docs.po
@@ -3570,7 +3570,7 @@ msgid "Overview of Transactions"
 msgstr ""
 
 #: ../undo.md:9
-msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction` and a decorator called `@transactional`."
+msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction`."
 msgstr ""
 
 #: ../undo.md:16

--- a/docs/locale/hu/LC_MESSAGES/docs.po
+++ b/docs/locale/hu/LC_MESSAGES/docs.po
@@ -3423,7 +3423,7 @@ msgid "Overview of Transactions"
 msgstr ""
 
 #: ../undo.md:9
-msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction` and a decorator called `@transactional`."
+msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction`."
 msgstr ""
 
 #: ../undo.md:16

--- a/docs/locale/it/LC_MESSAGES/docs.po
+++ b/docs/locale/it/LC_MESSAGES/docs.po
@@ -6800,7 +6800,7 @@ msgid "Overview of Transactions"
 msgstr ""
 
 #: ../undo.md:9
-msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction` and a decorator called `@transactional`."
+msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction`."
 msgstr ""
 
 #: ../undo.md:16

--- a/docs/locale/nl/LC_MESSAGES/docs.po
+++ b/docs/locale/nl/LC_MESSAGES/docs.po
@@ -3426,7 +3426,7 @@ msgid "Overview of Transactions"
 msgstr ""
 
 #: ../undo.md:9
-msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction` and a decorator called `@transactional`."
+msgid "The recording and playback of changes in Gaphor is handled by the the Undo Manager. The Undo Manager works transactionally. A transaction must succeed or fail as a complete unit. If the transaction fails in the middle, it is rolled back. In Gaphor this is achieved by the `transaction` module, which provides a context manager `Transaction`."
 msgstr ""
 
 #: ../undo.md:16

--- a/docs/locale/pt_BR/LC_MESSAGES/docs.po
+++ b/docs/locale/pt_BR/LC_MESSAGES/docs.po
@@ -8477,8 +8477,7 @@ msgid ""
 "Manager. The Undo Manager works transactionally. A transaction must succeed "
 "or fail as a complete unit. If the transaction fails in the middle, it is "
 "rolled back. In Gaphor this is achieved by the `transaction` module, which "
-"provides a context manager `Transaction` and a decorator called "
-"`@transactional`."
+"provides a context manager `Transaction`."
 msgstr ""
 
 #: ../undo.md:16

--- a/docs/locale/tr/LC_MESSAGES/docs.po
+++ b/docs/locale/tr/LC_MESSAGES/docs.po
@@ -8169,8 +8169,7 @@ msgid ""
 "Manager. The Undo Manager works transactionally. A transaction must succeed "
 "or fail as a complete unit. If the transaction fails in the middle, it is "
 "rolled back. In Gaphor this is achieved by the `transaction` module, which "
-"provides a context manager `Transaction` and a decorator called "
-"`@transactional`."
+"provides a context manager `Transaction`."
 msgstr ""
 
 #: ../undo.md:16

--- a/docs/undo.md
+++ b/docs/undo.md
@@ -11,7 +11,7 @@ Manager. The Undo Manager works transactionally.
 A transaction must succeed or fail as a complete unit. If
 the transaction fails in the middle, it is rolled back. In Gaphor this is
 achieved by the {mod}`~gaphor.transaction` module, which provides a context manager
-{obj}`~gaphor.transaction.Transaction` and a decorator called `@transactional`.
+{obj}`~gaphor.transaction.Transaction`.
 
 When transactions take place, they emit events when the top-most transaction begins and is finished.
 The event notifications are for the begin of the transaction, and the commit of the
@@ -50,8 +50,6 @@ You only require transactions if the undo manager is active.
 ```{eval-rst}
 .. autoclass:: gaphor.transaction.Transaction
    :members:
-
-.. autofunction:: gaphor.transaction.transactional
 
 .. autoclass:: gaphor.event.TransactionBegin
 

--- a/gaphor/C4Model/propertypages.py
+++ b/gaphor/C4Model/propertypages.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from gaphor.C4Model import c4model
-from gaphor.core import transactional
+from gaphor.core import Transaction
 from gaphor.diagram.propertypages import (
     PropertyPageBase,
     PropertyPages,
@@ -18,10 +18,13 @@ new_builder = new_resource_builder("gaphor.C4Model")
 class DescriptionPropertyPage(PropertyPageBase):
     order = 14
 
-    def __init__(self, subject: Union[c4model.C4Container, c4model.C4Person]):
+    def __init__(
+        self, subject: Union[c4model.C4Container, c4model.C4Person], event_manager
+    ):
         super().__init__()
         assert subject
         self.subject = subject
+        self.event_manager = event_manager
         self.watcher = subject.watcher()
 
     def construct(self):
@@ -48,21 +51,22 @@ class DescriptionPropertyPage(PropertyPageBase):
             builder.get_object("description-editor"), self.watcher
         )
 
-    @transactional
     def _on_description_changed(self, buffer):
-        self.subject.description = buffer.get_text(
-            buffer.get_start_iter(), buffer.get_end_iter(), False
-        )
+        with Transaction(self.event_manager):
+            self.subject.description = buffer.get_text(
+                buffer.get_start_iter(), buffer.get_end_iter(), False
+            )
 
 
 @PropertyPages.register(c4model.C4Container)
 class TechnologyPropertyPage(PropertyPageBase):
     order = 15
 
-    def __init__(self, subject: c4model.C4Container):
+    def __init__(self, subject: c4model.C4Container, event_manager):
         super().__init__()
         assert subject
         self.subject = subject
+        self.event_manager = event_manager
 
     def construct(self):
         builder = new_builder(
@@ -78,6 +82,6 @@ class TechnologyPropertyPage(PropertyPageBase):
 
         return builder.get_object("technology-editor")
 
-    @transactional
     def _on_technology_changed(self, entry):
-        self.subject.technology = entry.get_text()
+        with Transaction(self.event_manager):
+            self.subject.technology = entry.get_text()

--- a/gaphor/C4Model/tests/test_propertypages.py
+++ b/gaphor/C4Model/tests/test_propertypages.py
@@ -3,9 +3,9 @@ from gaphor.C4Model.propertypages import DescriptionPropertyPage, TechnologyProp
 from gaphor.diagram.tests.fixtures import find
 
 
-def test_description_property_page(element_factory):
+def test_description_property_page(event_manager, element_factory):
     subject = element_factory.create(C4Model.c4model.C4Container)
-    property_page = DescriptionPropertyPage(subject)
+    property_page = DescriptionPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     description = find(widget, "description")
@@ -14,9 +14,9 @@ def test_description_property_page(element_factory):
     assert subject.description == "test"
 
 
-def test_technology_property_page(element_factory):
+def test_technology_property_page(event_manager, element_factory):
     subject = element_factory.create(C4Model.c4model.C4Container)
-    property_page = TechnologyPropertyPage(subject)
+    property_page = TechnologyPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     technology = find(widget, "technology")

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -80,12 +80,14 @@ def test_requirement_height_reset(diagram, element_factory):
     assert item.height == DEFAULT_HEIGHT
 
 
-def test_show_property_type_property_page_show_type(diagram, element_factory):
+def test_show_property_type_property_page_show_type(
+    diagram, element_factory, event_manager
+):
     item = diagram.create(
         SysML.blocks.ProxyPortItem,
         subject=element_factory.create(SysML.sysml.ProxyPort),
     )
-    property_page = ShowTypedElementPropertyPage(item)
+    property_page = ShowTypedElementPropertyPage(item, event_manager)
 
     widget = property_page.construct()
     show_parts = find(widget, "show-type")
@@ -155,12 +157,12 @@ def test_no_property_aggregation_page_for_ports(element_factory, event_manager):
     assert not widget
 
 
-def test_property_type(element_factory):
+def test_property_type(element_factory, event_manager):
     subject = element_factory.create(UML.Property)
 
     type = element_factory.create(UML.Class)
     type.name = "Bar"
-    property_page = TypedElementPropertyPage(subject)
+    property_page = TypedElementPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     dropdown = find(widget, "element-type")

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -31,9 +31,9 @@ def connector(element_factory):
     return UML.recipes.create_connector(prop_a, prop_b)
 
 
-def test_requirement_property_page_id(element_factory):
+def test_requirement_property_page_id(element_factory, event_manager):
     subject = element_factory.create(SysML.sysml.Requirement)
-    property_page = RequirementPropertyPage(subject)
+    property_page = RequirementPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     requirement_id = find(widget, "requirement-id")
@@ -42,9 +42,9 @@ def test_requirement_property_page_id(element_factory):
     assert subject.externalId == "test"
 
 
-def test_requirement_property_page_text(element_factory):
+def test_requirement_property_page_text(element_factory, event_manager):
     subject = element_factory.create(SysML.sysml.Requirement)
-    property_page = RequirementPropertyPage(subject)
+    property_page = RequirementPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     requirement_text = find(widget, "requirement-text")
@@ -53,12 +53,12 @@ def test_requirement_property_page_text(element_factory):
     assert subject.text == "test"
 
 
-def test_requirement_property_page_show_text(diagram, element_factory):
+def test_requirement_property_page_show_text(diagram, element_factory, event_manager):
     item = diagram.create(
         SysML.requirements.RequirementItem,
         subject=element_factory.create(SysML.sysml.Requirement),
     )
-    property_page = RequirementItemPropertyPage(item)
+    property_page = RequirementItemPropertyPage(item, event_manager)
 
     widget = property_page.construct()
     show_requirement_text = find(widget, "show-requirement-text")
@@ -94,11 +94,11 @@ def test_show_property_type_property_page_show_type(diagram, element_factory):
     assert item.show_type
 
 
-def test_compartment_property_page_show_parts(diagram, element_factory):
+def test_compartment_property_page_show_parts(diagram, element_factory, event_manager):
     item = diagram.create(
         SysML.blocks.BlockItem, subject=element_factory.create(SysML.sysml.Block)
     )
-    property_page = CompartmentPage(item)
+    property_page = CompartmentPage(item, event_manager)
 
     widget = property_page.construct()
     show_parts = find(widget, "show-parts")
@@ -107,11 +107,13 @@ def test_compartment_property_page_show_parts(diagram, element_factory):
     assert item.show_parts
 
 
-def test_compartment_property_page_show_references(diagram, element_factory):
+def test_compartment_property_page_show_references(
+    diagram, element_factory, event_manager
+):
     item = diagram.create(
         SysML.blocks.BlockItem, subject=element_factory.create(SysML.sysml.Block)
     )
-    property_page = CompartmentPage(item)
+    property_page = CompartmentPage(item, event_manager)
 
     widget = property_page.construct()
     show_references = find(widget, "show-references")
@@ -120,11 +122,11 @@ def test_compartment_property_page_show_references(diagram, element_factory):
     assert item.show_references
 
 
-def test_compartment_property_page_show_values(diagram, element_factory):
+def test_compartment_property_page_show_values(diagram, element_factory, event_manager):
     item = diagram.create(
         SysML.blocks.BlockItem, subject=element_factory.create(SysML.sysml.Block)
     )
-    property_page = CompartmentPage(item)
+    property_page = CompartmentPage(item, event_manager)
 
     widget = property_page.construct()
     show_references = find(widget, "show-values")
@@ -133,9 +135,9 @@ def test_compartment_property_page_show_values(diagram, element_factory):
     assert item.show_values
 
 
-def test_property_aggregation_page(element_factory):
+def test_property_aggregation_page(element_factory, event_manager):
     subject = element_factory.create(SysML.sysml.Property)
-    property_page = PropertyAggregationPropertyPage(subject)
+    property_page = PropertyAggregationPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     show_references = find(widget, "aggregation")
@@ -144,9 +146,9 @@ def test_property_aggregation_page(element_factory):
     assert subject.aggregation == "composite"
 
 
-def test_no_property_aggregation_page_for_ports(element_factory):
+def test_no_property_aggregation_page_for_ports(element_factory, event_manager):
     subject = element_factory.create(UML.Port)
-    property_page = PropertyAggregationPropertyPage(subject)
+    property_page = PropertyAggregationPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
 
@@ -171,8 +173,8 @@ def test_property_type(element_factory):
     assert subject.type is type
 
 
-def test_association_item_flow(association):
-    property_page = ItemFlowPropertyPage(association)
+def test_association_item_flow(association, event_manager):
+    property_page = ItemFlowPropertyPage(association, event_manager)
 
     widget = property_page.construct()
     use = find(widget, "use-item-flow")
@@ -184,8 +186,8 @@ def test_association_item_flow(association):
     assert association.abstraction[0].informationTarget is association.memberEnd[1]
 
 
-def test_connector_item_flow(connector):
-    property_page = ItemFlowPropertyPage(connector)
+def test_connector_item_flow(connector, event_manager):
+    property_page = ItemFlowPropertyPage(connector, event_manager)
 
     widget = property_page.construct()
     use = find(widget, "use-item-flow")
@@ -195,9 +197,9 @@ def test_connector_item_flow(connector):
     assert connector.informationFlow[0].itemProperty
 
 
-def test_disable_item_flow(element_factory):
+def test_disable_item_flow(element_factory, event_manager):
     subject = element_factory.create(SysML.sysml.Connector)
-    property_page = ItemFlowPropertyPage(subject)
+    property_page = ItemFlowPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     use = find(widget, "use-item-flow")
@@ -207,8 +209,8 @@ def test_disable_item_flow(element_factory):
     assert not subject.informationFlow
 
 
-def test_item_flow_name(connector):
-    property_page = ItemFlowPropertyPage(connector)
+def test_item_flow_name(connector, event_manager):
+    property_page = ItemFlowPropertyPage(connector, event_manager)
 
     widget = property_page.construct()
     use = find(widget, "use-item-flow")
@@ -220,10 +222,10 @@ def test_item_flow_name(connector):
     assert connector.informationFlow[0].itemProperty.name == "foo"
 
 
-def test_item_flow_type(connector, element_factory):
+def test_item_flow_type(connector, element_factory, event_manager):
     type = element_factory.create(UML.Class)
     type.name = "Bar"
-    property_page = ItemFlowPropertyPage(connector)
+    property_page = ItemFlowPropertyPage(connector, event_manager)
 
     widget = property_page.construct()
     use = find(widget, "use-item-flow")
@@ -245,7 +247,7 @@ def test_item_flow_is_loaded(element_factory):
     assert any(issubclass(page, ItemFlowPropertyPage) for page in property_pages)
 
 
-def test_item_flow_source_and_target(element_factory):
+def test_item_flow_source_and_target(element_factory, event_manager):
     subject = element_factory.create(UML.Connector)
     head_end = element_factory.create(UML.ConnectorEnd)
     head_end.role = element_factory.create(UML.Property)
@@ -254,7 +256,7 @@ def test_item_flow_source_and_target(element_factory):
     subject.end = head_end
     subject.end = tail_end
 
-    property_page = ItemFlowPropertyPage(subject)
+    property_page = ItemFlowPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     use = find(widget, "use-item-flow")
@@ -264,8 +266,8 @@ def test_item_flow_source_and_target(element_factory):
     assert subject.informationFlow[0].informationTarget is tail_end.role
 
 
-def test_connector_item_flow_invert_direction(connector):
-    property_page = ItemFlowPropertyPage(connector)
+def test_connector_item_flow_invert_direction(connector, event_manager):
+    property_page = ItemFlowPropertyPage(connector, event_manager)
 
     widget = property_page.construct()
     use = find(widget, "use-item-flow")
@@ -278,8 +280,8 @@ def test_connector_item_flow_invert_direction(connector):
     assert information_flow.informationTarget is connector.end[0].role
 
 
-def test_association_item_flow_invert_direction(association):
-    property_page = ItemFlowPropertyPage(association)
+def test_association_item_flow_invert_direction(association, event_manager):
+    property_page = ItemFlowPropertyPage(association, event_manager)
 
     widget = property_page.construct()
     use = find(widget, "use-item-flow")

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -240,9 +240,9 @@ def test_item_flow_type(connector, element_factory):
 
 def test_item_flow_is_loaded(element_factory):
     subject = element_factory.create(UML.Connector)
-    property_pages = PropertyPages(subject)
+    property_pages = PropertyPages.find(subject)
 
-    assert any(isinstance(page, ItemFlowPropertyPage) for page in property_pages)
+    assert any(issubclass(page, ItemFlowPropertyPage) for page in property_pages)
 
 
 def test_item_flow_source_and_target(element_factory):

--- a/gaphor/UML/actions/tests/test_actionspropertypages.py
+++ b/gaphor/UML/actions/tests/test_actionspropertypages.py
@@ -10,11 +10,13 @@ from gaphor.UML.actions.actionspropertypages import (
 )
 
 
-def test_object_node_property_page_show_ordering(diagram, element_factory):
+def test_object_node_property_page_show_ordering(
+    diagram, element_factory, event_manager
+):
     item = diagram.create(
         UML.actions.ObjectNodeItem, subject=element_factory.create(UML.ObjectNode)
     )
-    property_page = ShowObjectNodePropertyPage(item)
+    property_page = ShowObjectNodePropertyPage(item, event_manager)
 
     widget = property_page.construct()
     show_ordering = find(widget, "show-ordering")
@@ -23,9 +25,9 @@ def test_object_node_property_page_show_ordering(diagram, element_factory):
     assert item.show_ordering
 
 
-def test_object_node_property_page_upper_bound(diagram, element_factory):
+def test_object_node_property_page_upper_bound(diagram, element_factory, event_manager):
     subject = element_factory.create(UML.ObjectNode)
-    property_page = ObjectNodePropertyPage(subject)
+    property_page = ObjectNodePropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     upper_bound = find(widget, "upper-bound")
@@ -34,11 +36,11 @@ def test_object_node_property_page_upper_bound(diagram, element_factory):
     assert subject.upperBound == "test"
 
 
-def test_object_node_property_page_ordering(diagram, element_factory):
+def test_object_node_property_page_ordering(diagram, element_factory, event_manager):
     subject = element_factory.create(UML.ObjectNode)
 
     assert subject.ordering == "unordered"
-    property_page = ObjectNodePropertyPage(subject)
+    property_page = ObjectNodePropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     ordering = find(widget, "ordering")
@@ -47,11 +49,11 @@ def test_object_node_property_page_ordering(diagram, element_factory):
     assert subject.ordering == "FIFO"
 
 
-def test_decision_node_property_page_show_type(diagram, element_factory):
+def test_decision_node_property_page_show_type(diagram, element_factory, event_manager):
     item = diagram.create(
         UML.actions.DecisionNodeItem, subject=element_factory.create(UML.DecisionNode)
     )
-    property_page = DecisionNodePropertyPage(item)
+    property_page = DecisionNodePropertyPage(item, event_manager)
 
     widget = property_page.construct()
     show_type = find(widget, "show-type")
@@ -60,12 +62,12 @@ def test_decision_node_property_page_show_type(diagram, element_factory):
     assert item.show_underlying_type
 
 
-def test_fork_node_property_page(diagram, element_factory):
+def test_fork_node_property_page(diagram, element_factory, event_manager):
     item = diagram.create(
         UML.actions.ForkNodeItem, subject=element_factory.create(UML.ForkNode)
     )
     orig_matrix = item.matrix.tuple()
-    property_page = ForkNodePropertyPage(item)
+    property_page = ForkNodePropertyPage(item, event_manager)
 
     widget = property_page.construct()
     horizontal = find(widget, "horizontal")
@@ -74,9 +76,9 @@ def test_fork_node_property_page(diagram, element_factory):
     assert item.matrix.tuple() != orig_matrix
 
 
-def test_join_node_property_page(element_factory):
+def test_join_node_property_page(element_factory, event_manager):
     subject = element_factory.create(UML.JoinNode)
-    property_page = JoinNodePropertyPage(subject)
+    property_page = JoinNodePropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     join_spec = find(widget, "join-spec")
@@ -85,9 +87,9 @@ def test_join_node_property_page(element_factory):
     assert subject.joinSpec == "test"
 
 
-def test_flow_property_page(element_factory):
+def test_flow_property_page(element_factory, event_manager):
     subject = element_factory.create(UML.ObjectFlow)
-    property_page = FlowPropertyPageAbstract(subject)
+    property_page = FlowPropertyPageAbstract(subject, event_manager)
 
     widget = property_page.construct()
     guard = find(widget, "guard")

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -196,11 +196,13 @@ def test_construct_activity_item_property_page(element_factory):
     assert widget
 
 
-def test_construct_activity_parameter_node_type_property_page(element_factory):
+def test_construct_activity_parameter_node_type_property_page(
+    element_factory, event_manager
+):
     subject = element_factory.create(UML.ActivityParameterNode)
     subject.parameter = element_factory.create(UML.Parameter)
 
-    property_page = ActivityParameterNodeTypePropertyPage(subject)
+    property_page = ActivityParameterNodeTypePropertyPage(subject, event_manager)
     widget = property_page.construct()
 
     assert widget

--- a/gaphor/UML/actions/tests/test_activitypropertypage.py
+++ b/gaphor/UML/actions/tests/test_activitypropertypage.py
@@ -19,19 +19,19 @@ def activity_parameter_node(element_factory, name=None):
     return node
 
 
-def test_activity_parameter_node_empty(element_factory):
+def test_activity_parameter_node_empty(element_factory, event_manager):
     activity = element_factory.create(UML.Activity)
-    model = activity_parameter_node_model(activity)
+    model = activity_parameter_node_model(activity, event_manager)
 
     empty = model.get_item(0)
 
     assert not empty.node
 
 
-def test_activity_parameter_node_in_model(element_factory):
+def test_activity_parameter_node_in_model(element_factory, event_manager):
     activity = element_factory.create(UML.Activity)
     activity.node = activity_parameter_node(element_factory, "name")
-    model = activity_parameter_node_model(activity)
+    model = activity_parameter_node_model(activity, event_manager)
 
     param = model.get_item(0)
     empty = model.get_item(1)
@@ -40,11 +40,13 @@ def test_activity_parameter_node_in_model(element_factory):
     assert not empty.node
 
 
-def test_activity_parameter_node_edit_existing_parameter(element_factory):
+def test_activity_parameter_node_edit_existing_parameter(
+    element_factory, event_manager
+):
     activity = element_factory.create(UML.Activity)
     activity.node = activity_parameter_node(element_factory)
     parameter = activity.node[0].parameter
-    model = activity_parameter_node_model(activity)
+    model = activity_parameter_node_model(activity, event_manager)
 
     view = model.get_item(0)
     view.parameter = "in attr: str"
@@ -54,9 +56,9 @@ def test_activity_parameter_node_edit_existing_parameter(element_factory):
     assert parameter.typeValue == "str"
 
 
-def test_activity_parameter_node_add_new_parameter(element_factory):
+def test_activity_parameter_node_add_new_parameter(element_factory, event_manager):
     activity = element_factory.create(UML.Activity)
-    model = activity_parameter_node_model(activity)
+    model = activity_parameter_node_model(activity, event_manager)
 
     view = model.get_item(0)
     view.parameter = "in attr: str"
@@ -68,10 +70,10 @@ def test_activity_parameter_node_add_new_parameter(element_factory):
     assert parameter.typeValue == "str"
 
 
-def test_update_model_when_new_parameter_added(element_factory):
+def test_update_model_when_new_parameter_added(element_factory, event_manager):
     subject = element_factory.create(UML.Activity)
 
-    property_page = ActivityPage(subject)
+    property_page = ActivityPage(subject, event_manager)
     property_page.construct()
 
     subject.node = activity_parameter_node(element_factory, "one")
@@ -79,10 +81,10 @@ def test_update_model_when_new_parameter_added(element_factory):
     assert property_page.model.get_n_items() == 2  # one + empty row
 
 
-def test_activity_parameter_node_name_editing(element_factory):
+def test_activity_parameter_node_name_editing(element_factory, event_manager):
     subject = element_factory.create(UML.ActivityParameterNode)
     subject.parameter = element_factory.create(UML.Parameter)
-    property_page = ActivityParameterNodeNamePropertyPage(subject)
+    property_page = ActivityParameterNodeNamePropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     name = find(widget, "name-entry")
@@ -91,10 +93,12 @@ def test_activity_parameter_node_name_editing(element_factory):
     assert subject.parameter.name == "A new name"
 
 
-def test_update_model_when_new_parameter_added_via_list_model(element_factory):
+def test_update_model_when_new_parameter_added_via_list_model(
+    element_factory, event_manager
+):
     subject = element_factory.create(UML.Activity)
 
-    property_page = ActivityPage(subject)
+    property_page = ActivityPage(subject, event_manager)
     property_page.construct()
 
     new_view = property_page.model.get_item(0)
@@ -105,11 +109,13 @@ def test_update_model_when_new_parameter_added_via_list_model(element_factory):
     assert property_page.model.get_item(1).node is None
 
 
-def test_update_model_with_single_node_when_parameter_deleted(element_factory):
+def test_update_model_with_single_node_when_parameter_deleted(
+    element_factory, event_manager
+):
     subject = element_factory.create(UML.Activity)
     subject.node = node = activity_parameter_node(element_factory, "one")
 
-    property_page = ActivityPage(subject)
+    property_page = ActivityPage(subject, event_manager)
     property_page.construct()
 
     del subject.node[node]
@@ -119,12 +125,14 @@ def test_update_model_with_single_node_when_parameter_deleted(element_factory):
     assert property_page.model.get_item(0).node is None
 
 
-def test_update_model_with_multiple_nodes_when_parameter_deleted(element_factory):
+def test_update_model_with_multiple_nodes_when_parameter_deleted(
+    element_factory, event_manager
+):
     subject = element_factory.create(UML.Activity)
     subject.node = node = activity_parameter_node(element_factory, "one")
     subject.node = activity_parameter_node(element_factory, "two")
 
-    property_page = ActivityPage(subject)
+    property_page = ActivityPage(subject, event_manager)
     property_page.construct()
 
     del subject.node[node]
@@ -134,13 +142,13 @@ def test_update_model_with_multiple_nodes_when_parameter_deleted(element_factory
     assert property_page.model.get_item(1).node is None
 
 
-def test_activity_parameter_node_reorder_down(element_factory):
+def test_activity_parameter_node_reorder_down(element_factory, event_manager):
     subject = element_factory.create(UML.Activity)
     subject.node = activity_parameter_node(element_factory, "one")
     subject.node = activity_parameter_node(element_factory, "two")
     node_one, node_two = subject.node
 
-    property_page = ActivityPage(subject)
+    property_page = ActivityPage(subject, event_manager)
     widget = property_page.construct()
 
     list_view = find(widget, "parameter-list")
@@ -151,13 +159,13 @@ def test_activity_parameter_node_reorder_down(element_factory):
     assert subject.node[1] is node_one
 
 
-def test_activity_parameter_node_reorder_up(element_factory):
+def test_activity_parameter_node_reorder_up(element_factory, event_manager):
     subject = element_factory.create(UML.Activity)
     subject.node = activity_parameter_node(element_factory, "one")
     subject.node = activity_parameter_node(element_factory, "two")
     node_one, node_two = subject.node
 
-    property_page = ActivityPage(subject)
+    property_page = ActivityPage(subject, event_manager)
     widget = property_page.construct()
 
     list_view = find(widget, "parameter-list")
@@ -170,13 +178,13 @@ def test_activity_parameter_node_reorder_up(element_factory):
     assert subject.node[1] is node_one
 
 
-def test_activity_parameter_node_reorder_first_node_up(element_factory):
+def test_activity_parameter_node_reorder_first_node_up(element_factory, event_manager):
     subject = element_factory.create(UML.Activity)
     subject.node = activity_parameter_node(element_factory, "one")
     subject.node = activity_parameter_node(element_factory, "two")
     node_one, node_two = subject.node
 
-    property_page = ActivityPage(subject)
+    property_page = ActivityPage(subject, event_manager)
     widget = property_page.construct()
 
     list_view = find(widget, "parameter-list")
@@ -187,10 +195,10 @@ def test_activity_parameter_node_reorder_first_node_up(element_factory):
     assert subject.node[1] is node_two
 
 
-def test_construct_activity_item_property_page(element_factory):
+def test_construct_activity_item_property_page(element_factory, event_manager):
     subject = element_factory.create(UML.Activity)
 
-    property_page = ActivityPage(subject)
+    property_page = ActivityPage(subject, event_manager)
     widget = property_page.construct()
 
     assert widget
@@ -208,21 +216,25 @@ def test_construct_activity_parameter_node_type_property_page(
     assert widget
 
 
-def test_construct_activity_parameter_node_direction_property_page(element_factory):
+def test_construct_activity_parameter_node_direction_property_page(
+    element_factory, event_manager
+):
     subject = element_factory.create(UML.ActivityParameterNode)
     subject.parameter = element_factory.create(UML.Parameter)
 
-    property_page = ActivityParameterNodeDirectionPropertyPage(subject)
+    property_page = ActivityParameterNodeDirectionPropertyPage(subject, event_manager)
     widget = property_page.construct()
 
     assert widget
 
 
-def test_construct_activity_parameter_node_direction_changed(element_factory):
+def test_construct_activity_parameter_node_direction_changed(
+    element_factory, event_manager
+):
     subject = element_factory.create(UML.ActivityParameterNode)
     subject.parameter = element_factory.create(UML.Parameter)
 
-    property_page = ActivityParameterNodeDirectionPropertyPage(subject)
+    property_page = ActivityParameterNodeDirectionPropertyPage(subject, event_manager)
     widget = property_page.construct()
 
     direction = find(widget, "parameter-direction")

--- a/gaphor/UML/actions/tests/test_partitionpage.py
+++ b/gaphor/UML/actions/tests/test_partitionpage.py
@@ -3,11 +3,11 @@ from gaphor.diagram.tests.fixtures import find
 from gaphor.UML.actions.partitionpage import PartitionPropertyPage
 
 
-def test_partition_page(diagram, element_factory):
+def test_partition_page(diagram, element_factory, event_manager):
     item = diagram.create(
         UML.actions.PartitionItem, subject=element_factory.create(UML.ActivityPartition)
     )
-    property_page = PartitionPropertyPage(item)
+    property_page = PartitionPropertyPage(item, event_manager)
 
     widget = property_page.construct()
 
@@ -17,11 +17,11 @@ def test_partition_page(diagram, element_factory):
     assert len(item.partition) == 4
 
 
-def test_partition_name(diagram, element_factory):
+def test_partition_name(diagram, element_factory, event_manager):
     item = diagram.create(
         UML.actions.PartitionItem, subject=element_factory.create(UML.ActivityPartition)
     )
-    property_page = PartitionPropertyPage(item)
+    property_page = PartitionPropertyPage(item, event_manager)
     property_page.construct()
     property_page.update_partitions(1)
 
@@ -33,13 +33,13 @@ def test_partition_name(diagram, element_factory):
     assert item.partition[0].name == "Name"
 
 
-def test_partition_type(diagram, element_factory):
+def test_partition_type(diagram, element_factory, event_manager):
     class_ = element_factory.create(UML.Class)
     class_.name = "Foobar"
     item = diagram.create(
         UML.actions.PartitionItem, subject=element_factory.create(UML.ActivityPartition)
     )
-    property_page = PartitionPropertyPage(item)
+    property_page = PartitionPropertyPage(item, event_manager)
     property_page.construct()
     property_page.update_partitions(1)
 

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -23,8 +23,9 @@ class AssociationPropertyPage(PropertyPageBase):
 
     order = 20
 
-    def __init__(self, subject: UML.Association):
+    def __init__(self, subject: UML.Association, event_manager):
         self.subject = subject
+        self.event_manager = event_manager
         self.watcher = subject and subject.watcher()
         self.end_name_change_semaphore = 0
 
@@ -41,7 +42,7 @@ class AssociationPropertyPage(PropertyPageBase):
         aggregation = builder.get_object(f"{end_name}-aggregation")
         aggregation.set_selected(self.AGGREGATION.index(subject.aggregation))
 
-        if stereotypes_model := stereotype_model(subject):
+        if stereotypes_model := stereotype_model(subject, self.event_manager):
             stereotype_list = builder.get_object(f"{end_name}-stereotype-list")
             stereotype_set_model_with_interaction(stereotype_list, stereotypes_model)
         else:

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -45,8 +45,8 @@ class NamedElementPropertyPage(NamePropertyPage):
 
     order = 10
 
-    def __init__(self, subject: UML.NamedElement | None):
-        super().__init__(subject)
+    def __init__(self, subject: UML.NamedElement | None, event_manager):
+        super().__init__(subject, event_manager)
 
     def construct(self):
         if (

--- a/gaphor/UML/classes/tests/test_associationpropertypages.py
+++ b/gaphor/UML/classes/tests/test_associationpropertypages.py
@@ -20,7 +20,9 @@ def test_association_property_page(element_factory, event_manager):
     assert subject.memberEnd[0].name == "head"
 
 
-def test_association_property_page_invert_direction(diagram, element_factory):
+def test_association_property_page_invert_direction(
+    diagram, element_factory, event_manager
+):
     end1 = element_factory.create(UML.Class)
     end2 = element_factory.create(UML.Class)
     item = diagram.create(
@@ -28,7 +30,7 @@ def test_association_property_page_invert_direction(diagram, element_factory):
     )
     item.head_subject = item.subject.memberEnd[0]
     item.tail_subject = item.subject.memberEnd[1]
-    property_page = AssociationDirectionPropertyPage(item)
+    property_page = AssociationDirectionPropertyPage(item, event_manager)
 
     property_page.on_invert_direction_change(None)
 

--- a/gaphor/UML/classes/tests/test_associationpropertypages.py
+++ b/gaphor/UML/classes/tests/test_associationpropertypages.py
@@ -6,12 +6,12 @@ from gaphor.UML.classes.associationpropertypages import (
 )
 
 
-def test_association_property_page(element_factory):
+def test_association_property_page(element_factory, event_manager):
     end1 = element_factory.create(UML.Class)
     end2 = element_factory.create(UML.Class)
     subject = UML.recipes.create_association(end1, end2)
 
-    property_page = AssociationPropertyPage(subject)
+    property_page = AssociationPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     head_name = find(widget, "head-name")
@@ -44,13 +44,13 @@ def metaclass_and_stereotype(element_factory):
     return metaclass, stereotype
 
 
-def test_association_property_with_stereotype(element_factory):
+def test_association_property_with_stereotype(element_factory, event_manager):
     end1 = element_factory.create(UML.Class)
     end2 = element_factory.create(UML.Class)
     subject = UML.recipes.create_association(end1, end2)
     metaclass_and_stereotype(element_factory)
 
-    property_page = AssociationPropertyPage(subject)
+    property_page = AssociationPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
 

--- a/gaphor/UML/classes/tests/test_classespropertypages.py
+++ b/gaphor/UML/classes/tests/test_classespropertypages.py
@@ -41,9 +41,9 @@ def test_no_named_element_property_page_for_metaclass(metaclass, event_manager):
     assert widget is None
 
 
-def test_classifier_property_page(element_factory):
+def test_classifier_property_page(element_factory, event_manager):
     subject = element_factory.create(UML.Class)
-    property_page = ClassifierPropertyPage(subject)
+    property_page = ClassifierPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     abstract = find(widget, "abstract")
@@ -52,18 +52,18 @@ def test_classifier_property_page(element_factory):
     assert subject.isAbstract
 
 
-def test_no_classifier_property_page_for_metaclass(metaclass):
-    property_page = ClassifierPropertyPage(metaclass)
+def test_no_classifier_property_page_for_metaclass(metaclass, event_manager):
+    property_page = ClassifierPropertyPage(metaclass, event_manager)
     widget = property_page.construct()
 
     assert widget is None
 
 
-def test_interface_property_page(diagram, element_factory):
+def test_interface_property_page(diagram, element_factory, event_manager):
     item = diagram.create(
         UML.classes.InterfaceItem, subject=element_factory.create(UML.Interface)
     )
-    property_page = InterfacePropertyPage(item)
+    property_page = InterfacePropertyPage(item, event_manager)
 
     widget = property_page.construct()
     folded = find(widget, "folded")
@@ -72,11 +72,11 @@ def test_interface_property_page(diagram, element_factory):
     assert item.folded == Folded.PROVIDED
 
 
-def test_show_attributes_page(diagram, element_factory):
+def test_show_attributes_page(diagram, element_factory, event_manager):
     item = diagram.create(
         UML.classes.InterfaceItem, subject=element_factory.create(UML.Interface)
     )
-    property_page = ShowAttributesPage(item)
+    property_page = ShowAttributesPage(item, event_manager)
 
     widget = property_page.construct()
     show_attributes = find(widget, "show-attributes")
@@ -85,10 +85,10 @@ def test_show_attributes_page(diagram, element_factory):
     assert not item.show_attributes
 
 
-def test_attributes_page_add_attribute(diagram, element_factory):
+def test_attributes_page_add_attribute(element_factory, event_manager):
     subject = element_factory.create(UML.Interface)
 
-    property_page = AttributesPage(subject)
+    property_page = AttributesPage(subject, event_manager)
 
     property_page.construct()
     property_page.model.get_item(0).attribute = "+ attr: str"
@@ -97,7 +97,7 @@ def test_attributes_page_add_attribute(diagram, element_factory):
     assert subject.attribute[0].typeValue == "str"
 
 
-def test_attribute_create_model(element_factory):
+def test_attribute_create_model(element_factory, event_manager):
     subject = element_factory.create(UML.Class)
 
     attr1 = element_factory.create(UML.Property)
@@ -110,18 +110,18 @@ def test_attribute_create_model(element_factory):
     attr3.name = "attr3"
     subject.ownedAttribute = attr3
 
-    list_store = attribute_model(subject)
+    list_store = attribute_model(subject, event_manager)
 
     assert list_store[0].attr is attr1
     assert list_store[1].attr is attr2
     assert list_store[2].attr is attr3
 
 
-def test_show_operations_page(diagram, element_factory):
+def test_show_operations_page(diagram, element_factory, event_manager):
     item = diagram.create(
         UML.classes.InterfaceItem, subject=element_factory.create(UML.Interface)
     )
-    property_page = ShowOperationsPage(item)
+    property_page = ShowOperationsPage(item, event_manager)
 
     widget = property_page.construct()
     show_operations = find(widget, "show-operations")
@@ -130,10 +130,10 @@ def test_show_operations_page(diagram, element_factory):
     assert not item.show_operations
 
 
-def test_operations_page_add_operation(element_factory):
+def test_operations_page_add_operation(element_factory, event_manager):
     subject = element_factory.create(UML.Interface)
 
-    property_page = OperationsPage(subject)
+    property_page = OperationsPage(subject, event_manager)
 
     property_page.construct()
     property_page.model.get_item(0).operation = "+ oper()"

--- a/gaphor/UML/classes/tests/test_classespropertypages.py
+++ b/gaphor/UML/classes/tests/test_classespropertypages.py
@@ -23,9 +23,9 @@ def metaclass(element_factory):
     return klass
 
 
-def test_named_element_property_page(element_factory):
+def test_named_element_property_page(element_factory, event_manager):
     subject = element_factory.create(UML.Class)
-    property_page = NamedElementPropertyPage(subject)
+    property_page = NamedElementPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     name_entry = find(widget, "name-entry")
@@ -34,8 +34,8 @@ def test_named_element_property_page(element_factory):
     assert subject.name == "Name"
 
 
-def test_no_named_element_property_page_for_metaclass(metaclass):
-    property_page = NamedElementPropertyPage(metaclass)
+def test_no_named_element_property_page_for_metaclass(metaclass, event_manager):
+    property_page = NamedElementPropertyPage(metaclass, event_manager)
     widget = property_page.construct()
 
     assert widget is None

--- a/gaphor/UML/classes/tests/test_dependencypropertypages.py
+++ b/gaphor/UML/classes/tests/test_dependencypropertypages.py
@@ -3,11 +3,11 @@ from gaphor.diagram.tests.fixtures import find
 from gaphor.UML.classes.dependencypropertypages import DependencyPropertyPage
 
 
-def test_dependency_property_page(diagram, element_factory):
+def test_dependency_property_page(diagram, element_factory, event_manager):
     item = diagram.create(
         UML.classes.DependencyItem, subject=element_factory.create(UML.Dependency)
     )
-    property_page = DependencyPropertyPage(item)
+    property_page = DependencyPropertyPage(item, event_manager)
 
     widget = property_page.construct()
     dependency_combo = find(widget, "dependency-dropdown")
@@ -16,9 +16,9 @@ def test_dependency_property_page(diagram, element_factory):
     assert item.dependency_type is UML.Realization
 
 
-def test_dependency_property_page_without_subject(diagram, element_factory):
+def test_dependency_property_page_without_subject(diagram, event_manager):
     item = diagram.create(UML.classes.DependencyItem)
-    property_page = DependencyPropertyPage(item)
+    property_page = DependencyPropertyPage(item, event_manager)
 
     widget = property_page.construct()
 

--- a/gaphor/UML/classes/tests/test_enumerationpropertypages.py
+++ b/gaphor/UML/classes/tests/test_enumerationpropertypages.py
@@ -5,18 +5,18 @@ from gaphor.UML.classes.enumerationpropertypages import (
 )
 
 
-def test_enumeration_property_page(diagram, element_factory):
+def test_enumeration_property_page(element_factory, event_manager):
     subject = element_factory.create(UML.Enumeration)
 
-    property_page = EnumerationPage(subject)
+    property_page = EnumerationPage(subject, event_manager)
 
     property_page.construct()
 
 
-def test_show_enumeration_property_page(diagram, element_factory):
+def test_show_enumeration_property_page(diagram, element_factory, event_manager):
     item = diagram.create(
         UML.classes.EnumerationItem, subject=element_factory.create(UML.Enumeration)
     )
-    property_page = ShowEnumerationPage(item)
+    property_page = ShowEnumerationPage(item, event_manager)
 
     property_page.construct()

--- a/gaphor/UML/interactions/tests/test_interactionspropertypages.py
+++ b/gaphor/UML/interactions/tests/test_interactionspropertypages.py
@@ -6,12 +6,12 @@ from gaphor.UML.interactions.interactionspropertypages import (
 )
 
 
-def test_lifeline_property_page(diagram, element_factory):
+def test_lifeline_property_page(diagram, element_factory, event_manager):
     subject = element_factory.create(UML.Lifeline)
 
     type = element_factory.create(UML.Interface)
     type.name = "Bar"
-    property_page = LifelinePropertyPage(subject)
+    property_page = LifelinePropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     dropdown = find(widget, "element-type")
@@ -24,11 +24,11 @@ def test_lifeline_property_page(diagram, element_factory):
     assert subject.represents is type
 
 
-def test_message_property_page(diagram, element_factory):
+def test_message_property_page(diagram, element_factory, event_manager):
     item = diagram.create(
         UML.interactions.MessageItem, subject=element_factory.create(UML.Message)
     )
-    property_page = MessagePropertyPage(item)
+    property_page = MessagePropertyPage(item, event_manager)
 
     widget = property_page.construct()
     message_combo = find(widget, "message-combo")

--- a/gaphor/UML/profiles/metaclasspropertypage.py
+++ b/gaphor/UML/profiles/metaclasspropertypage.py
@@ -1,7 +1,6 @@
 from gi.repository import Gtk
 
 from gaphor import UML
-from gaphor.core import transactional
 from gaphor.diagram.propertypages import (
     PropertyPageBase,
     PropertyPages,
@@ -9,6 +8,7 @@ from gaphor.diagram.propertypages import (
     new_resource_builder,
     unsubscribe_all_on_destroy,
 )
+from gaphor.transaction import Transaction
 
 new_builder = new_resource_builder("gaphor.UML.profiles")
 
@@ -37,8 +37,9 @@ class MetaclassPropertyPage(PropertyPageBase):
         if _issubclass(getattr(UML, c), UML.Element) and c != "Stereotype"
     )
 
-    def __init__(self, subject: UML.Class):
+    def __init__(self, subject: UML.Class, event_manager):
         self.subject = subject
+        self.event_manager = event_manager
         self.watcher = subject.watcher()
 
     def construct(self):
@@ -65,6 +66,6 @@ class MetaclassPropertyPage(PropertyPageBase):
             builder.get_object("metaclass-editor"), self.watcher
         )
 
-    @transactional
     def _on_name_changed(self, dropdown, _pspec):
-        self.subject.name = dropdown.get_selected_item().get_string()
+        with Transaction(self.event_manager):
+            self.subject.name = dropdown.get_selected_item().get_string()

--- a/gaphor/UML/profiles/tests/test_metaclasspropertypage.py
+++ b/gaphor/UML/profiles/tests/test_metaclasspropertypage.py
@@ -16,23 +16,23 @@ def class_(element_factory):
     del class_
 
 
-def test_name_input_field_for_normal_class(class_):
+def test_name_input_field_for_normal_class(class_, event_manager):
     """Test Metaclass Property Page not create for normal Class."""
 
-    editor = MetaclassPropertyPage(class_)
+    editor = MetaclassPropertyPage(class_, event_manager)
     page = editor.construct()
 
     assert not page
 
 
-def test_name_selection_for_metaclass(element_factory, class_):
+def test_name_selection_for_metaclass(element_factory, class_, event_manager):
     """Test the creation of Metaclass Property Page."""
 
     stereotype = element_factory.create(UML.Stereotype)
     stereotype.name = "NewStereotype"
     UML.recipes.create_extension(class_, stereotype)
 
-    editor = MetaclassPropertyPage(class_)
+    editor = MetaclassPropertyPage(class_, event_manager)
     page = editor.construct()
 
     assert page

--- a/gaphor/UML/profiles/tests/test_stereotypepage.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepage.py
@@ -7,16 +7,16 @@ from gaphor.diagram.tests.fixtures import find
 from gaphor.UML.profiles.stereotypepropertypages import StereotypePage
 
 
-def test_stereotype_page_with_no_stereotype(element_factory):
+def test_stereotype_page_with_no_stereotype(element_factory, event_manager):
     subject = element_factory.create(UML.Class)
 
-    editor = StereotypePage(subject)
+    editor = StereotypePage(subject, event_manager)
     page = editor.construct()
 
     assert page is None
 
 
-def test_stereotype_page_with_stereotype(element_factory):
+def test_stereotype_page_with_stereotype(element_factory, event_manager):
     subject = element_factory.create(UML.Class)
 
     # Create a stereotype applicable to Class types:
@@ -28,7 +28,7 @@ def test_stereotype_page_with_stereotype(element_factory):
     attr = element_factory.create(UML.Property)
     attr.name = "Property"
 
-    editor = StereotypePage(subject)
+    editor = StereotypePage(subject, event_manager)
     page = editor.construct()
 
     stereotype_view = find(page, "stereotype-list")

--- a/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
+++ b/gaphor/UML/profiles/tests/test_stereotypepropertypages.py
@@ -6,15 +6,17 @@ from gaphor.UML.profiles.stereotypepropertypages import (
 )
 
 
-def create_property_page(diagram, element_factory) -> StereotypePage:
-    return StereotypePage(element_factory.create(UML.Class))
+def create_property_page(diagram, element_factory, event_manager) -> StereotypePage:
+    return StereotypePage(element_factory.create(UML.Class), event_manager)
 
 
-def create_show_property_page(diagram, element_factory) -> ShowStereotypePage:
+def create_show_property_page(
+    diagram, element_factory, event_manager
+) -> ShowStereotypePage:
     item = diagram.create(
         UML.classes.ClassItem, subject=element_factory.create(UML.Class)
     )
-    return ShowStereotypePage(item)
+    return ShowStereotypePage(item, event_manager)
 
 
 def get_model(property_page: StereotypePage):
@@ -32,9 +34,11 @@ def metaclass_and_stereotype(element_factory):
     return metaclass, stereotype
 
 
-def test_show_stereotype_property_page_with_stereotype(diagram, element_factory):
+def test_show_stereotype_property_page_with_stereotype(
+    diagram, element_factory, event_manager
+):
     metaclass, stereotype = metaclass_and_stereotype(element_factory)
-    property_page = create_show_property_page(diagram, element_factory)
+    property_page = create_show_property_page(diagram, element_factory, event_manager)
 
     widget = property_page.construct()
     show_stereotypes = find(widget, "show-stereotypes")
@@ -43,10 +47,12 @@ def test_show_stereotype_property_page_with_stereotype(diagram, element_factory)
     assert property_page.item.show_stereotypes
 
 
-def test_stereotype_property_page_apply_stereotype(diagram, element_factory):
+def test_stereotype_property_page_apply_stereotype(
+    diagram, element_factory, event_manager
+):
     _metaclass, stereotype = metaclass_and_stereotype(element_factory)
 
-    property_page = create_property_page(diagram, element_factory)
+    property_page = create_property_page(diagram, element_factory, event_manager)
     subject = property_page.subject
     model = get_model(property_page)
     view = model[0]
@@ -55,7 +61,7 @@ def test_stereotype_property_page_apply_stereotype(diagram, element_factory):
     assert stereotype in subject.appliedStereotype[0].classifier
 
 
-def test_stereotype_property_page_slot_value(diagram, element_factory):
+def test_stereotype_property_page_slot_value(diagram, element_factory, event_manager):
     metaclass = element_factory.create(UML.Class)
     metaclass.name = "Class"
     stereotype = element_factory.create(UML.Stereotype)
@@ -63,7 +69,7 @@ def test_stereotype_property_page_slot_value(diagram, element_factory):
     stereotype.ownedAttribute = element_factory.create(UML.Property)
     UML.recipes.create_extension(metaclass, stereotype)
 
-    property_page = create_property_page(diagram, element_factory)
+    property_page = create_property_page(diagram, element_factory, event_manager)
     model = get_model(property_page)
     model[0].applied = True
     model[1].slot_value = "test"
@@ -74,13 +80,13 @@ def test_stereotype_property_page_slot_value(diagram, element_factory):
     assert "test" == slot.value
 
 
-def test_inherited_stereotype(diagram, element_factory):
+def test_inherited_stereotype(diagram, element_factory, event_manager):
     metaclass, stereotype = metaclass_and_stereotype(element_factory)
     substereotype = element_factory.create(UML.Stereotype)
     substereotype.name = "SubStereotype"
     UML.recipes.create_generalization(stereotype, substereotype)
 
-    property_page = create_property_page(diagram, element_factory)
+    property_page = create_property_page(diagram, element_factory, event_manager)
     model = get_model(property_page)
 
     assert model[0]
@@ -89,7 +95,7 @@ def test_inherited_stereotype(diagram, element_factory):
     assert model[1].name == "SubStereotype"
 
 
-def test_inherited_stereotype_with_attributes(diagram, element_factory):
+def test_inherited_stereotype_with_attributes(diagram, element_factory, event_manager):
     metaclass, stereotype = metaclass_and_stereotype(element_factory)
     attr = element_factory.create(UML.Property)
     attr.name = "Attr"
@@ -98,7 +104,7 @@ def test_inherited_stereotype_with_attributes(diagram, element_factory):
     substereotype.name = "SubStereotype"
     UML.recipes.create_generalization(stereotype, substereotype)
 
-    property_page = create_property_page(diagram, element_factory)
+    property_page = create_property_page(diagram, element_factory, event_manager)
     model = get_model(property_page)
 
     assert model[0]

--- a/gaphor/UML/states/propertypages.py
+++ b/gaphor/UML/states/propertypages.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from gi.repository import Gio
 
 from gaphor import UML
-from gaphor.core import transactional
 from gaphor.diagram.propertypages import (
     LabelValue,
     PropertyPageBase,
@@ -18,6 +17,7 @@ from gaphor.diagram.propertypages import (
     new_resource_builder,
     unsubscribe_all_on_destroy,
 )
+from gaphor.transaction import Transaction
 from gaphor.UML.states.state import StateItem
 from gaphor.UML.states.statemachine import StateMachineItem
 
@@ -32,8 +32,9 @@ class TransitionPropertyPage(PropertyPageBase):
 
     subject: UML.Transition
 
-    def __init__(self, subject):
+    def __init__(self, subject, event_manager):
         self.subject = subject
+        self.event_manager = event_manager
         self.watcher = subject.watcher()
 
     def construct(self):
@@ -60,12 +61,12 @@ class TransitionPropertyPage(PropertyPageBase):
             builder.get_object("transition-editor"), self.watcher
         )
 
-    @transactional
     def _on_guard_change(self, entry):
         value = entry.get_text().strip()
-        if not self.subject.guard:
-            self.subject.guard = self.subject.model.create(UML.Constraint)
-        self.subject.guard.specification = value
+        with Transaction(self.event_manager):
+            if not self.subject.guard:
+                self.subject.guard = self.subject.model.create(UML.Constraint)
+            self.subject.guard.specification = value
 
 
 @PropertyPages.register(UML.State)
@@ -75,8 +76,9 @@ class StatePropertyPage(PropertyPageBase):
     order = 15
     subject: UML.State
 
-    def __init__(self, subject):
+    def __init__(self, subject, event_manager):
         self.subject = subject
+        self.event_manager = event_manager
 
     def construct(self):
         subject = self.subject
@@ -144,32 +146,32 @@ class StatePropertyPage(PropertyPageBase):
 
         return options
 
-    @transactional
     def _on_entry_behavior_changed(self, dropdown, _pspec):
-        if id := dropdown.get_selected_item().value:
-            element = self.subject.model.lookup(id)
-            assert isinstance(element, UML.Behavior)
-            self.subject.entry = element
-        else:
-            del self.subject.entry
+        with Transaction(self.event_manager):
+            if id := dropdown.get_selected_item().value:
+                element = self.subject.model.lookup(id)
+                assert isinstance(element, UML.Behavior)
+                self.subject.entry = element
+            else:
+                del self.subject.entry
 
-    @transactional
     def _on_exit_behavior_changed(self, dropdown, _pspec):
-        if id := dropdown.get_selected_item().value:
-            element = self.subject.model.lookup(id)
-            assert isinstance(element, UML.Behavior)
-            self.subject.exit = element
-        else:
-            del self.subject.exit
+        with Transaction(self.event_manager):
+            if id := dropdown.get_selected_item().value:
+                element = self.subject.model.lookup(id)
+                assert isinstance(element, UML.Behavior)
+                self.subject.exit = element
+            else:
+                del self.subject.exit
 
-    @transactional
     def _on_do_activity_behavior_changed(self, dropdown, _pspec):
-        if id := dropdown.get_selected_item().value:
-            element = self.subject.model.lookup(id)
-            assert isinstance(element, UML.Behavior)
-            self.subject.doActivity = element
-        else:
-            del self.subject.doActivity
+        with Transaction(self.event_manager):
+            if id := dropdown.get_selected_item().value:
+                element = self.subject.model.lookup(id)
+                assert isinstance(element, UML.Behavior)
+                self.subject.doActivity = element
+            else:
+                del self.subject.doActivity
 
 
 @PropertyPages.register(StateItem)
@@ -177,9 +179,10 @@ class StatePropertyPage(PropertyPageBase):
 class RegionPropertyPage(PropertyPageBase):
     order = 15
 
-    def __init__(self, item: StateItem | StateMachineItem):
+    def __init__(self, item: StateItem | StateMachineItem, event_manager):
         super().__init__()
         self.item = item
+        self.event_manager = event_manager
 
     def construct(self):
         if not self.item.subject:
@@ -202,14 +205,14 @@ class RegionPropertyPage(PropertyPageBase):
 
         return builder.get_object("region-editor")
 
-    @transactional
     def _on_num_regions_changed(self, spin_button):
         num_regions = spin_button.get_value_as_int()
-        self.update_regions(num_regions)
+        with Transaction(self.event_manager):
+            self.update_regions(num_regions)
 
-    @transactional
     def _on_show_regions_changed(self, button, gparam):
-        self.item.show_regions = button.get_active()
+        with Transaction(self.event_manager):
+            self.item.show_regions = button.get_active()
 
     def update_regions(self, num_regions) -> None:
         if not self.item.subject:

--- a/gaphor/UML/states/tests/test_propertypages.py
+++ b/gaphor/UML/states/tests/test_propertypages.py
@@ -8,7 +8,7 @@ from gaphor.UML.states.propertypages import (
 from gaphor.UML.states.state import StateItem
 
 
-def test_state_property_page_entry(element_factory):
+def test_state_property_page_entry(element_factory, event_manager):
     # Create some behavior elements
     opt1 = element_factory.create(UML.Activity)
     opt1.name = "option 1"
@@ -18,7 +18,7 @@ def test_state_property_page_entry(element_factory):
 
     # Create subject property page
     subject = element_factory.create(UML.State)
-    property_page = StatePropertyPage(subject)
+    property_page = StatePropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     do_activity = find(widget, "entry")
@@ -44,7 +44,7 @@ def test_state_property_page_entry(element_factory):
     assert not subject.entry
 
 
-def test_state_property_page_exit(element_factory):
+def test_state_property_page_exit(element_factory, event_manager):
     # Create some behavior elements
     opt1 = element_factory.create(UML.Activity)
     opt1.name = "option 1"
@@ -54,7 +54,7 @@ def test_state_property_page_exit(element_factory):
 
     # Create subject property page
     subject = element_factory.create(UML.State)
-    property_page = StatePropertyPage(subject)
+    property_page = StatePropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     do_activity = find(widget, "exit")
@@ -80,7 +80,7 @@ def test_state_property_page_exit(element_factory):
     assert not subject.exit
 
 
-def test_state_property_page_do_activity(element_factory):
+def test_state_property_page_do_activity(element_factory, event_manager):
     # Create some behavior elements
     opt1 = element_factory.create(UML.Activity)
     opt1.name = "option 1"
@@ -90,7 +90,7 @@ def test_state_property_page_do_activity(element_factory):
 
     # Create subject property page
     subject = element_factory.create(UML.State)
-    property_page = StatePropertyPage(subject)
+    property_page = StatePropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     do_activity = find(widget, "do-activity")
@@ -116,9 +116,9 @@ def test_state_property_page_do_activity(element_factory):
     assert not subject.doActivity
 
 
-def test_transition_property_page(element_factory):
+def test_transition_property_page(element_factory, event_manager):
     subject = element_factory.create(UML.Transition)
-    property_page = TransitionPropertyPage(subject)
+    property_page = TransitionPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     guard = find(widget, "guard")
@@ -127,9 +127,9 @@ def test_transition_property_page(element_factory):
     assert subject.guard.specification == "test"
 
 
-def test_region_property_page(create):
+def test_region_property_page(create, event_manager):
     item = create(StateItem, UML.State)
-    property_page = RegionPropertyPage(item)
+    property_page = RegionPropertyPage(item, event_manager)
 
     widget = property_page.construct()
     num_regions = find(widget, "num-regions")

--- a/gaphor/application.py
+++ b/gaphor/application.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Iterator, TypeVar, cast
 from uuid import uuid1
 
-from gaphor import transaction
 from gaphor.abc import ActionProvider, Service
 from gaphor.action import action
 from gaphor.core import event_handler
@@ -65,8 +64,6 @@ class Application(Service, ActionProvider):
         self.event_manager: EventManager = cast(
             EventManager, self._services_by_name["event_manager"]
         )
-
-        transaction.subscribers.add(self._transaction_proxy)
 
     def get_service(self, name):
         if not self._services_by_name:
@@ -158,8 +155,6 @@ class Application(Service, ActionProvider):
 
         This is mainly for testing purposes.
         """
-        transaction.subscribers.discard(self._transaction_proxy)
-
         while self._sessions:
             self.shutdown_session(self._sessions.pop())
 
@@ -187,10 +182,6 @@ class Application(Service, ActionProvider):
         return (
             (n, c) for n, c in self._services_by_name.items() if isinstance(c, base)
         )
-
-    def _transaction_proxy(self, event):
-        if self._active_session:
-            self._active_session.event_manager.handle(event)
 
 
 class Session(Service):

--- a/gaphor/core/__init__.py
+++ b/gaphor/core/__init__.py
@@ -5,4 +5,4 @@
 from gaphor.action import action
 from gaphor.core.eventmanager import event_handler
 from gaphor.i18n import gettext
-from gaphor.transaction import Transaction, transactional
+from gaphor.transaction import Transaction

--- a/gaphor/diagram/general/tests/test_generalpropertypages.py
+++ b/gaphor/diagram/general/tests/test_generalpropertypages.py
@@ -7,9 +7,9 @@ from gaphor.diagram.general.generalpropertypages import (
 from gaphor.diagram.tests.fixtures import find
 
 
-def test_comment_property_page_body(element_factory):
+def test_comment_property_page_body(element_factory, event_manager):
     subject = element_factory.create(Comment)
-    property_page = CommentPropertyPage(subject)
+    property_page = CommentPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     comment = find(widget, "comment")
@@ -18,9 +18,9 @@ def test_comment_property_page_body(element_factory):
     assert subject.body == "test"
 
 
-def test_comment_property_page_update_text(element_factory):
+def test_comment_property_page_update_text(element_factory, event_manager):
     subject = element_factory.create(Comment)
-    property_page = CommentPropertyPage(subject)
+    property_page = CommentPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
     comment = find(widget, "comment")
@@ -32,10 +32,10 @@ def test_comment_property_page_update_text(element_factory):
     )
 
 
-def test_metadata_property_page(diagram):
+def test_metadata_property_page(diagram, event_manager):
     metadata = diagram.create(MetadataItem)
 
-    property_page = MetadataPropertyPage(metadata)
+    property_page = MetadataPropertyPage(metadata, event_manager)
 
     widget = property_page.construct()
     description = find(widget, "description")

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import abc
 import textwrap
-from typing import Callable, List, Tuple, Type
+from typing import Iterator
 
 import gaphas.item
 from gaphas.segment import Segment
@@ -57,9 +57,7 @@ class _PropertyPages:
     """
 
     def __init__(self) -> None:
-        self.pages: List[
-            Tuple[Type[Element], Callable[[Element], PropertyPageBase]]
-        ] = []
+        self.pages: list[tuple[type[Element], type[PropertyPageBase]]] = []
 
     def register(self, subject_type, func=None):
         def reg(func):
@@ -68,10 +66,10 @@ class _PropertyPages:
 
         return reg(func) if func else reg
 
-    def __call__(self, subject):
-        for subject_type, func in self.pages:
+    def find(self, subject) -> Iterator[type[PropertyPageBase]]:
+        for subject_type, page in self.pages:
             if isinstance(subject, subject_type):
-                yield func(subject)
+                yield page
 
 
 PropertyPages = _PropertyPages()

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -14,7 +14,7 @@ import gaphas.item
 from gaphas.segment import Segment
 from gi.repository import GObject, Gtk
 
-from gaphor.core import transactional
+from gaphor.core import Transaction, transactional
 from gaphor.core.modeling import Diagram, Element, Presentation, qualifiedName
 from gaphor.i18n import gettext, translated_ui_string
 
@@ -137,10 +137,11 @@ class NamePropertyPage(PropertyPageBase):
 
     order = 10
 
-    def __init__(self, subject):
+    def __init__(self, subject, event_manager):
         assert subject is None or hasattr(subject, "name")
         super().__init__()
         self.subject = subject
+        self.event_manager = event_manager
         self.watcher = subject.watcher() if subject else None
 
     def construct(self):
@@ -171,10 +172,10 @@ class NamePropertyPage(PropertyPageBase):
             builder.get_object("name-editor"), self.watcher
         )
 
-    @transactional
     def _on_name_changed(self, entry):
-        if self.subject.name != entry.get_text():
-            self.subject.name = entry.get_text()
+        with Transaction(self.event_manager):
+            if self.subject.name != entry.get_text():
+                self.subject.name = entry.get_text()
 
 
 @PropertyPages.register(gaphas.item.Line)

--- a/gaphor/diagram/tests/test_propertypages.py
+++ b/gaphor/diagram/tests/test_propertypages.py
@@ -9,9 +9,9 @@ from gaphor.diagram.propertypages import (
 from gaphor.diagram.tests.fixtures import find
 
 
-def test_name_page(element_factory):
+def test_name_page(element_factory, event_manager):
     diagram = element_factory.create(Diagram)
-    property_page = NamePropertyPage(diagram)
+    property_page = NamePropertyPage(diagram, event_manager)
     widget = property_page.construct()
     name = find(widget, "name-entry")
     name.set_text("A new note")
@@ -19,9 +19,9 @@ def test_name_page(element_factory):
     assert diagram.name == "A new note"
 
 
-def test_line_style_page_rectilinear(diagram):
+def test_line_style_page_rectilinear(diagram, event_manager):
     item = diagram.create(Line)
-    property_page = LineStylePage(item)
+    property_page = LineStylePage(item, event_manager)
     widget = property_page.construct()
     line_rectangular = find(widget, "line-rectilinear")
 
@@ -30,9 +30,9 @@ def test_line_style_page_rectilinear(diagram):
     assert item.orthogonal
 
 
-def test_line_style_page_orientation(diagram):
+def test_line_style_page_orientation(diagram, event_manager):
     item = diagram.create(Line)
-    property_page = LineStylePage(item)
+    property_page = LineStylePage(item, event_manager)
     widget = property_page.construct()
     flip_orientation = find(widget, "flip-orientation")
     flip_orientation.set_active(True)
@@ -40,17 +40,17 @@ def test_line_style_page_orientation(diagram):
     assert item.horizontal
 
 
-def test_note_page_with_item_without_subject(diagram):
+def test_note_page_with_item_without_subject(diagram, event_manager):
     item = diagram.create(Line)
-    property_page = NotePropertyPage(item)
+    property_page = NotePropertyPage(item, event_manager)
     widget = property_page.construct()
 
     assert not widget
 
 
-def test_note_page_with_item_with_subject(create):
+def test_note_page_with_item_with_subject(create, event_manager):
     item = create(CommentItem, Comment)
-    property_page = NotePropertyPage(item)
+    property_page = NotePropertyPage(item, event_manager)
     widget = property_page.construct()
 
     note = find(widget, "note")
@@ -59,9 +59,9 @@ def test_note_page_with_item_with_subject(create):
     assert item.subject.note == "A new note"
 
 
-def test_note_page_with_subject(element_factory):
+def test_note_page_with_subject(element_factory, event_manager):
     comment = element_factory.create(Comment)
-    property_page = NotePropertyPage(comment)
+    property_page = NotePropertyPage(comment, event_manager)
     widget = property_page.construct()
 
     note = find(widget, "note")

--- a/gaphor/services/componentregistry.py
+++ b/gaphor/services/componentregistry.py
@@ -1,5 +1,7 @@
 """A registry for components (e.g. services) and event handling."""
 
+import functools
+import inspect
 from typing import Iterator, List, Tuple, Type, TypeVar
 
 from gaphor.abc import Service
@@ -48,3 +50,18 @@ class ComponentRegistry(Service):
 
     def all(self, base: Type[T]) -> Iterator[Tuple[str, T]]:
         return ((n, c) for n, c in self._comp if isinstance(c, base))
+
+    def partial(self, func):
+        """Return a new function with partial application of services."""
+        kwargs = {}
+
+        for param_name, _param in inspect.signature(func).parameters.items():
+            found = [(n, c) for n, c in self._comp if n == param_name]
+            if len(found) > 1:
+                raise ComponentLookupError(
+                    f"More than one component matches {param_name}: {found}"
+                )
+            if found:
+                kwargs[param_name] = found[0][1]
+
+        return functools.partial(func, **kwargs)

--- a/gaphor/services/tests/test_componentregistry.py
+++ b/gaphor/services/tests/test_componentregistry.py
@@ -1,0 +1,33 @@
+from gaphor.services.componentregistry import ComponentRegistry
+
+
+class Dependency:
+    pass
+
+
+def test_no_services_for_partial_service_application():
+    component_registry = ComponentRegistry()
+    dependency = Dependency()
+    component_registry.register("dependency", dependency)
+
+    class TestSubject:
+        def __init__(self, myarg):
+            self.myarg = myarg
+
+    subject = component_registry.partial(TestSubject)(1)
+
+    assert subject.myarg == 1
+
+
+def test_partial_service_application():
+    component_registry = ComponentRegistry()
+    dependency = Dependency()
+    component_registry.register("dependency", dependency)
+
+    class TestSubject:
+        def __init__(self, dependency):
+            self.dependency = dependency
+
+    subject = component_registry.partial(TestSubject)()
+
+    assert subject.dependency is dependency

--- a/gaphor/services/tests/test_undo_presentation.py
+++ b/gaphor/services/tests/test_undo_presentation.py
@@ -167,7 +167,6 @@ def test_line_handle_on_inserted_handle(diagram, undo_manager, event_manager):
         line = diagram.create(LinePresentation)
 
     handle = Handle()
-    # Note that inserting and removing handles is *not* transactional
     line.insert_handle(1, handle)
 
     old_pos = handle.pos.tuple()
@@ -191,7 +190,6 @@ def test_line_handle_no_events_for_removed_handle(diagram, undo_manager, event_m
     with Transaction(event_manager):
         line = diagram.create(LinePresentation)
 
-    # Note that inserting and removing handles is *not* transactional
     handle = Handle()
     line.insert_handle(1, handle)
     line.remove_handle(handle)

--- a/gaphor/tests/test_settings.py
+++ b/gaphor/tests/test_settings.py
@@ -1,0 +1,11 @@
+from gaphor.settings import get_cache_dir, get_config_dir
+
+
+def test_config_dir():
+    config_dir = get_config_dir()
+    assert str(config_dir).endswith("gaphor")
+
+
+def test_cache_dir():
+    cache_dir = get_cache_dir()
+    assert str(cache_dir).endswith("gaphor")

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -191,12 +191,14 @@ class EditorStack:
     def _get_adapters(self, item):
         """Return an ordered list of (order, name, adapter)."""
         page_map = {}
-        # TODO: Use DI to inject services in objects
+        partial = self.component_registry.partial
+
         if isinstance(item, Presentation) and item.subject:
             for page in PropertyPages.find(item.subject):
-                page_map[(page.order, page.__name__)] = page(item.subject)  # type: ignore[call-arg]
+                page_map[(page.order, page.__name__)] = partial(page)(item.subject)
+
         for page in PropertyPages.find(item):
-            page_map[(page.order, page.__name__)] = page(item)  # type: ignore[call-arg]
+            page_map[(page.order, page.__name__)] = partial(page)(item)
 
         return sorted(page_map.items())
 

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -181,14 +181,15 @@ class EditorStack:
 
     def _get_adapters(self, item):
         """Return an ordered list of (order, name, adapter)."""
-        adaptermap = {}
+        page_map = {}
+        # TODO: Use DI to inject services in objects
         if isinstance(item, Presentation) and item.subject:
-            for adapter in PropertyPages(item.subject):
-                adaptermap[(adapter.order, adapter.__class__.__name__)] = adapter
-        for adapter in PropertyPages(item):
-            adaptermap[(adapter.order, adapter.__class__.__name__)] = adapter
+            for page in PropertyPages.find(item.subject):
+                page_map[(page.order, page.__name__)] = page(item.subject)  # type: ignore[call-arg]
+        for page in PropertyPages.find(item):
+            page_map[(page.order, page.__name__)] = page(item)  # type: ignore[call-arg]
 
-        return sorted(adaptermap.items())
+        return sorted(page_map.items())
 
     def create_pages(self, item):
         """Load all tabs that can operate on the given item."""

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -64,7 +64,13 @@ class ElementEditor(UIComponent, ActionProvider):
     """
 
     def __init__(
-        self, event_manager, element_factory, modeling_language, diagrams, properties
+        self,
+        event_manager,
+        component_registry,
+        element_factory,
+        modeling_language,
+        diagrams,
+        properties,
     ):
         """Constructor.
 
@@ -74,7 +80,9 @@ class ElementEditor(UIComponent, ActionProvider):
         """
         self.event_manager = event_manager
         self.properties = properties
-        self.editors = EditorStack(event_manager, diagrams, properties)
+        self.editors = EditorStack(
+            event_manager, component_registry, diagrams, properties
+        )
         self.preferences = PreferencesStack(event_manager, diagrams, element_factory)
         self.modelmerge = ModelMerge(event_manager, element_factory, modeling_language)
         self.editor_stack: Gtk.Box | None = None
@@ -152,8 +160,9 @@ class ElementEditor(UIComponent, ActionProvider):
 
 
 class EditorStack:
-    def __init__(self, event_manager, diagrams, properties):
+    def __init__(self, event_manager, component_registry, diagrams, properties):
         self.event_manager = event_manager
+        self.component_registry = component_registry
         self.diagrams = diagrams
         self.properties = properties
 

--- a/gaphor/ui/tests/test_elementeditor.py
+++ b/gaphor/ui/tests/test_elementeditor.py
@@ -6,6 +6,7 @@ import gaphor.UML.classes.classespropertypages  # noqa
 from gaphor import UML
 from gaphor.core.modeling.diagram import StyledItem
 from gaphor.diagram.tests.fixtures import find
+from gaphor.services.componentregistry import ComponentRegistry
 from gaphor.ui.elementeditor import ElementEditor, dump_css_tree
 from gaphor.UML.diagramitems import ClassItem, PackageItem
 
@@ -20,15 +21,27 @@ def diagrams():
     return DiagramsStub()
 
 
+@pytest.fixture
+def component_registry():
+    return ComponentRegistry()
+
+
 class DummyProperties(dict):
     def set(self, key, val):
         self[key] = val
 
 
-def test_reopen_of_window(event_manager, element_factory, modeling_language, diagrams):
+def test_reopen_of_window(
+    event_manager, component_registry, element_factory, modeling_language, diagrams
+):
     properties = DummyProperties()
     editor = ElementEditor(
-        event_manager, element_factory, modeling_language, diagrams, properties
+        event_manager,
+        component_registry,
+        element_factory,
+        modeling_language,
+        diagrams,
+        properties,
     )
 
     editor.open()
@@ -38,11 +51,21 @@ def test_reopen_of_window(event_manager, element_factory, modeling_language, dia
 
 
 def test_create_pages(
-    event_manager, element_factory, modeling_language, diagrams, create
+    event_manager,
+    component_registry,
+    element_factory,
+    modeling_language,
+    diagrams,
+    create,
 ):
     properties = DummyProperties()
     editor = ElementEditor(
-        event_manager, element_factory, modeling_language, diagrams, properties
+        event_manager,
+        component_registry,
+        element_factory,
+        modeling_language,
+        diagrams,
+        properties,
     )
     package_item = create(PackageItem, UML.Package)
 

--- a/gaphor/ui/tests/test_elementeditor.py
+++ b/gaphor/ui/tests/test_elementeditor.py
@@ -22,8 +22,10 @@ def diagrams():
 
 
 @pytest.fixture
-def component_registry():
-    return ComponentRegistry()
+def component_registry(event_manager):
+    reg = ComponentRegistry()
+    reg.register("event_manager", event_manager)
+    return reg
 
 
 class DummyProperties(dict):

--- a/tests/test_composite_association.py
+++ b/tests/test_composite_association.py
@@ -7,20 +7,19 @@ from gaphor.conftest import (
     event_manager,
     modeling_language,
 )
-from gaphor.core.modeling import Diagram
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML.classes import AssociationItem, ClassItem
 from gaphor.UML.classes.associationpropertypages import AssociationPropertyPage
 from gaphor.UML.classes.classestoolbox import composite_association_config
 
 
-def test_connect_composite_association(create, diagram):
+def test_connect_composite_association(create, event_manager):
     c1 = create(ClassItem, UML.Class)
     c2 = create(ClassItem, UML.Class)
     a = create(AssociationItem)
     composite_association_config(a)
 
-    property_page = AssociationPropertyPage(a.subject)
+    property_page = AssociationPropertyPage(a.subject, event_manager)
     _widget = property_page.construct()
 
     connect(a, a.head, c1)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

We have a global `@transactional` decorator. This decorator works as long as the system is fully aware of the active session. This of course causes trouble if a non-active session starts to do something in the background.

Issue Number: Fixes #3351.

### What is the new behavior?

Instead, all places where transactions are started should have access to the services, mainly `event_manager`. This ensures that the transaction is run in the right context.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

The `@transactional` decorator has been removed.

### Other information

I wanted to fix this for a long time. #3348 was the trigger to rethink the problem again. In the end it seemed pretty simple: the `component_registry` should have a method to (partially) apply services to any function or class.