### PR TITLE
Fix deletion of attribute/operation in element editor

### DIFF
--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -71,7 +71,8 @@ class ActivityParameterNodeView(GObject.Object):
 
     def unlink(self):
         if self.node:
-            self.node.unlink()
+            with Transaction(self.event_manager):
+                self.node.unlink()
 
     def swap(self, item1, item2):
         return self.activity.node.swap(item1.node, item2.node)

--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -172,7 +172,8 @@ class AttributeView(GObject.Object):
 
     def unlink(self):
         if self.attr:
-            self.attr.unlink()
+            with Transaction(self.event_manager):
+                self.attr.unlink()
 
     def swap(self, item1, item2):
         return self.klass.ownedAttribute.swap(item1.attr, item2.attr)
@@ -367,7 +368,8 @@ class OperationView(GObject.Object):
 
     def unlink(self):
         if self.oper:
-            self.oper.unlink()
+            with Transaction(self.event_manager):
+                self.oper.unlink()
 
     def swap(self, item1, item2):
         return self.klass.ownedOperation.swap(item1.oper, item2.oper)

--- a/gaphor/UML/classes/enumerationpropertypages.py
+++ b/gaphor/UML/classes/enumerationpropertypages.py
@@ -60,7 +60,8 @@ class EnumerationView(GObject.Object):
 
     def unlink(self):
         if self.literal:
-            self.literal.unlink()
+            with Transaction(self.event_manager):
+                self.literal.unlink()
 
     def swap(self, item1, item2):
         return self.enum.ownedLiteral.swap(item1.literal, item2.literal)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

* (regression) Deletion of attribute/operation/enumeration/parameter in property editor does not work. 

Issue Number: N/A

### What is the new behavior?

Deletion works: it's wrapped in a transaction.

### Other information

Other things I like to fix here:

* Double click to edit a stereotype value
* Attribute/operation/enumeration reorder does not properly redraw the diagram item.
