### PR TITLE
KerML Root model

### DIFF
--- a/docs/models/core.rst
+++ b/docs/models/core.rst
@@ -10,7 +10,7 @@ in a diagram.
 All data models in Gaphor are generated from actual Gaphor model files.
 This allows us to provide you nice diagrams of Gaphor’s internal model.
 
-.. diagram:: core
+.. diagram:: Relationships
    :model: core
 
 The :obj:`~gaphor.core.modeling.Element` base class provides event notification and integrates
@@ -64,8 +64,24 @@ The class ``Element`` is the core of Gaphor’s data model.
    .. automethod:: gaphor.core.modeling.Element.isTypeOf
 
 
+Annotations
+-----------
+
+.. diagram:: Annotations
+   :model: core
+
+Presentations
+-------------
+
+Presentations are representations of model elements shown in a diagram.
+
+.. diagram:: Presentations
+   :model: core
+
+
 The ``Presentation`` class
---------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 
 .. autoclass:: gaphor.core.modeling.Presentation
 
@@ -77,7 +93,7 @@ The ``Presentation`` class
 
 
 The ``Diagram`` class
---------------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: gaphor.core.modeling.Diagram
 

--- a/docs/models/core.rst
+++ b/docs/models/core.rst
@@ -10,6 +10,9 @@ in a diagram.
 All data models in Gaphor are generated from actual Gaphor model files.
 This allows us to provide you nice diagrams of Gaphor’s internal model.
 
+Relationships
+-------------
+
 .. diagram:: Relationships
    :model: core
 
@@ -25,7 +28,7 @@ mechanisms.
 
 
 The ``Element`` Class
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 The class ``Element`` is the core of Gaphor’s data model.
 

--- a/docs/models/core.rst
+++ b/docs/models/core.rst
@@ -16,6 +16,9 @@ Relationships
 .. diagram:: Relationships
    :model: core
 
+The ``Element`` Class
+^^^^^^^^^^^^^^^^^^^^^
+
 The :obj:`~gaphor.core.modeling.Element` base class provides event notification and integrates
 with the model repository (internally known as :obj:`~gaphor.core.modeling.ElementFactory`).
 Bi-directional relationships are also possible, as well as derived
@@ -25,10 +28,6 @@ The :obj:`~gaphor.core.modeling.element.RepositoryProtocol`, and
 :obj:`~gaphor.core.modeling.element.EventWatcherProtocol`
 protocols are important to connect the model to the repository and event handling
 mechanisms.
-
-
-The ``Element`` Class
-^^^^^^^^^^^^^^^^^^^^^
 
 The class ``Element`` is the core of Gaphor’s data model.
 
@@ -67,10 +66,22 @@ The class ``Element`` is the core of Gaphor’s data model.
    .. automethod:: gaphor.core.modeling.Element.isTypeOf
 
 
+Dependencies
+------------
+
+.. diagram:: Dependencies
+   :model: core
+
 Annotations
 -----------
 
 .. diagram:: Annotations
+   :model: core
+
+Namespaces
+-----------
+
+.. diagram:: Namespaces
    :model: core
 
 Presentations

--- a/gaphor/C4Model/c4model.py
+++ b/gaphor/C4Model/c4model.py
@@ -39,7 +39,7 @@ class C4Database(C4Container):
 
 C4Container.ownerContainer = association("ownerContainer", C4Container, upper=1, opposite="owningContainer")
 C4Container.owningContainer = association("owningContainer", C4Container, composite=True, opposite="ownerContainer")
-from gaphor.UML.uml import NamedElement
-NamedElement.namespace.add(C4Container.ownerContainer)  # type: ignore[attr-defined]
+from gaphor.UML.uml import Element
+Element.namespace.add(C4Container.ownerContainer)  # type: ignore[attr-defined]
 from gaphor.UML.uml import Namespace
 Namespace.ownedMember.add(C4Container.owningContainer)  # type: ignore[attr-defined]

--- a/gaphor/C4Model/diagramitems/container.py
+++ b/gaphor/C4Model/diagramitems/container.py
@@ -9,7 +9,7 @@ class C4ContainerItem(Named, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject[C4Container].technology")
         self.watch("subject[C4Container].description")
         self.watch("subject[C4Container].type")

--- a/gaphor/C4Model/diagramitems/database.py
+++ b/gaphor/C4Model/diagramitems/database.py
@@ -9,7 +9,7 @@ class C4DatabaseItem(Named, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject[C4Container].technology")
         self.watch("subject[C4Container].description")
         self.watch("subject[C4Container].type")

--- a/gaphor/C4Model/diagramitems/person.py
+++ b/gaphor/C4Model/diagramitems/person.py
@@ -11,7 +11,7 @@ class C4PersonItem(Named, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=48, height=48)
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject[C4Person].description")
 
     def update_shapes(self, event=None):

--- a/gaphor/RAAML/fta/andgate.py
+++ b/gaphor/RAAML/fta/andgate.py
@@ -22,9 +22,7 @@ class ANDItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/andgate.py
+++ b/gaphor/RAAML/fta/andgate.py
@@ -22,7 +22,7 @@ class ANDItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/basicevent.py
+++ b/gaphor/RAAML/fta/basicevent.py
@@ -20,9 +20,7 @@ class BasicEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MAJOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/basicevent.py
+++ b/gaphor/RAAML/fta/basicevent.py
@@ -20,7 +20,7 @@ class BasicEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MAJOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/conditionalevent.py
+++ b/gaphor/RAAML/fta/conditionalevent.py
@@ -17,7 +17,7 @@ class ConditionalEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=70, height=35)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/conditionalevent.py
+++ b/gaphor/RAAML/fta/conditionalevent.py
@@ -17,9 +17,7 @@ class ConditionalEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=70, height=35)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/dormantevent.py
+++ b/gaphor/RAAML/fta/dormantevent.py
@@ -20,7 +20,7 @@ class DormantEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=70, height=35)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/dormantevent.py
+++ b/gaphor/RAAML/fta/dormantevent.py
@@ -20,9 +20,7 @@ class DormantEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=70, height=35)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/houseevent.py
+++ b/gaphor/RAAML/fta/houseevent.py
@@ -20,7 +20,7 @@ class HouseEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/houseevent.py
+++ b/gaphor/RAAML/fta/houseevent.py
@@ -20,9 +20,7 @@ class HouseEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/inhibitgate.py
+++ b/gaphor/RAAML/fta/inhibitgate.py
@@ -20,9 +20,7 @@ class InhibitItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MAJOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/inhibitgate.py
+++ b/gaphor/RAAML/fta/inhibitgate.py
@@ -20,7 +20,7 @@ class InhibitItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MAJOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/intermediateevent.py
+++ b/gaphor/RAAML/fta/intermediateevent.py
@@ -18,7 +18,7 @@ class IntermediateEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = Box(

--- a/gaphor/RAAML/fta/intermediateevent.py
+++ b/gaphor/RAAML/fta/intermediateevent.py
@@ -18,9 +18,7 @@ class IntermediateEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = Box(

--- a/gaphor/RAAML/fta/majorityvotegate.py
+++ b/gaphor/RAAML/fta/majorityvotegate.py
@@ -24,7 +24,7 @@ class MajorityVoteItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_WIDTH, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/majorityvotegate.py
+++ b/gaphor/RAAML/fta/majorityvotegate.py
@@ -24,9 +24,7 @@ class MajorityVoteItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_WIDTH, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/notgate.py
+++ b/gaphor/RAAML/fta/notgate.py
@@ -20,9 +20,7 @@ class NOTItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/notgate.py
+++ b/gaphor/RAAML/fta/notgate.py
@@ -20,7 +20,7 @@ class NOTItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/orgate.py
+++ b/gaphor/RAAML/fta/orgate.py
@@ -22,7 +22,7 @@ class ORItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/orgate.py
+++ b/gaphor/RAAML/fta/orgate.py
@@ -22,9 +22,7 @@ class ORItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/seqgate.py
+++ b/gaphor/RAAML/fta/seqgate.py
@@ -21,7 +21,7 @@ class SEQItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/seqgate.py
+++ b/gaphor/RAAML/fta/seqgate.py
@@ -21,9 +21,7 @@ class SEQItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/topevent.py
+++ b/gaphor/RAAML/fta/topevent.py
@@ -18,9 +18,7 @@ class TopEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = Box(

--- a/gaphor/RAAML/fta/topevent.py
+++ b/gaphor/RAAML/fta/topevent.py
@@ -18,7 +18,7 @@ class TopEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = Box(

--- a/gaphor/RAAML/fta/transferin.py
+++ b/gaphor/RAAML/fta/transferin.py
@@ -20,7 +20,7 @@ class TransferInItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MAJOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/transferin.py
+++ b/gaphor/RAAML/fta/transferin.py
@@ -20,9 +20,7 @@ class TransferInItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MAJOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/transferout.py
+++ b/gaphor/RAAML/fta/transferout.py
@@ -21,9 +21,7 @@ class TransferOutItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MAJOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/transferout.py
+++ b/gaphor/RAAML/fta/transferout.py
@@ -21,7 +21,7 @@ class TransferOutItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MAJOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/undevelopedevent.py
+++ b/gaphor/RAAML/fta/undevelopedevent.py
@@ -20,7 +20,7 @@ class UndevelopedEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=WIDE_FTA_WIDTH, height=WIDE_FTA_HEIGHT)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/undevelopedevent.py
+++ b/gaphor/RAAML/fta/undevelopedevent.py
@@ -20,9 +20,7 @@ class UndevelopedEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=WIDE_FTA_WIDTH, height=WIDE_FTA_HEIGHT)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/xorgate.py
+++ b/gaphor/RAAML/fta/xorgate.py
@@ -21,9 +21,7 @@ class XORItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/xorgate.py
+++ b/gaphor/RAAML/fta/xorgate.py
@@ -21,7 +21,7 @@ class XORItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/zeroevent.py
+++ b/gaphor/RAAML/fta/zeroevent.py
@@ -21,7 +21,7 @@ class ZeroEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/fta/zeroevent.py
+++ b/gaphor/RAAML/fta/zeroevent.py
@@ -21,9 +21,7 @@ class ZeroEventItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=DEFAULT_FTA_MINOR, height=DEFAULT_FTA_MAJOR)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = IconBox(

--- a/gaphor/RAAML/raaml.py
+++ b/gaphor/RAAML/raaml.py
@@ -23,7 +23,7 @@ class Situation(Block, Class):
 
 
 from gaphor.SysML.sysml import DirectedRelationshipPropertyPath
-from gaphor.UML.uml import Dependency
+from gaphor.core.modeling.coremodel import Dependency
 class RelevantTo(Dependency, DirectedRelationshipPropertyPath):
     pass
 
@@ -87,7 +87,7 @@ class AbstractRisk(Scenario):
     trigger: relation_many[AbstractEvent]
 
 
-from gaphor.UML.uml import Dependency
+from gaphor.core.modeling.coremodel import Dependency
 class Detection(ControllingMeasure, Dependency):
     pass
 

--- a/gaphor/RAAML/stpa/controlaction.py
+++ b/gaphor/RAAML/stpa/controlaction.py
@@ -18,7 +18,7 @@ class ControlActionItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = Box(

--- a/gaphor/RAAML/stpa/controlaction.py
+++ b/gaphor/RAAML/stpa/controlaction.py
@@ -18,9 +18,7 @@ class ControlActionItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = Box(

--- a/gaphor/RAAML/stpa/operationalsituation.py
+++ b/gaphor/RAAML/stpa/operationalsituation.py
@@ -19,9 +19,7 @@ class OperationalSituationItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = Box(

--- a/gaphor/RAAML/stpa/operationalsituation.py
+++ b/gaphor/RAAML/stpa/operationalsituation.py
@@ -19,7 +19,7 @@ class OperationalSituationItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = Box(

--- a/gaphor/RAAML/stpa/unsafecontrolaction.py
+++ b/gaphor/RAAML/stpa/unsafecontrolaction.py
@@ -18,9 +18,7 @@ class UnsafeControlActionItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = Box(

--- a/gaphor/RAAML/stpa/unsafecontrolaction.py
+++ b/gaphor/RAAML/stpa/unsafecontrolaction.py
@@ -18,7 +18,7 @@ class UnsafeControlActionItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id)
 
-        self.watch("subject.name").watch("subject[NamedElement].namespace.name")
+        self.watch("subject.name").watch("subject.namespace.name")
 
     def update_shapes(self, event=None):
         self.shape = Box(

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -28,13 +28,11 @@ class BlockItem(Classified, ElementPresentation[Block]):
             "show_parts", self.update_shapes
         ).watch("show_references", self.update_shapes).watch(
             "show_values", self.update_shapes
-        ).watch("show_operations", self.update_shapes).watch(
-            "subject[NamedElement].name"
-        ).watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        ).watch("subject[Classifier].isAbstract", self.update_shapes).watch(
-            "subject[Class].ownedAttribute.aggregation", self.update_shapes
-        )
+        ).watch("show_operations", self.update_shapes).watch("subject.name").watch(
+            "subject.name"
+        ).watch("subject[NamedElement].namespace.name").watch(
+            "subject[Classifier].isAbstract", self.update_shapes
+        ).watch("subject[Class].ownedAttribute.aggregation", self.update_shapes)
         operation_watches(self, "Block")
         stereotype_watches(self)
 

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -30,7 +30,7 @@ class BlockItem(Classified, ElementPresentation[Block]):
             "show_values", self.update_shapes
         ).watch("show_operations", self.update_shapes).watch("subject.name").watch(
             "subject.name"
-        ).watch("subject[NamedElement].namespace.name").watch(
+        ).watch("subject.namespace.name").watch(
             "subject[Classifier].isAbstract", self.update_shapes
         ).watch("subject[Class].ownedAttribute.aggregation", self.update_shapes)
         operation_watches(self, "Block")

--- a/gaphor/SysML/blocks/interfaceblock.py
+++ b/gaphor/SysML/blocks/interfaceblock.py
@@ -29,7 +29,7 @@ class InterfaceBlockItem(Classified, ElementPresentation[InterfaceBlock]):
             "show_values", self.update_shapes
         ).watch("show_operations", self.update_shapes).watch("subject.name").watch(
             "subject.name"
-        ).watch("subject[NamedElement].namespace.name").watch(
+        ).watch("subject.namespace.name").watch(
             "subject[Classifier].isAbstract", self.update_shapes
         ).watch("subject[Class].ownedAttribute.aggregation", self.update_shapes)
         operation_watches(self, "Block")

--- a/gaphor/SysML/blocks/interfaceblock.py
+++ b/gaphor/SysML/blocks/interfaceblock.py
@@ -27,13 +27,11 @@ class InterfaceBlockItem(Classified, ElementPresentation[InterfaceBlock]):
             "show_parts", self.update_shapes
         ).watch("show_references", self.update_shapes).watch(
             "show_values", self.update_shapes
-        ).watch("show_operations", self.update_shapes).watch(
-            "subject[NamedElement].name"
-        ).watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        ).watch("subject[Classifier].isAbstract", self.update_shapes).watch(
-            "subject[Class].ownedAttribute.aggregation", self.update_shapes
-        )
+        ).watch("show_operations", self.update_shapes).watch("subject.name").watch(
+            "subject.name"
+        ).watch("subject[NamedElement].namespace.name").watch(
+            "subject[Classifier].isAbstract", self.update_shapes
+        ).watch("subject[Class].ownedAttribute.aggregation", self.update_shapes)
         operation_watches(self, "Block")
         stereotype_watches(self)
 

--- a/gaphor/SysML/blocks/proxyport.py
+++ b/gaphor/SysML/blocks/proxyport.py
@@ -27,9 +27,9 @@ def text_position(position):
 class ProxyPortItem(Named, AttachedPresentation[sysml.ProxyPort]):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=16, height=16)
-        self.watch("subject[NamedElement].name").watch(
-            "subject[TypedElement].type.name"
-        ).watch("show_type")
+        self.watch("subject.name").watch("subject[TypedElement].type.name").watch(
+            "show_type"
+        )
 
     show_type: attribute[int] = attribute("show_type", int, default=False)
 

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from gaphor import UML
+from gaphor.core.modeling import Relationship
 from gaphor.diagram.propertypages import (
     PropertyPageBase,
     PropertyPages,
@@ -256,7 +257,7 @@ class ItemFlowPropertyPage(PropertyPageBase):
         subject = self.subject
         if isinstance(subject, sysml.Connector):
             iflows = subject.informationFlow
-        elif isinstance(subject, UML.Relationship):
+        elif isinstance(subject, Relationship):
             iflows = subject.abstraction  # type: ignore[attr-defined]
         return iflows[0] if iflows else None
 
@@ -312,7 +313,7 @@ class ItemFlowPropertyPage(PropertyPageBase):
             if active and not iflow:
                 if isinstance(subject, sysml.Connector):
                     subject.informationFlow = create_item_flow(subject)
-                elif isinstance(subject, UML.Relationship):
+                elif isinstance(subject, Relationship):
                     subject.abstraction = create_item_flow(subject)
             elif not active and iflow:
                 iflow.unlink()
@@ -356,7 +357,7 @@ def create_item_flow(subject: UML.Association | sysml.Connector) -> sysml.ItemFl
     if isinstance(subject, sysml.Connector):
         iflow.informationSource = subject.end[0].role
         iflow.informationTarget = subject.end[1].role
-    elif isinstance(subject, UML.Relationship):
+    elif isinstance(subject, Relationship):
         iflow.informationSource = subject.memberEnd[0]
         iflow.informationTarget = subject.memberEnd[1]
     iflow.itemProperty = subject.model.create(sysml.Property)

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -257,7 +257,7 @@ class ItemFlowPropertyPage(PropertyPageBase):
         if isinstance(subject, sysml.Connector):
             iflows = subject.informationFlow
         elif isinstance(subject, UML.Relationship):
-            iflows = subject.abstraction
+            iflows = subject.abstraction  # type: ignore[attr-defined]
         return iflows[0] if iflows else None
 
     def construct(self):

--- a/gaphor/SysML/relationships.py
+++ b/gaphor/SysML/relationships.py
@@ -1,11 +1,11 @@
-from gaphor.diagram.presentation import LinePresentation, text_name
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
 from gaphor.diagram.shapes import Box, draw_arrow_head
 from gaphor.SysML import sysml
 from gaphor.UML.compartments import text_stereotypes
 
 
 class DirectedRelationshipPropertyPathItem(
-    LinePresentation[sysml.DirectedRelationshipPropertyPath]
+    Named, LinePresentation[sysml.DirectedRelationshipPropertyPath]
 ):
     relation_type = ""
 

--- a/gaphor/SysML/relationships.py
+++ b/gaphor/SysML/relationships.py
@@ -1,11 +1,11 @@
-from gaphor.diagram.presentation import LinePresentation, Named, text_name
+from gaphor.diagram.presentation import LinePresentation, text_name
 from gaphor.diagram.shapes import Box, draw_arrow_head
 from gaphor.SysML import sysml
 from gaphor.UML.compartments import text_stereotypes
 
 
 class DirectedRelationshipPropertyPathItem(
-    Named, LinePresentation[sysml.DirectedRelationshipPropertyPath]
+    LinePresentation[sysml.DirectedRelationshipPropertyPath]
 ):
     relation_type = ""
 

--- a/gaphor/SysML/relationships.py
+++ b/gaphor/SysML/relationships.py
@@ -20,6 +20,4 @@ class DirectedRelationshipPropertyPathItem(
         )
 
         self.draw_head = draw_arrow_head
-        self.watch("subject[NamedElement].name").watch(
-            "subject.appliedStereotype.classifier.name"
-        )
+        self.watch("subject.name").watch("subject.appliedStereotype.classifier.name")

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -32,11 +32,11 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
             "show_stereotypes", self.update_shapes
         ).watch("show_attributes", self.update_shapes).watch(
             "show_operations", self.update_shapes
-        ).watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        ).watch("subject[Classifier].isAbstract", self.update_shapes).watch(
-            "subject[AbstractRequirement].externalId", self.update_shapes
-        ).watch("subject[AbstractRequirement].text", self.update_shapes)
+        ).watch("subject.name").watch("subject[NamedElement].namespace.name").watch(
+            "subject[Classifier].isAbstract", self.update_shapes
+        ).watch("subject[AbstractRequirement].externalId", self.update_shapes).watch(
+            "subject[AbstractRequirement].text", self.update_shapes
+        )
         attribute_watches(self, "Requirement")
         operation_watches(self, "Requirement")
         stereotype_watches(self)

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -32,7 +32,7 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
             "show_stereotypes", self.update_shapes
         ).watch("show_attributes", self.update_shapes).watch(
             "show_operations", self.update_shapes
-        ).watch("subject.name").watch("subject[NamedElement].namespace.name").watch(
+        ).watch("subject.name").watch("subject.namespace.name").watch(
             "subject[Classifier].isAbstract", self.update_shapes
         ).watch("subject[AbstractRequirement].externalId", self.update_shapes).watch(
             "subject[AbstractRequirement].text", self.update_shapes

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -24,7 +24,7 @@ def _directed_relationship_property_path_target_source(type):
         if element.sourceContext is self and element.targetContext
     ]
 
-from gaphor.UML.uml import NamedElement
+from gaphor.core.modeling.coremodel import NamedElement
 class AbstractRequirement(NamedElement):
     derived: derived[AbstractRequirement]
     derivedFrom: derived[AbstractRequirement]

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -50,7 +50,7 @@ class DirectedRelationshipPropertyPath(DirectedRelationship):
     targetPropertyPath: relation_many[Property]
 
 
-from gaphor.UML.uml import Dependency
+from gaphor.core.modeling.coremodel import Dependency
 class Trace(Dependency, DirectedRelationshipPropertyPath):
     pass
 

--- a/gaphor/SysML/tests/test_diagramitems.py
+++ b/gaphor/SysML/tests/test_diagramitems.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gaphor.core.modeling import Presentation
+from gaphor.core.modeling import Presentation, Relationship
 from gaphor.diagram.general import CommentLineItem
 from gaphor.diagram.presentation import Classified, Named
 from gaphor.diagram.support import get_model_element
@@ -49,7 +49,7 @@ def test_all_named_elements_have_named_items(item_class, element_class):
         assert issubclass(item_class, Named)
 
     if issubclass(item_class, Named):
-        assert issubclass(element_class, NamedElement)
+        assert issubclass(element_class, (NamedElement, Relationship))
 
 
 CLASSIFIED_EXCLUSIONS = []

--- a/gaphor/SysML/tests/test_diagramtype.py
+++ b/gaphor/SysML/tests/test_diagramtype.py
@@ -1,14 +1,14 @@
 import pytest
 
+from gaphor.core.modeling import Element
 from gaphor.SysML.diagramtype import DiagramDefault, SysMLDiagramType
-from gaphor.UML.uml import NamedElement
 
 
-class MockElementA(NamedElement):
+class MockElementA(Element):
     pass
 
 
-class MockElementB(NamedElement):
+class MockElementB(Element):
     pass
 
 

--- a/gaphor/SysML/tests/test_sysml.py
+++ b/gaphor/SysML/tests/test_sysml.py
@@ -1,7 +1,5 @@
 from gaphor.SysML import sysml
 
-# sysml.AbstractRequirement.tracedTo = derived('tracedTo', UML.NamedElement, 0, '*', lambda self: [drrp.targetContext for drrp in self.model.select(sysml.DirectedRelationshipPropertyPath) if drrp.targetContext and isinstance(drrp, sysml.Trace)])
-
 
 def test_requirement_traced_to(element_factory):
     req = element_factory.create(sysml.Requirement)

--- a/gaphor/UML/actions/action.py
+++ b/gaphor/UML/actions/action.py
@@ -20,7 +20,7 @@ class ActionItem(Named, ElementPresentation):
             draw=draw_border,
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
 
@@ -97,7 +97,7 @@ class SendSignalActionItem(Named, ElementPresentation):
             draw=self.draw_border,
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
     def draw_border(self, box, context, bounding_box):
@@ -125,7 +125,7 @@ class AcceptEventActionItem(Named, ElementPresentation):
             draw=self.draw_border,
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
     def draw_border(self, box, context, bounding_box):

--- a/gaphor/UML/actions/activity.py
+++ b/gaphor/UML/actions/activity.py
@@ -19,7 +19,7 @@ class ActivityItem(Classified, ElementPresentation):
 
         self.width = 100
 
-        self.watch("subject[NamedElement].name").watch(
+        self.watch("subject.name").watch(
             "subject.appliedStereotype.classifier.name"
         ).watch("subject[Classifier].isAbstract", self.update_shapes).watch(
             "subject[Activity].node[ActivityParameterNode].parameter.name",

--- a/gaphor/UML/actions/activitynodes.py
+++ b/gaphor/UML/actions/activitynodes.py
@@ -54,7 +54,7 @@ class InitialNodeItem(ActivityNodeItem, ElementPresentation):
             text_name(self),
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
 
@@ -87,7 +87,7 @@ class ActivityFinalNodeItem(ActivityNodeItem, ElementPresentation):
             text_name(self),
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
 
@@ -131,7 +131,7 @@ class FlowFinalNodeItem(ActivityNodeItem, ElementPresentation):
             text_name(self),
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
 
@@ -167,7 +167,7 @@ class DecisionNodeItem(ActivityNodeItem, ElementPresentation):
         )
 
         self.watch("show_underlying_type")
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
     show_underlying_type: attribute[int] = attribute("show_underlying_type", int, 0)
@@ -230,7 +230,7 @@ class ForkNodeItem(Named, Presentation[UML.ForkNode], HandlePositionUpdate):
             ),
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[JoinNode].joinSpec")
 

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -182,7 +182,6 @@ class ActivityParameterNodeNamePropertyPage(PropertyPageBase):
     order = 10
 
     def __init__(self, subject: UML.ActivityParameterNode, event_manager: EventManager):
-        assert subject is None or hasattr(subject, "name")
         super().__init__()
         self.subject = subject
         self.event_manager = event_manager

--- a/gaphor/UML/actions/flow.py
+++ b/gaphor/UML/actions/flow.py
@@ -37,7 +37,7 @@ class ControlFlowItem(Named, LinePresentation):
             shape_tail=Box(text_stereotypes(self), text_name(self)),
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
         self.watch("subject[ControlFlow].guard")
@@ -70,7 +70,7 @@ class ObjectFlowItem(Named, LinePresentation):
             shape_tail=Box(text_stereotypes(self), text_name(self)),
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
         self.watch("subject[ObjectFlow].guard")

--- a/gaphor/UML/actions/objectnode.py
+++ b/gaphor/UML/actions/objectnode.py
@@ -61,7 +61,7 @@ class ObjectNodeItem(Named, ElementPresentation):
             height=30,
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[ObjectNode].upperBound")
         self.watch("subject[ObjectNode].ordering")

--- a/gaphor/UML/actions/partition.py
+++ b/gaphor/UML/actions/partition.py
@@ -22,7 +22,7 @@ class PartitionItem(ElementPresentation[UML.ActivityPartition]):
         super().__init__(diagram, id)
         self.min_height = 300
         self._loading = False
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("partition", self.update_shapes)
         self.watch("partition.name")

--- a/gaphor/UML/actions/partition.py
+++ b/gaphor/UML/actions/partition.py
@@ -26,7 +26,7 @@ class PartitionItem(ElementPresentation[UML.ActivityPartition]):
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("partition", self.update_shapes)
         self.watch("partition.name")
-        self.watch("partition[ActivityPartition].represents[NamedElement].name")
+        self.watch("partition[ActivityPartition].represents.name")
         self.handles()[NW].pos.add_handler(self.update_width)
         self.handles()[SE].pos.add_handler(self.update_width)
 

--- a/gaphor/UML/actions/pin.py
+++ b/gaphor/UML/actions/pin.py
@@ -26,7 +26,7 @@ def text_position(position):
 class PinItem(Named, AttachedPresentation[UML.Pin]):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=16, height=16)
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject[TypedElement].type")
         self.watch("subject[MultiplicityElement].lowerValue")
         self.watch("subject[MultiplicityElement].upperValue")

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -74,7 +74,7 @@ class AssociationItem(Named, LinePresentation[UML.Association]):
 
         # For the association ends:
         base = "subject[Association].memberEnd[Property]"
-        self.watch("subject[NamedElement].name").watch(
+        self.watch("subject.name").watch(
             "subject.appliedStereotype.classifier.name"
         ).watch(f"{base}.name").watch(
             f"{base}.appliedStereotype.slot.definingFeature.name",

--- a/gaphor/UML/classes/association.py
+++ b/gaphor/UML/classes/association.py
@@ -200,12 +200,12 @@ class AssociationItem(Named, LinePresentation[UML.Association]):
     def draw(self, context):
         super().draw(context)
 
-        if self.subject and self.subject.abstraction:
+        if self.subject and self.subject.abstraction:  # type: ignore[attr-defined]
             draw_information_flow(
                 self,
                 context,
                 self.subject.memberEnd[0]
-                in self.subject.abstraction[:].informationTarget,
+                in self.subject.abstraction[:].informationTarget,  # type: ignore[attr-defined]
             )
 
         if self.show_direction:

--- a/gaphor/UML/classes/classconnect.py
+++ b/gaphor/UML/classes/classconnect.py
@@ -21,11 +21,6 @@ class DependencyConnect(DirectionalRelationshipConnect):
 
     line: DependencyItem
 
-    def allow(self, handle, port):
-        return super().allow(handle, port) and isinstance(
-            self.element.subject, UML.NamedElement
-        )
-
     def connect_subject(self, handle):
         dependency_type = self.update_dependency_type(handle)
 

--- a/gaphor/UML/classes/component.py
+++ b/gaphor/UML/classes/component.py
@@ -16,7 +16,7 @@ class ComponentItem(Classified, ElementPresentation):
 
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject.name")
-        self.watch("subject[NamedElement].namespace.name")
+        self.watch("subject.namespace.name")
         self.watch("subject[Classifier].useCase", self.update_shapes)
         self.watch("children", self.update_shapes)
         stereotype_watches(self)

--- a/gaphor/UML/classes/component.py
+++ b/gaphor/UML/classes/component.py
@@ -15,7 +15,7 @@ class ComponentItem(Classified, ElementPresentation):
         super().__init__(diagram, id)
 
         self.watch("show_stereotypes", self.update_shapes)
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject[NamedElement].namespace.name")
         self.watch("subject[Classifier].useCase", self.update_shapes)
         self.watch("children", self.update_shapes)

--- a/gaphor/UML/classes/datatype.py
+++ b/gaphor/UML/classes/datatype.py
@@ -35,9 +35,7 @@ class DataTypeItem(Classified, ElementPresentation[UML.DataType]):
 
         self.watch("show_attributes", self.update_shapes).watch(
             "show_operations", self.update_shapes
-        ).watch("subject[NamedElement].name").watch(
-            "subject[NamedElement].namespace.name"
-        )
+        ).watch("subject.name").watch("subject[NamedElement].namespace.name")
         attribute_watches(self, "DataType")
         operation_watches(self, "DataType")
         stereotype_watches(self)

--- a/gaphor/UML/classes/datatype.py
+++ b/gaphor/UML/classes/datatype.py
@@ -35,7 +35,7 @@ class DataTypeItem(Classified, ElementPresentation[UML.DataType]):
 
         self.watch("show_attributes", self.update_shapes).watch(
             "show_operations", self.update_shapes
-        ).watch("subject.name").watch("subject[NamedElement].namespace.name")
+        ).watch("subject.name").watch("subject.namespace.name")
         attribute_watches(self, "DataType")
         operation_watches(self, "DataType")
         stereotype_watches(self)

--- a/gaphor/UML/classes/dependency.py
+++ b/gaphor/UML/classes/dependency.py
@@ -17,7 +17,7 @@ the type of dependency in an automatic way.
 from gaphor import UML
 from gaphor.core.modeling import Dependency
 from gaphor.core.modeling.properties import attribute
-from gaphor.diagram.presentation import LinePresentation, text_name
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
 from gaphor.diagram.shapes import Box, stroke
 from gaphor.diagram.support import represents
 from gaphor.i18n import i18nize
@@ -27,7 +27,7 @@ from gaphor.UML.compartments import text_stereotypes
 
 @represents(Dependency, head=Dependency.supplier, tail=Dependency.client)
 @represents(UML.Usage, head=UML.Usage.supplier, tail=UML.Usage.client)
-class DependencyItem(LinePresentation):
+class DependencyItem(Named, LinePresentation):
     """Dependency item represents several types of dependencies, i.e. normal
     dependency or usage.
 

--- a/gaphor/UML/classes/dependency.py
+++ b/gaphor/UML/classes/dependency.py
@@ -16,7 +16,7 @@ the type of dependency in an automatic way.
 
 from gaphor import UML
 from gaphor.core.modeling.properties import attribute
-from gaphor.diagram.presentation import LinePresentation, Named, text_name
+from gaphor.diagram.presentation import LinePresentation, text_name
 from gaphor.diagram.shapes import Box, stroke
 from gaphor.diagram.support import represents
 from gaphor.i18n import i18nize
@@ -26,7 +26,7 @@ from gaphor.UML.compartments import text_stereotypes
 
 @represents(UML.Dependency, head=UML.Dependency.supplier, tail=UML.Dependency.client)
 @represents(UML.Usage, head=UML.Usage.supplier, tail=UML.Usage.client)
-class DependencyItem(Named, LinePresentation):
+class DependencyItem(LinePresentation):
     """Dependency item represents several types of dependencies, i.e. normal
     dependency or usage.
 

--- a/gaphor/UML/classes/dependency.py
+++ b/gaphor/UML/classes/dependency.py
@@ -15,6 +15,7 @@ the type of dependency in an automatic way.
 """
 
 from gaphor import UML
+from gaphor.core.modeling import Dependency
 from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.presentation import LinePresentation, text_name
 from gaphor.diagram.shapes import Box, stroke
@@ -24,7 +25,7 @@ from gaphor.UML.classes.interface import Folded, InterfacePort
 from gaphor.UML.compartments import text_stereotypes
 
 
-@represents(UML.Dependency, head=UML.Dependency.supplier, tail=UML.Dependency.client)
+@represents(Dependency, head=Dependency.supplier, tail=Dependency.client)
 @represents(UML.Usage, head=UML.Usage.supplier, tail=UML.Usage.client)
 class DependencyItem(LinePresentation):
     """Dependency item represents several types of dependencies, i.e. normal
@@ -45,7 +46,7 @@ class DependencyItem(LinePresentation):
             UML.InterfaceRealization: (i18nize("implements"),),
         }
 
-        self._dependency_type = UML.Dependency
+        self._dependency_type = Dependency
 
         super().__init__(
             diagram,

--- a/gaphor/UML/classes/dependency.py
+++ b/gaphor/UML/classes/dependency.py
@@ -66,7 +66,7 @@ class DependencyItem(LinePresentation):
         self._handles[0].pos = (30, 20)
         self._handles[1].pos = (0, 0)
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
     auto_dependency: attribute[int] = attribute("auto_dependency", int, default=True)

--- a/gaphor/UML/classes/dependencypropertypages.py
+++ b/gaphor/UML/classes/dependencypropertypages.py
@@ -1,4 +1,5 @@
 from gaphor import UML
+from gaphor.core.modeling import Dependency
 from gaphor.diagram.propertypages import (
     PropertyPageBase,
     PropertyPages,
@@ -16,7 +17,7 @@ class DependencyPropertyPage(PropertyPageBase):
     order = 20
 
     DEPENDENCIES = (
-        UML.Dependency,
+        Dependency,
         UML.Usage,
         UML.Realization,
         UML.InterfaceRealization,

--- a/gaphor/UML/classes/enumeration.py
+++ b/gaphor/UML/classes/enumeration.py
@@ -36,7 +36,7 @@ class EnumerationItem(Classified, ElementPresentation[UML.Enumeration]):
         self.watch("show_attributes", self.update_shapes).watch(
             "show_operations", self.update_shapes
         ).watch("show_enumerations", self.update_shapes).watch("subject.name").watch(
-            "subject[NamedElement].namespace.name"
+            "subject.namespace.name"
         ).watch("subject[Enumeration].ownedLiteral", self.update_shapes).watch(
             "subject[Enumeration].ownedLiteral.name", self.update_shapes
         )

--- a/gaphor/UML/classes/enumeration.py
+++ b/gaphor/UML/classes/enumeration.py
@@ -35,11 +35,11 @@ class EnumerationItem(Classified, ElementPresentation[UML.Enumeration]):
 
         self.watch("show_attributes", self.update_shapes).watch(
             "show_operations", self.update_shapes
-        ).watch("show_enumerations", self.update_shapes).watch(
-            "subject[NamedElement].name"
-        ).watch("subject[NamedElement].namespace.name").watch(
-            "subject[Enumeration].ownedLiteral", self.update_shapes
-        ).watch("subject[Enumeration].ownedLiteral.name", self.update_shapes)
+        ).watch("show_enumerations", self.update_shapes).watch("subject.name").watch(
+            "subject[NamedElement].namespace.name"
+        ).watch("subject[Enumeration].ownedLiteral", self.update_shapes).watch(
+            "subject[Enumeration].ownedLiteral.name", self.update_shapes
+        )
         attribute_watches(self, "Enumeration")
         operation_watches(self, "Enumeration")
         stereotype_watches(self)

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -183,11 +183,9 @@ class InterfaceItem(Classified, ElementPresentation):
 
         self.watch("show_stereotypes", self.update_shapes).watch(
             "show_attributes", self.update_shapes
-        ).watch("show_operations", self.update_shapes).watch(
-            "subject[NamedElement].name"
-        ).watch("subject[NamedElement].namespace.name").watch(
-            "subject[Interface].supplierDependency", self.update_shapes
-        )
+        ).watch("show_operations", self.update_shapes).watch("subject.name").watch(
+            "subject[NamedElement].namespace.name"
+        ).watch("subject[Interface].supplierDependency", self.update_shapes)
         attribute_watches(self, "Interface")
         operation_watches(self, "Interface")
         stereotype_watches(self)

--- a/gaphor/UML/classes/interface.py
+++ b/gaphor/UML/classes/interface.py
@@ -184,7 +184,7 @@ class InterfaceItem(Classified, ElementPresentation):
         self.watch("show_stereotypes", self.update_shapes).watch(
             "show_attributes", self.update_shapes
         ).watch("show_operations", self.update_shapes).watch("subject.name").watch(
-            "subject[NamedElement].namespace.name"
+            "subject.namespace.name"
         ).watch("subject[Interface].supplierDependency", self.update_shapes)
         attribute_watches(self, "Interface")
         operation_watches(self, "Interface")

--- a/gaphor/UML/classes/interfacerealization.py
+++ b/gaphor/UML/classes/interfacerealization.py
@@ -3,7 +3,7 @@
 
 from gaphor import UML
 from gaphor.core.styling import Style
-from gaphor.diagram.presentation import LinePresentation, text_name
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
 from gaphor.diagram.shapes import Box, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.interface import Folded, InterfacePort
@@ -15,7 +15,7 @@ from gaphor.UML.compartments import text_stereotypes
     head=UML.InterfaceRealization.contract,
     tail=UML.InterfaceRealization.implementatingClassifier,
 )
-class InterfaceRealizationItem(LinePresentation):
+class InterfaceRealizationItem(Named, LinePresentation):
     def __init__(self, diagram, id=None):
         super().__init__(
             diagram,

--- a/gaphor/UML/classes/interfacerealization.py
+++ b/gaphor/UML/classes/interfacerealization.py
@@ -3,7 +3,7 @@
 
 from gaphor import UML
 from gaphor.core.styling import Style
-from gaphor.diagram.presentation import LinePresentation, Named, text_name
+from gaphor.diagram.presentation import LinePresentation, text_name
 from gaphor.diagram.shapes import Box, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.classes.interface import Folded, InterfacePort
@@ -15,7 +15,7 @@ from gaphor.UML.compartments import text_stereotypes
     head=UML.InterfaceRealization.contract,
     tail=UML.InterfaceRealization.implementatingClassifier,
 )
-class InterfaceRealizationItem(Named, LinePresentation):
+class InterfaceRealizationItem(LinePresentation):
     def __init__(self, diagram, id=None):
         super().__init__(
             diagram,

--- a/gaphor/UML/classes/interfacerealization.py
+++ b/gaphor/UML/classes/interfacerealization.py
@@ -26,7 +26,7 @@ class InterfaceRealizationItem(LinePresentation):
             ),
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
         self._inline_style: Style = {}
 

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -30,7 +30,7 @@ class ClassItem(Classified, ElementPresentation[UML.Class]):
         self.watch("show_stereotypes", self.update_shapes).watch(
             "show_attributes", self.update_shapes
         ).watch("show_operations", self.update_shapes).watch("subject.name").watch(
-            "subject[NamedElement].namespace.name"
+            "subject.namespace.name"
         ).watch("subject[Classifier].isAbstract", self.update_shapes)
         attribute_watches(self, "Class")
         operation_watches(self, "Class")

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -29,11 +29,9 @@ class ClassItem(Classified, ElementPresentation[UML.Class]):
 
         self.watch("show_stereotypes", self.update_shapes).watch(
             "show_attributes", self.update_shapes
-        ).watch("show_operations", self.update_shapes).watch(
-            "subject[NamedElement].name"
-        ).watch("subject[NamedElement].namespace.name").watch(
-            "subject[Classifier].isAbstract", self.update_shapes
-        )
+        ).watch("show_operations", self.update_shapes).watch("subject.name").watch(
+            "subject[NamedElement].namespace.name"
+        ).watch("subject[Classifier].isAbstract", self.update_shapes)
         attribute_watches(self, "Class")
         operation_watches(self, "Class")
         stereotype_watches(self)

--- a/gaphor/UML/classes/package.py
+++ b/gaphor/UML/classes/package.py
@@ -19,7 +19,7 @@ class PackageItem(Named, ElementPresentation):
 
         self.watch("children", self.update_shapes)
         self.watch("subject.name")
-        self.watch("subject[NamedElement].namespace.name")
+        self.watch("subject.namespace.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
     def update_shapes(self, event=None):

--- a/gaphor/UML/classes/package.py
+++ b/gaphor/UML/classes/package.py
@@ -18,7 +18,7 @@ class PackageItem(Named, ElementPresentation):
         super().__init__(diagram, id, width=70, height=70)
 
         self.watch("children", self.update_shapes)
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject[NamedElement].namespace.name")
         self.watch("subject.appliedStereotype.classifier.name")
 

--- a/gaphor/UML/classes/tests/test_copypaste.py
+++ b/gaphor/UML/classes/tests/test_copypaste.py
@@ -158,16 +158,8 @@ def test_copy_remove_paste_items_with_connections(diagram, element_factory):
     new_items = copy_clear_and_paste_link(
         {gen_cls_item, assoc_item, spc_cls_item}, diagram, element_factory
     )
-    new_cls1 = next(
-        element_factory.select(
-            lambda e: isinstance(e, UML.NamedElement) and e.name == "Gen"
-        )
-    )
-    new_cls2 = next(
-        element_factory.select(
-            lambda e: isinstance(e, UML.NamedElement) and e.name == "Spc"
-        )
-    )
+    new_cls1 = next(element_factory.select(lambda e: e.name == "Gen"))
+    new_cls2 = next(element_factory.select(lambda e: e.name == "Spc"))
     new_assoc = next(element_factory.select(UML.Association))
 
     assert new_assoc.memberEnd[0].type is new_cls2

--- a/gaphor/UML/classes/tests/test_dependencyconnect.py
+++ b/gaphor/UML/classes/tests/test_dependencyconnect.py
@@ -1,5 +1,3 @@
-"""Classes related adapter connection tests."""
-
 from gaphor import UML
 from gaphor.core.modeling import Diagram
 from gaphor.diagram.tests.fixtures import allow, connect, disconnect, get_connected
@@ -79,12 +77,12 @@ def test_dependency_reconnect_should_keep_attributes(create):
     connect(dep, dep.head, a1)
     connect(dep, dep.tail, a2)
 
-    dep.subject.name = "Name"
+    dep.subject.note = "Note"
 
     # reconnect: a1 -> a3
     connect(dep, dep.tail, a3)
 
-    assert dep.subject.name == "Name"
+    assert dep.subject.note == "Note"
 
 
 def test_dependency_disconnect(create, element_factory, sanitizer_service):

--- a/gaphor/UML/classes/tests/test_dependencyconnect.py
+++ b/gaphor/UML/classes/tests/test_dependencyconnect.py
@@ -1,5 +1,5 @@
 from gaphor import UML
-from gaphor.core.modeling import Diagram
+from gaphor.core.modeling import Dependency, Diagram
 from gaphor.diagram.tests.fixtures import allow, connect, disconnect, get_connected
 from gaphor.UML.classes.dependency import DependencyItem
 from gaphor.UML.classes.interface import InterfaceItem
@@ -32,7 +32,7 @@ def test_dependency_connect(create, element_factory):
     connect(dep, dep.tail, actor2)
 
     assert dep.subject is not None
-    assert isinstance(dep.subject, UML.Dependency)
+    assert isinstance(dep.subject, Dependency)
     assert dep.subject in element_factory.select()
 
     hct = get_connected(dep, dep.head)

--- a/gaphor/UML/classes/tests/test_dependencypropertypages.py
+++ b/gaphor/UML/classes/tests/test_dependencypropertypages.py
@@ -1,11 +1,12 @@
 from gaphor import UML
+from gaphor.core.modeling import Dependency
 from gaphor.diagram.tests.fixtures import find
 from gaphor.UML.classes.dependencypropertypages import DependencyPropertyPage
 
 
 def test_dependency_property_page(diagram, element_factory, event_manager):
     item = diagram.create(
-        UML.classes.DependencyItem, subject=element_factory.create(UML.Dependency)
+        UML.classes.DependencyItem, subject=element_factory.create(Dependency)
     )
     property_page = DependencyPropertyPage(item, event_manager)
 

--- a/gaphor/UML/deployments/artifact.py
+++ b/gaphor/UML/deployments/artifact.py
@@ -16,7 +16,7 @@ class ArtifactItem(Classified, ElementPresentation):
 
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("subject.name")
-        self.watch("subject[NamedElement].namespace.name")
+        self.watch("subject.namespace.name")
         self.watch("children", self.update_shapes)
         stereotype_watches(self)
 

--- a/gaphor/UML/deployments/artifact.py
+++ b/gaphor/UML/deployments/artifact.py
@@ -15,7 +15,7 @@ class ArtifactItem(Classified, ElementPresentation):
         super().__init__(diagram, id)
 
         self.watch("show_stereotypes", self.update_shapes)
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject[NamedElement].namespace.name")
         self.watch("children", self.update_shapes)
         stereotype_watches(self)

--- a/gaphor/UML/deployments/connector.py
+++ b/gaphor/UML/deployments/connector.py
@@ -137,7 +137,7 @@ class ConnectorItem(Named, LinePresentation[UML.Connector]):
             ),
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
         watch_information_flow(self, "Connector", "informationFlow")
 

--- a/gaphor/UML/deployments/node.py
+++ b/gaphor/UML/deployments/node.py
@@ -33,7 +33,7 @@ class NodeItem(Classified, ElementPresentation):
 
         self.watch("children", self.update_shapes)
         self.watch("show_stereotypes", self.update_shapes)
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject[Node].ownedConnector", self.update_shapes)
         stereotype_watches(self)
 

--- a/gaphor/UML/drop.py
+++ b/gaphor/UML/drop.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from gaphor import UML
-from gaphor.core.modeling import Diagram
+from gaphor.core.modeling import Diagram, Relationship
 from gaphor.diagram.drop import drop
 from gaphor.diagram.presentation import connect
 from gaphor.diagram.support import get_diagram_item, get_diagram_item_metadata
 
 
-@drop.register(UML.Relationship, Diagram)
-def drop_relationship(element: UML.Relationship, diagram: Diagram, x, y):
+@drop.register(Relationship, Diagram)
+def drop_relationship(element: Relationship, diagram: Diagram, x, y):
     item_class = get_diagram_item(type(element))
     if not item_class:
         return None

--- a/gaphor/UML/drop.py
+++ b/gaphor/UML/drop.py
@@ -1,56 +1,27 @@
 from __future__ import annotations
 
 from gaphor import UML
-from gaphor.core.modeling import Diagram, Relationship
-from gaphor.diagram.drop import drop
-from gaphor.diagram.presentation import connect
-from gaphor.diagram.support import get_diagram_item, get_diagram_item_metadata
-
-
-@drop.register(Relationship, Diagram)
-def drop_relationship(element: Relationship, diagram: Diagram, x, y):
-    item_class = get_diagram_item(type(element))
-    if not item_class:
-        return None
-
-    metadata = get_diagram_item_metadata(item_class)
-    return (
-        _drop(
-            element,
-            metadata["head"].get(element),
-            metadata["tail"].get(element),
-            diagram,
-            x,
-            y,
-        )
-        if metadata
-        else None
-    )
-
-
-def diagram_has_presentation(diagram, element):
-    return (
-        next((p for p in element.presentation if p.diagram is diagram), None)
-        if element
-        else None
-    )
+from gaphor.core.modeling import Diagram
+from gaphor.diagram.drop import drop, drop_relationship
 
 
 @drop.register(UML.Association, Diagram)
 def drop_association(element: UML.Association, diagram: Diagram, x, y):
-    return _drop(
+    return drop_relationship(
         element, element.memberEnd[0].type, element.memberEnd[1].type, diagram, x, y
     )
 
 
 @drop.register(UML.Connector, Diagram)
 def drop_connector(element: UML.Connector, diagram: Diagram, x, y):
-    return _drop(element, element.end[0].role, element.end[1].role, diagram, x, y)
+    return drop_relationship(
+        element, element.end[0].role, element.end[1].role, diagram, x, y
+    )
 
 
 @drop.register(UML.Message, Diagram)
 def drop_message(element: UML.Message, diagram: Diagram, x, y):
-    return _drop(
+    return drop_relationship(
         element,
         element.sendEvent.covered
         if isinstance(element.sendEvent, UML.MessageOccurrenceSpecification)
@@ -62,27 +33,3 @@ def drop_message(element: UML.Message, diagram: Diagram, x, y):
         x,
         y,
     )
-
-
-def _drop(element, head_element, tail_element, diagram, x, y):
-    item_class = get_diagram_item(type(element))
-    if not item_class:
-        return None
-
-    head_item = diagram_has_presentation(diagram, head_element)
-    tail_item = diagram_has_presentation(diagram, tail_element)
-    if (head_element and not head_item) or (tail_element and not tail_item):
-        return None
-
-    item = diagram.create(item_class)
-    assert item
-
-    item.matrix.translate(x, y)
-    item.subject = element
-
-    if head_item:
-        connect(item, item.head, head_item)
-    if tail_item:
-        connect(item, item.tail, tail_item)
-
-    return item

--- a/gaphor/UML/interactions/interaction.py
+++ b/gaphor/UML/interactions/interaction.py
@@ -24,7 +24,7 @@ class InteractionItem(Named, ElementPresentation):
             draw=draw_interaction,
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
 

--- a/gaphor/UML/interactions/lifeline.py
+++ b/gaphor/UML/interactions/lifeline.py
@@ -184,7 +184,7 @@ class LifelineItem(Named, ElementPresentation[UML.Lifeline]):
             draw=draw_border,
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[Lifeline].represents.name")
         self.watch("subject[Lifeline].represents.type.name")

--- a/gaphor/UML/interactions/message.py
+++ b/gaphor/UML/interactions/message.py
@@ -98,7 +98,7 @@ class MessageItem(Named, LinePresentation[UML.Message]):
         self._arrow_pos = 0, 0
         self._arrow_angle = 0
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[Message].messageEnd", self._update_message_end)
 

--- a/gaphor/UML/profiles/extension.py
+++ b/gaphor/UML/profiles/extension.py
@@ -27,7 +27,7 @@ class ExtensionItem(Named, LinePresentation):
             ),
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
     def draw_head(self, context):

--- a/gaphor/UML/profiles/tests/test_copypaste.py
+++ b/gaphor/UML/profiles/tests/test_copypaste.py
@@ -44,16 +44,8 @@ def test_cut_paste_of_stereotype(diagram, element_factory):
     copy_clear_and_paste_link(
         {m_cls_item, st_cls_item, ext_item}, diagram, element_factory
     )
-    new_m_cls = next(
-        element_factory.select(
-            lambda e: isinstance(e, UML.NamedElement) and e.name == "Class"
-        )
-    )
-    new_st_cls = next(
-        element_factory.select(
-            lambda e: isinstance(e, UML.NamedElement) and e.name == "Stereotype"
-        )
-    )
+    new_m_cls = next(element_factory.select(lambda e: e.name == "Class"))
+    new_st_cls = next(element_factory.select(lambda e: e.name == "Stereotype"))
     new_ext = next(element_factory.select(UML.Extension))
 
     assert new_m_cls in new_ext.memberEnd[:].type

--- a/gaphor/UML/states/copypaste.py
+++ b/gaphor/UML/states/copypaste.py
@@ -16,6 +16,6 @@ def copy_state(element: State):
 
 @copy.register
 def copy_transition(element: Transition):
-    yield element.id, copy_named_element(element)
+    yield element.id, copy_named_element(element)  # type: ignore[arg-type]
     if element.guard:
         yield from copy(element.guard)

--- a/gaphor/UML/states/copypaste.py
+++ b/gaphor/UML/states/copypaste.py
@@ -16,6 +16,6 @@ def copy_state(element: State):
 
 @copy.register
 def copy_transition(element: Transition):
-    yield element.id, copy_named_element(element)  # type: ignore[arg-type]
+    yield element.id, copy_named_element(element)
     if element.guard:
         yield from copy(element.guard)

--- a/gaphor/UML/states/finalstate.py
+++ b/gaphor/UML/states/finalstate.py
@@ -20,7 +20,7 @@ class FinalStateItem(ElementPresentation, Named):
             text_name(self),
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
 

--- a/gaphor/UML/states/pseudostates.py
+++ b/gaphor/UML/states/pseudostates.py
@@ -36,7 +36,7 @@ class PseudostateItem(ElementPresentation, Named):
         for h in self.handles():
             h.movable = False
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[Pseudostate].kind", self.update_shapes)
 

--- a/gaphor/UML/states/state.py
+++ b/gaphor/UML/states/state.py
@@ -19,7 +19,7 @@ class StateItem(ElementPresentation[UML.State], Named):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, width=50, height=30)
         self._region_heights = []
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[State].entry.name", self.update_shapes)
         self.watch("subject[State].exit.name", self.update_shapes)

--- a/gaphor/UML/states/statemachine.py
+++ b/gaphor/UML/states/statemachine.py
@@ -21,7 +21,7 @@ class StateMachineItem(Classified, ElementPresentation[UML.StateMachine]):
         self.watch("children", self.update_shapes)
         self.watch("show_stereotypes", self.update_shapes)
         self.watch("show_regions", self.update_shapes)
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject[StateMachine].region.name")
         self.watch("subject[StateMachine].region", self.update_shapes)
         stereotype_watches(self)

--- a/gaphor/UML/states/transition.py
+++ b/gaphor/UML/states/transition.py
@@ -32,7 +32,7 @@ class TransitionItem(Named, LinePresentation[UML.Transition]):
             ),
         )
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
 
         self.watch("subject[Transition].guard[Constraint].specification")

--- a/gaphor/UML/tests/test_diagramitems.py
+++ b/gaphor/UML/tests/test_diagramitems.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gaphor.core.modeling import Presentation
+from gaphor.core.modeling import Presentation, Relationship
 from gaphor.diagram.general import Box, CommentLineItem, Ellipse, Line, MetadataItem
 from gaphor.diagram.presentation import Classified, Named
 from gaphor.diagram.support import get_model_element
@@ -61,7 +61,7 @@ def test_all_named_elements_have_named_items(item_class, element_class):
         assert issubclass(item_class, Named)
 
     if issubclass(item_class, Named):
-        assert issubclass(element_class, NamedElement)
+        assert issubclass(element_class, (NamedElement, Relationship))
 
 
 CLASSIFIED_EXCLUSIONS = [

--- a/gaphor/UML/tests/test_drop.py
+++ b/gaphor/UML/tests/test_drop.py
@@ -1,4 +1,5 @@
 from gaphor import UML
+from gaphor.core.modeling import Dependency
 from gaphor.diagram.drop import drop
 from gaphor.UML.interactions import MessageItem
 from gaphor.UML.interactions.interactionsconnect import connect_lifelines
@@ -17,7 +18,7 @@ def test_drop_class(diagram, element_factory):
 def test_drop_dependency(diagram, element_factory):
     client = element_factory.create(UML.Class)
     supplier = element_factory.create(UML.Class)
-    dependency = element_factory.create(UML.Dependency)
+    dependency = element_factory.create(Dependency)
     dependency.client = client
     dependency.supplier = supplier
 

--- a/gaphor/UML/tests/test_uml2.py
+++ b/gaphor/UML/tests/test_uml2.py
@@ -3,7 +3,7 @@ import pytest
 from gaphor import UML
 from gaphor.core.eventmanager import EventManager
 from gaphor.core.format import parse
-from gaphor.core.modeling import Comment, ElementFactory
+from gaphor.core.modeling import Comment, Dependency, ElementFactory
 
 
 @pytest.fixture
@@ -111,7 +111,7 @@ def test_constraint(factory):
 def test_dependency(factory):
     """Testing Dependency elements in the meta-model."""
 
-    element = factory.create(UML.Dependency)
+    element = factory.create(Dependency)
 
     client = factory.create(UML.Package)
     supplier = factory.create(UML.Package)

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -54,11 +54,7 @@ class EnumerationLiteral(InstanceSpecification):
     enumeration: relation_one[Enumeration]
 
 
-class Relationship(Element):
-    abstraction: relation_many[InformationFlow]
-    relatedElement: relation_many[Element]
-
-
+from gaphor.core.modeling.coremodel import Relationship
 class DirectedRelationship(Relationship):
     source: relation_many[Element]
     target: relation_many[Element]
@@ -788,7 +784,6 @@ class ValueSpecificationAction(Action):
 # defined in umloverrides.py
 
 
-Element.relationship = derivedunion("relationship", Relationship)
 Element.directedRelationship = derivedunion("directedRelationship", DirectedRelationship)
 Element.appliedStereotype = association("appliedStereotype", InstanceSpecification, composite=True, opposite="extended")
 Element.relationship.add(Element.directedRelationship)  # type: ignore[attr-defined]
@@ -826,7 +821,6 @@ InstanceSpecification.extended = association("extended", Element, opposite="appl
 Element.ownedElement.add(InstanceSpecification.slot)  # type: ignore[attr-defined]
 EnumerationLiteral.enumeration = association("enumeration", Enumeration, upper=1, opposite="ownedLiteral")
 NamedElement.namespace.add(EnumerationLiteral.enumeration)  # type: ignore[attr-defined]
-Relationship.relatedElement = derivedunion("relatedElement", Element, lower=1)
 Relationship.abstraction = association("abstraction", InformationFlow, composite=True, opposite="realization")
 DirectedRelationship.target = derivedunion("target", Element, lower=1)
 DirectedRelationship.source = derivedunion("source", Element, lower=1)
@@ -835,6 +829,7 @@ Relationship.relatedElement.add(DirectedRelationship.source)  # type: ignore[att
 PackageMerge.mergingPackage = association("mergingPackage", Package, upper=1, opposite="packageMerge")
 PackageMerge.mergedPackage = association("mergedPackage", Package, upper=1)
 DirectedRelationship.source.add(PackageMerge.mergingPackage)  # type: ignore[attr-defined]
+from gaphor.core.modeling.coremodel import Element
 Element.owner.add(PackageMerge.mergingPackage)  # type: ignore[attr-defined]
 DirectedRelationship.target.add(PackageMerge.mergedPackage)  # type: ignore[attr-defined]
 RedefinableElement.redefinedElement = derivedunion("redefinedElement", RedefinableElement)

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -19,11 +19,7 @@ from gaphor.core.modeling.properties import (
 from typing import Callable
 
 
-from gaphor.core.modeling.element import Element
-class NamedElement(Element):
-    visibility = _enumeration("visibility", ("public", "private", "package", "protected"), "public")
-
-
+from gaphor.core.modeling.coremodel import NamedElement
 class PackageableElement(NamedElement):
     component: relation_one[Component]
     owningPackage: relation_one[Package]
@@ -177,6 +173,7 @@ class ObjectNode(ActivityNode, TypedElement):
     upperBound: _attribute[str] = _attribute("upperBound", str)
 
 
+from gaphor.core.modeling.element import Element
 class MultiplicityElement(Element):
     isOrdered: _attribute[int] = _attribute("isOrdered", int, default=True)
     isUnique: _attribute[int] = _attribute("isUnique", int, default=True)
@@ -765,9 +762,9 @@ class ValueSpecificationAction(Action):
 # defined in umloverrides.py
 
 
-Element.appliedStereotype = association("appliedStereotype", InstanceSpecification, composite=True, opposite="extended")
 PackageableElement.owningPackage = derivedunion("owningPackage", Package, upper=1)
 PackageableElement.component = association("component", Component, upper=1, opposite="packagedElement")
+from gaphor.core.modeling.coremodel import Element
 Element.namespace.add(PackageableElement.owningPackage)  # type: ignore[attr-defined]
 Element.namespace.add(PackageableElement.component)  # type: ignore[attr-defined]
 DeployedArtifact.deployment = association("deployment", Deployment, opposite="deployedArtifact")
@@ -783,7 +780,6 @@ Relationship.abstraction = association("abstraction", InformationFlow, composite
 PackageMerge.mergingPackage = association("mergingPackage", Package, upper=1, opposite="packageMerge")
 PackageMerge.mergedPackage = association("mergedPackage", Package, upper=1)
 Relationship.source.add(PackageMerge.mergingPackage)  # type: ignore[attr-defined]
-from gaphor.core.modeling.coremodel import Element
 Element.owner.add(PackageMerge.mergingPackage)  # type: ignore[attr-defined]
 Relationship.target.add(PackageMerge.mergedPackage)  # type: ignore[attr-defined]
 RedefinableElement.redefinedElement = derivedunion("redefinedElement", RedefinableElement)
@@ -860,6 +856,7 @@ ActivityEdge.redefinedElement = redefine(ActivityEdge, "redefinedElement", Activ
 Element.owner.add(ActivityEdge.activity)  # type: ignore[attr-defined]
 TypedElement.type = association("type", Type, upper=1)
 ObjectNode.selection = association("selection", Behavior, upper=1)
+Element.appliedStereotype = association("appliedStereotype", InstanceSpecification, composite=True, opposite="extended")
 # 18: override MultiplicityElement.lower(MultiplicityElement.lowerValue): _attribute[str]
 MultiplicityElement.lower = MultiplicityElement.lowerValue
 

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -22,9 +22,7 @@ from typing import Callable
 from gaphor.core.modeling.element import Element
 class NamedElement(Element):
     memberNamespace: relation_one[Namespace]
-    name: _attribute[str] = _attribute("name", str)
     namespace: relation_one[Namespace]
-    qualifiedName: derived[list[str]]
     visibility = _enumeration("visibility", ("public", "private", "package", "protected"), "public")
 
 
@@ -770,27 +768,15 @@ class ValueSpecificationAction(Action):
     value: _attribute[str] = _attribute("value", str)
 
 
-# 86: override Lifeline.parse: Callable[[Lifeline, str], None]
+# 74: override Lifeline.parse: Callable[[Lifeline, str], None]
 # defined in umloverrides.py
 
-# 89: override Lifeline.render: Callable[[Lifeline], str]
+# 77: override Lifeline.render: Callable[[Lifeline], str]
 # defined in umloverrides.py
 
 
 Element.appliedStereotype = association("appliedStereotype", InstanceSpecification, composite=True, opposite="extended")
 NamedElement.namespace = derivedunion("namespace", Namespace, upper=1)
-# 68: override NamedElement.qualifiedName: derived[list[str]]
-
-from gaphor.core.modeling import qualifiedName
-
-NamedElement.qualifiedName = derived(
-    "qualifiedName",
-    list[str],
-    0,
-    1,
-    lambda obj: [qualifiedName(obj)],
-)
-
 NamedElement.memberNamespace = derivedunion("memberNamespace", Namespace, upper=1)
 Element.owner.add(NamedElement.namespace)  # type: ignore[attr-defined]
 NamedElement.memberNamespace.add(NamedElement.namespace)  # type: ignore[attr-defined]
@@ -904,7 +890,7 @@ Relationship.relatedElement.add(Generalization.general)  # type: ignore[attr-def
 Relationship.source.add(Generalization.specific)  # type: ignore[attr-defined]
 Element.owner.add(Generalization.specific)  # type: ignore[attr-defined]
 StructuredClassifier.role = derivedunion("role", ConnectableElement)
-# 101: override StructuredClassifier.part: property
+# 89: override StructuredClassifier.part: property
 StructuredClassifier.part = property(lambda self: tuple(a for a in self.ownedAttribute if a.isComposite), doc="""
     Properties owned by a classifier by composition.
 """)
@@ -962,11 +948,11 @@ InputPin.opaqueAction = association("opaqueAction", Action, upper=1, opposite="i
 Element.owner.add(InputPin.opaqueAction)  # type: ignore[attr-defined]
 Manifestation.artifact = association("artifact", Artifact, upper=1, opposite="manifestation")
 Element.owner.add(Manifestation.artifact)  # type: ignore[attr-defined]
-# 92: override Component.provided: property
+# 80: override Component.provided: property
 # defined in umloverrides.py
 
 Component.packagedElement = association("packagedElement", PackageableElement, composite=True, opposite="component")
-# 95: override Component.required: property
+# 83: override Component.required: property
 # defined in umloverrides.py
 
 Component.realization = redefine(Component, "realization", ComponentRealization, NamedElement.supplierDependency)
@@ -1010,7 +996,7 @@ Property.datatype = association("datatype", DataType, upper=1, opposite="ownedAt
 # 59: override Property.opposite(Property.association, Association.memberEnd): relation_one[Property | None]
 # defined in umloverrides.py
 
-# 80: override Property.navigability(Property.opposite, Property.association): derived[bool | None]
+# 68: override Property.navigability(Property.opposite, Property.association): derived[bool | None]
 # defined in umloverrides.py
 
 Property.artifact = association("artifact", Artifact, upper=1, opposite="ownedAttribute")
@@ -1099,7 +1085,7 @@ Operation.redefinedOperation = association("redefinedOperation", Operation)
 Operation.raisedException = association("raisedException", Type)
 Operation.bodyCondition = association("bodyCondition", Constraint, upper=1, composite=True)
 Operation.datatype = association("datatype", DataType, upper=1, opposite="ownedOperation")
-# 83: override Operation.type: derivedunion[DataType]
+# 71: override Operation.type: derivedunion[DataType]
 Operation.type = derivedunion('type', DataType, 0, 1)
 
 Operation.artifact = association("artifact", Artifact, upper=1, opposite="ownedOperation")
@@ -1177,7 +1163,7 @@ Lifeline.interaction = association("interaction", Interaction, upper=1, opposite
 Lifeline.coveredBy = association("coveredBy", InteractionFragment, opposite="covered")
 Lifeline.represents = association("represents", ConnectableElement, upper=1, opposite="lifeline")
 NamedElement.namespace.add(Lifeline.interaction)  # type: ignore[attr-defined]
-# 98: override Message.messageKind: property
+# 86: override Message.messageKind: property
 # defined in umloverrides.py
 
 Message.sendEvent = association("sendEvent", MessageEnd, upper=1, composite=True, opposite="sendMessage")
@@ -1271,11 +1257,11 @@ Collaboration.collaborationRole = association("collaborationRole", ConnectableEl
 StructuredClassifier.role.add(Collaboration.collaborationRole)  # type: ignore[attr-defined]
 Trigger.event = association("event", Event, upper=1)
 Trigger.port = association("port", Port)
-# 110: override ExecutionSpecification.finish(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
+# 98: override ExecutionSpecification.finish(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
 ExecutionSpecification.finish = derived('finish', OccurrenceSpecification, 0, 1,
     lambda obj: [eos for i, eos in enumerate(obj.executionOccurrenceSpecification) if i == 1])
 
-# 106: override ExecutionSpecification.start(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
+# 94: override ExecutionSpecification.start(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
 ExecutionSpecification.start = derived('start', OccurrenceSpecification, 0, 1,
     lambda obj: [eos for i, eos in enumerate(obj.executionOccurrenceSpecification) if i == 0])
 

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -182,11 +182,6 @@ def format_slot(el):
     return f'{el.definingFeature.name} = "{el.value}"'
 
 
-@format.register(UML.NamedElement)
-def format_namedelement(el, **kwargs):
-    return el.name or ""
-
-
 @format.register(UML.Pin)
 def format_pin(el, **kwargs):
     if not el:

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -211,11 +211,6 @@ def format_multiplicity(el, bare=False):
     return f"[{m}]" if m and not bare else m
 
 
-@format.register(UML.Relationship)
-def format_relationship(el):
-    return el.__class__.__name__
-
-
 @format.register(UML.Generalization)
 def format_generalization(el):
     return gettext("general: {name}").format(name=el.general and el.general.name or "")

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -216,13 +216,6 @@ def format_generalization(el):
     return gettext("general: {name}").format(name=el.general and el.general.name or "")
 
 
-@format.register(UML.Dependency)
-def format_dependency(el):
-    return gettext("supplier: {name}").format(
-        name=el.supplier and el.supplier.name or ""
-    )
-
-
 @format.register(UML.Extend)
 def format_extend(el):
     return gettext("extend: {name}").format(

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -348,9 +348,3 @@ def parse_lifeline(el: uml.Lifeline, s: str) -> None:
 
 def render_lifeline(el: uml.Lifeline) -> str:
     return el.name or ""
-
-
-@parse.register(uml.NamedElement)
-def parse_namedelement(el: uml.NamedElement, text: str) -> None:
-    """Parse named element by simply assigning text to its name."""
-    el.name = text

--- a/gaphor/UML/umloverrides.py
+++ b/gaphor/UML/umloverrides.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import itertools
 
+from gaphor.core.modeling import Element
 from gaphor.core.modeling.properties import derived
 from gaphor.UML import uml, umllex
 
@@ -77,7 +78,7 @@ def property_navigability(self: uml.Property) -> list[bool | None]:
 uml.Property.navigability = derived("navigability", bool, 0, 1, property_navigability)
 
 
-def _pr_interface_deps(classifier: uml.NamedElement, dep_type):
+def _pr_interface_deps(classifier: Element, dep_type):
     """Return all interfaces, which are connected to a classifier with given
     dependency type."""
     return (

--- a/gaphor/UML/usecases/actor.py
+++ b/gaphor/UML/usecases/actor.py
@@ -63,7 +63,7 @@ class ActorItem(Classified, ElementPresentation):
         )
         add(self, constraint(vertical=(self._handles[SE].pos, self._sub_text_port.end)))
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[Classifier].isAbstract", self.update_shapes)
 

--- a/gaphor/UML/usecases/extend.py
+++ b/gaphor/UML/usecases/extend.py
@@ -24,7 +24,5 @@ class ExtendItem(Named, LinePresentation):
         self._handles[0].pos = (30, 20)
         self._handles[1].pos = (0, 0)
 
-        self.watch("subject.appliedStereotype.classifier.name").watch(
-            "subject[NamedElement].name"
-        )
+        self.watch("subject.appliedStereotype.classifier.name").watch("subject.name")
         self.draw_head = draw_arrow_head

--- a/gaphor/UML/usecases/include.py
+++ b/gaphor/UML/usecases/include.py
@@ -24,7 +24,5 @@ class IncludeItem(Named, LinePresentation):
         self._handles[0].pos = (30, 20)
         self._handles[1].pos = (0, 0)
 
-        self.watch("subject.appliedStereotype.classifier.name").watch(
-            "subject[NamedElement].name"
-        )
+        self.watch("subject.appliedStereotype.classifier.name").watch("subject.name")
         self.draw_head = draw_arrow_head

--- a/gaphor/UML/usecases/usecase.py
+++ b/gaphor/UML/usecases/usecase.py
@@ -14,7 +14,7 @@ class UseCaseItem(Classified, ElementPresentation):
     def __init__(self, diagram, id=None):
         super().__init__(diagram, id, height=30)
 
-        self.watch("subject[NamedElement].name")
+        self.watch("subject.name")
         self.watch("subject.appliedStereotype.classifier.name")
         self.watch("subject[Classifier].isAbstract", self.update_shapes)
 

--- a/gaphor/codegen/coder.py
+++ b/gaphor/codegen/coder.py
@@ -215,7 +215,7 @@ def variables(class_: UML.Class, overrides: Overrides | None = None):
                 comment = "  # type: ignore[assignment]" if is_reassignment(a) else ""
                 yield f"{a.name}: relation_{mult}[{a.type.name}]{comment}"
             else:
-                assert isinstance(a.owner, UML.NamedElement)
+                assert isinstance(a.owner, UML.Element)
                 raise ValueError(
                     f"{a.name}: {a.type} can not be written; owner={a.owner.name}"
                 )
@@ -280,8 +280,8 @@ def subsets(
                 element_type, d = attribute(c, value.strip(), super_models)
                 if d and d.isDerived:
                     if element_type:
-                        yield f"from {element_type.__module__} import {d.owner.name}"  # type: ignore[attr-defined]
-                    yield f"{d.owner.name}.{d.name}.add({full_name})  # type: ignore[attr-defined]"  # type: ignore[attr-defined]
+                        yield f"from {element_type.__module__} import {d.owner.name}"
+                    yield f"{d.owner.name}.{d.name}.add({full_name})  # type: ignore[attr-defined]"
                 elif not d:
                     log.warning(
                         f"{full_name} wants to subset {value.strip()}, but it is not defined"

--- a/gaphor/codegen/tests/test_coder.py
+++ b/gaphor/codegen/tests/test_coder.py
@@ -266,11 +266,11 @@ def test_attribute_from_super_model(uml_metamodel: ElementFactory):
     class_.name = "Package"
 
     element_type, base = attribute(
-        class_, "relationship", [(UMLModelingLanguage(), uml_metamodel)]
+        class_, "member", [(UMLModelingLanguage(), uml_metamodel)]
     )
 
     assert element_type is UML.Package
-    assert base.owner.name == "Element"
+    assert base.owner.name == "Namespace"
 
 
 def test_replace_simple_attribute(uml_metamodel: ElementFactory):

--- a/gaphor/codegen/tests/test_coder.py
+++ b/gaphor/codegen/tests/test_coder.py
@@ -210,8 +210,8 @@ def test_simple_attribute(uml_metamodel: ElementFactory):
 def test_order_classes(uml_metamodel):
     classes = list(order_classes(uml_metamodel.select(UML.Class)))
 
-    assert classes[0].name == "Element"
-    assert classes[1].name == "NamedElement"
+    assert classes[0].name == "NamedElement"
+    assert classes[1].name == "PackageableElement"
 
 
 def test_coder_write_association(navigable_association: UML.Association):
@@ -279,8 +279,9 @@ def test_attribute_from_super_model(
         class_,
         "member",
         [
-            (UMLModelingLanguage(), uml_metamodel),
+            # Order matters! Base model first.
             (CoreModelingLanguage(), core_metamodel),
+            (UMLModelingLanguage(), uml_metamodel),
         ],
     )
 

--- a/gaphor/codegen/tests/test_coder.py
+++ b/gaphor/codegen/tests/test_coder.py
@@ -26,6 +26,14 @@ from gaphor.UML.modelinglanguage import UMLModelingLanguage
 
 
 @pytest.fixture(scope="session")
+def core_metamodel():
+    return load_model(
+        "models/Core.gaphor",
+        MockModelingLanguage(CoreModelingLanguage(), UMLModelingLanguage()),
+    )
+
+
+@pytest.fixture(scope="session")
 def uml_metamodel():
     return load_model(
         "models/UML.gaphor",
@@ -261,12 +269,19 @@ def test_coder_write_association_opposite_not_navigable(
     assert a == ['A.b = association("b", B)']
 
 
-def test_attribute_from_super_model(uml_metamodel: ElementFactory):
+def test_attribute_from_super_model(
+    uml_metamodel: ElementFactory, core_metamodel: ElementFactory
+):
     class_ = UML.Class()
     class_.name = "Package"
 
     element_type, base = attribute(
-        class_, "member", [(UMLModelingLanguage(), uml_metamodel)]
+        class_,
+        "member",
+        [
+            (UMLModelingLanguage(), uml_metamodel),
+            (CoreModelingLanguage(), core_metamodel),
+        ],
     )
 
     assert element_type is UML.Package

--- a/gaphor/core/format.py
+++ b/gaphor/core/format.py
@@ -22,11 +22,22 @@ def parse(el: Element, text: str) -> None:
     raise TypeError(f"Parsing routine for type {type(el)} not implemented yet")
 
 
+@format.register(Element)
+def format_namedelement(el: Element, **kwargs):
+    return el.name or ""
+
+
 @format.register(Diagram)
-def format_diagram(el, **kwargs) -> str:
+def format_diagram(el: Diagram, **kwargs) -> str:
     if el.diagramType:
         return f"[{el.diagramType}] {el.name}"
     return el.name or ""
+
+
+@parse.register(Element)
+def parse_namedelement(el: Element, text: str) -> None:
+    """Parse element by simply assigning text to its name."""
+    el.name = text
 
 
 @parse.register(Diagram)

--- a/gaphor/core/format.py
+++ b/gaphor/core/format.py
@@ -6,7 +6,7 @@
 
 from functools import singledispatch
 
-from gaphor.core.modeling import Diagram, Element
+from gaphor.core.modeling import Diagram, Element, Relationship
 
 
 @singledispatch
@@ -31,3 +31,8 @@ def format_diagram(el, **kwargs) -> str:
 @parse.register(Diagram)
 def parse_Diagram(el: Diagram, text: str) -> None:
     el.name = text
+
+
+@format.register(Relationship)
+def format_relationship(el):
+    return el.__class__.__name__

--- a/gaphor/core/format.py
+++ b/gaphor/core/format.py
@@ -6,7 +6,8 @@
 
 from functools import singledispatch
 
-from gaphor.core.modeling import Diagram, Element, Relationship
+from gaphor.core.modeling import Dependency, Diagram, Element, Relationship
+from gaphor.i18n import gettext
 
 
 @singledispatch
@@ -36,3 +37,10 @@ def parse_Diagram(el: Diagram, text: str) -> None:
 @format.register(Relationship)
 def format_relationship(el):
     return el.__class__.__name__
+
+
+@format.register(Dependency)
+def format_dependency(el):
+    return gettext("supplier: {name}").format(
+        name=el.supplier and el.supplier.name or ""
+    )

--- a/gaphor/core/modeling/__init__.py
+++ b/gaphor/core/modeling/__init__.py
@@ -2,10 +2,12 @@
 
 from gaphor.core.modeling.coremodel import (
     Comment,
+    Dependency,
     ElementChange,
     PendingChange,
     Picture,
     RefChange,
+    Relationship,
     ValueChange,
 )
 from gaphor.core.modeling.diagram import (

--- a/gaphor/core/modeling/__init__.py
+++ b/gaphor/core/modeling/__init__.py
@@ -14,7 +14,6 @@ from gaphor.core.modeling.diagram import (
     Diagram,
     DrawContext,
     UpdateContext,
-    qualifiedName,
 )
 from gaphor.core.modeling.element import Element, self_and_owners
 from gaphor.core.modeling.elementfactory import ElementFactory

--- a/gaphor/core/modeling/collection.py
+++ b/gaphor/core/modeling/collection.py
@@ -122,11 +122,11 @@ class collection(Generic[T]):
             i1 = self.items.index(item1)
             i2 = self.items.index(item2)
             self.items[i1], self.items[i2] = self.items[i2], self.items[i1]
-
-            self.object.handle(AssociationUpdated(self.object, self.property))
-            return True
         except (IndexError, ValueError):
             return False
+        else:
+            self.object.handle(AssociationUpdated(self.object, self.property))
+            return True
 
     def order(self, key):
         self.items.sort(key=key)

--- a/gaphor/core/modeling/coremodel.py
+++ b/gaphor/core/modeling/coremodel.py
@@ -60,16 +60,32 @@ class Picture(Element):
 
 class Relationship(Element):
     relatedElement: relation_many[Element]
+    source: relation_many[Element]
+    target: relation_many[Element]
+
+
+class Dependency(Relationship):
+    client: relation_one[Element]
+    supplier: relation_one[Element]
 
 
 
-Element.relationship = derivedunion("relationship", Relationship)
 Element.ownedElement = derivedunion("ownedElement", Element)
 Element.owner = derivedunion("owner", Element, upper=1)
 Element.presentation = association("presentation", Presentation, composite=True, opposite="subject")
 Element.ownedDiagram = association("ownedDiagram", Diagram, composite=True, opposite="element")
 Element.comment = association("comment", Comment, opposite="annotatedElement")
+Element.targetRelationship = derivedunion("targetRelationship", Relationship)
+Element.sourceRelationship = derivedunion("sourceRelationship", Relationship)
+Element.relationship = derivedunion("relationship", Relationship)
+Element.clientDependency = association("clientDependency", Dependency, composite=True, opposite="client")
+Element.supplierDependency = association("supplierDependency", Dependency, opposite="supplier")
 Element.ownedElement.add(Element.ownedDiagram)  # type: ignore[attr-defined]
+Element.relationship.add(Element.targetRelationship)  # type: ignore[attr-defined]
+Element.relationship.add(Element.sourceRelationship)  # type: ignore[attr-defined]
+Element.ownedElement.add(Element.clientDependency)  # type: ignore[attr-defined]
+Element.sourceRelationship.add(Element.clientDependency)  # type: ignore[attr-defined]
+Element.targetRelationship.add(Element.supplierDependency)  # type: ignore[attr-defined]
 # 10: override Diagram.qualifiedName: property[list[str]]
 # defined in gaphor.core.modeling.diagram
 
@@ -83,4 +99,13 @@ Presentation.diagram = association("diagram", Diagram, upper=1, opposite="ownedP
 Presentation.subject = association("subject", Element, upper=1, opposite="presentation")
 Element.owner.add(Presentation.diagram)  # type: ignore[attr-defined]
 Comment.annotatedElement = association("annotatedElement", Element, opposite="comment")
+Relationship.target = derivedunion("target", Element)
+Relationship.source = derivedunion("source", Element)
 Relationship.relatedElement = derivedunion("relatedElement", Element, lower=1)
+Relationship.relatedElement.add(Relationship.target)  # type: ignore[attr-defined]
+Relationship.relatedElement.add(Relationship.source)  # type: ignore[attr-defined]
+Dependency.client = association("client", Element, upper=1, opposite="clientDependency")
+Dependency.supplier = association("supplier", Element, upper=1, opposite="supplierDependency")
+Element.owner.add(Dependency.client)  # type: ignore[attr-defined]
+Relationship.source.add(Dependency.client)  # type: ignore[attr-defined]
+Relationship.target.add(Dependency.supplier)  # type: ignore[attr-defined]

--- a/gaphor/core/modeling/coremodel.py
+++ b/gaphor/core/modeling/coremodel.py
@@ -69,10 +69,13 @@ class Dependency(Relationship):
     supplier: relation_one[Element]
 
 
-class Namespace(Element):
+class NamedElement(Element):
+    visibility = _enumeration("visibility", ("public", "private", "package", "protected"), "public")
+
+
+class Namespace(NamedElement):
     member: relation_many[Element]
     ownedMember: relation_many[Element]
-    visibility = _enumeration("visibility", ("public", "private", "package", "protected"), "public")
 
 
 

--- a/gaphor/core/modeling/coremodel.py
+++ b/gaphor/core/modeling/coremodel.py
@@ -75,20 +75,17 @@ Element.owner = derivedunion("owner", Element, upper=1)
 Element.presentation = association("presentation", Presentation, composite=True, opposite="subject")
 Element.ownedDiagram = association("ownedDiagram", Diagram, composite=True, opposite="element")
 Element.comment = association("comment", Comment, opposite="annotatedElement")
-Element.targetRelationship = derivedunion("targetRelationship", Relationship)
-Element.sourceRelationship = derivedunion("sourceRelationship", Relationship)
 Element.relationship = derivedunion("relationship", Relationship)
 Element.clientDependency = association("clientDependency", Dependency, composite=True, opposite="client")
 Element.supplierDependency = association("supplierDependency", Dependency, opposite="supplier")
+Element.sourceRelationship = derivedunion("sourceRelationship", Relationship)
+Element.targetRelationship = derivedunion("targetRelationship", Relationship)
 Element.ownedElement.add(Element.ownedDiagram)  # type: ignore[attr-defined]
-Element.relationship.add(Element.targetRelationship)  # type: ignore[attr-defined]
-Element.relationship.add(Element.sourceRelationship)  # type: ignore[attr-defined]
 Element.ownedElement.add(Element.clientDependency)  # type: ignore[attr-defined]
 Element.sourceRelationship.add(Element.clientDependency)  # type: ignore[attr-defined]
 Element.targetRelationship.add(Element.supplierDependency)  # type: ignore[attr-defined]
-# 10: override Diagram.qualifiedName: property[list[str]]
-# defined in gaphor.core.modeling.diagram
-
+Element.relationship.add(Element.sourceRelationship)  # type: ignore[attr-defined]
+Element.relationship.add(Element.targetRelationship)  # type: ignore[attr-defined]
 Diagram.ownedPresentation = association("ownedPresentation", Presentation, composite=True, opposite="diagram")
 Diagram.element = association("element", Element, upper=1, opposite="ownedDiagram")
 Element.ownedElement.add(Diagram.ownedPresentation)  # type: ignore[attr-defined]
@@ -99,11 +96,11 @@ Presentation.diagram = association("diagram", Diagram, upper=1, opposite="ownedP
 Presentation.subject = association("subject", Element, upper=1, opposite="presentation")
 Element.owner.add(Presentation.diagram)  # type: ignore[attr-defined]
 Comment.annotatedElement = association("annotatedElement", Element, opposite="comment")
-Relationship.target = derivedunion("target", Element)
-Relationship.source = derivedunion("source", Element)
 Relationship.relatedElement = derivedunion("relatedElement", Element, lower=1)
-Relationship.relatedElement.add(Relationship.target)  # type: ignore[attr-defined]
+Relationship.source = derivedunion("source", Element)
+Relationship.target = derivedunion("target", Element)
 Relationship.relatedElement.add(Relationship.source)  # type: ignore[attr-defined]
+Relationship.relatedElement.add(Relationship.target)  # type: ignore[attr-defined]
 Dependency.client = association("client", Element, upper=1, opposite="clientDependency")
 Dependency.supplier = association("supplier", Element, upper=1, opposite="supplierDependency")
 Element.owner.add(Dependency.client)  # type: ignore[attr-defined]

--- a/gaphor/core/modeling/coremodel.py
+++ b/gaphor/core/modeling/coremodel.py
@@ -58,23 +58,29 @@ class Picture(Element):
     content: _attribute[str] = _attribute("content", str)
 
 
+class Relationship(Element):
+    relatedElement: relation_many[Element]
 
-Element.comment = association("comment", Comment, opposite="annotatedElement")
-Element.ownedDiagram = association("ownedDiagram", Diagram, composite=True, opposite="element")
-Element.presentation = association("presentation", Presentation, composite=True, opposite="subject")
+
+
+Element.relationship = derivedunion("relationship", Relationship)
 Element.ownedElement = derivedunion("ownedElement", Element)
 Element.owner = derivedunion("owner", Element, upper=1)
+Element.presentation = association("presentation", Presentation, composite=True, opposite="subject")
+Element.ownedDiagram = association("ownedDiagram", Diagram, composite=True, opposite="element")
+Element.comment = association("comment", Comment, opposite="annotatedElement")
 Element.ownedElement.add(Element.ownedDiagram)  # type: ignore[attr-defined]
 # 10: override Diagram.qualifiedName: property[list[str]]
 # defined in gaphor.core.modeling.diagram
 
-Diagram.element = association("element", Element, upper=1, opposite="ownedDiagram")
 Diagram.ownedPresentation = association("ownedPresentation", Presentation, composite=True, opposite="diagram")
-Element.owner.add(Diagram.element)  # type: ignore[attr-defined]
+Diagram.element = association("element", Element, upper=1, opposite="ownedDiagram")
 Element.ownedElement.add(Diagram.ownedPresentation)  # type: ignore[attr-defined]
-Presentation.subject = association("subject", Element, upper=1, opposite="presentation")
+Element.owner.add(Diagram.element)  # type: ignore[attr-defined]
 Presentation.parent = association("parent", Presentation, upper=1, opposite="children")
 Presentation.children = association("children", Presentation, composite=True, opposite="parent")
 Presentation.diagram = association("diagram", Diagram, upper=1, opposite="ownedPresentation")
+Presentation.subject = association("subject", Element, upper=1, opposite="presentation")
 Element.owner.add(Presentation.diagram)  # type: ignore[attr-defined]
 Comment.annotatedElement = association("annotatedElement", Element, opposite="comment")
+Relationship.relatedElement = derivedunion("relatedElement", Element, lower=1)

--- a/gaphor/core/modeling/coremodel.py
+++ b/gaphor/core/modeling/coremodel.py
@@ -69,6 +69,12 @@ class Dependency(Relationship):
     supplier: relation_one[Element]
 
 
+class Namespace(Element):
+    member: relation_many[Element]
+    ownedMember: relation_many[Element]
+    visibility = _enumeration("visibility", ("public", "private", "package", "protected"), "public")
+
+
 
 Element.ownedElement = derivedunion("ownedElement", Element)
 Element.owner = derivedunion("owner", Element, upper=1)
@@ -80,12 +86,16 @@ Element.clientDependency = association("clientDependency", Dependency, composite
 Element.supplierDependency = association("supplierDependency", Dependency, opposite="supplier")
 Element.sourceRelationship = derivedunion("sourceRelationship", Relationship)
 Element.targetRelationship = derivedunion("targetRelationship", Relationship)
+Element.memberNamespace = derivedunion("memberNamespace", Namespace, upper=1)
+Element.namespace = derivedunion("namespace", Namespace, upper=1)
 Element.ownedElement.add(Element.ownedDiagram)  # type: ignore[attr-defined]
 Element.ownedElement.add(Element.clientDependency)  # type: ignore[attr-defined]
 Element.sourceRelationship.add(Element.clientDependency)  # type: ignore[attr-defined]
 Element.targetRelationship.add(Element.supplierDependency)  # type: ignore[attr-defined]
 Element.relationship.add(Element.sourceRelationship)  # type: ignore[attr-defined]
 Element.relationship.add(Element.targetRelationship)  # type: ignore[attr-defined]
+Element.memberNamespace.add(Element.namespace)  # type: ignore[attr-defined]
+Element.owner.add(Element.namespace)  # type: ignore[attr-defined]
 Diagram.ownedPresentation = association("ownedPresentation", Presentation, composite=True, opposite="diagram")
 Diagram.element = association("element", Element, upper=1, opposite="ownedDiagram")
 Element.ownedElement.add(Diagram.ownedPresentation)  # type: ignore[attr-defined]
@@ -106,3 +116,7 @@ Dependency.supplier = association("supplier", Element, upper=1, opposite="suppli
 Element.owner.add(Dependency.client)  # type: ignore[attr-defined]
 Relationship.source.add(Dependency.client)  # type: ignore[attr-defined]
 Relationship.target.add(Dependency.supplier)  # type: ignore[attr-defined]
+Namespace.member = derivedunion("member", Element)
+Namespace.ownedMember = derivedunion("ownedMember", Element)
+Namespace.member.add(Namespace.ownedMember)  # type: ignore[attr-defined]
+Element.ownedElement.add(Namespace.ownedMember)  # type: ignore[attr-defined]

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -24,7 +24,6 @@ from gaphor.core.modeling.element import (
     Id,
     RepositoryProtocol,
     generate_id,
-    self_and_owners,
 )
 from gaphor.core.modeling.event import (
     AssociationAdded,
@@ -138,13 +137,6 @@ def lookup_attribute(element: Element, name: str) -> str | None:
     return " ".join(map(attrstr, attr_values)).strip()
 
 
-def qualifiedName(element: Element) -> list[str]:
-    """Returns the qualified name of the element as a tuple."""
-    qname = [getattr(e, "name", "??") for e in self_and_owners(element)]
-    qname.reverse()
-    return qname
-
-
 class StyledDiagram:
     def __init__(
         self,
@@ -242,7 +234,7 @@ class StyledItem:
 
     def attribute(self, name: str) -> str | None:
         a = lookup_attribute(self.item, name)
-        if a is None and self.item.subject:
+        if a in (None, "") and self.item.subject:
             a = lookup_attribute(self.item.subject, name)
         return a
 
@@ -267,7 +259,6 @@ P = TypeVar("P", bound=Presentation)
 class Diagram(Element):
     """Diagrams may contain :obj:`Presentation` elements and can be owned by any element."""
 
-    name: attribute[str] = attribute("name", str)
     diagramType: attribute[str] = attribute("diagramType", str)
     element: relation_one[Element]
 
@@ -289,11 +280,6 @@ class Diagram(Element):
     ownedPresentation: relation_many[Presentation] = association(
         "ownedPresentation", Presentation, composite=True, opposite="diagram"
     )
-
-    @property
-    def qualifiedName(self) -> list[str]:
-        """Returns the qualified name of the element as a tuple."""
-        return qualifiedName(self)
 
     def _owned_presentation_changed(self, event):
         if isinstance(event, AssociationDeleted) and event.old_value:

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -17,7 +17,12 @@ from gaphor.core.modeling.properties import (
 )
 
 if TYPE_CHECKING:
-    from gaphor.core.modeling.coremodel import Comment, Dependency, Relationship
+    from gaphor.core.modeling.coremodel import (
+        Comment,
+        Dependency,
+        Namespace,
+        Relationship,
+    )
     from gaphor.core.modeling.diagram import Diagram
     from gaphor.core.modeling.presentation import Presentation
 
@@ -83,6 +88,8 @@ class Element:
     targetRelationship: relation_many[Relationship]
     clientDependency: relation_many[Dependency]
     supplierDependency: relation_many[Dependency]
+    memberNamespace: relation_one[Namespace]
+    namespace: relation_one[Namespace]
 
     # From UML:
     appliedStereotype: relation_many[Element]

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -71,6 +71,7 @@ def self_and_owners(element: Element | None) -> Iterator[Element]:
 class Element:
     """Base class for all model data classes."""
 
+    name: attribute[str] = attribute("name", str)
     note: attribute[str] = attribute("note", str)
     comment: relation_many[Comment]
     ownedDiagram: relation_many[Diagram]
@@ -113,6 +114,13 @@ class Element:
                 "Can't retrieve the model since it's not set on construction"
             )
         return self._model
+
+    @property
+    def qualifiedName(self) -> list[str]:
+        """Returns the qualified name of the element as a list."""
+        qname = [e.name or "??" for e in self_and_owners(self)]
+        qname.reverse()
+        return qname
 
     @classmethod
     def umlproperties(cls) -> Iterator[umlproperty]:

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Callable, Iterator, Protocol, TypeVar, overload
 from uuid import uuid1
 
+from gaphor.core.modeling.collection import collection
 from gaphor.core.modeling.event import ElementUpdated
 from gaphor.core.modeling.properties import (
     attribute,
@@ -122,12 +123,19 @@ class Element:
                 if isinstance(prop, umlprop):
                     yield prop
 
-    def save(self, save_func) -> None:
+    def save(
+        self,
+        save_func: Callable[
+            [str, str | bool | int | Element | collection[Element]], None
+        ],
+    ) -> None:
         """Save the state by calling ``save_func(name, value)``."""
         for prop in self.umlproperties():
-            prop.save(self, save_func)
+            prop.save(self, save_func)  # type: ignore[arg-type]
 
-    def load(self, name, value) -> None:
+    def load(
+        self, name: str, value: str | bool | int | Element | collection[Element]
+    ) -> None:
         """Loads value in name.
 
         Make sure that after all elements are loaded, postload() should be called.

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -17,7 +17,7 @@ from gaphor.core.modeling.properties import (
 )
 
 if TYPE_CHECKING:
-    from gaphor.core.modeling.coremodel import Comment
+    from gaphor.core.modeling.coremodel import Comment, Dependency, Relationship
     from gaphor.core.modeling.diagram import Diagram
     from gaphor.core.modeling.presentation import Presentation
 
@@ -77,10 +77,11 @@ class Element:
     ownedElement: relation_many[Element]
     owner: relation_one[Element]
     presentation: relation_many[Presentation]
+    relationship: relation_many[Relationship]
+    clientDependency: relation_many[Dependency]
+    supplierDependency: relation_many[Dependency]
 
     # From UML:
-    directedRelationship: relation_many[Element]
-    relationship: relation_many[Element]
     appliedStereotype: relation_many[Element]
 
     def __init__(self, id: Id | None = None, model: RepositoryProtocol | None = None):

--- a/gaphor/core/modeling/element.py
+++ b/gaphor/core/modeling/element.py
@@ -79,6 +79,8 @@ class Element:
     owner: relation_one[Element]
     presentation: relation_many[Presentation]
     relationship: relation_many[Relationship]
+    sourceRelationship: relation_many[Relationship]
+    targetRelationship: relation_many[Relationship]
     clientDependency: relation_many[Dependency]
     supplierDependency: relation_many[Dependency]
 

--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -69,7 +69,7 @@ class Presentation(Matrices, Element, Generic[S]):
 
         .. code::
 
-            self.watch("subject[NamedElement].name")
+            self.watch("subject.name")
 
         This interface is fluent: returns ``self``.
         """

--- a/gaphor/diagram/copypaste.py
+++ b/gaphor/diagram/copypaste.py
@@ -143,7 +143,7 @@ def paste_element(
     diagram,
     lookup,
     filter: Callable[[str, str | int | Element], bool] | None = None,
-):
+) -> Iterator[Element]:
     cls, _id, data = copy_data
     element = diagram.model.create(cls)
     yield element

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -23,7 +23,7 @@ DEFAULT_WIDTH = 100
 
 
 class Named:
-    """Marker for any NamedElement presentations."""
+    """Marker for any presentations with a name."""
 
 
 class Valued:

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -15,7 +15,7 @@ from gaphas.segment import Segment
 from gi.repository import GObject, Gtk
 
 from gaphor.core import Transaction
-from gaphor.core.modeling import Diagram, Element, Presentation, qualifiedName
+from gaphor.core.modeling import Diagram, Element, Presentation
 from gaphor.i18n import gettext, translated_ui_string
 
 
@@ -138,7 +138,6 @@ class NamePropertyPage(PropertyPageBase):
     order = 10
 
     def __init__(self, subject, event_manager):
-        assert subject is None or hasattr(subject, "name")
         super().__init__()
         self.subject = subject
         self.event_manager = event_manager
@@ -305,7 +304,7 @@ class InternalsPropertyPage(PropertyPageBase):
             textwrap.dedent(
                 f"""\
                 {gettext('Model Element')}:
-                  {gettext('qname')}: {'.'.join(map(str, qualifiedName(element)))}
+                  {gettext('qname')}: {'.'.join(map(str, element.qualifiedName))}
                   {gettext('class')}: {model_element_class(element)}
                   {gettext('id')}: {element.id}"""
             )

--- a/gaphor/diagram/tests/test_instanteditors.py
+++ b/gaphor/diagram/tests/test_instanteditors.py
@@ -1,6 +1,7 @@
 import pytest
 
 from gaphor import UML
+from gaphor.core.modeling import Dependency
 from gaphor.diagram.instanteditors import named_item_editor
 
 
@@ -17,7 +18,7 @@ def test_named_item_editor_with_element(diagram, element_factory, view, event_ma
 @pytest.mark.xfail(reason="Will fail as long as Element.name is not defined")
 def test_named_item_editor_with_line(diagram, element_factory, view, event_manager):
     item = diagram.create(
-        UML.classes.DependencyItem, subject=element_factory.create(UML.Dependency)
+        UML.classes.DependencyItem, subject=element_factory.create(Dependency)
     )
     view.selection.hovered_item = item
     result = named_item_editor(item, view, event_manager)

--- a/gaphor/diagram/tests/test_instanteditors.py
+++ b/gaphor/diagram/tests/test_instanteditors.py
@@ -1,3 +1,5 @@
+import pytest
+
 from gaphor import UML
 from gaphor.diagram.instanteditors import named_item_editor
 
@@ -12,6 +14,7 @@ def test_named_item_editor_with_element(diagram, element_factory, view, event_ma
     assert result is True
 
 
+@pytest.mark.xfail(reason="Will fail as long as Element.name is not defined")
 def test_named_item_editor_with_line(diagram, element_factory, view, event_manager):
     item = diagram.create(
         UML.classes.DependencyItem, subject=element_factory.create(UML.Dependency)

--- a/gaphor/diagram/tests/test_instanteditors.py
+++ b/gaphor/diagram/tests/test_instanteditors.py
@@ -1,5 +1,3 @@
-import pytest
-
 from gaphor import UML
 from gaphor.core.modeling import Dependency
 from gaphor.diagram.instanteditors import named_item_editor
@@ -15,7 +13,6 @@ def test_named_item_editor_with_element(diagram, element_factory, view, event_ma
     assert result is True
 
 
-@pytest.mark.xfail(reason="Will fail as long as Element.name is not defined")
 def test_named_item_editor_with_line(diagram, element_factory, view, event_manager):
     item = diagram.create(
         UML.classes.DependencyItem, subject=element_factory.create(Dependency)

--- a/gaphor/diagram/tests/test_presentation.py
+++ b/gaphor/diagram/tests/test_presentation.py
@@ -1,6 +1,7 @@
 import pytest
 
 from gaphor import UML
+from gaphor.core.modeling import Dependency
 from gaphor.diagram.presentation import ElementPresentation, LinePresentation
 from gaphor.diagram.tests.fixtures import connect
 from gaphor.UML import diagramitems
@@ -82,7 +83,7 @@ def test_element_loading(element_factory, diagram):
 
 
 def test_line_saving(element_factory, diagram):
-    subject = element_factory.create(UML.Dependency)
+    subject = element_factory.create(Dependency)
     p = diagram.create(StubLine, subject=subject)
 
     properties = {}
@@ -122,7 +123,7 @@ def test_line_saving_without_subject(diagram):
 
 def test_line_loading(element_factory, diagram):
     with element_factory.block_events():
-        subject = element_factory.create(UML.Dependency)
+        subject = element_factory.create(Dependency)
         p = diagram.create(StubLine)
 
         p.load("matrix", "(2.0, 0.0, 0.0, 2.0, 0.0, 0.0)")

--- a/gaphor/plugins/autolayout/pydot.py
+++ b/gaphor/plugins/autolayout/pydot.py
@@ -23,7 +23,6 @@ from gaphor.diagram.presentation import (
 )
 from gaphor.i18n import gettext
 from gaphor.transaction import Transaction
-from gaphor.UML import NamedElement
 from gaphor.UML.actions.activitynodes import ForkNodeItem
 
 DOT = "dot"
@@ -232,9 +231,7 @@ def _(presentation: ElementPresentation):
         graph = pydot.Cluster(
             presentation.id,
             id=presentation.id,
-            label=f"{presentation.subject.name}\n\n\n"
-            if isinstance(presentation.subject, NamedElement)
-            else "\n\n",
+            label=f"{presentation.subject.name}\n\n\n",
             margin=20,
         )
 

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -17,6 +17,7 @@ from gaphor.core.modeling import (
     ElementUpdated,
     ModelFlushed,
     ModelReady,
+    Relationship,
 )
 from gaphor.diagram.deletable import deletable
 from gaphor.diagram.diagramtoolbox import DiagramType
@@ -358,7 +359,7 @@ def select_element(
             return 0
         if (n := expand_up_to_element(element.owner, expand=True)) is None:
             return None
-        is_relationship = isinstance(element, UML.Relationship)
+        is_relationship = isinstance(element, Relationship)
         while row := selection.get_item(n):
             if is_relationship and isinstance(row.get_item(), RelationshipItem):
                 row.set_expanded(True)

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -187,8 +187,6 @@ class ModelBrowser(UIComponent, ActionProvider):
     @action(name="win.create-diagram")
     def tree_view_create_diagram(self, diagram_kind: str):
         element = self.get_selected_element()
-        while element and not isinstance(element, UML.NamedElement):
-            element = element.owner
 
         with Transaction(self.event_manager):
             diagram_type = self._diagram_type_or(
@@ -274,7 +272,7 @@ class ModelBrowser(UIComponent, ActionProvider):
         # Should check on ownedElement as well, since it may not have been updated
         # before this thing triggers
         if (
-            event.property not in (Element.owner, UML.NamedElement.memberNamespace)
+            event.property not in (Element.owner, Element.memberNamespace)
         ) or not visible(event.element):
             return
         element = event.element

--- a/gaphor/ui/modelmerge/organize.py
+++ b/gaphor/ui/modelmerge/organize.py
@@ -165,7 +165,7 @@ def organize_changes(element_factory, modeling_language):
                 gettext("Update element “{name}”").format(
                     name=element.name or gettext("<None>")
                 )
-                if hasattr(element, "name")
+                if element.name
                 else gettext("Update element of type “{type}”").format(
                     type=type(element).__name__
                 ),

--- a/gaphor/ui/modelmerge/tests/test_organize.py
+++ b/gaphor/ui/modelmerge/tests/test_organize.py
@@ -162,7 +162,7 @@ def test_update_model_attribute(element_factory, modeling_language, change):
     add_element = tree[0]
 
     assert len(tree) == 1
-    assert add_element.label == "Update element “<None>”"
+    assert add_element.label == "Update element of type “Class”"
     assert vchange in add_element.elements
     assert not add_element.children
 

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -6,7 +6,7 @@ from gi.repository import Gio, GObject, Pango
 
 from gaphor import UML
 from gaphor.core.format import format
-from gaphor.core.modeling import Diagram, Element
+from gaphor.core.modeling import Diagram, Element, Relationship
 from gaphor.diagram.iconname import icon_name
 from gaphor.i18n import gettext
 
@@ -71,7 +71,7 @@ class Branch:
         self.relationships = Gio.ListStore.new(TreeItem.__gtype__)
 
     def append(self, element: Element):
-        if isinstance(element, UML.Relationship):
+        if isinstance(element, Relationship):
             if self.relationships.get_n_items() == 0:
                 self.elements.insert(0, RelationshipItem(self.relationships))
             self.relationships.append(TreeItem(element))
@@ -80,9 +80,7 @@ class Branch:
 
     def remove(self, element):
         list_store = (
-            self.relationships
-            if isinstance(element, UML.Relationship)
-            else self.elements
+            self.relationships if isinstance(element, Relationship) else self.elements
         )
         if (
             index := next(
@@ -105,9 +103,7 @@ class Branch:
 
     def changed(self, element: Element):
         list_store = (
-            self.relationships
-            if isinstance(element, UML.Relationship)
-            else self.elements
+            self.relationships if isinstance(element, Relationship) else self.elements
         )
         if not (
             tree_item := next((ti for ti in list_store if ti.element is element), None)
@@ -130,7 +126,7 @@ class Branch:
 
 def visible(element):
     return isinstance(
-        element, (UML.Relationship, UML.NamedElement, Diagram)
+        element, (Relationship, UML.NamedElement, Diagram)
     ) and not isinstance(
         element, (UML.InstanceSpecification, UML.OccurrenceSpecification)
     )

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -140,6 +140,7 @@ def visible(element):
             StyleSheet,
             UML.InstanceSpecification,
             UML.OccurrenceSpecification,
+            UML.Slot,
         ),
     ) or (not element.owner and isinstance(element, UML.MultiplicityElement))
 

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -29,7 +29,7 @@ class TreeItem(GObject.Object):
     can_edit = GObject.Property(type=bool, default=True)
 
     def read_only(self):
-        return not self.element or not hasattr(self.element, "name")
+        return not self.element
 
     @GObject.Property(type=str)
     def editable_text(self):

--- a/models/Core.gaphor
+++ b/models/Core.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.24.0">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.25.1">
 <Package id="3867dda4-7a95-11ea-a112-7f953848cf85">
 <name>
 <val>Core</val>
@@ -7,6 +7,8 @@
 <ownedDiagram>
 <reflist>
 <ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
+<ref refid="1d89f46e-2ed1-11ef-8125-be7f4daace40"/>
 </reflist>
 </ownedDiagram>
 <ownedType>
@@ -23,6 +25,8 @@
 <ref refid="446a3743-4465-11eb-8946-9bdfa28f7a50"/>
 <ref refid="216581c9-4465-11eb-8946-9bdfa28f7a50"/>
 <ref refid="e873d808-3c55-11ee-99bb-48a4721e5d5c"/>
+<ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
+<ref refid="88a2c400-2e32-11ef-8125-be7f4daace40"/>
 </reflist>
 </ownedType>
 <presentation>
@@ -36,14 +40,13 @@
 <ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
 </element>
 <name>
-<val>core</val>
+<val>Presentations</val>
 </name>
 <ownedPresentation>
 <reflist>
 <ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="5cdae47f-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="639b48d1-7a95-11ea-a112-7f953848cf85"/>
-<ref refid="5175e1cd-7cf9-11ea-b719-1f391582df99"/>
 <ref refid="15e4b0b3-9f17-11ea-b537-dfaaecc5bf61"/>
 <ref refid="9bdd3fed-9f17-11ea-b537-dfaaecc5bf61"/>
 <ref refid="d6e5886b-478f-11eb-a938-8fcfae32d12c"/>
@@ -51,42 +54,45 @@
 <ref refid="68e63fac-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="1875194e-7a96-11ea-a112-7f953848cf85"/>
 <ref refid="c9b0922c-7a97-11ea-a112-7f953848cf85"/>
-<ref refid="4b561cdd-7cf9-11ea-b719-1f391582df99"/>
 <ref refid="29de062c-9f17-11ea-b537-dfaaecc5bf61"/>
 <ref refid="ada170c7-9f17-11ea-b537-dfaaecc5bf61"/>
-<ref refid="cf596824-e0b9-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="216581ca-4465-11eb-8946-9bdfa28f7a50"/>
 <ref refid="446a3744-4465-11eb-8946-9bdfa28f7a50"/>
 <ref refid="f4982c28-478f-11eb-a938-8fcfae32d12c"/>
 <ref refid="1cb6f4e2-b9a9-11eb-93ad-535118859f0b"/>
-<ref refid="d3077da0-529e-11ec-b0e5-0456e5e540ed"/>
 <ref refid="04992128-3c56-11ee-99bb-48a4721e5d5c"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
 <ClassItem id="4cda498f-7a95-11ea-a112-7f953848cf85">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 496.59873557593505, -38.4765625)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 600.8699035644528, -38.4765625)</val>
 </matrix>
 <top-left>
-<val>(0.0, 0.0)</val>
+<val>(0.0, 90.62012779653692)</val>
 </top-left>
 <width>
 <val>163.99951171875</val>
 </width>
 <height>
-<val>175.0</val>
+<val>84.37987220346308</val>
 </height>
 <diagram>
 <ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
 </diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
 <subject>
 <ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
 </subject>
 </ClassItem>
 <ClassItem id="5cdae47f-7a95-11ea-a112-7f953848cf85">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 560.8694152832031, 484.41876220703125)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 564.3821308661957, 480.9060466240388)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -147,7 +153,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 495.59873557593505, 88.71278381347656)</val>
 </matrix>
 <points>
-<val>[(1.0, 9.319456063758082), (-372.36436057593505, 9.319456063758082), (-372.36436057593505, 353.0009150649562), (-273.91714006387684, 353.0009150649562)]</val>
+<val>[(105.27116798851773, 29.25132605013954), (-359.41958062421014, 29.25132605013954), (-359.41958062421014, 353.0009150649562), (-273.91714006387684, 353.0009150649562)]</val>
 </points>
 <head-connection>
 <ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
@@ -173,7 +179,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 578.427734375, 121.22430419921875)</val>
 </matrix>
 <points>
-<val>[(74.44168090820312, 363.1944580078125), (74.44168090820312, 74.77569580078125), (1.1707570603100521, 74.77569580078125), (1.1707570603100521, 15.29913330078125)]</val>
+<val>[(77.95439649119567, 359.68174242481996), (77.95439649119567, 74.77569580078125), (105.44192504882778, 74.77569580078125), (105.44192504882778, 15.29913330078125)]</val>
 </points>
 <head-connection>
 <ref refid="5cdae47f-7a95-11ea-a112-7f953848cf85"/>
@@ -199,7 +205,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 579.0381469726562, 121.22430419921875)</val>
 </matrix>
 <points>
-<val>[(-263.35655146059804, 268.1044921875), (-263.35655146059804, 74.77569580078125), (0.5603444626538021, 74.77569580078125), (0.5603444626538021, 15.29913330078125)]</val>
+<val>[(-263.35655146059804, 268.1044921875), (-263.35655146059804, 74.77569580078125), (104.83151245117153, 74.77569580078125), (104.83151245117153, 15.29913330078125)]</val>
 </points>
 <head-connection>
 <ref refid="639b48d1-7a95-11ea-a112-7f953848cf85"/>
@@ -208,58 +214,9 @@
 <ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
 </tail-connection>
 </GeneralizationItem>
-<GeneralizationItem id="4b561cdd-7cf9-11ea-b719-1f391582df99">
-<diagram>
-<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
-</diagram>
-<horizontal>
-<val>0</val>
-</horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
-<subject>
-<ref refid="58d8be2c-4bbe-11ec-aa3d-0456e5e540ed"/>
-</subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 578.9716990819549, 121.22430419921875)</val>
-</matrix>
-<points>
-<val>[(369.6518665918733, 119.97470092773438), (369.6518665918733, 74.77569580078125), (0.6267923533551993, 74.77569580078125), (0.6267923533551993, 15.29913330078125)]</val>
-</points>
-<head-connection>
-<ref refid="5175e1cd-7cf9-11ea-b719-1f391582df99"/>
-</head-connection>
-<tail-connection>
-<ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
-</tail-connection>
-</GeneralizationItem>
-<ClassItem id="5175e1cd-7cf9-11ea-b719-1f391582df99">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 894.1235656738281, 241.19900512695312)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>109.0</val>
-</width>
-<height>
-<val>72.0</val>
-</height>
-<diagram>
-<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
-</diagram>
-<show_operations>
-<val>0</val>
-</show_operations>
-<subject>
-<ref refid="5175e1cc-7cf9-11ea-b719-1f391582df99"/>
-</subject>
-</ClassItem>
 <ClassItem id="15e4b0b3-9f17-11ea-b537-dfaaecc5bf61">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 772.714640616123, 521.4187622070312)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 706.1386901855468, 306.1990051269531)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -297,7 +254,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 578.8867180749799, 121.22430419921875)</val>
 </matrix>
 <points>
-<val>[(277.32792254114315, 400.1944580078125), (277.32792254114315, 74.77569580078125), (0.7117733603301986, 74.77569580078125), (0.7117733603301986, 15.29913330078125)]</val>
+<val>[(210.75197211056707, 184.97470092773438), (210.75197211056707, 74.77569580078125), (104.98294134884793, 74.77569580078125), (104.98294134884793, 15.29913330078125)]</val>
 </points>
 <head-connection>
 <ref refid="15e4b0b3-9f17-11ea-b537-dfaaecc5bf61"/>
@@ -308,7 +265,7 @@
 </GeneralizationItem>
 <CommentItem id="9bdd3fed-9f17-11ea-b537-dfaaecc5bf61">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 879.1386901855469, 418.12652587890625)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 816.9043762207032, 439.3287963867187)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -340,47 +297,12 @@
 <val>(1.0, 0.0, 0.0, 1.0, 432.1161416499558, 523.8687744140625)</val>
 </matrix>
 <points>
-<val>[(478.7705668619011, -2.45001220703125), (507.8702047855911, -55.74224853515625)]</val>
+<val>[(401.33705652578635, -125.66976928710938), (429.43878118972657, -86.68961773496676)]</val>
 </points>
 <head-connection>
 <ref refid="15e4b0b3-9f17-11ea-b537-dfaaecc5bf61"/>
 </head-connection>
-<tail-connection>
-<ref refid="9bdd3fed-9f17-11ea-b537-dfaaecc5bf61"/>
-</tail-connection>
 </CommentLineItem>
-<AssociationItem id="cf596824-e0b9-11ea-b7ab-f5b4c130f24e">
-<diagram>
-<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
-</diagram>
-<head_subject>
-<ref refid="d092794d-e0b9-11ea-b7ab-f5b4c130f24e"/>
-</head_subject>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
-<subject>
-<ref refid="d092794c-e0b9-11ea-b7ab-f5b4c130f24e"/>
-</subject>
-<tail_subject>
-<ref refid="d092794e-e0b9-11ea-b7ab-f5b4c130f24e"/>
-</tail_subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 659.598247294685, 88.0)</val>
-</matrix>
-<points>
-<val>[(1.0, 10.032239877234645), (423.85332130883063, 10.032239877234645), (423.85332130883063, 189.19900512695312), (343.5253183791431, 189.19900512695312)]</val>
-</points>
-<head-connection>
-<ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
-</head-connection>
-<tail-connection>
-<ref refid="5175e1cd-7cf9-11ea-b719-1f391582df99"/>
-</tail-connection>
-</AssociationItem>
 <AssociationItem id="216581ca-4465-11eb-8946-9bdfa28f7a50">
 <diagram>
 <ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
@@ -404,7 +326,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 451.0, 554.0)</val>
 </matrix>
 <points>
-<val>[(-41.31840448794179, -116.82084332090437), (36.234375, -116.82084332090437), (36.234375, -27.118733052767766), (109.86941528320312, -27.118733052767766)]</val>
+<val>[(-41.31840448794179, -116.82084332090437), (36.234375, -116.82084332090437), (36.234375, -30.631448635760307), (113.38213086619567, -30.631448635760307)]</val>
 </points>
 <head-connection>
 <ref refid="639b48d1-7a95-11ea-a112-7f953848cf85"/>
@@ -479,7 +401,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 505.0, 557.0)</val>
 </matrix>
 <points>
-<val>[(-17.765625, -115.28630112156725), (86.671875, -156.0)]</val>
+<val>[(-17.765625, -115.46387283083624), (86.671875, -156.0)]</val>
 </points>
 <head-connection>
 <ref refid="216581ca-4465-11eb-8946-9bdfa28f7a50"/>
@@ -511,7 +433,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 493.234375, 60.59765625)</val>
 </matrix>
 <points>
-<val>[(3.364360575935052, -49.356679329123025), (-393.0, -49.356679329123025), (-393.0, 557.0629033405122), (67.63504028320312, 557.0629033405122)]</val>
+<val>[(107.63552856445278, 15.518249747132558), (-379.88787133772644, 15.518249747132558), (-379.88787133772644, 553.5501877575197), (71.14775586619567, 553.5501877575197)]</val>
 </points>
 <head-connection>
 <ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
@@ -530,12 +452,13 @@
 <ownedAttribute>
 <reflist>
 <ref refid="8e8ab29e-eb5f-11ee-a6cb-be7f4daace3f"/>
-<ref refid="d092794e-e0b9-11ea-b7ab-f5b4c130f24e"/>
-<ref refid="1ee6aec6-b9a9-11eb-93ad-535118859f0b"/>
-<ref refid="69c2575a-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="a4c6f704-ce0f-11eb-abe3-018035c40dd4"/>
+<ref refid="88a30320-2e32-11ef-8125-be7f4daace40"/>
 <ref refid="da0b2408-529e-11ec-b0e5-0456e5e540ed"/>
 <ref refid="da0b3ede-529e-11ec-b0e5-0456e5e540ed"/>
+<ref refid="69c2575a-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="1ee6aec6-b9a9-11eb-93ad-535118859f0b"/>
+<ref refid="d092794e-e0b9-11ea-b7ab-f5b4c130f24e"/>
 </reflist>
 </ownedAttribute>
 <ownedOperation>
@@ -555,6 +478,8 @@
 <reflist>
 <ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="f8ef5c9c-5ee4-11ed-9155-0456e5e540ed"/>
+<ref refid="7845dfd4-2e32-11ef-8125-be7f4daace40"/>
+<ref refid="2ac32ccc-2ed1-11ef-8125-be7f4daace40"/>
 </reflist>
 </presentation>
 <specialization>
@@ -565,6 +490,7 @@
 <ref refid="53513194-3e9a-11ed-812d-0456e5e540ed"/>
 <ref refid="d7dfe61e-5ee6-11ed-9155-0456e5e540ed"/>
 <ref refid="05872486-3c56-11ee-99bb-48a4721e5d5c"/>
+<ref refid="87f4ff18-2e33-11ef-8125-be7f4daace40"/>
 </reflist>
 </specialization>
 </Class>
@@ -581,9 +507,9 @@
 <reflist>
 <ref refid="d2bfe41e-ba68-11eb-a73b-13340a6bc6e1"/>
 <ref refid="e3513a58-ba68-11eb-a73b-13340a6bc6e1"/>
-<ref refid="1ee6aec5-b9a9-11eb-93ad-535118859f0b"/>
 <ref refid="5b2c0930-6000-11ec-a085-0456e5e540ed"/>
 <ref refid="216581cb-4465-11eb-8946-9bdfa28f7a50"/>
+<ref refid="1ee6aec5-b9a9-11eb-93ad-535118859f0b"/>
 </reflist>
 </ownedAttribute>
 <ownedOperation>
@@ -618,10 +544,10 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="69c25759-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="446a3745-4465-11eb-8946-9bdfa28f7a50"/>
 <ref refid="446a3746-4465-11eb-8946-9bdfa28f7a50"/>
 <ref refid="216581cc-4465-11eb-8946-9bdfa28f7a50"/>
+<ref refid="69c25759-7a95-11ea-a112-7f953848cf85"/>
 </reflist>
 </ownedAttribute>
 <ownedOperation>
@@ -725,7 +651,7 @@
 </package>
 <presentation>
 <reflist>
-<ref refid="5175e1cd-7cf9-11ea-b719-1f391582df99"/>
+<ref refid="2ac6839a-2ed1-11ef-8125-be7f4daace40"/>
 </reflist>
 </presentation>
 </Class>
@@ -741,11 +667,6 @@
 </typeValue>
 </Property>
 <Class id="15e4b0b2-9f17-11ea-b537-dfaaecc5bf61">
-<comment>
-<reflist>
-<ref refid="9bdd3fec-9f17-11ea-b537-dfaaecc5bf61"/>
-</reflist>
-</comment>
 <generalization>
 <reflist>
 <ref refid="53513194-3e9a-11ed-812d-0456e5e540ed"/>
@@ -781,11 +702,6 @@
 </typeValue>
 </Property>
 <Comment id="9bdd3fec-9f17-11ea-b537-dfaaecc5bf61">
-<annotatedElement>
-<reflist>
-<ref refid="15e4b0b2-9f17-11ea-b537-dfaaecc5bf61"/>
-</reflist>
-</annotatedElement>
 <body>
 <val>One instance per model.</val>
 </body>
@@ -812,7 +728,7 @@
 </package>
 <presentation>
 <reflist>
-<ref refid="cf596824-e0b9-11ea-b7ab-f5b4c130f24e"/>
+<ref refid="2ac599c6-2ed1-11ef-8125-be7f4daace40"/>
 </reflist>
 </presentation>
 </Association>
@@ -1159,7 +1075,7 @@
 </general>
 <presentation>
 <reflist>
-<ref refid="4b561cdd-7cf9-11ea-b719-1f391582df99"/>
+<ref refid="2ac7e316-2ed1-11ef-8125-be7f4daace40"/>
 </reflist>
 </presentation>
 <specific>
@@ -1556,38 +1472,6 @@
 <val>owner</val>
 </value>
 </Slot>
-<AssociationItem id="d3077da0-529e-11ec-b0e5-0456e5e540ed">
-<diagram>
-<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
-</diagram>
-<head_subject>
-<ref refid="da0b2408-529e-11ec-b0e5-0456e5e540ed"/>
-</head_subject>
-<horizontal>
-<val>0</val>
-</horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
-<subject>
-<ref refid="da0afff0-529e-11ec-b0e5-0456e5e540ed"/>
-</subject>
-<tail_subject>
-<ref refid="da0b3ede-529e-11ec-b0e5-0456e5e540ed"/>
-</tail_subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 578.4089033018868, 33.5234375)</val>
-</matrix>
-<points>
-<val>[(39.59109669811323, -72.0), (39.59109669811323, -102.7823017514981), (180.20437794811323, -102.7823017514981), (180.20437794811323, -22.28246057912302), (82.18934399279829, -22.28246057912302)]</val>
-</points>
-<head-connection>
-<ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
-</head-connection>
-<tail-connection>
-<ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
-</tail-connection>
-</AssociationItem>
 <Association id="da0afff0-529e-11ec-b0e5-0456e5e540ed">
 <memberEnd>
 <reflist>
@@ -1600,7 +1484,7 @@
 </package>
 <presentation>
 <reflist>
-<ref refid="d3077da0-529e-11ec-b0e5-0456e5e540ed"/>
+<ref refid="9ab83010-2e34-11ef-8125-be7f4daace40"/>
 </reflist>
 </presentation>
 </Association>
@@ -2338,7 +2222,7 @@
 </Class>
 <ClassItem id="ec990458-3c55-11ee-99bb-48a4721e5d5c">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 169.28606833722074, 241.19900512695312)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 925.463559267447, 306.1990051269532)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -2387,7 +2271,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 778.3550711239087, 152.11792815252807)</val>
 </matrix>
 <points>
-<val>[(-554.9364784667554, 89.08107697442506), (-554.9364784667554, 43.882071847471934), (-198.75657968859866, 43.882071847471934), (-198.75657968859866, -15.594490652528066)]</val>
+<val>[(201.24101246347084, 154.081076974425), (201.24101246347084, 43.882071847471934), (-94.48541170008093, 43.882071847471934), (-94.48541170008093, -15.594490652528066)]</val>
 </points>
 <head-connection>
 <ref refid="ec990458-3c55-11ee-99bb-48a4721e5d5c"/>
@@ -2529,4 +2413,393 @@
 <val>id</val>
 </name>
 </Property>
+<Diagram id="67914ef8-2e32-11ef-8125-be7f4daace40">
+<diagramType>
+<val></val>
+</diagramType>
+<element>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</element>
+<name>
+<val>Relationships</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
+<ref refid="7845dfd4-2e32-11ef-8125-be7f4daace40"/>
+<ref refid="8816eea8-2e32-11ef-8125-be7f4daace40"/>
+<ref refid="86eca396-2e33-11ef-8125-be7f4daace40"/>
+<ref refid="9ab83010-2e34-11ef-8125-be7f4daace40"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<ClassItem id="7323bbfc-2e32-11ef-8125-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 204.4845890410959, 346.11328125)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>155.0</val>
+</width>
+<height>
+<val>77.0</val>
+</height>
+<diagram>
+<ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<show_stereotypes>
+<val>0</val>
+</show_stereotypes>
+<subject>
+<ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
+</subject>
+</ClassItem>
+<Class id="7325bf10-2e32-11ef-8125-be7f4daace40">
+<generalization>
+<reflist>
+<ref refid="87f4ff18-2e33-11ef-8125-be7f4daace40"/>
+</reflist>
+</generalization>
+<isAbstract>
+<val>1</val>
+</isAbstract>
+<name>
+<val>Relationship</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="88a32774-2e32-11ef-8125-be7f4daace40"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
+</reflist>
+</presentation>
+</Class>
+<ClassItem id="7845dfd4-2e32-11ef-8125-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 203.20355308219172, 87.5)</val>
+</matrix>
+<top-left>
+<val>(3.7964469178082823, 0.0)</val>
+</top-left>
+<width>
+<val>149.96917808219172</val>
+</width>
+<height>
+<val>175.0</val>
+</height>
+<diagram>
+<ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
+</diagram>
+<subject>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</subject>
+</ClassItem>
+<AssociationItem id="8816eea8-2e32-11ef-8125-be7f4daace40">
+<diagram>
+<ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
+</diagram>
+<head_subject>
+<ref refid="88a30320-2e32-11ef-8125-be7f4daace40"/>
+</head_subject>
+<horizontal>
+<val>1</val>
+</horizontal>
+<orthogonal>
+<val>1</val>
+</orthogonal>
+<subject>
+<ref refid="88a2c400-2e32-11ef-8125-be7f4daace40"/>
+</subject>
+<tail_subject>
+<ref refid="88a32774-2e32-11ef-8125-be7f4daace40"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 68.39212328767121, 253.0)</val>
+</matrix>
+<points>
+<val>[(136.09246575342468, 123.61328125), (28.0, 123.61328125), (28.0, -25.5), (138.6078767123288, -25.5)]</val>
+</points>
+<head-connection>
+<ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="7845dfd4-2e32-11ef-8125-be7f4daace40"/>
+</tail-connection>
+</AssociationItem>
+<Association id="88a2c400-2e32-11ef-8125-be7f4daace40">
+<memberEnd>
+<reflist>
+<ref refid="88a30320-2e32-11ef-8125-be7f4daace40"/>
+<ref refid="88a32774-2e32-11ef-8125-be7f4daace40"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="8816eea8-2e32-11ef-8125-be7f4daace40"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="88a30320-2e32-11ef-8125-be7f4daace40">
+<association>
+<ref refid="88a2c400-2e32-11ef-8125-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<isDerived>
+<val>1</val>
+</isDerived>
+<name>
+<val>relationship</val>
+</name>
+<type>
+<ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
+</type>
+<upperValue>
+<val>*</val>
+</upperValue>
+<upperValue>
+<val>*</val>
+</upperValue>
+</Property>
+<Property id="88a32774-2e32-11ef-8125-be7f4daace40">
+<association>
+<ref refid="88a2c400-2e32-11ef-8125-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
+</class_>
+<isDerived>
+<val>1</val>
+</isDerived>
+<lowerValue>
+<val>1</val>
+</lowerValue>
+<lowerValue>
+<val>1</val>
+</lowerValue>
+<name>
+<val>relatedElement</val>
+</name>
+<type>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</type>
+<upperValue>
+<val>*</val>
+</upperValue>
+<upperValue>
+<val>*</val>
+</upperValue>
+</Property>
+<GeneralizationItem id="86eca396-2e33-11ef-8125-be7f4daace40">
+<diagram>
+<ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="87f4ff18-2e33-11ef-8125-be7f4daace40"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 277.0, 154.0)</val>
+</matrix>
+<points>
+<val>[(2.5154109589041695, 192.11328125), (2.5154109589041695, 108.5)]</val>
+</points>
+<head-connection>
+<ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="7845dfd4-2e32-11ef-8125-be7f4daace40"/>
+</tail-connection>
+</GeneralizationItem>
+<Generalization id="87f4ff18-2e33-11ef-8125-be7f4daace40">
+<general>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="86eca396-2e33-11ef-8125-be7f4daace40"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
+</specific>
+</Generalization>
+<AssociationItem id="9ab83010-2e34-11ef-8125-be7f4daace40">
+<diagram>
+<ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
+</diagram>
+<head_subject>
+<ref refid="da0b2408-529e-11ec-b0e5-0456e5e540ed"/>
+</head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>1</val>
+</orthogonal>
+<subject>
+<ref refid="da0afff0-529e-11ec-b0e5-0456e5e540ed"/>
+</subject>
+<tail_subject>
+<ref refid="da0b3ede-529e-11ec-b0e5-0456e5e540ed"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 317.3780813840785, 109.78246057912301)</val>
+</matrix>
+<points>
+<val>[(-3.3780813840784845, -22.28246057912301), (-3.3780813840784845, -65.28246057912301), (142.62191861592152, -65.28246057912301), (142.62191861592152, 32.71753942087699), (39.59109669811323, 32.71753942087699)]</val>
+</points>
+<head-connection>
+<ref refid="7845dfd4-2e32-11ef-8125-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="7845dfd4-2e32-11ef-8125-be7f4daace40"/>
+</tail-connection>
+</AssociationItem>
+<Diagram id="1d89f46e-2ed1-11ef-8125-be7f4daace40">
+<diagramType>
+<val></val>
+</diagramType>
+<element>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</element>
+<name>
+<val>Annotations</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="2ac32ccc-2ed1-11ef-8125-be7f4daace40"/>
+<ref refid="2ac6839a-2ed1-11ef-8125-be7f4daace40"/>
+<ref refid="2ac599c6-2ed1-11ef-8125-be7f4daace40"/>
+<ref refid="2ac7e316-2ed1-11ef-8125-be7f4daace40"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<ClassItem id="2ac32ccc-2ed1-11ef-8125-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 191.86101860258236, 87.98046875)</val>
+</matrix>
+<top-left>
+<val>(0.0, 114.11579500368384)</val>
+</top-left>
+<width>
+<val>152.01096400519157</val>
+</width>
+<height>
+<val>60.88420499631616</val>
+</height>
+<diagram>
+<ref refid="1d89f46e-2ed1-11ef-8125-be7f4daace40"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</subject>
+</ClassItem>
+<AssociationItem id="2ac599c6-2ed1-11ef-8125-be7f4daace40">
+<diagram>
+<ref refid="1d89f46e-2ed1-11ef-8125-be7f4daace40"/>
+</diagram>
+<head_subject>
+<ref refid="d092794d-e0b9-11ea-b7ab-f5b4c130f24e"/>
+</head_subject>
+<horizontal>
+<val>1</val>
+</horizontal>
+<orthogonal>
+<val>1</val>
+</orthogonal>
+<subject>
+<ref refid="d092794c-e0b9-11ea-b7ab-f5b4c130f24e"/>
+</subject>
+<tail_subject>
+<ref refid="d092794e-e0b9-11ea-b7ab-f5b4c130f24e"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 346.78781028296635, 214.45703125)</val>
+</matrix>
+<points>
+<val>[(-2.9158276751924177, 18.08133500184192), (161.71218971703365, 18.08133500184192), (161.71218971703365, 206.19900512695312), (-23.134631347656295, 206.19900512695312)]</val>
+</points>
+<head-connection>
+<ref refid="2ac32ccc-2ed1-11ef-8125-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="2ac6839a-2ed1-11ef-8125-be7f4daace40"/>
+</tail-connection>
+</AssociationItem>
+<ClassItem id="2ac6839a-2ed1-11ef-8125-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 214.65317893531005, 384.6560363769531)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>109.0</val>
+</width>
+<height>
+<val>72.0</val>
+</height>
+<diagram>
+<ref refid="1d89f46e-2ed1-11ef-8125-be7f4daace40"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="5175e1cc-7cf9-11ea-b719-1f391582df99"/>
+</subject>
+</ClassItem>
+<GeneralizationItem id="2ac7e316-2ed1-11ef-8125-be7f4daace40">
+<diagram>
+<ref refid="1d89f46e-2ed1-11ef-8125-be7f4daace40"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>1</val>
+</orthogonal>
+<subject>
+<ref refid="58d8be2c-4bbe-11ec-aa3d-0456e5e540ed"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 267.52638658195485, 247.68133544921875)</val>
+</matrix>
+<points>
+<val>[(1.6267923533551993, 136.97470092773438), (1.6267923533551993, 74.77569580078125), (1.2670129048851209, 74.77569580078125), (1.2670129048851209, 15.29913330078125)]</val>
+</points>
+<head-connection>
+<ref refid="2ac6839a-2ed1-11ef-8125-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="2ac32ccc-2ed1-11ef-8125-be7f4daace40"/>
+</tail-connection>
+</GeneralizationItem>
 </gaphor>

--- a/models/Core.gaphor
+++ b/models/Core.gaphor
@@ -29,6 +29,10 @@
 <ref refid="8c1a77a0-3232-11ef-8506-be7f4daace40"/>
 <ref refid="c65b2548-3234-11ef-8506-be7f4daace40"/>
 <ref refid="f0d0b0e0-3234-11ef-8506-be7f4daace40"/>
+<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="ed926808-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="ef227000-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="fec6b8fe-331d-11ef-84c5-be7f4daace40"/>
 </reflist>
 </ownedType>
 <presentation>
@@ -467,6 +471,8 @@
 <ref refid="2b608842-32f9-11ef-95f2-be7f4daace40"/>
 <ref refid="c65b782c-3234-11ef-8506-be7f4daace40"/>
 <ref refid="f0d1199a-3234-11ef-8506-be7f4daace40"/>
+<ref refid="ef22d04a-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="ed92bb78-331d-11ef-84c5-be7f4daace40"/>
 </reflist>
 </ownedAttribute>
 <ownedOperation>
@@ -501,6 +507,7 @@
 <ref refid="d7dfe61e-5ee6-11ed-9155-0456e5e540ed"/>
 <ref refid="05872486-3c56-11ee-99bb-48a4721e5d5c"/>
 <ref refid="87f4ff18-2e33-11ef-8125-be7f4daace40"/>
+<ref refid="2428734e-331e-11ef-84c5-be7f4daace40"/>
 </reflist>
 </specialization>
 </Class>
@@ -1189,6 +1196,8 @@
 <ref refid="0090308c-3235-11ef-8506-be7f4daace40"/>
 <ref refid="05064796-3235-11ef-8506-be7f4daace40"/>
 <ref refid="2b47c1b4-3235-11ef-8506-be7f4daace40"/>
+<ref refid="98f4e0bc-331f-11ef-84c5-be7f4daace40"/>
+<ref refid="9a8461b4-331f-11ef-84c5-be7f4daace40"/>
 </reflist>
 </instanceSpecification>
 <name>
@@ -1324,6 +1333,8 @@
 <ref refid="034be6b8-3235-11ef-8506-be7f4daace40"/>
 <ref refid="109119ec-3235-11ef-8506-be7f4daace40"/>
 <ref refid="32df0022-3235-11ef-8506-be7f4daace40"/>
+<ref refid="b190fb1a-331f-11ef-84c5-be7f4daace40"/>
+<ref refid="bf753340-331f-11ef-84c5-be7f4daace40"/>
 </reflist>
 </slot>
 <typeValue>
@@ -3705,21 +3716,28 @@
 <ownedPresentation>
 <reflist>
 <ref refid="76564f8a-32c7-11ef-bb85-be7f4daace40"/>
+<ref refid="fec3a81c-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="e837dcc6-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="a0ad1b36-331e-11ef-84c5-be7f4daace40"/>
+<ref refid="e829ea44-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="e838b74a-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="237bb2c6-331e-11ef-84c5-be7f4daace40"/>
+<ref refid="b22512f6-331e-11ef-84c5-be7f4daace40"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
 <ClassItem id="76564f8a-32c7-11ef-bb85-be7f4daace40">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 213.4609375, 96.83984375)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 254.26908064787528, 58.83984375)</val>
 </matrix>
 <top-left>
-<val>(0.0, 0.0)</val>
+<val>(56.38371370424943, 101.7550837989499)</val>
 </top-left>
 <width>
-<val>113.5390625</val>
+<val>189.15534879575057</val>
 </width>
 <height>
-<val>57.16015625</val>
+<val>56.4050724510501</val>
 </height>
 <diagram>
 <ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
@@ -3759,4 +3777,525 @@
 <val>String</val>
 </typeValue>
 </Property>
+<AssociationItem id="e829ea44-331d-11ef-84c5-be7f4daace40">
+<diagram>
+<ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
+</diagram>
+<head_subject>
+<ref refid="ef228658-331d-11ef-84c5-be7f4daace40"/>
+</head_subject>
+<horizontal>
+<val>1</val>
+</horizontal>
+<orthogonal>
+<val>1</val>
+</orthogonal>
+<subject>
+<ref refid="ef227000-331d-11ef-84c5-be7f4daace40"/>
+</subject>
+<tail_subject>
+<ref refid="ef22d04a-331d-11ef-84c5-be7f4daace40"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 350.66666666666663, 291.5185185185186)</val>
+</matrix>
+<points>
+<val>[(149.14147648120866, -95.41387626987824), (277.92403986460675, -95.41387626987824), (277.92403986460675, 44.98148148148141), (147.56380208333337, 44.98148148148141)]</val>
+</points>
+<head-connection>
+<ref refid="76564f8a-32c7-11ef-bb85-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="e837dcc6-331d-11ef-84c5-be7f4daace40"/>
+</tail-connection>
+</AssociationItem>
+<AssociationItem id="e838b74a-331d-11ef-84c5-be7f4daace40">
+<diagram>
+<ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
+</diagram>
+<head_subject>
+<ref refid="ed927c30-331d-11ef-84c5-be7f4daace40"/>
+</head_subject>
+<horizontal>
+<val>1</val>
+</horizontal>
+<orthogonal>
+<val>1</val>
+</orthogonal>
+<subject>
+<ref refid="ed926808-331d-11ef-84c5-be7f4daace40"/>
+</subject>
+<tail_subject>
+<ref refid="ed92bb78-331d-11ef-84c5-be7f4daace40"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 350.66666666666663, 228.5185185185186)</val>
+</matrix>
+<points>
+<val>[(-40.01387231454191, -32.413876269878244), (-260.8220154624172, -32.413876269878244), (-260.8220154624172, 107.98148148148141), (-38.43619791666663, 107.98148148148141)]</val>
+</points>
+<head-connection>
+<ref refid="76564f8a-32c7-11ef-bb85-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="e837dcc6-331d-11ef-84c5-be7f4daace40"/>
+</tail-connection>
+</AssociationItem>
+<ClassItem id="fec3a81c-331d-11ef-84c5-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 667.9240398646061, 58.83984375)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>117.33333333333348</val>
+</width>
+<height>
+<val>132.0</val>
+</height>
+<diagram>
+<ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<show_stereotypes>
+<val>0</val>
+</show_stereotypes>
+<subject>
+<ref refid="fec6b8fe-331d-11ef-84c5-be7f4daace40"/>
+</subject>
+</ClassItem>
+<Class id="fec6b8fe-331d-11ef-84c5-be7f4daace40">
+<name>
+<val>VisibilityKind</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="fec7197a-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="fec84264-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="fec8ef5c-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="fec9936c-331d-11ef-84c5-be7f4daace40"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="fec3a81c-331d-11ef-84c5-be7f4daace40"/>
+</reflist>
+</presentation>
+</Class>
+<Property id="fec7197a-331d-11ef-84c5-be7f4daace40">
+<class_>
+<ref refid="fec6b8fe-331d-11ef-84c5-be7f4daace40"/>
+</class_>
+<name>
+<val>public</val>
+</name>
+</Property>
+<Property id="fec84264-331d-11ef-84c5-be7f4daace40">
+<class_>
+<ref refid="fec6b8fe-331d-11ef-84c5-be7f4daace40"/>
+</class_>
+<name>
+<val>private</val>
+</name>
+</Property>
+<Property id="fec8ef5c-331d-11ef-84c5-be7f4daace40">
+<class_>
+<ref refid="fec6b8fe-331d-11ef-84c5-be7f4daace40"/>
+</class_>
+<name>
+<val>package</val>
+</name>
+</Property>
+<Property id="fec9936c-331d-11ef-84c5-be7f4daace40">
+<class_>
+<ref refid="fec6b8fe-331d-11ef-84c5-be7f4daace40"/>
+</class_>
+<name>
+<val>protected</val>
+</name>
+</Property>
+<ClassItem id="e837dcc6-331d-11ef-84c5-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 301.5638020833335, 311.4466145833333)</val>
+</matrix>
+<top-left>
+<val>(10.666666666666515, 0.0)</val>
+</top-left>
+<width>
+<val>186.0</val>
+</width>
+<height>
+<val>81.05338541666674</val>
+</height>
+<diagram>
+<ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<show_stereotypes>
+<val>0</val>
+</show_stereotypes>
+<subject>
+<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
+</subject>
+</ClassItem>
+<Class id="e82eaac0-331d-11ef-84c5-be7f4daace40">
+<comment>
+<reflist>
+<ref refid="a0ad1352-331e-11ef-84c5-be7f4daace40"/>
+</reflist>
+</comment>
+<generalization>
+<reflist>
+<ref refid="2428734e-331e-11ef-84c5-be7f4daace40"/>
+</reflist>
+</generalization>
+<isAbstract>
+<val>1</val>
+</isAbstract>
+<name>
+<val>Namespace</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="1de6ee20-331e-11ef-84c5-be7f4daace40"/>
+<ref refid="ef228658-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="ed927c30-331d-11ef-84c5-be7f4daace40"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="e837dcc6-331d-11ef-84c5-be7f4daace40"/>
+</reflist>
+</presentation>
+</Class>
+<Association id="ef227000-331d-11ef-84c5-be7f4daace40">
+<memberEnd>
+<reflist>
+<ref refid="ef228658-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="ef22d04a-331d-11ef-84c5-be7f4daace40"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="e829ea44-331d-11ef-84c5-be7f4daace40"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="ef22d04a-331d-11ef-84c5-be7f4daace40">
+<association>
+<ref refid="ef227000-331d-11ef-84c5-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<isDerived>
+<val>1</val>
+</isDerived>
+<name>
+<val>memberNamespace</val>
+</name>
+<type>
+<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<Property id="ef228658-331d-11ef-84c5-be7f4daace40">
+<association>
+<ref refid="ef227000-331d-11ef-84c5-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
+</class_>
+<isDerived>
+<val>1</val>
+</isDerived>
+<name>
+<val>member</val>
+</name>
+<type>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</type>
+<upperValue>
+<val>*</val>
+</upperValue>
+<upperValue>
+<val>*</val>
+</upperValue>
+</Property>
+<Property id="1de6ee20-331e-11ef-84c5-be7f4daace40">
+<class_>
+<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>visibility</val>
+</name>
+<typeValue>
+<val>VisibilityKind</val>
+</typeValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<GeneralizationItem id="237bb2c6-331e-11ef-84c5-be7f4daace40">
+<diagram>
+<ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="2428734e-331e-11ef-84c5-be7f4daace40"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 388.6311099875504, 188.86889001244958)</val>
+</matrix>
+<points>
+<val>[(16.599358762449583, 122.57772457088373), (16.599358762449583, 28.131109987550417)]</val>
+</points>
+<head-connection>
+<ref refid="e837dcc6-331d-11ef-84c5-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="76564f8a-32c7-11ef-bb85-be7f4daace40"/>
+</tail-connection>
+</GeneralizationItem>
+<Generalization id="2428734e-331e-11ef-84c5-be7f4daace40">
+<general>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="237bb2c6-331e-11ef-84c5-be7f4daace40"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
+</specific>
+</Generalization>
+<Comment id="a0ad1352-331e-11ef-84c5-be7f4daace40">
+<annotatedElement>
+<reflist>
+<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
+</reflist>
+</annotatedElement>
+<body>
+<val>Visibility is not officially a property of Namespace.</val>
+</body>
+<presentation>
+<reflist>
+<ref refid="a0ad1b36-331e-11ef-84c5-be7f4daace40"/>
+</reflist>
+</presentation>
+</Comment>
+<CommentItem id="a0ad1b36-331e-11ef-84c5-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 383.7297221082374, 462.31121129981057)</val>
+</matrix>
+<top-left>
+<val>(0.0, 1.0)</val>
+</top-left>
+<width>
+<val>103.22265625000003</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
+</diagram>
+<subject>
+<ref refid="a0ad1352-331e-11ef-84c5-be7f4daace40"/>
+</subject>
+</CommentItem>
+<CommentLineItem id="b22512f6-331e-11ef-84c5-be7f4daace40">
+<diagram>
+<ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 412.9523783582374, 374.31121129981057)</val>
+</matrix>
+<points>
+<val>[(2.668448037525067, 18.18878870018949), (12.573504452101531, 89.0)]</val>
+</points>
+<head-connection>
+<ref refid="e837dcc6-331d-11ef-84c5-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="a0ad1b36-331e-11ef-84c5-be7f4daace40"/>
+</tail-connection>
+</CommentLineItem>
+<Association id="ed926808-331d-11ef-84c5-be7f4daace40">
+<memberEnd>
+<reflist>
+<ref refid="ed927c30-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="ed92bb78-331d-11ef-84c5-be7f4daace40"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="e838b74a-331d-11ef-84c5-be7f4daace40"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="ed92bb78-331d-11ef-84c5-be7f4daace40">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<appliedStereotype>
+<reflist>
+<ref refid="9a8461b4-331f-11ef-84c5-be7f4daace40"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="ed926808-331d-11ef-84c5-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<isDerived>
+<val>1</val>
+</isDerived>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>namespace</val>
+</name>
+<type>
+<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<InstanceSpecification id="9a8461b4-331f-11ef-84c5-be7f4daace40">
+<classifier>
+<reflist>
+<ref refid="d632222a-529c-11ec-b0e5-0456e5e540ed"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="ed92bb78-331d-11ef-84c5-be7f4daace40"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="b190fb1a-331f-11ef-84c5-be7f4daace40"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="b190fb1a-331f-11ef-84c5-be7f4daace40">
+<definingFeature>
+<ref refid="e8c61a5e-529c-11ec-b0e5-0456e5e540ed"/>
+</definingFeature>
+<owningInstance>
+<ref refid="9a8461b4-331f-11ef-84c5-be7f4daace40"/>
+</owningInstance>
+<value>
+<val>memberNamespace, owner</val>
+</value>
+</Slot>
+<Property id="ed927c30-331d-11ef-84c5-be7f4daace40">
+<appliedStereotype>
+<reflist>
+<ref refid="98f4e0bc-331f-11ef-84c5-be7f4daace40"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="ed926808-331d-11ef-84c5-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
+</class_>
+<isDerived>
+<val>1</val>
+</isDerived>
+<name>
+<val>ownedMember</val>
+</name>
+<type>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</type>
+<upperValue>
+<val>*</val>
+</upperValue>
+<upperValue>
+<val>*</val>
+</upperValue>
+</Property>
+<InstanceSpecification id="98f4e0bc-331f-11ef-84c5-be7f4daace40">
+<classifier>
+<reflist>
+<ref refid="d632222a-529c-11ec-b0e5-0456e5e540ed"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="ed927c30-331d-11ef-84c5-be7f4daace40"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="bf753340-331f-11ef-84c5-be7f4daace40"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="bf753340-331f-11ef-84c5-be7f4daace40">
+<definingFeature>
+<ref refid="e8c61a5e-529c-11ec-b0e5-0456e5e540ed"/>
+</definingFeature>
+<owningInstance>
+<ref refid="98f4e0bc-331f-11ef-84c5-be7f4daace40"/>
+</owningInstance>
+<value>
+<val>member, ownedElement</val>
+</value>
+</Slot>
 </gaphor>

--- a/models/Core.gaphor
+++ b/models/Core.gaphor
@@ -33,6 +33,7 @@
 <ref refid="ed926808-331d-11ef-84c5-be7f4daace40"/>
 <ref refid="ef227000-331d-11ef-84c5-be7f4daace40"/>
 <ref refid="fec6b8fe-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="8ece7232-3398-11ef-8ac6-be7f4daace40"/>
 </reflist>
 </ownedType>
 <presentation>
@@ -507,7 +508,7 @@
 <ref refid="d7dfe61e-5ee6-11ed-9155-0456e5e540ed"/>
 <ref refid="05872486-3c56-11ee-99bb-48a4721e5d5c"/>
 <ref refid="87f4ff18-2e33-11ef-8125-be7f4daace40"/>
-<ref refid="2428734e-331e-11ef-84c5-be7f4daace40"/>
+<ref refid="bd3900ba-3398-11ef-8ac6-be7f4daace40"/>
 </reflist>
 </specialization>
 </Class>
@@ -3719,10 +3720,12 @@
 <ref refid="fec3a81c-331d-11ef-84c5-be7f4daace40"/>
 <ref refid="e837dcc6-331d-11ef-84c5-be7f4daace40"/>
 <ref refid="a0ad1b36-331e-11ef-84c5-be7f4daace40"/>
+<ref refid="8ecc6866-3398-11ef-8ac6-be7f4daace40"/>
 <ref refid="e829ea44-331d-11ef-84c5-be7f4daace40"/>
 <ref refid="e838b74a-331d-11ef-84c5-be7f4daace40"/>
 <ref refid="237bb2c6-331e-11ef-84c5-be7f4daace40"/>
 <ref refid="b22512f6-331e-11ef-84c5-be7f4daace40"/>
+<ref refid="bc232a0c-3398-11ef-8ac6-be7f4daace40"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
@@ -3800,7 +3803,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 350.66666666666663, 291.5185185185186)</val>
 </matrix>
 <points>
-<val>[(149.14147648120866, -95.41387626987824), (277.92403986460675, -95.41387626987824), (277.92403986460675, 44.98148148148141), (147.56380208333337, 44.98148148148141)]</val>
+<val>[(149.14147648120866, -95.41387626987824), (277.92403986460675, -95.41387626987824), (277.92403986460675, 280.9814814814814), (149.14147648120866, 280.9814814814814)]</val>
 </points>
 <head-connection>
 <ref refid="76564f8a-32c7-11ef-bb85-be7f4daace40"/>
@@ -3832,7 +3835,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 350.66666666666663, 228.5185185185186)</val>
 </matrix>
 <points>
-<val>[(-40.01387231454191, -32.413876269878244), (-260.8220154624172, -32.413876269878244), (-260.8220154624172, 107.98148148148141), (-38.43619791666663, 107.98148148148141)]</val>
+<val>[(-40.01387231454191, -32.413876269878244), (-260.8220154624172, -32.413876269878244), (-260.8220154624172, 343.9814814814814), (-36.858523518791344, 343.9814814814814)]</val>
 </points>
 <head-connection>
 <ref refid="76564f8a-32c7-11ef-bb85-be7f4daace40"/>
@@ -3922,7 +3925,7 @@
 </Property>
 <ClassItem id="e837dcc6-331d-11ef-84c5-be7f4daace40">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 301.5638020833335, 311.4466145833333)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 303.14147648120877, 547.4466145833333)</val>
 </matrix>
 <top-left>
 <val>(10.666666666666515, 0.0)</val>
@@ -3947,14 +3950,9 @@
 </subject>
 </ClassItem>
 <Class id="e82eaac0-331d-11ef-84c5-be7f4daace40">
-<comment>
-<reflist>
-<ref refid="a0ad1352-331e-11ef-84c5-be7f4daace40"/>
-</reflist>
-</comment>
 <generalization>
 <reflist>
-<ref refid="2428734e-331e-11ef-84c5-be7f4daace40"/>
+<ref refid="9be87e90-3398-11ef-8ac6-be7f4daace40"/>
 </reflist>
 </generalization>
 <isAbstract>
@@ -3965,7 +3963,6 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="1de6ee20-331e-11ef-84c5-be7f4daace40"/>
 <ref refid="ef228658-331d-11ef-84c5-be7f4daace40"/>
 <ref refid="ed927c30-331d-11ef-84c5-be7f4daace40"/>
 </reflist>
@@ -4041,29 +4038,6 @@
 <val>*</val>
 </upperValue>
 </Property>
-<Property id="1de6ee20-331e-11ef-84c5-be7f4daace40">
-<class_>
-<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
-</class_>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<name>
-<val>visibility</val>
-</name>
-<typeValue>
-<val>VisibilityKind</val>
-</typeValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-</Property>
 <GeneralizationItem id="237bb2c6-331e-11ef-84c5-be7f4daace40">
 <diagram>
 <ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
@@ -4075,42 +4049,29 @@
 <val>0</val>
 </orthogonal>
 <subject>
-<ref refid="2428734e-331e-11ef-84c5-be7f4daace40"/>
+<ref refid="9be87e90-3398-11ef-8ac6-be7f4daace40"/>
 </subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 388.6311099875504, 188.86889001244958)</val>
 </matrix>
 <points>
-<val>[(16.599358762449583, 122.57772457088373), (16.599358762449583, 28.131109987550417)]</val>
+<val>[(18.177033160324868, 358.5777245708837), (18.177033160324868, 251.79777665421705)]</val>
 </points>
 <head-connection>
 <ref refid="e837dcc6-331d-11ef-84c5-be7f4daace40"/>
 </head-connection>
 <tail-connection>
-<ref refid="76564f8a-32c7-11ef-bb85-be7f4daace40"/>
+<ref refid="8ecc6866-3398-11ef-8ac6-be7f4daace40"/>
 </tail-connection>
 </GeneralizationItem>
-<Generalization id="2428734e-331e-11ef-84c5-be7f4daace40">
-<general>
-<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
-</general>
-<presentation>
-<reflist>
-<ref refid="237bb2c6-331e-11ef-84c5-be7f4daace40"/>
-</reflist>
-</presentation>
-<specific>
-<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
-</specific>
-</Generalization>
 <Comment id="a0ad1352-331e-11ef-84c5-be7f4daace40">
 <annotatedElement>
 <reflist>
-<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="8ece7232-3398-11ef-8ac6-be7f4daace40"/>
 </reflist>
 </annotatedElement>
 <body>
-<val>Visibility is not officially a property of Namespace.</val>
+<val>Temporary, so we keep the core model compatible with UML 2.5.</val>
 </body>
 <presentation>
 <reflist>
@@ -4120,7 +4081,7 @@
 </Comment>
 <CommentItem id="a0ad1b36-331e-11ef-84c5-be7f4daace40">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 383.7297221082374, 462.31121129981057)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 151.619140625, 396.5)</val>
 </matrix>
 <top-left>
 <val>(0.0, 1.0)</val>
@@ -4129,7 +4090,7 @@
 <val>103.22265625000003</val>
 </width>
 <height>
-<val>74.0</val>
+<val>113.0</val>
 </height>
 <diagram>
 <ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
@@ -4152,10 +4113,10 @@
 <val>(1.0, 0.0, 0.0, 1.0, 412.9523783582374, 374.31121129981057)</val>
 </matrix>
 <points>
-<val>[(2.668448037525067, 18.18878870018949), (12.573504452101531, 89.0)]</val>
+<val>[(-117.8885762749041, 46.26008082314131), (-158.11058148323738, 60.420383626093006)]</val>
 </points>
 <head-connection>
-<ref refid="e837dcc6-331d-11ef-84c5-be7f4daace40"/>
+<ref refid="8ecc6866-3398-11ef-8ac6-be7f4daace40"/>
 </head-connection>
 <tail-connection>
 <ref refid="a0ad1b36-331e-11ef-84c5-be7f4daace40"/>
@@ -4298,4 +4259,141 @@
 <val>member, ownedElement</val>
 </value>
 </Slot>
+<ClassItem id="8ecc6866-3398-11ef-8ac6-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 295.0638020833333, 323.66666666666663)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>220.33333333333337</val>
+</width>
+<height>
+<val>117.0</val>
+</height>
+<diagram>
+<ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<show_stereotypes>
+<val>0</val>
+</show_stereotypes>
+<subject>
+<ref refid="8ece7232-3398-11ef-8ac6-be7f4daace40"/>
+</subject>
+</ClassItem>
+<Class id="8ece7232-3398-11ef-8ac6-be7f4daace40">
+<comment>
+<reflist>
+<ref refid="a0ad1352-331e-11ef-84c5-be7f4daace40"/>
+</reflist>
+</comment>
+<generalization>
+<reflist>
+<ref refid="bd3900ba-3398-11ef-8ac6-be7f4daace40"/>
+</reflist>
+</generalization>
+<isAbstract>
+<val>1</val>
+</isAbstract>
+<name>
+<val>NamedElement</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="8ecfaa30-3398-11ef-8ac6-be7f4daace40"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="8ecc6866-3398-11ef-8ac6-be7f4daace40"/>
+</reflist>
+</presentation>
+<specialization>
+<reflist>
+<ref refid="9be87e90-3398-11ef-8ac6-be7f4daace40"/>
+</reflist>
+</specialization>
+</Class>
+<Property id="8ecfaa30-3398-11ef-8ac6-be7f4daace40">
+<class_>
+<ref refid="8ece7232-3398-11ef-8ac6-be7f4daace40"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>visibility</val>
+</name>
+<typeValue>
+<val>VisibilityKind</val>
+</typeValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<Generalization id="9be87e90-3398-11ef-8ac6-be7f4daace40">
+<general>
+<ref refid="8ece7232-3398-11ef-8ac6-be7f4daace40"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="237bb2c6-331e-11ef-84c5-be7f4daace40"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="e82eaac0-331d-11ef-84c5-be7f4daace40"/>
+</specific>
+</Generalization>
+<GeneralizationItem id="bc232a0c-3398-11ef-8ac6-be7f4daace40">
+<diagram>
+<ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="bd3900ba-3398-11ef-8ac6-be7f4daace40"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 359.63482274563154, 197.5)</val>
+</matrix>
+<points>
+<val>[(45.59564600436846, 126.16666666666663), (45.59564600436846, 19.5)]</val>
+</points>
+<head-connection>
+<ref refid="8ecc6866-3398-11ef-8ac6-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="76564f8a-32c7-11ef-bb85-be7f4daace40"/>
+</tail-connection>
+</GeneralizationItem>
+<Generalization id="bd3900ba-3398-11ef-8ac6-be7f4daace40">
+<general>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="bc232a0c-3398-11ef-8ac6-be7f4daace40"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="8ece7232-3398-11ef-8ac6-be7f4daace40"/>
+</specific>
+</Generalization>
 </gaphor>

--- a/models/Core.gaphor
+++ b/models/Core.gaphor
@@ -8,6 +8,7 @@
 <reflist>
 <ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
 <ref refid="1d89f46e-2ed1-11ef-8125-be7f4daace40"/>
+<ref refid="fbfda48a-3231-11ef-8506-be7f4daace40"/>
 </reflist>
 </ownedDiagram>
 <ownedType>
@@ -22,6 +23,11 @@
 <ref refid="216581c9-4465-11eb-8946-9bdfa28f7a50"/>
 <ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
 <ref refid="88a2c400-2e32-11ef-8125-be7f4daace40"/>
+<ref refid="15dbc42c-3232-11ef-8506-be7f4daace40"/>
+<ref refid="4fa1439e-3232-11ef-8506-be7f4daace40"/>
+<ref refid="8c1a77a0-3232-11ef-8506-be7f4daace40"/>
+<ref refid="c65b2548-3234-11ef-8506-be7f4daace40"/>
+<ref refid="f0d0b0e0-3234-11ef-8506-be7f4daace40"/>
 </reflist>
 </ownedType>
 <presentation>
@@ -448,12 +454,16 @@
 <reflist>
 <ref refid="8e8ab29e-eb5f-11ee-a6cb-be7f4daace3f"/>
 <ref refid="a4c6f704-ce0f-11eb-abe3-018035c40dd4"/>
-<ref refid="88a30320-2e32-11ef-8125-be7f4daace40"/>
 <ref refid="da0b2408-529e-11ec-b0e5-0456e5e540ed"/>
 <ref refid="da0b3ede-529e-11ec-b0e5-0456e5e540ed"/>
 <ref refid="69c2575a-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="1ee6aec6-b9a9-11eb-93ad-535118859f0b"/>
 <ref refid="d092794e-e0b9-11ea-b7ab-f5b4c130f24e"/>
+<ref refid="f0d1199a-3234-11ef-8506-be7f4daace40"/>
+<ref refid="c65b782c-3234-11ef-8506-be7f4daace40"/>
+<ref refid="88a30320-2e32-11ef-8125-be7f4daace40"/>
+<ref refid="4fa655f0-3232-11ef-8506-be7f4daace40"/>
+<ref refid="8c1af8ce-3232-11ef-8506-be7f4daace40"/>
 </reflist>
 </ownedAttribute>
 <ownedOperation>
@@ -475,6 +485,7 @@
 <ref refid="f8ef5c9c-5ee4-11ed-9155-0456e5e540ed"/>
 <ref refid="7845dfd4-2e32-11ef-8125-be7f4daace40"/>
 <ref refid="2ac32ccc-2ed1-11ef-8125-be7f4daace40"/>
+<ref refid="015ede30-3232-11ef-8506-be7f4daace40"/>
 </reflist>
 </presentation>
 <specialization>
@@ -1193,6 +1204,14 @@
 <ref refid="4f18283c-529e-11ec-b0e5-0456e5e540ed"/>
 <ref refid="602d80b8-529e-11ec-b0e5-0456e5e540ed"/>
 <ref refid="6530f82e-529e-11ec-b0e5-0456e5e540ed"/>
+<ref refid="72f8448c-3232-11ef-8506-be7f4daace40"/>
+<ref refid="24ea13cc-3234-11ef-8506-be7f4daace40"/>
+<ref refid="326b312a-3234-11ef-8506-be7f4daace40"/>
+<ref refid="6aabd6e8-3234-11ef-8506-be7f4daace40"/>
+<ref refid="e09dabba-3234-11ef-8506-be7f4daace40"/>
+<ref refid="0090308c-3235-11ef-8506-be7f4daace40"/>
+<ref refid="05064796-3235-11ef-8506-be7f4daace40"/>
+<ref refid="2b47c1b4-3235-11ef-8506-be7f4daace40"/>
 </reflist>
 </instanceSpecification>
 <name>
@@ -1320,6 +1339,14 @@
 <ref refid="52204ae6-529e-11ec-b0e5-0456e5e540ed"/>
 <ref refid="62e55920-529e-11ec-b0e5-0456e5e540ed"/>
 <ref refid="6c6e8fa2-529e-11ec-b0e5-0456e5e540ed"/>
+<ref refid="2e2ce84c-3234-11ef-8506-be7f4daace40"/>
+<ref refid="4d3c0c86-3234-11ef-8506-be7f4daace40"/>
+<ref refid="60769604-3234-11ef-8506-be7f4daace40"/>
+<ref refid="724386bc-3234-11ef-8506-be7f4daace40"/>
+<ref refid="e5d91998-3234-11ef-8506-be7f4daace40"/>
+<ref refid="034be6b8-3235-11ef-8506-be7f4daace40"/>
+<ref refid="109119ec-3235-11ef-8506-be7f4daace40"/>
+<ref refid="32df0022-3235-11ef-8506-be7f4daace40"/>
 </reflist>
 </slot>
 <typeValue>
@@ -2427,6 +2454,8 @@
 <ref refid="8816eea8-2e32-11ef-8125-be7f4daace40"/>
 <ref refid="86eca396-2e33-11ef-8125-be7f4daace40"/>
 <ref refid="9ab83010-2e34-11ef-8125-be7f4daace40"/>
+<ref refid="c461b946-3234-11ef-8506-be7f4daace40"/>
+<ref refid="ef4eb4d8-3234-11ef-8506-be7f4daace40"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
@@ -2435,13 +2464,13 @@
 <val>(1.0, 0.0, 0.0, 1.0, 204.4845890410959, 346.11328125)</val>
 </matrix>
 <top-left>
-<val>(0.0, 0.0)</val>
+<val>(2.5154109589041127, -9.11328125)</val>
 </top-left>
 <width>
-<val>155.0</val>
+<val>152.4845890410959</val>
 </width>
 <height>
-<val>77.0</val>
+<val>117.7578125</val>
 </height>
 <diagram>
 <ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
@@ -2470,6 +2499,8 @@
 </name>
 <ownedAttribute>
 <reflist>
+<ref refid="f0d166ca-3234-11ef-8506-be7f4daace40"/>
+<ref refid="c65bad56-3234-11ef-8506-be7f4daace40"/>
 <ref refid="88a32774-2e32-11ef-8125-be7f4daace40"/>
 </reflist>
 </ownedAttribute>
@@ -2479,8 +2510,14 @@
 <presentation>
 <reflist>
 <ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
+<ref refid="0a0efca4-3232-11ef-8506-be7f4daace40"/>
 </reflist>
 </presentation>
+<specialization>
+<reflist>
+<ref refid="1f4c6656-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</specialization>
 </Class>
 <ClassItem id="7845dfd4-2e32-11ef-8125-be7f4daace40">
 <matrix>
@@ -2522,10 +2559,10 @@
 <ref refid="88a32774-2e32-11ef-8125-be7f4daace40"/>
 </tail_subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 68.39212328767121, 253.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 68.39212328767121, 252.4765625)</val>
 </matrix>
 <points>
-<val>[(136.09246575342468, 123.61328125), (28.0, 123.61328125), (28.0, -25.5), (138.6078767123288, -25.5)]</val>
+<val>[(138.6078767123288, 105.5234375), (28.0, 105.5234375), (28.0, -24.9765625), (138.6078767123288, -24.9765625)]</val>
 </points>
 <head-connection>
 <ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
@@ -2619,7 +2656,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 277.0, 154.0)</val>
 </matrix>
 <points>
-<val>[(2.5154109589041695, 192.11328125), (2.5154109589041695, 108.5)]</val>
+<val>[(3.813187390662222, 183.0), (2.5154109589041695, 108.5)]</val>
 </points>
 <head-connection>
 <ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
@@ -2635,6 +2672,7 @@
 <presentation>
 <reflist>
 <ref refid="86eca396-2e33-11ef-8125-be7f4daace40"/>
+<ref refid="0f828aa2-3232-11ef-8506-be7f4daace40"/>
 </reflist>
 </presentation>
 <specific>
@@ -2821,9 +2859,9 @@
 <ownedType>
 <reflist>
 <ref refid="5cdae47e-7a95-11ea-a112-7f953848cf85"/>
-<ref refid="e873d808-3c55-11ee-99bb-48a4721e5d5c"/>
-<ref refid="15e4b0b2-9f17-11ea-b537-dfaaecc5bf61"/>
 <ref refid="639b48d0-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="15e4b0b2-9f17-11ea-b537-dfaaecc5bf61"/>
+<ref refid="e873d808-3c55-11ee-99bb-48a4721e5d5c"/>
 </reflist>
 </ownedType>
 <presentation>
@@ -2872,4 +2910,809 @@
 <ref refid="13c29352-2ef2-11ef-8125-be7f4daace40"/>
 </subject>
 </PackageItem>
+<Diagram id="fbfda48a-3231-11ef-8506-be7f4daace40">
+<diagramType>
+<val></val>
+</diagramType>
+<element>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</element>
+<name>
+<val>Dependencies</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="015ede30-3232-11ef-8506-be7f4daace40"/>
+<ref refid="0a0efca4-3232-11ef-8506-be7f4daace40"/>
+<ref refid="15dc354c-3232-11ef-8506-be7f4daace40"/>
+<ref refid="0f828aa2-3232-11ef-8506-be7f4daace40"/>
+<ref refid="1e24b436-3232-11ef-8506-be7f4daace40"/>
+<ref refid="4e94a5f4-3232-11ef-8506-be7f4daace40"/>
+<ref refid="8b13e404-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<ClassItem id="015ede30-3232-11ef-8506-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 236.453125, 108.33984375)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>130.546875</val>
+</width>
+<height>
+<val>58.66015625</val>
+</height>
+<diagram>
+<ref refid="fbfda48a-3231-11ef-8506-be7f4daace40"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</subject>
+</ClassItem>
+<ClassItem id="0a0efca4-3232-11ef-8506-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 251.7265625, 253.8046875)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>55.0</val>
+</height>
+<diagram>
+<ref refid="fbfda48a-3231-11ef-8506-be7f4daace40"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
+</subject>
+</ClassItem>
+<GeneralizationItem id="0f828aa2-3232-11ef-8506-be7f4daace40">
+<diagram>
+<ref refid="fbfda48a-3231-11ef-8506-be7f4daace40"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="87f4ff18-2e33-11ef-8125-be7f4daace40"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 300.0, 158.0)</val>
+</matrix>
+<points>
+<val>[(1.7265625, 95.8046875), (1.7265625, 9.0)]</val>
+</points>
+<head-connection>
+<ref refid="0a0efca4-3232-11ef-8506-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="015ede30-3232-11ef-8506-be7f4daace40"/>
+</tail-connection>
+</GeneralizationItem>
+<Class id="15dbc42c-3232-11ef-8506-be7f4daace40">
+<generalization>
+<reflist>
+<ref refid="1f4c6656-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</generalization>
+<name>
+<val>Dependency</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="4fa678b4-3232-11ef-8506-be7f4daace40"/>
+<ref refid="8c1ac37c-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="15dc354c-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</presentation>
+</Class>
+<ClassItem id="15dc354c-3232-11ef-8506-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 251.7265625, 391.640625)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>55.0</val>
+</height>
+<diagram>
+<ref refid="fbfda48a-3231-11ef-8506-be7f4daace40"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="15dbc42c-3232-11ef-8506-be7f4daace40"/>
+</subject>
+</ClassItem>
+<GeneralizationItem id="1e24b436-3232-11ef-8506-be7f4daace40">
+<diagram>
+<ref refid="fbfda48a-3231-11ef-8506-be7f4daace40"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="1f4c6656-3232-11ef-8506-be7f4daace40"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 277.0, 295.0)</val>
+</matrix>
+<points>
+<val>[(24.7265625, 96.640625), (24.7265625, 13.8046875)]</val>
+</points>
+<head-connection>
+<ref refid="15dc354c-3232-11ef-8506-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="0a0efca4-3232-11ef-8506-be7f4daace40"/>
+</tail-connection>
+</GeneralizationItem>
+<Generalization id="1f4c6656-3232-11ef-8506-be7f4daace40">
+<general>
+<ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
+</general>
+<presentation>
+<reflist>
+<ref refid="1e24b436-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</presentation>
+<specific>
+<ref refid="15dbc42c-3232-11ef-8506-be7f4daace40"/>
+</specific>
+</Generalization>
+<AssociationItem id="4e94a5f4-3232-11ef-8506-be7f4daace40">
+<diagram>
+<ref refid="fbfda48a-3231-11ef-8506-be7f4daace40"/>
+</diagram>
+<head_subject>
+<ref refid="4fa655f0-3232-11ef-8506-be7f4daace40"/>
+</head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="4fa1439e-3232-11ef-8506-be7f4daace40"/>
+</subject>
+<tail_subject>
+<ref refid="4fa678b4-3232-11ef-8506-be7f4daace40"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 251.0, 418.0)</val>
+</matrix>
+<points>
+<val>[(0.7265625, 0.0), (-149.0, 0.0), (-149.0, -280.330078125), (-14.546875, -280.330078125)]</val>
+</points>
+<head-connection>
+<ref refid="15dc354c-3232-11ef-8506-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="015ede30-3232-11ef-8506-be7f4daace40"/>
+</tail-connection>
+</AssociationItem>
+<Association id="4fa1439e-3232-11ef-8506-be7f4daace40">
+<memberEnd>
+<reflist>
+<ref refid="4fa655f0-3232-11ef-8506-be7f4daace40"/>
+<ref refid="4fa678b4-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="4e94a5f4-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="4fa655f0-3232-11ef-8506-be7f4daace40">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<appliedStereotype>
+<reflist>
+<ref refid="72f8448c-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="4fa1439e-3232-11ef-8506-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>clientDependency</val>
+</name>
+<type>
+<ref refid="15dbc42c-3232-11ef-8506-be7f4daace40"/>
+</type>
+<upperValue>
+<val>*</val>
+</upperValue>
+<upperValue>
+<val>*</val>
+</upperValue>
+</Property>
+<Property id="4fa678b4-3232-11ef-8506-be7f4daace40">
+<appliedStereotype>
+<reflist>
+<ref refid="326b312a-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="4fa1439e-3232-11ef-8506-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="15dbc42c-3232-11ef-8506-be7f4daace40"/>
+</class_>
+<name>
+<val>client</val>
+</name>
+<type>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<InstanceSpecification id="72f8448c-3232-11ef-8506-be7f4daace40">
+<classifier>
+<reflist>
+<ref refid="d632222a-529c-11ec-b0e5-0456e5e540ed"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="4fa655f0-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="2e2ce84c-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<AssociationItem id="8b13e404-3232-11ef-8506-be7f4daace40">
+<diagram>
+<ref refid="fbfda48a-3231-11ef-8506-be7f4daace40"/>
+</diagram>
+<head_subject>
+<ref refid="8c1ac37c-3232-11ef-8506-be7f4daace40"/>
+</head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="8c1a77a0-3232-11ef-8506-be7f4daace40"/>
+</subject>
+<tail_subject>
+<ref refid="8c1af8ce-3232-11ef-8506-be7f4daace40"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 400.0, 132.0)</val>
+</matrix>
+<points>
+<val>[(-33.0, 5.669921875), (102.0, 5.669921875), (102.0, 286.0), (-48.2734375, 286.0)]</val>
+</points>
+<head-connection>
+<ref refid="015ede30-3232-11ef-8506-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="15dc354c-3232-11ef-8506-be7f4daace40"/>
+</tail-connection>
+</AssociationItem>
+<Association id="8c1a77a0-3232-11ef-8506-be7f4daace40">
+<memberEnd>
+<reflist>
+<ref refid="8c1ac37c-3232-11ef-8506-be7f4daace40"/>
+<ref refid="8c1af8ce-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="8b13e404-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="8c1ac37c-3232-11ef-8506-be7f4daace40">
+<appliedStereotype>
+<reflist>
+<ref refid="24ea13cc-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="8c1a77a0-3232-11ef-8506-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="15dbc42c-3232-11ef-8506-be7f4daace40"/>
+</class_>
+<name>
+<val>supplier</val>
+</name>
+<type>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</type>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
+<Property id="8c1af8ce-3232-11ef-8506-be7f4daace40">
+<appliedStereotype>
+<reflist>
+<ref refid="6aabd6e8-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="8c1a77a0-3232-11ef-8506-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>supplierDependency</val>
+</name>
+<type>
+<ref refid="15dbc42c-3232-11ef-8506-be7f4daace40"/>
+</type>
+<upperValue>
+<val>*</val>
+</upperValue>
+<upperValue>
+<val>*</val>
+</upperValue>
+</Property>
+<InstanceSpecification id="24ea13cc-3234-11ef-8506-be7f4daace40">
+<classifier>
+<reflist>
+<ref refid="d632222a-529c-11ec-b0e5-0456e5e540ed"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="8c1ac37c-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="60769604-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="2e2ce84c-3234-11ef-8506-be7f4daace40">
+<definingFeature>
+<ref refid="e8c61a5e-529c-11ec-b0e5-0456e5e540ed"/>
+</definingFeature>
+<owningInstance>
+<ref refid="72f8448c-3232-11ef-8506-be7f4daace40"/>
+</owningInstance>
+<value>
+<val>ownedElement, sourceRelationship</val>
+</value>
+</Slot>
+<InstanceSpecification id="326b312a-3234-11ef-8506-be7f4daace40">
+<classifier>
+<reflist>
+<ref refid="d632222a-529c-11ec-b0e5-0456e5e540ed"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="4fa678b4-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="4d3c0c86-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="4d3c0c86-3234-11ef-8506-be7f4daace40">
+<definingFeature>
+<ref refid="e8c61a5e-529c-11ec-b0e5-0456e5e540ed"/>
+</definingFeature>
+<owningInstance>
+<ref refid="326b312a-3234-11ef-8506-be7f4daace40"/>
+</owningInstance>
+<value>
+<val>owner, source</val>
+</value>
+</Slot>
+<Slot id="60769604-3234-11ef-8506-be7f4daace40">
+<definingFeature>
+<ref refid="e8c61a5e-529c-11ec-b0e5-0456e5e540ed"/>
+</definingFeature>
+<owningInstance>
+<ref refid="24ea13cc-3234-11ef-8506-be7f4daace40"/>
+</owningInstance>
+<value>
+<val>target</val>
+</value>
+</Slot>
+<InstanceSpecification id="6aabd6e8-3234-11ef-8506-be7f4daace40">
+<classifier>
+<reflist>
+<ref refid="d632222a-529c-11ec-b0e5-0456e5e540ed"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="8c1af8ce-3232-11ef-8506-be7f4daace40"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="724386bc-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="724386bc-3234-11ef-8506-be7f4daace40">
+<definingFeature>
+<ref refid="e8c61a5e-529c-11ec-b0e5-0456e5e540ed"/>
+</definingFeature>
+<owningInstance>
+<ref refid="6aabd6e8-3234-11ef-8506-be7f4daace40"/>
+</owningInstance>
+<value>
+<val>targetRelationship</val>
+</value>
+</Slot>
+<AssociationItem id="c461b946-3234-11ef-8506-be7f4daace40">
+<diagram>
+<ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
+</diagram>
+<head_subject>
+<ref refid="c65b782c-3234-11ef-8506-be7f4daace40"/>
+</head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="c65b2548-3234-11ef-8506-be7f4daace40"/>
+</subject>
+<tail_subject>
+<ref refid="c65bad56-3234-11ef-8506-be7f4daace40"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 69.93835616438355, 463.88671875)</val>
+</matrix>
+<points>
+<val>[(137.06164383561645, -75.0), (-11.93835616438355, -75.0), (-11.93835616438355, -288.88671875), (137.06164383561645, -288.88671875)]</val>
+</points>
+<head-connection>
+<ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="7845dfd4-2e32-11ef-8125-be7f4daace40"/>
+</tail-connection>
+</AssociationItem>
+<Association id="c65b2548-3234-11ef-8506-be7f4daace40">
+<memberEnd>
+<reflist>
+<ref refid="c65b782c-3234-11ef-8506-be7f4daace40"/>
+<ref refid="c65bad56-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="c461b946-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="c65b782c-3234-11ef-8506-be7f4daace40">
+<appliedStereotype>
+<reflist>
+<ref refid="e09dabba-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="c65b2548-3234-11ef-8506-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<isDerived>
+<val>1</val>
+</isDerived>
+<name>
+<val>sourceRelationship</val>
+</name>
+<type>
+<ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
+</type>
+</Property>
+<Property id="c65bad56-3234-11ef-8506-be7f4daace40">
+<appliedStereotype>
+<reflist>
+<ref refid="2b47c1b4-3235-11ef-8506-be7f4daace40"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="c65b2548-3234-11ef-8506-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
+</class_>
+<isDerived>
+<val>1</val>
+</isDerived>
+<name>
+<val>source</val>
+</name>
+<type>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</type>
+</Property>
+<InstanceSpecification id="e09dabba-3234-11ef-8506-be7f4daace40">
+<classifier>
+<reflist>
+<ref refid="d632222a-529c-11ec-b0e5-0456e5e540ed"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="c65b782c-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="e5d91998-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="e5d91998-3234-11ef-8506-be7f4daace40">
+<definingFeature>
+<ref refid="e8c61a5e-529c-11ec-b0e5-0456e5e540ed"/>
+</definingFeature>
+<owningInstance>
+<ref refid="e09dabba-3234-11ef-8506-be7f4daace40"/>
+</owningInstance>
+<value>
+<val>relationship</val>
+</value>
+</Slot>
+<AssociationItem id="ef4eb4d8-3234-11ef-8506-be7f4daace40">
+<diagram>
+<ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
+</diagram>
+<head_subject>
+<ref refid="f0d1199a-3234-11ef-8506-be7f4daace40"/>
+</head_subject>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="f0d0b0e0-3234-11ef-8506-be7f4daace40"/>
+</subject>
+<tail_subject>
+<ref refid="f0d166ca-3234-11ef-8506-be7f4daace40"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 203.0, 428.890625)</val>
+</matrix>
+<points>
+<val>[(4.0, 6.109375), (-175.0, 6.109375), (-175.0, -309.890625), (4.0, -309.890625)]</val>
+</points>
+<head-connection>
+<ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
+</head-connection>
+<tail-connection>
+<ref refid="7845dfd4-2e32-11ef-8125-be7f4daace40"/>
+</tail-connection>
+</AssociationItem>
+<Association id="f0d0b0e0-3234-11ef-8506-be7f4daace40">
+<memberEnd>
+<reflist>
+<ref refid="f0d1199a-3234-11ef-8506-be7f4daace40"/>
+<ref refid="f0d166ca-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</memberEnd>
+<package>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="ef4eb4d8-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</presentation>
+</Association>
+<Property id="f0d1199a-3234-11ef-8506-be7f4daace40">
+<appliedStereotype>
+<reflist>
+<ref refid="0090308c-3235-11ef-8506-be7f4daace40"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="f0d0b0e0-3234-11ef-8506-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<isDerived>
+<val>1</val>
+</isDerived>
+<name>
+<val>targetRelationship</val>
+</name>
+<type>
+<ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
+</type>
+</Property>
+<Property id="f0d166ca-3234-11ef-8506-be7f4daace40">
+<appliedStereotype>
+<reflist>
+<ref refid="05064796-3235-11ef-8506-be7f4daace40"/>
+</reflist>
+</appliedStereotype>
+<association>
+<ref refid="f0d0b0e0-3234-11ef-8506-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
+</class_>
+<isDerived>
+<val>1</val>
+</isDerived>
+<name>
+<val>target</val>
+</name>
+<type>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</type>
+</Property>
+<InstanceSpecification id="0090308c-3235-11ef-8506-be7f4daace40">
+<classifier>
+<reflist>
+<ref refid="d632222a-529c-11ec-b0e5-0456e5e540ed"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="f0d1199a-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="034be6b8-3235-11ef-8506-be7f4daace40"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="034be6b8-3235-11ef-8506-be7f4daace40">
+<definingFeature>
+<ref refid="e8c61a5e-529c-11ec-b0e5-0456e5e540ed"/>
+</definingFeature>
+<owningInstance>
+<ref refid="0090308c-3235-11ef-8506-be7f4daace40"/>
+</owningInstance>
+<value>
+<val>relationship</val>
+</value>
+</Slot>
+<InstanceSpecification id="05064796-3235-11ef-8506-be7f4daace40">
+<classifier>
+<reflist>
+<ref refid="d632222a-529c-11ec-b0e5-0456e5e540ed"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="f0d166ca-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="109119ec-3235-11ef-8506-be7f4daace40"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="109119ec-3235-11ef-8506-be7f4daace40">
+<definingFeature>
+<ref refid="e8c61a5e-529c-11ec-b0e5-0456e5e540ed"/>
+</definingFeature>
+<owningInstance>
+<ref refid="05064796-3235-11ef-8506-be7f4daace40"/>
+</owningInstance>
+<value>
+<val>relatedElement</val>
+</value>
+</Slot>
+<InstanceSpecification id="2b47c1b4-3235-11ef-8506-be7f4daace40">
+<classifier>
+<reflist>
+<ref refid="d632222a-529c-11ec-b0e5-0456e5e540ed"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="c65bad56-3234-11ef-8506-be7f4daace40"/>
+</reflist>
+</extended>
+<slot>
+<reflist>
+<ref refid="32df0022-3235-11ef-8506-be7f4daace40"/>
+</reflist>
+</slot>
+</InstanceSpecification>
+<Slot id="32df0022-3235-11ef-8506-be7f4daace40">
+<definingFeature>
+<ref refid="e8c61a5e-529c-11ec-b0e5-0456e5e540ed"/>
+</definingFeature>
+<owningInstance>
+<ref refid="2b47c1b4-3235-11ef-8506-be7f4daace40"/>
+</owningInstance>
+<value>
+<val>relatedElement</val>
+</value>
+</Slot>
 </gaphor>

--- a/models/Core.gaphor
+++ b/models/Core.gaphor
@@ -454,17 +454,19 @@
 <ownedAttribute>
 <reflist>
 <ref refid="8e8ab29e-eb5f-11ee-a6cb-be7f4daace3f"/>
-<ref refid="a4c6f704-ce0f-11eb-abe3-018035c40dd4"/>
+<ref refid="02a8f7fe-32f9-11ef-95f2-be7f4daace40"/>
 <ref refid="da0b2408-529e-11ec-b0e5-0456e5e540ed"/>
 <ref refid="da0b3ede-529e-11ec-b0e5-0456e5e540ed"/>
 <ref refid="69c2575a-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="1ee6aec6-b9a9-11eb-93ad-535118859f0b"/>
 <ref refid="d092794e-e0b9-11ea-b7ab-f5b4c130f24e"/>
-<ref refid="f0d1199a-3234-11ef-8506-be7f4daace40"/>
-<ref refid="c65b782c-3234-11ef-8506-be7f4daace40"/>
 <ref refid="88a30320-2e32-11ef-8125-be7f4daace40"/>
 <ref refid="4fa655f0-3232-11ef-8506-be7f4daace40"/>
 <ref refid="8c1af8ce-3232-11ef-8506-be7f4daace40"/>
+<ref refid="a4c6f704-ce0f-11eb-abe3-018035c40dd4"/>
+<ref refid="2b608842-32f9-11ef-95f2-be7f4daace40"/>
+<ref refid="c65b782c-3234-11ef-8506-be7f4daace40"/>
+<ref refid="f0d1199a-3234-11ef-8506-be7f4daace40"/>
 </reflist>
 </ownedAttribute>
 <ownedOperation>
@@ -513,8 +515,6 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="d2bfe41e-ba68-11eb-a73b-13340a6bc6e1"/>
-<ref refid="e3513a58-ba68-11eb-a73b-13340a6bc6e1"/>
 <ref refid="5b2c0930-6000-11ec-a085-0456e5e540ed"/>
 <ref refid="216581cb-4465-11eb-8946-9bdfa28f7a50"/>
 <ref refid="1ee6aec5-b9a9-11eb-93ad-535118859f0b"/>
@@ -1015,31 +1015,6 @@
 <val>*</val>
 </upperValue>
 </Property>
-<Property id="d2bfe41e-ba68-11eb-a73b-13340a6bc6e1">
-<class_>
-<ref refid="5cdae47e-7a95-11ea-a112-7f953848cf85"/>
-</class_>
-<name>
-<val>name</val>
-</name>
-<typeValue>
-<val>String</val>
-</typeValue>
-</Property>
-<Property id="e3513a58-ba68-11eb-a73b-13340a6bc6e1">
-<class_>
-<ref refid="5cdae47e-7a95-11ea-a112-7f953848cf85"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<name>
-<val>qualifiedName</val>
-</name>
-<typeValue>
-<val>String</val>
-</typeValue>
-</Property>
 <Property id="a4c6f704-ce0f-11eb-abe3-018035c40dd4">
 <class_>
 <ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
@@ -1048,7 +1023,7 @@
 <val>note</val>
 </name>
 <typeValue>
-<val>str</val>
+<val>String</val>
 </typeValue>
 </Property>
 <Generalization id="17b8b56e-4bbe-11ec-aa3d-0456e5e540ed">
@@ -2501,9 +2476,9 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="f0d166ca-3234-11ef-8506-be7f4daace40"/>
-<ref refid="c65bad56-3234-11ef-8506-be7f4daace40"/>
 <ref refid="88a32774-2e32-11ef-8125-be7f4daace40"/>
+<ref refid="c65bad56-3234-11ef-8506-be7f4daace40"/>
+<ref refid="f0d166ca-3234-11ef-8506-be7f4daace40"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -2523,16 +2498,16 @@
 </Class>
 <ClassItem id="7845dfd4-2e32-11ef-8125-be7f4daace40">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 203.20355308219172, 87.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 202.03215143175805, 80.0)</val>
 </matrix>
 <top-left>
 <val>(3.7964469178082823, 0.0)</val>
 </top-left>
 <width>
-<val>149.96917808219172</val>
+<val>160.0</val>
 </width>
 <height>
-<val>175.0</val>
+<val>205.0</val>
 </height>
 <diagram>
 <ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
@@ -2564,7 +2539,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 68.39212328767121, 252.4765625)</val>
 </matrix>
 <points>
-<val>[(138.6078767123288, 105.5234375), (28.0, 105.5234375), (28.0, -24.9765625), (138.6078767123288, -24.9765625)]</val>
+<val>[(138.6078767123288, 105.5234375), (28.0, 105.5234375), (28.0, -8.4765625), (137.43647506189512, -8.4765625)]</val>
 </points>
 <head-connection>
 <ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
@@ -2658,7 +2633,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 277.0, 154.0)</val>
 </matrix>
 <points>
-<val>[(3.813187390662222, 183.0), (2.5154109589041695, 108.5)]</val>
+<val>[(3.813187390662222, 183.0), (6.194267094285692, 131.0)]</val>
 </points>
 <head-connection>
 <ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
@@ -2704,7 +2679,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 317.3780813840785, 109.78246057912301)</val>
 </matrix>
 <points>
-<val>[(-3.3780813840784845, -22.28246057912301), (-3.3780813840784845, -65.28246057912301), (142.62191861592152, -65.28246057912301), (142.62191861592152, 32.71753942087699), (39.59109669811323, 32.71753942087699)]</val>
+<val>[(2.6073071735215194, -29.78246057912301), (2.6073071735215194, -65.28246057912301), (142.62191861592152, -65.28246057912301), (142.62191861592152, 34.646110849448434), (48.45051696548785, 34.646110849448434)]</val>
 </points>
 <head-connection>
 <ref refid="7845dfd4-2e32-11ef-8125-be7f4daace40"/>
@@ -3444,7 +3419,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 69.93835616438355, 463.88671875)</val>
 </matrix>
 <points>
-<val>[(137.06164383561645, -75.0), (-11.93835616438355, -75.0), (-11.93835616438355, -288.88671875), (137.06164383561645, -288.88671875)]</val>
+<val>[(137.06164383561645, -75.0), (-11.93835616438355, -75.0), (-11.93835616438355, -288.88671875), (135.89024218518279, -288.88671875)]</val>
 </points>
 <head-connection>
 <ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
@@ -3564,7 +3539,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 203.0, 428.890625)</val>
 </matrix>
 <points>
-<val>[(4.0, 6.109375), (-175.0, 6.109375), (-175.0, -309.890625), (4.0, -309.890625)]</val>
+<val>[(4.0, 6.109375), (-175.0, 6.109375), (-175.0, -309.890625), (2.8285983495663345, -309.890625)]</val>
 </points>
 <head-connection>
 <ref refid="7323bbfc-2e32-11ef-8125-be7f4daace40"/>
@@ -3759,4 +3734,29 @@
 <ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
 </subject>
 </ClassItem>
+<Property id="02a8f7fe-32f9-11ef-95f2-be7f4daace40">
+<class_>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<name>
+<val>name</val>
+</name>
+<typeValue>
+<val>String</val>
+</typeValue>
+</Property>
+<Property id="2b608842-32f9-11ef-95f2-be7f4daace40">
+<class_>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</class_>
+<isDerived>
+<val>1</val>
+</isDerived>
+<name>
+<val>qualifiedName</val>
+</name>
+<typeValue>
+<val>String</val>
+</typeValue>
+</Property>
 </gaphor>

--- a/models/Core.gaphor
+++ b/models/Core.gaphor
@@ -2,11 +2,10 @@
 <gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.25.1">
 <Package id="3867dda4-7a95-11ea-a112-7f953848cf85">
 <name>
-<val>Core</val>
+<val>Root</val>
 </name>
 <ownedDiagram>
 <reflist>
-<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
 <ref refid="1d89f46e-2ed1-11ef-8125-be7f4daace40"/>
 </reflist>
@@ -14,17 +13,13 @@
 <ownedType>
 <reflist>
 <ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
-<ref refid="5cdae47e-7a95-11ea-a112-7f953848cf85"/>
-<ref refid="639b48d0-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="69c25758-7a95-11ea-a112-7f953848cf85"/>
 <ref refid="5175e1cc-7cf9-11ea-b719-1f391582df99"/>
-<ref refid="15e4b0b2-9f17-11ea-b537-dfaaecc5bf61"/>
 <ref refid="d092794c-e0b9-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="1ee6aec4-b9a9-11eb-93ad-535118859f0b"/>
 <ref refid="da0afff0-529e-11ec-b0e5-0456e5e540ed"/>
 <ref refid="446a3743-4465-11eb-8946-9bdfa28f7a50"/>
 <ref refid="216581c9-4465-11eb-8946-9bdfa28f7a50"/>
-<ref refid="e873d808-3c55-11ee-99bb-48a4721e5d5c"/>
 <ref refid="7325bf10-2e32-11ef-8125-be7f4daace40"/>
 <ref refid="88a2c400-2e32-11ef-8125-be7f4daace40"/>
 </reflist>
@@ -37,7 +32,7 @@
 </Package>
 <Diagram id="3867dda5-7a95-11ea-a112-7f953848cf85">
 <element>
-<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="13c29352-2ef2-11ef-8125-be7f4daace40"/>
 </element>
 <name>
 <val>Presentations</val>
@@ -101,7 +96,7 @@
 <val>184.0</val>
 </width>
 <height>
-<val>175.0</val>
+<val>187.0</val>
 </height>
 <diagram>
 <ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
@@ -121,7 +116,7 @@
 <val>188.0</val>
 </width>
 <height>
-<val>100.0</val>
+<val>112.0</val>
 </height>
 <diagram>
 <ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
@@ -153,7 +148,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 495.59873557593505, 88.71278381347656)</val>
 </matrix>
 <points>
-<val>[(105.27116798851773, 29.25132605013954), (-359.41958062421014, 29.25132605013954), (-359.41958062421014, 353.0009150649562), (-273.91714006387684, 353.0009150649562)]</val>
+<val>[(105.27116798851773, 29.25132605013954), (-359.41958062421014, 29.25132605013954), (-359.41958062421014, 359.2871033639619), (-273.91714006387684, 359.2871033639619)]</val>
 </points>
 <head-connection>
 <ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
@@ -326,7 +321,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 451.0, 554.0)</val>
 </matrix>
 <points>
-<val>[(-41.31840448794179, -116.82084332090437), (36.234375, -116.82084332090437), (36.234375, -30.631448635760307), (113.38213086619567, -30.631448635760307)]</val>
+<val>[(-41.31840448794179, -111.07880008581913), (36.234375, -111.07880008581913), (36.234375, -27.719734025003618), (113.38213086619567, -27.719734025003618)]</val>
 </points>
 <head-connection>
 <ref refid="639b48d1-7a95-11ea-a112-7f953848cf85"/>
@@ -358,7 +353,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 414.0, 618.0)</val>
 </matrix>
 <points>
-<val>[(-61.5, -128.67120361328125), (-61.5, -75.5), (-137.5, -75.5), (-137.5, -128.67120361328125)]</val>
+<val>[(-61.5, -116.67120361328125), (-61.5, -75.5), (-137.5, -75.5), (-137.5, -116.67120361328125)]</val>
 </points>
 <head-connection>
 <ref refid="639b48d1-7a95-11ea-a112-7f953848cf85"/>
@@ -401,7 +396,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 505.0, 557.0)</val>
 </matrix>
 <points>
-<val>[(-17.765625, -115.46387283083624), (86.671875, -156.0)]</val>
+<val>[(-17.765625, -109.8649058795379), (86.671875, -156.0)]</val>
 </points>
 <head-connection>
 <ref refid="216581ca-4465-11eb-8946-9bdfa28f7a50"/>
@@ -433,7 +428,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 493.234375, 60.59765625)</val>
 </matrix>
 <points>
-<val>[(107.63552856445278, 15.518249747132558), (-379.88787133772644, 15.518249747132558), (-379.88787133772644, 553.5501877575197), (71.14775586619567, 553.5501877575197)]</val>
+<val>[(107.63552856445278, 15.518249747132558), (-379.88787133772644, 15.518249747132558), (-379.88787133772644, 562.6867681495298), (71.14775586619567, 562.6867681495298)]</val>
 </points>
 <head-connection>
 <ref refid="4cda498f-7a95-11ea-a112-7f953848cf85"/>
@@ -522,7 +517,7 @@
 </reflist>
 </ownedOperation>
 <package>
-<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="13c29352-2ef2-11ef-8125-be7f4daace40"/>
 </package>
 <presentation>
 <reflist>
@@ -558,7 +553,7 @@
 </reflist>
 </ownedOperation>
 <package>
-<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="13c29352-2ef2-11ef-8125-be7f4daace40"/>
 </package>
 <presentation>
 <reflist>
@@ -682,7 +677,7 @@
 </reflist>
 </ownedAttribute>
 <package>
-<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="13c29352-2ef2-11ef-8125-be7f4daace40"/>
 </package>
 <presentation>
 <reflist>
@@ -1091,6 +1086,8 @@
 <ref refid="a3db8672-529c-11ec-b0e5-0456e5e540ed"/>
 <ref refid="f8808b96-529c-11ec-b0e5-0456e5e540ed"/>
 <ref refid="65f4ae92-5ee4-11ed-9155-0456e5e540ed"/>
+<ref refid="38111562-2ef2-11ef-8125-be7f4daace40"/>
+<ref refid="4f1402d8-2ef2-11ef-8125-be7f4daace40"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
@@ -1118,7 +1115,7 @@
 </Profile>
 <PackageItem id="a3db8672-529c-11ec-b0e5-0456e5e540ed">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 300.0, 105.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 300.0, 350.67578125)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -1569,7 +1566,7 @@
 </Generalization>
 <Package id="65f4352a-5ee4-11ed-9155-0456e5e540ed">
 <name>
-<val>Change Sets</val>
+<val>Change Set</val>
 </name>
 <ownedDiagram>
 <reflist>
@@ -1593,7 +1590,7 @@
 </Package>
 <PackageItem id="65f4ae92-5ee4-11ed-9155-0456e5e540ed">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 91.0, 234.19139099121094)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 300.0, 218.0)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -2212,7 +2209,7 @@
 </reflist>
 </ownedAttribute>
 <package>
-<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="13c29352-2ef2-11ef-8125-be7f4daace40"/>
 </package>
 <presentation>
 <reflist>
@@ -2231,7 +2228,7 @@
 <val>107.21393166277926</val>
 </width>
 <height>
-<val>72.0</val>
+<val>74.0</val>
 </height>
 <diagram>
 <ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
@@ -2744,7 +2741,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 346.78781028296635, 214.45703125)</val>
 </matrix>
 <points>
-<val>[(-2.9158276751924177, 18.08133500184192), (161.71218971703365, 18.08133500184192), (161.71218971703365, 206.19900512695312), (-23.134631347656295, 206.19900512695312)]</val>
+<val>[(-2.9158276751924177, 18.08133500184192), (98.29845179816027, 18.08133500184192), (98.29845179816027, 206.19900512695312), (-23.134631347656295, 206.19900512695312)]</val>
 </points>
 <head-connection>
 <ref refid="2ac32ccc-2ed1-11ef-8125-be7f4daace40"/>
@@ -2802,4 +2799,77 @@
 <ref refid="2ac32ccc-2ed1-11ef-8125-be7f4daace40"/>
 </tail-connection>
 </GeneralizationItem>
+<Package id="00f713d8-2ef2-11ef-8125-be7f4daace40">
+<name>
+<val>Core</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="38111562-2ef2-11ef-8125-be7f4daace40"/>
+</reflist>
+</presentation>
+</Package>
+<Package id="13c29352-2ef2-11ef-8125-be7f4daace40">
+<name>
+<val>Presentation</val>
+</name>
+<ownedDiagram>
+<reflist>
+<ref refid="3867dda5-7a95-11ea-a112-7f953848cf85"/>
+</reflist>
+</ownedDiagram>
+<ownedType>
+<reflist>
+<ref refid="5cdae47e-7a95-11ea-a112-7f953848cf85"/>
+<ref refid="e873d808-3c55-11ee-99bb-48a4721e5d5c"/>
+<ref refid="15e4b0b2-9f17-11ea-b537-dfaaecc5bf61"/>
+<ref refid="639b48d0-7a95-11ea-a112-7f953848cf85"/>
+</reflist>
+</ownedType>
+<presentation>
+<reflist>
+<ref refid="4f1402d8-2ef2-11ef-8125-be7f4daace40"/>
+</reflist>
+</presentation>
+</Package>
+<PackageItem id="38111562-2ef2-11ef-8125-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 91.0, 218.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>138.0</val>
+</width>
+<height>
+<val>70.0</val>
+</height>
+<diagram>
+<ref refid="9a29080c-529c-11ec-b0e5-0456e5e540ed"/>
+</diagram>
+<subject>
+<ref refid="00f713d8-2ef2-11ef-8125-be7f4daace40"/>
+</subject>
+</PackageItem>
+<PackageItem id="4f1402d8-2ef2-11ef-8125-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 91.0, 350.67578125)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>138.0</val>
+</width>
+<height>
+<val>70.0</val>
+</height>
+<diagram>
+<ref refid="9a29080c-529c-11ec-b0e5-0456e5e540ed"/>
+</diagram>
+<subject>
+<ref refid="13c29352-2ef2-11ef-8125-be7f4daace40"/>
+</subject>
+</PackageItem>
 </gaphor>

--- a/models/Core.gaphor
+++ b/models/Core.gaphor
@@ -9,6 +9,7 @@
 <ref refid="67914ef8-2e32-11ef-8125-be7f4daace40"/>
 <ref refid="1d89f46e-2ed1-11ef-8125-be7f4daace40"/>
 <ref refid="fbfda48a-3231-11ef-8506-be7f4daace40"/>
+<ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
 </reflist>
 </ownedDiagram>
 <ownedType>
@@ -486,6 +487,7 @@
 <ref refid="7845dfd4-2e32-11ef-8125-be7f4daace40"/>
 <ref refid="2ac32ccc-2ed1-11ef-8125-be7f4daace40"/>
 <ref refid="015ede30-3232-11ef-8506-be7f4daace40"/>
+<ref refid="76564f8a-32c7-11ef-bb85-be7f4daace40"/>
 </reflist>
 </presentation>
 <specialization>
@@ -3715,4 +3717,46 @@
 <val>relatedElement</val>
 </value>
 </Slot>
+<Diagram id="6f96d08e-32c7-11ef-bb85-be7f4daace40">
+<diagramType>
+<val></val>
+</diagramType>
+<element>
+<ref refid="3867dda4-7a95-11ea-a112-7f953848cf85"/>
+</element>
+<name>
+<val>Namespaces</val>
+</name>
+<ownedPresentation>
+<reflist>
+<ref refid="76564f8a-32c7-11ef-bb85-be7f4daace40"/>
+</reflist>
+</ownedPresentation>
+</Diagram>
+<ClassItem id="76564f8a-32c7-11ef-bb85-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 213.4609375, 96.83984375)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>113.5390625</val>
+</width>
+<height>
+<val>57.16015625</val>
+</height>
+<diagram>
+<ref refid="6f96d08e-32c7-11ef-bb85-be7f4daace40"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="4cda498e-7a95-11ea-a112-7f953848cf85"/>
+</subject>
+</ClassItem>
 </gaphor>

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -21,19 +21,6 @@
 </reflist>
 </presentation>
 </Association>
-<Generalization id="DCE:84C5B02A-464D-11D7-AA08-1B85D5275D8A">
-<general>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</general>
-<presentation>
-<reflist>
-<ref refid="DCE:8360FB04-464D-11D7-AA08-1B85D5275D8A"/>
-</reflist>
-</presentation>
-<specific>
-<ref refid="DCE:7D753EF0-464D-11D7-AA08-1B85D5275D8A"/>
-</specific>
-</Generalization>
 <Property id="DCE:4A11636C-83E1-11D7-ADE2-4B1972AF3391">
 <association>
 <ref refid="DCE:4A112B20-83E1-11D7-ADE2-4B1972AF3391"/>
@@ -1062,8 +1049,6 @@
 <ref refid="DCE:07DBA3DA-4A8A-11D7-B090-133D836EF880"/>
 <ref refid="DCE:52EE3722-863A-11D7-8239-5A25B8C2F569"/>
 <ref refid="DCE:C021A320-4695-11D7-B567-379CA7034986"/>
-<ref refid="DCE:D339DC26-4694-11D7-B567-379CA7034986"/>
-<ref refid="DCE:B7B77E54-4694-11D7-B567-379CA7034986"/>
 <ref refid="DCE:7D11DA3A-4697-11D7-B567-379CA7034986"/>
 <ref refid="DCE:881E7D46-65CF-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:677088BA-65CE-11D7-89A9-9C62884CFFDE"/>
@@ -4797,22 +4782,6 @@
 <val>1</val>
 </upperValue>
 </Property>
-<Association id="DCE:D339DC26-4694-11D7-B567-379CA7034986">
-<memberEnd>
-<reflist>
-<ref refid="DCE:D33A9738-4694-11D7-B567-379CA7034986"/>
-<ref refid="DCE:D33A1420-4694-11D7-B567-379CA7034986"/>
-</reflist>
-</memberEnd>
-<package>
-<ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="DCE:D1B0707C-4694-11D7-B567-379CA7034986"/>
-</reflist>
-</presentation>
-</Association>
 <Class id="DCE:A3E40740-65CE-11D7-89A9-9C62884CFFDE">
 <generalization>
 <reflist>
@@ -6043,9 +6012,7 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="DCE:D33A9738-4694-11D7-B567-379CA7034986"/>
 <ref refid="aa8a8fb0-e185-11ea-b7ab-f5b4c130f24e"/>
-<ref refid="DCE:B7B7E77C-4694-11D7-B567-379CA7034986"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -6072,7 +6039,6 @@
 </presentation>
 <specialization>
 <reflist>
-<ref refid="DCE:84C5B02A-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:266F4F50-8406-11D8-82A2-7B88E55A3BEC"/>
 <ref refid="DCE:E216A6F4-4B33-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:79EAD5A4-464D-11D7-AA08-1B85D5275D8A"/>
@@ -6389,37 +6355,6 @@
 </reflist>
 </presentation>
 </Association>
-<Property id="DCE:D33A1420-4694-11D7-B567-379CA7034986">
-<aggregation>
-<val>composite</val>
-</aggregation>
-<appliedStereotype>
-<reflist>
-<ref refid="171d444e-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:D339DC26-4694-11D7-B567-379CA7034986"/>
-</association>
-<class_>
-<ref refid="DCE:7D753EF0-464D-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<name>
-<val>ownedMember</val>
-</name>
-<type>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</type>
-<upperValue>
-<val>*</val>
-</upperValue>
-<upperValue>
-<val>*</val>
-</upperValue>
-</Property>
 <Class id="DCE:AFE3193E-8323-11D8-8D1E-00C00C03A405">
 <generalization>
 <reflist>
@@ -10254,34 +10189,6 @@
 <ref refid="DCE:3B6508EE-A35C-11D8-9D85-00C00C03A405"/>
 </type>
 </Property>
-<Property id="DCE:B7B7B610-4694-11D7-B567-379CA7034986">
-<appliedStereotype>
-<reflist>
-<ref refid="172b2122-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:B7B77E54-4694-11D7-B567-379CA7034986"/>
-</association>
-<class_>
-<ref refid="DCE:7D753EF0-464D-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<name>
-<val>member</val>
-</name>
-<type>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</type>
-<upperValue>
-<val>*</val>
-</upperValue>
-<upperValue>
-<val>*</val>
-</upperValue>
-</Property>
 <Class id="DCE:DECC6864-4A87-11D7-B08A-133D836EF880">
 <generalization>
 <reflist>
@@ -11081,19 +10988,6 @@
 <ref refid="DCE:5C468152-4A89-11D7-B08F-133D836EF880"/>
 </tail-connection>
 </AssociationItem>
-<Property id="DCE:4DEEA4E4-464D-11D7-AA08-1B85D5275D8A">
-<appliedStereotype>
-<reflist>
-<ref refid="17304ba2-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<class_>
-<ref refid="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<name>
-<val>public</val>
-</name>
-</Property>
 <Property id="DCE:04842A92-4696-11D7-B567-379CA7034986">
 <appliedStereotype>
 <reflist>
@@ -11853,19 +11747,6 @@
 <ref refid="DCE:3DB14614-97BA-11D8-9E36-00C00C03A405"/>
 </type>
 </Property>
-<Property id="DCE:4EEC02D8-464D-11D7-AA08-1B85D5275D8A">
-<appliedStereotype>
-<reflist>
-<ref refid="1739ca42-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<class_>
-<ref refid="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<name>
-<val>private</val>
-</name>
-</Property>
 <Generalization id="DCE:B6C5CFA4-509D-11D7-811E-AF5893A6470D">
 <general>
 <ref refid="DCE:BDC038A2-4A88-11D7-B08D-133D836EF880"/>
@@ -12038,29 +11919,6 @@
 </reflist>
 </presentation>
 </Class>
-<Property id="DCE:B7B7E77C-4694-11D7-B567-379CA7034986">
-<association>
-<ref refid="DCE:B7B77E54-4694-11D7-B567-379CA7034986"/>
-</association>
-<class_>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<name>
-<val>memberNamespace</val>
-</name>
-<type>
-<ref refid="DCE:7D753EF0-464D-11D7-AA08-1B85D5275D8A"/>
-</type>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-</Property>
 <Association id="DCE:B0D2CA8A-4B35-11D7-B391-02BBFE4396CE">
 <memberEnd>
 <reflist>
@@ -14166,22 +14024,6 @@
 <val>1</val>
 </upperValue>
 </Property>
-<Association id="DCE:B7B77E54-4694-11D7-B567-379CA7034986">
-<memberEnd>
-<reflist>
-<ref refid="DCE:B7B7B610-4694-11D7-B567-379CA7034986"/>
-<ref refid="DCE:B7B7E77C-4694-11D7-B567-379CA7034986"/>
-</reflist>
-</memberEnd>
-<package>
-<ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="DCE:B613E0FE-4694-11D7-B567-379CA7034986"/>
-</reflist>
-</presentation>
-</Association>
 <Generalization id="DCE:9C3F5B7E-8321-11D8-BEC8-00C00C03A405">
 <general>
 <ref refid="DCE:4B2A095E-8320-11D8-BEC8-00C00C03A405"/>
@@ -19865,11 +19707,6 @@
 </specialization>
 </Class>
 <Class id="DCE:7D753EF0-464D-11D7-AA08-1B85D5275D8A">
-<generalization>
-<reflist>
-<ref refid="DCE:84C5B02A-464D-11D7-AA08-1B85D5275D8A"/>
-</reflist>
-</generalization>
 <isAbstract>
 <val>1</val>
 </isAbstract>
@@ -19879,9 +19716,7 @@
 <ownedAttribute>
 <reflist>
 <ref refid="DCE:8F7D73F4-464D-11D7-AA08-1B85D5275D8A"/>
-<ref refid="DCE:D33A1420-4694-11D7-B567-379CA7034986"/>
 <ref refid="DCE:18E7ADF0-4697-11D7-B567-379CA7034986"/>
-<ref refid="DCE:B7B7B610-4694-11D7-B567-379CA7034986"/>
 <ref refid="DCE:7D124DD0-4697-11D7-B567-379CA7034986"/>
 <ref refid="5d8d968e-e96c-11ea-96dc-bf74f1f80424"/>
 </reflist>
@@ -21773,7 +21608,6 @@ specially for Gaphor</val>
 <reflist>
 <ref refid="DCE:F661C206-464C-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:FF58ABDE-464C-11D7-AA08-1B85D5275D8A"/>
-<ref refid="DCE:483FA366-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:6D97E670-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:7D74A628-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:5CA6131C-4695-11D7-B567-379CA7034986"/>
@@ -21781,12 +21615,10 @@ specially for Gaphor</val>
 <ref refid="DCE:A70E26A6-4695-11D7-B567-379CA7034986"/>
 <ref refid="DCE:B4456442-4695-11D7-B567-379CA7034986"/>
 <ref refid="7bc86a7e-e187-11ea-b7ab-f5b4c130f24e"/>
+<ref refid="DCE:483FA366-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:0CD87EBC-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:793D3FDC-464D-11D7-AA08-1B85D5275D8A"/>
-<ref refid="DCE:8360FB04-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:8E26F430-464D-11D7-AA08-1B85D5275D8A"/>
-<ref refid="DCE:B613E0FE-4694-11D7-B567-379CA7034986"/>
-<ref refid="DCE:D1B0707C-4694-11D7-B567-379CA7034986"/>
 <ref refid="DCE:714C4A70-4695-11D7-B567-379CA7034986"/>
 <ref refid="DCE:78848136-4695-11D7-B567-379CA7034986"/>
 <ref refid="DCE:AE844B5E-4695-11D7-B567-379CA7034986"/>
@@ -21878,32 +21710,6 @@ specially for Gaphor</val>
 <ref refid="DCE:F661C206-464C-11D7-AA08-1B85D5275D8A"/>
 </tail-connection>
 </GeneralizationItem>
-<ClassItem id="DCE:483FA366-464D-11D7-AA08-1B85D5275D8A">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 832.4999999999999, 78.66666666666666)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>117.33333333333348</val>
-</width>
-<height>
-<val>132.0</val>
-</height>
-<diagram>
-<ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
-</diagram>
-<show_operations>
-<val>0</val>
-</show_operations>
-<show_stereotypes>
-<val>0</val>
-</show_stereotypes>
-<subject>
-<ref refid="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A"/>
-</subject>
-</ClassItem>
 <ClassItem id="DCE:6D97E670-464D-11D7-AA08-1B85D5275D8A">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 922.8333333333334, 403.2951070335969)</val>
@@ -21982,32 +21788,6 @@ specially for Gaphor</val>
 <ref refid="DCE:7D753EF0-464D-11D7-AA08-1B85D5275D8A"/>
 </subject>
 </ClassItem>
-<GeneralizationItem id="DCE:8360FB04-464D-11D7-AA08-1B85D5275D8A">
-<diagram>
-<ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
-</diagram>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:84C5B02A-464D-11D7-AA08-1B85D5275D8A"/>
-</subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 430.5, 317.66666666666663)</val>
-</matrix>
-<points>
-<val>[(-6.618996138996408, 90.16666666666669), (-6.618996138996408, 0.0)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:7D74A628-464D-11D7-AA08-1B85D5275D8A"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:FF58ABDE-464C-11D7-AA08-1B85D5275D8A"/>
-</tail-connection>
-</GeneralizationItem>
 <AssociationItem id="DCE:8E26F430-464D-11D7-AA08-1B85D5275D8A">
 <diagram>
 <ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
@@ -22035,70 +21815,6 @@ specially for Gaphor</val>
 </points>
 <head-connection>
 <ref refid="DCE:6D97E670-464D-11D7-AA08-1B85D5275D8A"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:7D74A628-464D-11D7-AA08-1B85D5275D8A"/>
-</tail-connection>
-</AssociationItem>
-<AssociationItem id="DCE:B613E0FE-4694-11D7-B567-379CA7034986">
-<diagram>
-<ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
-</diagram>
-<head_subject>
-<ref refid="DCE:B7B7B610-4694-11D7-B567-379CA7034986"/>
-</head_subject>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:B7B77E54-4694-11D7-B567-379CA7034986"/>
-</subject>
-<tail_subject>
-<ref refid="DCE:B7B7E77C-4694-11D7-B567-379CA7034986"/>
-</tail_subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 340.66666666666663, 281.5185185185186)</val>
-</matrix>
-<points>
-<val>[(-22.500000000000057, 0.0), (-144.66666666666663, 0.0), (-144.66666666666663, 206.0), (-10.666666666666629, 206.0)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:FF58ABDE-464C-11D7-AA08-1B85D5275D8A"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:7D74A628-464D-11D7-AA08-1B85D5275D8A"/>
-</tail-connection>
-</AssociationItem>
-<AssociationItem id="DCE:D1B0707C-4694-11D7-B567-379CA7034986">
-<diagram>
-<ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
-</diagram>
-<head_subject>
-<ref refid="DCE:D33A1420-4694-11D7-B567-379CA7034986"/>
-</head_subject>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:D339DC26-4694-11D7-B567-379CA7034986"/>
-</subject>
-<tail_subject>
-<ref refid="DCE:D33A9738-4694-11D7-B567-379CA7034986"/>
-</tail_subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 340.66666666666663, 218.5185185185186)</val>
-</matrix>
-<points>
-<val>[(-22.500000000000057, 0.0), (-269.16666666666663, 0.0), (-269.16666666666663, 350.0), (-10.666666666666629, 350.0)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:FF58ABDE-464C-11D7-AA08-1B85D5275D8A"/>
 </head-connection>
 <tail-connection>
 <ref refid="DCE:7D74A628-464D-11D7-AA08-1B85D5275D8A"/>
@@ -22455,27 +22171,6 @@ specially for Gaphor</val>
 <ref refid="7bc86a7e-e187-11ea-b7ab-f5b4c130f24e"/>
 </tail-connection>
 </AssociationItem>
-<Class id="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A">
-<name>
-<val>VisibilityKind</val>
-</name>
-<ownedAttribute>
-<reflist>
-<ref refid="DCE:4DEEA4E4-464D-11D7-AA08-1B85D5275D8A"/>
-<ref refid="DCE:4EEC02D8-464D-11D7-AA08-1B85D5275D8A"/>
-<ref refid="DCE:51B324EC-464D-11D7-AA08-1B85D5275D8A"/>
-<ref refid="DCE:4FE6661A-464D-11D7-AA08-1B85D5275D8A"/>
-</reflist>
-</ownedAttribute>
-<package>
-<ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="DCE:483FA366-464D-11D7-AA08-1B85D5275D8A"/>
-</reflist>
-</presentation>
-</Class>
 <Association id="DCE:068A66A0-6692-11D7-A84E-6C8643AD0CA4">
 <memberEnd>
 <reflist>
@@ -22558,19 +22253,6 @@ specially for Gaphor</val>
 <ref refid="DCE:5C465FB0-4A89-11D7-B090-133D836EF880"/>
 </specific>
 </Generalization>
-<Property id="DCE:51B324EC-464D-11D7-AA08-1B85D5275D8A">
-<appliedStereotype>
-<reflist>
-<ref refid="175b1f08-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<class_>
-<ref refid="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<name>
-<val>package</val>
-</name>
-</Property>
 <Class id="DCE:DD16C7BA-A41C-11D8-B0B1-00061BC22919">
 <generalization>
 <reflist>
@@ -22989,19 +22671,6 @@ specially for Gaphor</val>
 </reflist>
 </presentation>
 </Class>
-<Property id="DCE:4FE6661A-464D-11D7-AA08-1B85D5275D8A">
-<appliedStereotype>
-<reflist>
-<ref refid="175ed60c-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<class_>
-<ref refid="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<name>
-<val>protected</val>
-</name>
-</Property>
 <Property id="DCE:8A3D5476-4B53-11D7-A5E6-6257AF3C5118">
 <appliedStereotype>
 <reflist>
@@ -24330,40 +23999,6 @@ specially for Gaphor</val>
 <typeValue>
 <val>Boolean</val>
 </typeValue>
-</Property>
-<Property id="DCE:D33A9738-4694-11D7-B567-379CA7034986">
-<appliedStereotype>
-<reflist>
-<ref refid="1760a1b2-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:D339DC26-4694-11D7-B567-379CA7034986"/>
-</association>
-<class_>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<name>
-<val>namespace</val>
-</name>
-<type>
-<ref refid="DCE:7D753EF0-464D-11D7-AA08-1B85D5275D8A"/>
-</type>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
-</upperValue>
 </Property>
 <Class id="DCE:6B38D020-83D9-11D7-ADE2-4B1972AF3391">
 <generalization>
@@ -36595,7 +36230,6 @@ swimlanes</val>
 <ref refid="171b12aa-fa90-11de-bd51-00224128e79d"/>
 <ref refid="171b4d60-fa90-11de-bd51-00224128e79d"/>
 <ref refid="171b887a-fa90-11de-bd51-00224128e79d"/>
-<ref refid="171d444e-fa90-11de-bd51-00224128e79d"/>
 <ref refid="171de502-fa90-11de-bd51-00224128e79d"/>
 <ref refid="171e8570-fa90-11de-bd51-00224128e79d"/>
 <ref refid="171f6b48-fa90-11de-bd51-00224128e79d"/>
@@ -36619,7 +36253,6 @@ swimlanes</val>
 <ref refid="172a6dcc-fa90-11de-bd51-00224128e79d"/>
 <ref refid="172aa972-fa90-11de-bd51-00224128e79d"/>
 <ref refid="172ae50e-fa90-11de-bd51-00224128e79d"/>
-<ref refid="172b2122-fa90-11de-bd51-00224128e79d"/>
 <ref refid="172b5f8e-fa90-11de-bd51-00224128e79d"/>
 <ref refid="172bffc0-fa90-11de-bd51-00224128e79d"/>
 <ref refid="172c3bac-fa90-11de-bd51-00224128e79d"/>
@@ -36728,7 +36361,6 @@ swimlanes</val>
 <ref refid="175f1342-fa90-11de-bd51-00224128e79d"/>
 <ref refid="175fc026-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17606742-fa90-11de-bd51-00224128e79d"/>
-<ref refid="1760a1b2-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17622636-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17626056-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17630d8a-fa90-11de-bd51-00224128e79d"/>
@@ -37050,7 +36682,6 @@ swimlanes</val>
 <ref refid="1719e498-fa90-11de-bd51-00224128e79d"/>
 <ref refid="171a8164-fa90-11de-bd51-00224128e79d"/>
 <ref refid="171c2a78-fa90-11de-bd51-00224128e79d"/>
-<ref refid="171d8a80-fa90-11de-bd51-00224128e79d"/>
 <ref refid="171e2d78-fa90-11de-bd51-00224128e79d"/>
 <ref refid="171fb058-fa90-11de-bd51-00224128e79d"/>
 <ref refid="172051ca-fa90-11de-bd51-00224128e79d"/>
@@ -37110,7 +36741,6 @@ swimlanes</val>
 <ref refid="175d1a42-fa90-11de-bd51-00224128e79d"/>
 <ref refid="175db9d4-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1760098c-fa90-11de-bd51-00224128e79d"/>
-<ref refid="1760e55a-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1762acfa-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1763574a-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1763f876-fa90-11de-bd51-00224128e79d"/>
@@ -38659,34 +38289,6 @@ swimlanes</val>
 <val>parameter, ownedMember</val>
 </value>
 </Slot>
-<InstanceSpecification id="171d444e-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:D33A1420-4694-11D7-B567-379CA7034986"/>
-</reflist>
-</extended>
-<slot>
-<reflist>
-<ref refid="171d8a80-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</slot>
-</InstanceSpecification>
-<Slot id="171d8a80-fa90-11de-bd51-00224128e79d">
-<definingFeature>
-<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
-</definingFeature>
-<owningInstance>
-<ref refid="171d444e-fa90-11de-bd51-00224128e79d"/>
-</owningInstance>
-<value>
-<val>member, ownedElement</val>
-</value>
-</Slot>
 <InstanceSpecification id="171de502-fa90-11de-bd51-00224128e79d">
 <classifier>
 <reflist>
@@ -39170,18 +38772,6 @@ swimlanes</val>
 </reflist>
 </slot>
 </InstanceSpecification>
-<InstanceSpecification id="172b2122-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:B7B7B610-4694-11D7-B567-379CA7034986"/>
-</reflist>
-</extended>
-</InstanceSpecification>
 <InstanceSpecification id="172b5f8e-fa90-11de-bd51-00224128e79d">
 <classifier>
 <reflist>
@@ -39379,18 +38969,6 @@ swimlanes</val>
 <extended>
 <reflist>
 <ref refid="DCE:00501E12-4B38-11D7-B391-02BBFE4396CE"/>
-</reflist>
-</extended>
-</InstanceSpecification>
-<InstanceSpecification id="17304ba2-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:4DEEA4E4-464D-11D7-AA08-1B85D5275D8A"/>
 </reflist>
 </extended>
 </InstanceSpecification>
@@ -39786,18 +39364,6 @@ swimlanes</val>
 <ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
 </reflist>
 </classifier>
-</InstanceSpecification>
-<InstanceSpecification id="1739ca42-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:4EEC02D8-464D-11D7-AA08-1B85D5275D8A"/>
-</reflist>
-</extended>
 </InstanceSpecification>
 <InstanceSpecification id="173a05d4-fa90-11de-bd51-00224128e79d">
 <classifier>
@@ -41095,18 +40661,6 @@ swimlanes</val>
 </reflist>
 </extended>
 </InstanceSpecification>
-<InstanceSpecification id="175b1f08-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:51B324EC-464D-11D7-AA08-1B85D5275D8A"/>
-</reflist>
-</extended>
-</InstanceSpecification>
 <InstanceSpecification id="175b5be4-fa90-11de-bd51-00224128e79d">
 <classifier>
 <reflist>
@@ -41262,18 +40816,6 @@ swimlanes</val>
 </reflist>
 </extended>
 </InstanceSpecification>
-<InstanceSpecification id="175ed60c-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:4FE6661A-464D-11D7-AA08-1B85D5275D8A"/>
-</reflist>
-</extended>
-</InstanceSpecification>
 <InstanceSpecification id="175f1342-fa90-11de-bd51-00224128e79d">
 <classifier>
 <reflist>
@@ -41342,34 +40884,6 @@ swimlanes</val>
 </reflist>
 </extended>
 </InstanceSpecification>
-<InstanceSpecification id="1760a1b2-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:D33A9738-4694-11D7-B567-379CA7034986"/>
-</reflist>
-</extended>
-<slot>
-<reflist>
-<ref refid="1760e55a-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</slot>
-</InstanceSpecification>
-<Slot id="1760e55a-fa90-11de-bd51-00224128e79d">
-<definingFeature>
-<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
-</definingFeature>
-<owningInstance>
-<ref refid="1760a1b2-fa90-11de-bd51-00224128e79d"/>
-</owningInstance>
-<value>
-<val>owner, memberNamespace</val>
-</value>
-</Slot>
 <InstanceSpecification id="17622636-fa90-11de-bd51-00224128e79d">
 <classifier>
 <reflist>
@@ -56797,4 +56311,151 @@ have an opposite end.
 <val>1</val>
 </upperValue>
 </Property>
+<ClassItem id="DCE:483FA366-464D-11D7-AA08-1B85D5275D8A">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 832.4999999999999, 78.66666666666666)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>117.33333333333348</val>
+</width>
+<height>
+<val>132.0</val>
+</height>
+<diagram>
+<ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<show_stereotypes>
+<val>0</val>
+</show_stereotypes>
+<subject>
+<ref refid="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A"/>
+</subject>
+</ClassItem>
+<Class id="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A">
+<name>
+<val>VisibilityKind</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="DCE:4DEEA4E4-464D-11D7-AA08-1B85D5275D8A"/>
+<ref refid="DCE:4EEC02D8-464D-11D7-AA08-1B85D5275D8A"/>
+<ref refid="DCE:51B324EC-464D-11D7-AA08-1B85D5275D8A"/>
+<ref refid="DCE:4FE6661A-464D-11D7-AA08-1B85D5275D8A"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="DCE:483FA366-464D-11D7-AA08-1B85D5275D8A"/>
+</reflist>
+</presentation>
+</Class>
+<Property id="DCE:4FE6661A-464D-11D7-AA08-1B85D5275D8A">
+<appliedStereotype>
+<reflist>
+<ref refid="175ed60c-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</appliedStereotype>
+<class_>
+<ref refid="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A"/>
+</class_>
+<name>
+<val>protected</val>
+</name>
+</Property>
+<InstanceSpecification id="175ed60c-fa90-11de-bd51-00224128e79d">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="DCE:4FE6661A-464D-11D7-AA08-1B85D5275D8A"/>
+</reflist>
+</extended>
+</InstanceSpecification>
+<Property id="DCE:51B324EC-464D-11D7-AA08-1B85D5275D8A">
+<appliedStereotype>
+<reflist>
+<ref refid="175b1f08-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</appliedStereotype>
+<class_>
+<ref refid="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A"/>
+</class_>
+<name>
+<val>package</val>
+</name>
+</Property>
+<InstanceSpecification id="175b1f08-fa90-11de-bd51-00224128e79d">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="DCE:51B324EC-464D-11D7-AA08-1B85D5275D8A"/>
+</reflist>
+</extended>
+</InstanceSpecification>
+<Property id="DCE:4EEC02D8-464D-11D7-AA08-1B85D5275D8A">
+<appliedStereotype>
+<reflist>
+<ref refid="1739ca42-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</appliedStereotype>
+<class_>
+<ref refid="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A"/>
+</class_>
+<name>
+<val>private</val>
+</name>
+</Property>
+<InstanceSpecification id="1739ca42-fa90-11de-bd51-00224128e79d">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="DCE:4EEC02D8-464D-11D7-AA08-1B85D5275D8A"/>
+</reflist>
+</extended>
+</InstanceSpecification>
+<Property id="DCE:4DEEA4E4-464D-11D7-AA08-1B85D5275D8A">
+<appliedStereotype>
+<reflist>
+<ref refid="17304ba2-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</appliedStereotype>
+<class_>
+<ref refid="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A"/>
+</class_>
+<name>
+<val>public</val>
+</name>
+</Property>
+<InstanceSpecification id="17304ba2-fa90-11de-bd51-00224128e79d">
+<classifier>
+<reflist>
+<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
+</reflist>
+</classifier>
+<extended>
+<reflist>
+<ref refid="DCE:4DEEA4E4-464D-11D7-AA08-1B85D5275D8A"/>
+</reflist>
+</extended>
+</InstanceSpecification>
 </gaphor>

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -3376,19 +3376,6 @@
 </reflist>
 </presentation>
 </Class>
-<Generalization id="DCE:0E5B8FFE-464D-11D7-AA08-1B85D5275D8A">
-<general>
-<ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
-</general>
-<presentation>
-<reflist>
-<ref refid="DCE:0CD87EBC-464D-11D7-AA08-1B85D5275D8A"/>
-</reflist>
-</presentation>
-<specific>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</specific>
-</Generalization>
 <Association id="DCE:72656E80-83D9-11D7-ADE2-4B1972AF3391">
 <memberEnd>
 <reflist>
@@ -5999,22 +5986,12 @@
 </upperValue>
 </Property>
 <Class id="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A">
-<generalization>
-<reflist>
-<ref refid="DCE:0E5B8FFE-464D-11D7-AA08-1B85D5275D8A"/>
-</reflist>
-</generalization>
 <isAbstract>
 <val>1</val>
 </isAbstract>
 <name>
 <val>NamedElement</val>
 </name>
-<ownedAttribute>
-<reflist>
-<ref refid="aa8a8fb0-e185-11ea-b7ab-f5b4c130f24e"/>
-</reflist>
-</ownedAttribute>
 <package>
 <ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
 </package>
@@ -6874,7 +6851,6 @@
 <ref refid="DCE:FC12D436-45CE-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:DB9158E8-4B32-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:F337B7AA-4A89-11D7-B090-133D836EF880"/>
-<ref refid="DCE:F661C206-464C-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:C6A7D496-AAE5-11DA-B34F-000D936B094A"/>
 <ref refid="fa6dda7a-e967-11ea-96dc-bf74f1f80424"/>
 <ref refid="92ab6c36-ea01-11ea-96dc-bf74f1f80424"/>
@@ -6882,7 +6858,6 @@
 </presentation>
 <specialization>
 <reflist>
-<ref refid="DCE:0E5B8FFE-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:E7330EBA-4B32-11D7-B391-02BBFE4396CE"/>
 <ref refid="d3ad48ee-b5bf-11e9-ac46-784f435640ba"/>
 <ref refid="01a5b826-e968-11ea-96dc-bf74f1f80424"/>
@@ -16175,10 +16150,8 @@
 <ref refid="DCE:38CAFEF6-45CF-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:3F0AFFA8-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="a06fc75a-7cf9-11ea-b719-1f391582df99"/>
-<ref refid="e993ec75-ec89-11ea-96dc-bf74f1f80424"/>
 <ref refid="0a356994-52b9-11ec-b0e5-0456e5e540ed"/>
 <ref refid="DCE:4D4F8048-45D1-11D7-B5CA-613352B2821F"/>
-<ref refid="18a9b72f-ec8a-11ea-96dc-bf74f1f80424"/>
 <ref refid="cc955e1a-52bc-11ec-b0e5-0456e5e540ed"/>
 <ref refid="d4d1c5ec-2e32-11ef-8125-be7f4daace40"/>
 </reflist>
@@ -16314,49 +16287,6 @@
 <ref refid="a06fc759-7cf9-11ea-b719-1f391582df99"/>
 </subject>
 </CommentItem>
-<CommentItem id="e993ec75-ec89-11ea-96dc-bf74f1f80424">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 153.96917808219172, 668.5)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>204.5</val>
-</width>
-<height>
-<val>136.0</val>
-</height>
-<diagram>
-<ref refid="DCE:E71AAA3E-45CE-11D7-B5CA-613352B2821F"/>
-</diagram>
-<subject>
-<ref refid="e993ec74-ec89-11ea-96dc-bf74f1f80424"/>
-</subject>
-</CommentItem>
-<CommentLineItem id="18a9b72f-ec8a-11ea-96dc-bf74f1f80424">
-<diagram>
-<ref refid="DCE:E71AAA3E-45CE-11D7-B5CA-613352B2821F"/>
-</diagram>
-<horizontal>
-<val>0</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 187.5, 597.3046874999998)</val>
-</matrix>
-<points>
-<val>[(83.5, 4.195312500000227), (59.73016709318074, 71.19531250000023)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:3F0AFFA8-45D1-11D7-B5CA-613352B2821F"/>
-</head-connection>
-<tail-connection>
-<ref refid="e993ec75-ec89-11ea-96dc-bf74f1f80424"/>
-</tail-connection>
-</CommentLineItem>
 <Generalization id="DCE:DC267B64-A41C-11D8-B0B1-00061BC22919">
 <general>
 <ref refid="DCE:CE617CC2-A41C-11D8-B0B1-00061BC22919"/>
@@ -17066,11 +16996,6 @@
 </typeValue>
 </Property>
 <Class id="DCE:3F0B9972-45D1-11D7-B5CA-613352B2821F">
-<comment>
-<reflist>
-<ref refid="e993ec74-ec89-11ea-96dc-bf74f1f80424"/>
-</reflist>
-</comment>
 <generalization>
 <reflist>
 <ref refid="DCE:4E6DB742-45D1-11D7-B5CA-613352B2821F"/>
@@ -21606,7 +21531,6 @@ specially for Gaphor</val>
 </name>
 <ownedPresentation>
 <reflist>
-<ref refid="DCE:F661C206-464C-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:FF58ABDE-464C-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:6D97E670-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:7D74A628-464D-11D7-AA08-1B85D5275D8A"/>
@@ -21616,7 +21540,6 @@ specially for Gaphor</val>
 <ref refid="DCE:B4456442-4695-11D7-B567-379CA7034986"/>
 <ref refid="7bc86a7e-e187-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="DCE:483FA366-464D-11D7-AA08-1B85D5275D8A"/>
-<ref refid="DCE:0CD87EBC-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:793D3FDC-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:8E26F430-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:714C4A70-4695-11D7-B567-379CA7034986"/>
@@ -21629,18 +21552,18 @@ specially for Gaphor</val>
 </reflist>
 </ownedPresentation>
 </Diagram>
-<ClassItem id="DCE:F661C206-464C-11D7-AA08-1B85D5275D8A">
+<ClassItem id="DCE:FF58ABDE-464C-11D7-AA08-1B85D5275D8A">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 362.8810038610036, 78.66666666666666)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 719.1224882629167, 210.66666666666663)</val>
 </matrix>
 <top-left>
-<val>(0.0, 0.0)</val>
+<val>(60.08835680749962, 61.57952898910983)</val>
 </top-left>
 <width>
-<val>122.0</val>
+<val>160.24497652583375</val>
 </width>
 <height>
-<val>64.0</val>
+<val>55.42047101089017</val>
 </height>
 <diagram>
 <ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
@@ -21655,61 +21578,9 @@ specially for Gaphor</val>
 <val>0</val>
 </show_stereotypes>
 <subject>
-<ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
-</subject>
-</ClassItem>
-<ClassItem id="DCE:FF58ABDE-464C-11D7-AA08-1B85D5275D8A">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 318.1666666666666, 200.66666666666666)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>220.33333333333337</val>
-</width>
-<height>
-<val>117.0</val>
-</height>
-<diagram>
-<ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
-</diagram>
-<show_operations>
-<val>0</val>
-</show_operations>
-<show_stereotypes>
-<val>0</val>
-</show_stereotypes>
-<subject>
 <ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
 </subject>
 </ClassItem>
-<GeneralizationItem id="DCE:0CD87EBC-464D-11D7-AA08-1B85D5275D8A">
-<diagram>
-<ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
-</diagram>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:0E5B8FFE-464D-11D7-AA08-1B85D5275D8A"/>
-</subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 447.8333333333333, 142.66666666666666)</val>
-</matrix>
-<points>
-<val>[(-22.500000000000057, 58.0), (-23.55549549549579, 0.0)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:FF58ABDE-464C-11D7-AA08-1B85D5275D8A"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:F661C206-464C-11D7-AA08-1B85D5275D8A"/>
-</tail-connection>
-</GeneralizationItem>
 <ClassItem id="DCE:6D97E670-464D-11D7-AA08-1B85D5275D8A">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 922.8333333333334, 403.2951070335969)</val>
@@ -21753,7 +21624,7 @@ specially for Gaphor</val>
 <val>(1.0, 0.0, 0.0, 1.0, 524.5, 317.66666666666663)</val>
 </matrix>
 <points>
-<val>[(474.3375121233686, 85.62844036693025), (474.3375121233686, 47.12844036693025), (-21.0, 47.12844036693025), (-21.0, 0.0)]</val>
+<val>[(474.3375121233686, 85.62844036693025), (474.3375121233686, 47.12844036693025), (334.83333333333314, 47.12844036693025), (334.83333333333314, 10.0)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:6D97E670-464D-11D7-AA08-1B85D5275D8A"/>
@@ -21764,7 +21635,7 @@ specially for Gaphor</val>
 </GeneralizationItem>
 <ClassItem id="DCE:7D74A628-464D-11D7-AA08-1B85D5275D8A">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 330.0, 407.8333333333333)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 330.0, 407.8333333333334)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -21778,6 +21649,9 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:D2653A36-464C-11D7-AA08-1B85D5275D8A"/>
 </diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -51487,25 +51361,6 @@ association:not([memberEnd.navigability*=true]) {
 </reflist>
 </extended>
 </InstanceSpecification>
-<Comment id="e993ec74-ec89-11ea-96dc-bf74f1f80424">
-<annotatedElement>
-<reflist>
-<ref refid="DCE:3F0B9972-45D1-11D7-B5CA-613352B2821F"/>
-</reflist>
-</annotatedElement>
-<body>
-<val>Defining directedRelationship
-once is sufficient.
-Derived unions do not
-have an opposite end.
-(implementation detail)</val>
-</body>
-<presentation>
-<reflist>
-<ref refid="e993ec75-ec89-11ea-96dc-bf74f1f80424"/>
-</reflist>
-</presentation>
-</Comment>
 <Slot id="b28c3610-ec8d-11ea-96dc-bf74f1f80424">
 <definingFeature>
 <ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
@@ -56288,29 +56143,6 @@ have an opposite end.
 <ref refid="1579f356-3236-11ef-8506-be7f4daace40"/>
 </tail-connection>
 </CommentLineItem>
-<Property id="aa8a8fb0-e185-11ea-b7ab-f5b4c130f24e">
-<class_>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<name>
-<val>visibility</val>
-</name>
-<typeValue>
-<val>VisibilityKind</val>
-</typeValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-</Property>
 <ClassItem id="DCE:483FA366-464D-11D7-AA08-1B85D5275D8A">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 832.4999999999999, 78.66666666666666)</val>

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.24.0">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.25.1">
 <Association id="DCE:12A2B620-4B3C-11D7-B391-02BBFE4396CE">
 <memberEnd>
 <reflist>
@@ -1070,7 +1070,6 @@
 <ref refid="DCE:F823FBA4-4A86-11D7-B087-133D836EF880"/>
 <ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-<ref refid="DCE:53756494-45CF-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:1E0D0BDC-4A8A-11D7-B090-133D836EF880"/>
 <ref refid="DCE:522B0894-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:18E7456A-4697-11D7-B567-379CA7034986"/>
@@ -2827,11 +2826,6 @@
 </tail-connection>
 </AssociationItem>
 <Class id="DCE:38CB97A8-45CF-11D7-B5CA-613352B2821F">
-<generalization>
-<reflist>
-<ref refid="DCE:958135E2-45D0-11D7-B5CA-613352B2821F"/>
-</reflist>
-</generalization>
 <isAbstract>
 <val>1</val>
 </isAbstract>
@@ -2840,7 +2834,6 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="DCE:5375CF56-45CF-11D7-B5CA-613352B2821F"/>
 <ref refid="3ae046f2-ebeb-11eb-8d68-2d4b211d5079"/>
 </reflist>
 </ownedAttribute>
@@ -7001,11 +6994,6 @@
 </presentation>
 </Association>
 <Class id="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F">
-<comment>
-<reflist>
-<ref refid="0a355dbe-52b9-11ec-b0e5-0456e5e540ed"/>
-</reflist>
-</comment>
 <isAbstract>
 <val>1</val>
 </isAbstract>
@@ -7014,7 +7002,6 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="DCE:53759D24-45CF-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:522B4098-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:53614994-E81E-11DD-BD54-000D936B094A"/>
 </reflist>
@@ -7038,7 +7025,6 @@
 <reflist>
 <ref refid="DCE:0E5B8FFE-464D-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:E7330EBA-4B32-11D7-B391-02BBFE4396CE"/>
-<ref refid="DCE:958135E2-45D0-11D7-B5CA-613352B2821F"/>
 <ref refid="d3ad48ee-b5bf-11e9-ac46-784f435640ba"/>
 <ref refid="01a5b826-e968-11ea-96dc-bf74f1f80424"/>
 </reflist>
@@ -10432,19 +10418,6 @@
 <ref refid="DCE:4A573094-509D-11D7-811E-AF5893A6470D"/>
 </specific>
 </Generalization>
-<Generalization id="DCE:958135E2-45D0-11D7-B5CA-613352B2821F">
-<general>
-<ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
-</general>
-<presentation>
-<reflist>
-<ref refid="DCE:4C625AC4-45CF-11D7-B5CA-613352B2821F"/>
-</reflist>
-</presentation>
-<specific>
-<ref refid="DCE:38CB97A8-45CF-11D7-B5CA-613352B2821F"/>
-</specific>
-</Generalization>
 <Association id="DCE:3A8414B0-4B53-11D7-A5E6-6257AF3C5118">
 <memberEnd>
 <reflist>
@@ -11666,29 +11639,6 @@
 </reflist>
 </presentation>
 </Class>
-<Property id="DCE:53759D24-45CF-11D7-B5CA-613352B2821F">
-<association>
-<ref refid="DCE:53756494-45CF-11D7-B5CA-613352B2821F"/>
-</association>
-<class_>
-<ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<name>
-<val>relationship</val>
-</name>
-<type>
-<ref refid="DCE:38CB97A8-45CF-11D7-B5CA-613352B2821F"/>
-</type>
-<upperValue>
-<val>*</val>
-</upperValue>
-<upperValue>
-<val>*</val>
-</upperValue>
-</Property>
 <Property id="DCE:C6B7B4C8-4B3A-11D7-B391-02BBFE4396CE">
 <appliedStereotype>
 <reflist>
@@ -13974,22 +13924,6 @@
 <val>1</val>
 </upperValue>
 </Property>
-<Association id="DCE:53756494-45CF-11D7-B5CA-613352B2821F">
-<memberEnd>
-<reflist>
-<ref refid="DCE:53759D24-45CF-11D7-B5CA-613352B2821F"/>
-<ref refid="DCE:5375CF56-45CF-11D7-B5CA-613352B2821F"/>
-</reflist>
-</memberEnd>
-<package>
-<ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="DCE:51414BA2-45CF-11D7-B5CA-613352B2821F"/>
-</reflist>
-</presentation>
-</Association>
 <Association id="DCE:C229073A-A418-11D8-B4C8-00061BC22919">
 <comment>
 <reflist>
@@ -16633,13 +16567,12 @@
 <ref refid="a06fc75a-7cf9-11ea-b719-1f391582df99"/>
 <ref refid="e993ec75-ec89-11ea-96dc-bf74f1f80424"/>
 <ref refid="0a356994-52b9-11ec-b0e5-0456e5e540ed"/>
-<ref refid="DCE:4C625AC4-45CF-11D7-B5CA-613352B2821F"/>
-<ref refid="DCE:51414BA2-45CF-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:4D4F8048-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:508961AC-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:5AF4E59E-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="18a9b72f-ec8a-11ea-96dc-bf74f1f80424"/>
 <ref refid="cc955e1a-52bc-11ec-b0e5-0456e5e540ed"/>
+<ref refid="d4d1c5ec-2e32-11ef-8125-be7f4daace40"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
@@ -16688,6 +16621,9 @@
 <diagram>
 <ref refid="DCE:E71AAA3E-45CE-11D7-B5CA-613352B2821F"/>
 </diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -16698,64 +16634,6 @@
 <ref refid="DCE:38CB97A8-45CF-11D7-B5CA-613352B2821F"/>
 </subject>
 </ClassItem>
-<GeneralizationItem id="DCE:4C625AC4-45CF-11D7-B5CA-613352B2821F">
-<diagram>
-<ref refid="DCE:E71AAA3E-45CE-11D7-B5CA-613352B2821F"/>
-</diagram>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:958135E2-45D0-11D7-B5CA-613352B2821F"/>
-</subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 359.0, 281.0)</val>
-</matrix>
-<points>
-<val>[(4.469178082191718, 84.5), (4.469178082191718, 0.0)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:38CAFEF6-45CF-11D7-B5CA-613352B2821F"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:FC12D436-45CE-11D7-B5CA-613352B2821F"/>
-</tail-connection>
-</GeneralizationItem>
-<AssociationItem id="DCE:51414BA2-45CF-11D7-B5CA-613352B2821F">
-<diagram>
-<ref refid="DCE:E71AAA3E-45CE-11D7-B5CA-613352B2821F"/>
-</diagram>
-<head_subject>
-<ref refid="DCE:53759D24-45CF-11D7-B5CA-613352B2821F"/>
-</head_subject>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:53756494-45CF-11D7-B5CA-613352B2821F"/>
-</subject>
-<tail_subject>
-<ref refid="DCE:5375CF56-45CF-11D7-B5CA-613352B2821F"/>
-</tail_subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 284.5, 422.3125)</val>
-</matrix>
-<points>
-<val>[(1.4691780821917177, -34.64749999999998), (-98.5, -34.64749999999998), (-98.5, -158.3125), (16.5, -158.3125)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:38CAFEF6-45CF-11D7-B5CA-613352B2821F"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:FC12D436-45CE-11D7-B5CA-613352B2821F"/>
-</tail-connection>
-</AssociationItem>
 <ClassItem id="DCE:3F0AFFA8-45D1-11D7-B5CA-613352B2821F">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 256.2191780821917, 499.0)</val>
@@ -16874,7 +16752,7 @@
 </AssociationItem>
 <CommentItem id="a06fc75a-7cf9-11ea-b719-1f391582df99">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 458.5, 290.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 515.5, 356.5)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -25097,40 +24975,6 @@ specially for Gaphor</val>
 </lowerValue>
 <name>
 <val>source</val>
-</name>
-<type>
-<ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
-</type>
-<upperValue>
-<val>*</val>
-</upperValue>
-<upperValue>
-<val>*</val>
-</upperValue>
-</Property>
-<Property id="DCE:5375CF56-45CF-11D7-B5CA-613352B2821F">
-<appliedStereotype>
-<reflist>
-<ref refid="1761eb58-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:53756494-45CF-11D7-B5CA-613352B2821F"/>
-</association>
-<class_>
-<ref refid="DCE:38CB97A8-45CF-11D7-B5CA-613352B2821F"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<lowerValue>
-<val>1</val>
-</lowerValue>
-<lowerValue>
-<val>1</val>
-</lowerValue>
-<name>
-<val>relatedElement</val>
 </name>
 <type>
 <ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
@@ -37505,7 +37349,6 @@ swimlanes</val>
 <ref refid="17606742-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1760a1b2-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17613dc0-fa90-11de-bd51-00224128e79d"/>
-<ref refid="1761eb58-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17622636-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17626056-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17630d8a-fa90-11de-bd51-00224128e79d"/>
@@ -42263,18 +42106,6 @@ swimlanes</val>
 <val>relatedElement</val>
 </value>
 </Slot>
-<InstanceSpecification id="1761eb58-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:5375CF56-45CF-11D7-B5CA-613352B2821F"/>
-</reflist>
-</extended>
-</InstanceSpecification>
 <InstanceSpecification id="17622636-fa90-11de-bd51-00224128e79d">
 <classifier>
 <reflist>
@@ -55394,11 +55225,6 @@ have an opposite end.
 </subject>
 </CommentItem>
 <Comment id="0a355dbe-52b9-11ec-b0e5-0456e5e540ed">
-<annotatedElement>
-<reflist>
-<ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
-</reflist>
-</annotatedElement>
 <body>
 <val>Defined in Core model.</val>
 </body>
@@ -55410,7 +55236,7 @@ have an opposite end.
 </Comment>
 <CommentItem id="0a356994-52b9-11ec-b0e5-0456e5e540ed">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 483.0, 196.44926264044943)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 507.0, 251.9567180669331)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -55442,14 +55268,11 @@ have an opposite end.
 <val>(1.0, 0.0, 0.0, 1.0, 389.2109375, 235.44926264044943)</val>
 </matrix>
 <points>
-<val>[(33.7890625, 2.5142513752965527), (93.7890625, 1.9567180669330924)]</val>
+<val>[(33.7890625, 2.5142513752965527), (117.7890625, 45.55073735955057)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:FC12D436-45CE-11D7-B5CA-613352B2821F"/>
 </head-connection>
-<tail-connection>
-<ref refid="0a356994-52b9-11ec-b0e5-0456e5e540ed"/>
-</tail-connection>
 </CommentLineItem>
 <InstanceSpecification id="659e28da-9a43-11ec-8e48-0456e5e540ed">
 <classifier>
@@ -57770,4 +57593,24 @@ have an opposite end.
 <val>ownedElement</val>
 </value>
 </Slot>
+<CommentLineItem id="d4d1c5ec-2e32-11ef-8125-be7f4daace40">
+<diagram>
+<ref refid="DCE:E71AAA3E-45CE-11D7-B5CA-613352B2821F"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 389.0, 367.0)</val>
+</matrix>
+<points>
+<val>[(0.0, -1.5), (118.0, -70.0)]</val>
+</points>
+<head-connection>
+<ref refid="DCE:38CAFEF6-45CF-11D7-B5CA-613352B2821F"/>
+</head-connection>
+</CommentLineItem>
 </gaphor>

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -929,22 +929,6 @@
 <ref refid="DCE:CC9DE0D0-6690-11D7-A84E-6C8643AD0CA4"/>
 </specific>
 </Generalization>
-<Association id="DCE:BAEA7364-65C6-11D7-89A9-9C62884CFFDE">
-<memberEnd>
-<reflist>
-<ref refid="DCE:BAEADF3E-65C6-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:BAEAACB2-65C6-11D7-89A9-9C62884CFFDE"/>
-</reflist>
-</memberEnd>
-<package>
-<ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="DCE:B952FCC4-65C6-11D7-89A9-9C62884CFFDE"/>
-</reflist>
-</presentation>
-</Association>
 <Property id="DCE:6A5F00AE-4A87-11D7-B089-133D836EF880">
 <aggregation>
 <val>composite</val>
@@ -1055,8 +1039,6 @@
 </ownedDiagram>
 <ownedType>
 <reflist>
-<ref refid="DCE:BAEA7364-65C6-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:5C68DFBE-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:38CB97A8-45CF-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:3F0B9972-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:48404A2A-464D-11D7-AA08-1B85D5275D8A"/>
@@ -1071,7 +1053,6 @@
 <ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
 <ref refid="DCE:1E0D0BDC-4A8A-11D7-B090-133D836EF880"/>
-<ref refid="DCE:522B0894-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:18E7456A-4697-11D7-B567-379CA7034986"/>
 <ref refid="DCE:7876B574-4A87-11D7-B089-133D836EF880"/>
 <ref refid="DCE:79C3FCAA-4695-11D7-B567-379CA7034986"/>
@@ -1085,7 +1066,6 @@
 <ref refid="DCE:B7B77E54-4694-11D7-B567-379CA7034986"/>
 <ref refid="DCE:7D11DA3A-4697-11D7-B567-379CA7034986"/>
 <ref refid="DCE:881E7D46-65CF-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:B71BDF0C-65C6-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:677088BA-65CE-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:D733DED0-65C5-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:A3E40740-65CE-11D7-89A9-9C62884CFFDE"/>
@@ -3016,40 +2996,6 @@
 <ref refid="DCE:CAD8A604-4B33-11D7-B391-02BBFE4396CE"/>
 </type>
 </Property>
-<Property id="DCE:522B7252-45D1-11D7-B5CA-613352B2821F">
-<appliedStereotype>
-<reflist>
-<ref refid="17030db8-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:522B0894-45D1-11D7-B5CA-613352B2821F"/>
-</association>
-<class_>
-<ref refid="DCE:3F0B9972-45D1-11D7-B5CA-613352B2821F"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<lowerValue>
-<val>1</val>
-</lowerValue>
-<lowerValue>
-<val>1</val>
-</lowerValue>
-<name>
-<val>target</val>
-</name>
-<type>
-<ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
-</type>
-<upperValue>
-<val>*</val>
-</upperValue>
-<upperValue>
-<val>*</val>
-</upperValue>
-</Property>
 <Class id="DCE:BDC038A2-4A88-11D7-B08D-133D836EF880">
 <comment>
 <reflist>
@@ -4538,22 +4484,6 @@
 <val>*</val>
 </upperValue>
 </Property>
-<Association id="DCE:B71BDF0C-65C6-11D7-89A9-9C62884CFFDE">
-<memberEnd>
-<reflist>
-<ref refid="DCE:B71C181E-65C6-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:B71C4ADE-65C6-11D7-89A9-9C62884CFFDE"/>
-</reflist>
-</memberEnd>
-<package>
-<ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="DCE:B5B5F8A0-65C6-11D7-89A9-9C62884CFFDE"/>
-</reflist>
-</presentation>
-</Association>
 <Property id="DCE:C58D3BE0-4B3A-11D7-B391-02BBFE4396CE">
 <appliedStereotype>
 <reflist>
@@ -5251,8 +5181,8 @@
 <ownedAttribute>
 <reflist>
 <ref refid="DCE:67C4FC98-4B35-11D7-B391-02BBFE4396CE"/>
-<ref refid="DCE:99FB75E6-4B35-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:B0D30324-4B35-11D7-B391-02BBFE4396CE"/>
+<ref refid="DCE:99FB75E6-4B35-11D7-B391-02BBFE4396CE"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -6113,8 +6043,6 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="DCE:B71C4ADE-65C6-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:BAEADF3E-65C6-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:D33A9738-4694-11D7-B567-379CA7034986"/>
 <ref refid="90a6d158-b9b1-11eb-93ad-535118859f0b"/>
 <ref refid="98bdb712-b9b1-11eb-93ad-535118859f0b"/>
@@ -6129,7 +6057,6 @@
 <reflist>
 <ref refid="DCE:968B8AF4-83D9-11D7-ADE2-4B1972AF3391"/>
 <ref refid="DCE:FF58ABDE-464C-11D7-AA08-1B85D5275D8A"/>
-<ref refid="DCE:AA00C386-50A5-11D7-807A-302CB4EF44FD"/>
 <ref refid="DCE:B7134052-4B33-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:D7695644-3B13-11D9-83CE-A0BAF22E8A12"/>
 <ref refid="DCE:39E47B92-3B16-11D9-83CE-A0BAF22E8A12"/>
@@ -6301,9 +6228,9 @@
 <ownedAttribute>
 <reflist>
 <ref refid="DCE:D0A34CAC-6691-11D7-A84E-6C8643AD0CA4"/>
+<ref refid="DCE:3EEBFECC-6698-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:068B31A2-6692-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:D18A5D92-6692-11D7-A84E-6C8643AD0CA4"/>
-<ref refid="DCE:3EEBFECC-6698-11D7-A84E-6C8643AD0CA4"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -7002,7 +6929,6 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="DCE:522B4098-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="DCE:53614994-E81E-11DD-BD54-000D936B094A"/>
 </reflist>
 </ownedAttribute>
@@ -7156,21 +7082,14 @@
 </presentation>
 </Class>
 <Class id="DCE:D733DED0-65C5-11D7-89A9-9C62884CFFDE">
-<generalization>
+<comment>
 <reflist>
-<ref refid="DCE:59967394-65CE-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:5C9925FA-65CE-11D7-89A9-9C62884CFFDE"/>
+<ref refid="1579ed2a-3236-11ef-8506-be7f4daace40"/>
 </reflist>
-</generalization>
+</comment>
 <name>
 <val>Dependency</val>
 </name>
-<ownedAttribute>
-<reflist>
-<ref refid="DCE:B71C181E-65C6-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:BAEAACB2-65C6-11D7-89A9-9C62884CFFDE"/>
-</reflist>
-</ownedAttribute>
 <package>
 <ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
 </package>
@@ -10541,7 +10460,6 @@
 <ref refid="DCE:B3BB753C-50A1-11D7-807A-302CB4EF44FD"/>
 <ref refid="DCE:12941E9E-4B32-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:6D97E670-464D-11D7-AA08-1B85D5275D8A"/>
-<ref refid="DCE:A3146A3A-65C6-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:45D91B2A-4A89-11D7-B08E-133D836EF880"/>
 <ref refid="f794e42a-40f1-11e0-9acb-0019d2b28af0"/>
 <ref refid="f4b1a568-ebea-11eb-8d68-2d4b211d5079"/>
@@ -10553,7 +10471,6 @@
 <ref refid="DCE:FC4F8AE4-A497-11D7-A186-46D6FB6BDAE4"/>
 <ref refid="DCE:D4B97310-50A1-11D7-807A-302CB4EF44FD"/>
 <ref refid="DCE:65B40688-4A89-11D7-B090-133D836EF880"/>
-<ref refid="DCE:5C9925FA-65CE-11D7-89A9-9C62884CFFDE"/>
 <ref refid="6c9cff50-40f2-11e0-9acb-0019d2b28af0"/>
 <ref refid="fef3fddc-ebea-11eb-8d68-2d4b211d5079"/>
 </reflist>
@@ -10585,34 +10502,6 @@
 <ref refid="DCE:39886AB6-8405-11D8-82A2-7B88E55A3BEC"/>
 </specific>
 </Generalization>
-<Property id="DCE:522B4098-45D1-11D7-B5CA-613352B2821F">
-<appliedStereotype>
-<reflist>
-<ref refid="c1bd2806-ec88-11ea-96dc-bf74f1f80424"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:522B0894-45D1-11D7-B5CA-613352B2821F"/>
-</association>
-<class_>
-<ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<name>
-<val>directedRelationship</val>
-</name>
-<type>
-<ref refid="DCE:3F0B9972-45D1-11D7-B5CA-613352B2821F"/>
-</type>
-<upperValue>
-<val>*</val>
-</upperValue>
-<upperValue>
-<val>*</val>
-</upperValue>
-</Property>
 <Generalization id="DCE:FC4F8AE4-A497-11D7-A186-46D6FB6BDAE4">
 <general>
 <ref refid="DCE:6D987F90-464D-11D7-AA08-1B85D5275D8A"/>
@@ -10754,47 +10643,6 @@
 <val>*</val>
 </upperValue>
 </Property>
-<Property id="DCE:B71C4ADE-65C6-11D7-89A9-9C62884CFFDE">
-<appliedStereotype>
-<reflist>
-<ref refid="172d8c14-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:B71BDF0C-65C6-11D7-89A9-9C62884CFFDE"/>
-</association>
-<class_>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<name>
-<val>supplierDependency</val>
-</name>
-<type>
-<ref refid="DCE:D733DED0-65C5-11D7-89A9-9C62884CFFDE"/>
-</type>
-<upperValue>
-<val>*</val>
-</upperValue>
-<upperValue>
-<val>*</val>
-</upperValue>
-</Property>
-<Association id="DCE:522B0894-45D1-11D7-B5CA-613352B2821F">
-<memberEnd>
-<reflist>
-<ref refid="DCE:522B7252-45D1-11D7-B5CA-613352B2821F"/>
-<ref refid="DCE:522B4098-45D1-11D7-B5CA-613352B2821F"/>
-</reflist>
-</memberEnd>
-<package>
-<ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="DCE:508961AC-45D1-11D7-B5CA-613352B2821F"/>
-</reflist>
-</presentation>
-</Association>
 <Property id="DCE:1122F03A-4696-11D7-B567-379CA7034986">
 <appliedStereotype>
 <reflist>
@@ -11738,32 +11586,6 @@
 <val>1</val>
 </upperValue>
 </Property>
-<Association id="DCE:5C68DFBE-45D1-11D7-B5CA-613352B2821F">
-<comment>
-<reflist>
-<ref refid="e993ec74-ec89-11ea-96dc-bf74f1f80424"/>
-</reflist>
-</comment>
-<memberEnd>
-<reflist>
-<ref refid="DCE:5C691878-45D1-11D7-B5CA-613352B2821F"/>
-<ref refid="DCE:5C694A28-45D1-11D7-B5CA-613352B2821F"/>
-</reflist>
-</memberEnd>
-<ownedEnd>
-<reflist>
-<ref refid="DCE:5C691878-45D1-11D7-B5CA-613352B2821F"/>
-</reflist>
-</ownedEnd>
-<package>
-<ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="DCE:5AF4E59E-45D1-11D7-B5CA-613352B2821F"/>
-</reflist>
-</presentation>
-</Association>
 <Association id="DCE:C314E05A-4B57-11D7-A5E6-6257AF3C5118">
 <memberEnd>
 <reflist>
@@ -12005,34 +11827,6 @@
 <val>*</val>
 </upperValue>
 </Property>
-<Property id="DCE:BAEADF3E-65C6-11D7-89A9-9C62884CFFDE">
-<aggregation>
-<val>composite</val>
-</aggregation>
-<appliedStereotype>
-<reflist>
-<ref refid="17395364-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:BAEA7364-65C6-11D7-89A9-9C62884CFFDE"/>
-</association>
-<class_>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<name>
-<val>clientDependency</val>
-</name>
-<type>
-<ref refid="DCE:D733DED0-65C5-11D7-89A9-9C62884CFFDE"/>
-</type>
-<upperValue>
-<val>*</val>
-</upperValue>
-<upperValue>
-<val>*</val>
-</upperValue>
-</Property>
 <Association id="DCE:0E00B206-4B56-11D7-A5E6-6257AF3C5118">
 <memberEnd>
 <reflist>
@@ -12050,17 +11844,6 @@
 </reflist>
 </presentation>
 </Association>
-<Property id="DCE:5C691878-45D1-11D7-B5CA-613352B2821F">
-<association>
-<ref refid="DCE:5C68DFBE-45D1-11D7-B5CA-613352B2821F"/>
-</association>
-<owningAssociation>
-<ref refid="DCE:5C68DFBE-45D1-11D7-B5CA-613352B2821F"/>
-</owningAssociation>
-<type>
-<ref refid="DCE:3F0B9972-45D1-11D7-B5CA-613352B2821F"/>
-</type>
-</Property>
 <Property id="DCE:1DCB8DCC-97BC-11D8-9E3C-00C00C03A405">
 <association>
 <ref refid="DCE:1DCA3E30-97BC-11D8-9E3C-00C00C03A405"/>
@@ -12085,19 +11868,6 @@
 <val>private</val>
 </name>
 </Property>
-<Generalization id="DCE:59967394-65CE-11D7-89A9-9C62884CFFDE">
-<general>
-<ref refid="DCE:3F0B9972-45D1-11D7-B5CA-613352B2821F"/>
-</general>
-<presentation>
-<reflist>
-<ref refid="DCE:578F57C8-65CE-11D7-89A9-9C62884CFFDE"/>
-</reflist>
-</presentation>
-<specific>
-<ref refid="DCE:D733DED0-65C5-11D7-89A9-9C62884CFFDE"/>
-</specific>
-</Generalization>
 <Generalization id="DCE:B6C5CFA4-509D-11D7-811E-AF5893A6470D">
 <general>
 <ref refid="DCE:BDC038A2-4A88-11D7-B08D-133D836EF880"/>
@@ -16568,8 +16338,6 @@
 <ref refid="e993ec75-ec89-11ea-96dc-bf74f1f80424"/>
 <ref refid="0a356994-52b9-11ec-b0e5-0456e5e540ed"/>
 <ref refid="DCE:4D4F8048-45D1-11D7-B5CA-613352B2821F"/>
-<ref refid="DCE:508961AC-45D1-11D7-B5CA-613352B2821F"/>
-<ref refid="DCE:5AF4E59E-45D1-11D7-B5CA-613352B2821F"/>
 <ref refid="18a9b72f-ec8a-11ea-96dc-bf74f1f80424"/>
 <ref refid="cc955e1a-52bc-11ec-b0e5-0456e5e540ed"/>
 <ref refid="d4d1c5ec-2e32-11ef-8125-be7f4daace40"/>
@@ -16686,70 +16454,6 @@
 <ref refid="DCE:38CAFEF6-45CF-11D7-B5CA-613352B2821F"/>
 </tail-connection>
 </GeneralizationItem>
-<AssociationItem id="DCE:508961AC-45D1-11D7-B5CA-613352B2821F">
-<diagram>
-<ref refid="DCE:E71AAA3E-45CE-11D7-B5CA-613352B2821F"/>
-</diagram>
-<head_subject>
-<ref refid="DCE:522B4098-45D1-11D7-B5CA-613352B2821F"/>
-</head_subject>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:522B0894-45D1-11D7-B5CA-613352B2821F"/>
-</subject>
-<tail_subject>
-<ref refid="DCE:522B7252-45D1-11D7-B5CA-613352B2821F"/>
-</tail_subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 254.75, 561.9421875)</val>
-</matrix>
-<points>
-<val>[(1.4691780821917177, -32.0), (-143.75, -32.0), (-143.75, -340.57855113636367), (46.25, -340.57855113636367)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:3F0AFFA8-45D1-11D7-B5CA-613352B2821F"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:FC12D436-45CE-11D7-B5CA-613352B2821F"/>
-</tail-connection>
-</AssociationItem>
-<AssociationItem id="DCE:5AF4E59E-45D1-11D7-B5CA-613352B2821F">
-<diagram>
-<ref refid="DCE:E71AAA3E-45CE-11D7-B5CA-613352B2821F"/>
-</diagram>
-<head_subject>
-<ref refid="DCE:5C691878-45D1-11D7-B5CA-613352B2821F"/>
-</head_subject>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>1</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:5C68DFBE-45D1-11D7-B5CA-613352B2821F"/>
-</subject>
-<tail_subject>
-<ref refid="DCE:5C694A28-45D1-11D7-B5CA-613352B2821F"/>
-</tail_subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 254.75, 597.3046874999998)</val>
-</matrix>
-<points>
-<val>[(1.4691780821917177, -32.0), (-184.25, -32.0), (-184.25, -434.91183035714266), (46.25, -434.91183035714266)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:3F0AFFA8-45D1-11D7-B5CA-613352B2821F"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:FC12D436-45CE-11D7-B5CA-613352B2821F"/>
-</tail-connection>
-</AssociationItem>
 <CommentItem id="a06fc75a-7cf9-11ea-b719-1f391582df99">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 515.5, 356.5)</val>
@@ -16772,7 +16476,7 @@
 </CommentItem>
 <CommentItem id="e993ec75-ec89-11ea-96dc-bf74f1f80424">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 99.0, 660.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 153.96917808219172, 668.5)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -16804,10 +16508,10 @@
 <val>(1.0, 0.0, 0.0, 1.0, 187.5, 597.3046874999998)</val>
 </matrix>
 <points>
-<val>[(0.9329380494785937, -32.0), (4.760989010989022, 63.19531250000023)]</val>
+<val>[(83.5, 4.195312500000227), (59.73016709318074, 71.19531250000023)]</val>
 </points>
 <head-connection>
-<ref refid="DCE:5AF4E59E-45D1-11D7-B5CA-613352B2821F"/>
+<ref refid="DCE:3F0AFFA8-45D1-11D7-B5CA-613352B2821F"/>
 </head-connection>
 <tail-connection>
 <ref refid="e993ec75-ec89-11ea-96dc-bf74f1f80424"/>
@@ -17522,6 +17226,11 @@
 </typeValue>
 </Property>
 <Class id="DCE:3F0B9972-45D1-11D7-B5CA-613352B2821F">
+<comment>
+<reflist>
+<ref refid="e993ec74-ec89-11ea-96dc-bf74f1f80424"/>
+</reflist>
+</comment>
 <generalization>
 <reflist>
 <ref refid="DCE:4E6DB742-45D1-11D7-B5CA-613352B2821F"/>
@@ -17533,12 +17242,6 @@
 <name>
 <val>DirectedRelationship</val>
 </name>
-<ownedAttribute>
-<reflist>
-<ref refid="DCE:522B7252-45D1-11D7-B5CA-613352B2821F"/>
-<ref refid="DCE:5C694A28-45D1-11D7-B5CA-613352B2821F"/>
-</reflist>
-</ownedAttribute>
 <package>
 <ref refid="DCE:E085A412-45CE-11D7-B5CA-613352B2821F"/>
 </package>
@@ -17546,7 +17249,6 @@
 <reflist>
 <ref refid="96e3d64e-e967-11ea-96dc-bf74f1f80424"/>
 <ref refid="DCE:3F0AFFA8-45D1-11D7-B5CA-613352B2821F"/>
-<ref refid="DCE:FC28D722-65C5-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:09D81820-50A3-11D7-807A-302CB4EF44FD"/>
 <ref refid="DCE:5CA6131C-4695-11D7-B567-379CA7034986"/>
 <ref refid="DCE:A78F7D8A-6690-11D7-A84E-6C8643AD0CA4"/>
@@ -17558,7 +17260,6 @@
 <reflist>
 <ref refid="DCE:A1782CCA-6691-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:0CD07134-4B36-11D7-B391-02BBFE4396CE"/>
-<ref refid="DCE:59967394-65CE-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:725A47B2-4695-11D7-B567-379CA7034986"/>
 <ref refid="DCE:59C1E950-97BD-11D8-9E0D-00C00C03A405"/>
 <ref refid="DCE:AF6D27C0-4695-11D7-B567-379CA7034986"/>
@@ -17589,7 +17290,6 @@
 <ref refid="DCE:BCEBC220-4B32-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:2889D960-6693-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:F1CF4FA4-4B33-11D7-B391-02BBFE4396CE"/>
-<ref refid="DCE:99FBA804-4B35-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:B0388110-4B34-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:00ED6378-4B35-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:38A9AE44-4B54-11D7-A5E6-6257AF3C5118"/>
@@ -17597,6 +17297,7 @@
 <ref refid="DCE:3EEBCC18-6698-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="e9507590-e962-11ea-87d1-cbf2d1fcaed0"/>
 <ref refid="DCE:BFC7B66E-4B37-11D7-B391-02BBFE4396CE"/>
+<ref refid="DCE:99FBA804-4B35-11D7-B391-02BBFE4396CE"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -18478,37 +18179,6 @@
 </upperValue>
 <upperValue>
 <val>*</val>
-</upperValue>
-</Property>
-<Property id="DCE:B71C181E-65C6-11D7-89A9-9C62884CFFDE">
-<appliedStereotype>
-<reflist>
-<ref refid="1753a732-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:B71BDF0C-65C6-11D7-89A9-9C62884CFFDE"/>
-</association>
-<class_>
-<ref refid="DCE:D733DED0-65C5-11D7-89A9-9C62884CFFDE"/>
-</class_>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<name>
-<val>supplier</val>
-</name>
-<type>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</type>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
 </upperValue>
 </Property>
 <Property id="DCE:4AAFA7DA-8402-11D8-82A2-7B88E55A3BEC">
@@ -21331,54 +21001,20 @@ specially for Gaphor</val>
 </name>
 <ownedPresentation>
 <reflist>
-<ref refid="DCE:AA00C386-50A5-11D7-807A-302CB4EF44FD"/>
 <ref refid="DCE:D7075AD6-65C5-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:FC28D722-65C5-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:A3146A3A-65C6-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:676FFC24-65CE-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:84BAC096-65CE-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:A3E3320C-65CE-11D7-89A9-9C62884CFFDE"/>
 <ref refid="0a8b38b2-e189-11ea-b7ab-f5b4c130f24e"/>
-<ref refid="DCE:B5B5F8A0-65C6-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:B952FCC4-65C6-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:578F57C8-65CE-11D7-89A9-9C62884CFFDE"/>
-<ref refid="DCE:5B5D2858-65CE-11D7-89A9-9C62884CFFDE"/>
+<ref refid="1579f356-3236-11ef-8506-be7f4daace40"/>
 <ref refid="DCE:B0B05438-65CE-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:8680CDF4-65CF-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:C02055A2-65CF-11D7-89A9-9C62884CFFDE"/>
 <ref refid="DCE:CB93CAB8-65CF-11D7-89A9-9C62884CFFDE"/>
+<ref refid="1be63344-3236-11ef-8506-be7f4daace40"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
-<ClassItem id="DCE:AA00C386-50A5-11D7-807A-302CB4EF44FD">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 8.625, 205.5)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>163.75</val>
-</width>
-<height>
-<val>68.0</val>
-</height>
-<diagram>
-<ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
-</diagram>
-<show_attributes>
-<val>0</val>
-</show_attributes>
-<show_operations>
-<val>0</val>
-</show_operations>
-<show_stereotypes>
-<val>0</val>
-</show_stereotypes>
-<subject>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</subject>
-</ClassItem>
 <ClassItem id="DCE:D7075AD6-65C5-11D7-89A9-9C62884CFFDE">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 628.5, 206.5)</val>
@@ -21395,6 +21031,9 @@ specially for Gaphor</val>
 <diagram>
 <ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
 </diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
 <show_operations>
 <val>0</val>
 </show_operations>
@@ -21405,180 +21044,6 @@ specially for Gaphor</val>
 <ref refid="DCE:D733DED0-65C5-11D7-89A9-9C62884CFFDE"/>
 </subject>
 </ClassItem>
-<ClassItem id="DCE:FC28D722-65C5-11D7-89A9-9C62884CFFDE">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 514.0, 77.0)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>197.0</val>
-</width>
-<height>
-<val>59.0</val>
-</height>
-<diagram>
-<ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
-</diagram>
-<show_attributes>
-<val>0</val>
-</show_attributes>
-<show_operations>
-<val>0</val>
-</show_operations>
-<show_stereotypes>
-<val>0</val>
-</show_stereotypes>
-<subject>
-<ref refid="DCE:3F0B9972-45D1-11D7-B5CA-613352B2821F"/>
-</subject>
-</ClassItem>
-<ClassItem id="DCE:A3146A3A-65C6-11D7-89A9-9C62884CFFDE">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 736.25, 77.0)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>194.0</val>
-</width>
-<height>
-<val>71.0</val>
-</height>
-<diagram>
-<ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
-</diagram>
-<show_attributes>
-<val>0</val>
-</show_attributes>
-<show_operations>
-<val>0</val>
-</show_operations>
-<show_stereotypes>
-<val>0</val>
-</show_stereotypes>
-<subject>
-<ref refid="DCE:6D987F90-464D-11D7-AA08-1B85D5275D8A"/>
-</subject>
-</ClassItem>
-<AssociationItem id="DCE:B5B5F8A0-65C6-11D7-89A9-9C62884CFFDE">
-<diagram>
-<ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
-</diagram>
-<head_subject>
-<ref refid="DCE:B71C181E-65C6-11D7-89A9-9C62884CFFDE"/>
-</head_subject>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:B71BDF0C-65C6-11D7-89A9-9C62884CFFDE"/>
-</subject>
-<tail_subject>
-<ref refid="DCE:B71C4ADE-65C6-11D7-89A9-9C62884CFFDE"/>
-</tail_subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 245.625, 223.5)</val>
-</matrix>
-<points>
-<val>[(-73.25, -1.0), (382.875, -3.2089552238805936)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:AA00C386-50A5-11D7-807A-302CB4EF44FD"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:D7075AD6-65C5-11D7-89A9-9C62884CFFDE"/>
-</tail-connection>
-</AssociationItem>
-<AssociationItem id="DCE:B952FCC4-65C6-11D7-89A9-9C62884CFFDE">
-<diagram>
-<ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
-</diagram>
-<head_subject>
-<ref refid="DCE:BAEAACB2-65C6-11D7-89A9-9C62884CFFDE"/>
-</head_subject>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:BAEA7364-65C6-11D7-89A9-9C62884CFFDE"/>
-</subject>
-<tail_subject>
-<ref refid="DCE:BAEADF3E-65C6-11D7-89A9-9C62884CFFDE"/>
-</tail_subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 245.625, 263.0)</val>
-</matrix>
-<points>
-<val>[(-73.25, -1.0), (382.875, -1.3358208955223745)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:AA00C386-50A5-11D7-807A-302CB4EF44FD"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:D7075AD6-65C5-11D7-89A9-9C62884CFFDE"/>
-</tail-connection>
-</AssociationItem>
-<GeneralizationItem id="DCE:578F57C8-65CE-11D7-89A9-9C62884CFFDE">
-<diagram>
-<ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
-</diagram>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:59967394-65CE-11D7-89A9-9C62884CFFDE"/>
-</subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 662.0, 136.0)</val>
-</matrix>
-<points>
-<val>[(0.0, 70.5), (-0.1488095238095184, 0.0)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:D7075AD6-65C5-11D7-89A9-9C62884CFFDE"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:FC28D722-65C5-11D7-89A9-9C62884CFFDE"/>
-</tail-connection>
-</GeneralizationItem>
-<GeneralizationItem id="DCE:5B5D2858-65CE-11D7-89A9-9C62884CFFDE">
-<diagram>
-<ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
-</diagram>
-<horizontal>
-<val>1</val>
-</horizontal>
-<orthogonal>
-<val>0</val>
-</orthogonal>
-<subject>
-<ref refid="DCE:5C9925FA-65CE-11D7-89A9-9C62884CFFDE"/>
-</subject>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 798.25, 148.0)</val>
-</matrix>
-<points>
-<val>[(0.0, 58.5), (0.25, 0.0)]</val>
-</points>
-<head-connection>
-<ref refid="DCE:D7075AD6-65C5-11D7-89A9-9C62884CFFDE"/>
-</head-connection>
-<tail-connection>
-<ref refid="DCE:A3146A3A-65C6-11D7-89A9-9C62884CFFDE"/>
-</tail-connection>
-</GeneralizationItem>
 <ClassItem id="DCE:676FFC24-65CE-11D7-89A9-9C62884CFFDE">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 601.5, 386.0)</val>
@@ -23191,10 +22656,10 @@ specially for Gaphor</val>
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="DCE:068AFED0-6692-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:B7523644-6691-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:54F98BE0-6692-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:FE7634AE-6690-11D7-A84E-6C8643AD0CA4"/>
+<ref refid="DCE:068AFED0-6692-11D7-A84E-6C8643AD0CA4"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -23426,19 +22891,6 @@ specially for Gaphor</val>
 <ref refid="DCE:3A787382-4B38-11D7-B391-02BBFE4396CE"/>
 </type>
 </Property>
-<Generalization id="DCE:5C9925FA-65CE-11D7-89A9-9C62884CFFDE">
-<general>
-<ref refid="DCE:6D987F90-464D-11D7-AA08-1B85D5275D8A"/>
-</general>
-<presentation>
-<reflist>
-<ref refid="DCE:5B5D2858-65CE-11D7-89A9-9C62884CFFDE"/>
-</reflist>
-</presentation>
-<specific>
-<ref refid="DCE:D733DED0-65C5-11D7-89A9-9C62884CFFDE"/>
-</specific>
-</Generalization>
 <Property id="DCE:E46BF7B4-4B52-11D7-A5E6-6257AF3C5118">
 <appliedStereotype>
 <reflist>
@@ -24952,40 +24404,6 @@ specially for Gaphor</val>
 </reflist>
 </specialization>
 </Class>
-<Property id="DCE:5C694A28-45D1-11D7-B5CA-613352B2821F">
-<appliedStereotype>
-<reflist>
-<ref refid="17613dc0-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:5C68DFBE-45D1-11D7-B5CA-613352B2821F"/>
-</association>
-<class_>
-<ref refid="DCE:3F0B9972-45D1-11D7-B5CA-613352B2821F"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<lowerValue>
-<val>1</val>
-</lowerValue>
-<lowerValue>
-<val>1</val>
-</lowerValue>
-<name>
-<val>source</val>
-</name>
-<type>
-<ref refid="DCE:FC139C48-45CE-11D7-B5CA-613352B2821F"/>
-</type>
-<upperValue>
-<val>*</val>
-</upperValue>
-<upperValue>
-<val>*</val>
-</upperValue>
-</Property>
 <Property id="DCE:7265D99A-83D9-11D7-ADE2-4B1972AF3391">
 <appliedStereotype>
 <reflist>
@@ -25534,10 +24952,10 @@ specially for Gaphor</val>
 <ref refid="DCE:99FBA804-4B35-11D7-B391-02BBFE4396CE"/>
 </tail_subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 718.5, 322.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 718.5, 321.03515625)</val>
 </matrix>
 <points>
-<val>[(0.0, 3.488742565845314), (355.727272727273, 3.488742565845314)]</val>
+<val>[(0.0, 4.453586315845314), (355.727272727273, 4.453586315845314)]</val>
 </points>
 <head-connection>
 <ref refid="DCE:EF08ECE4-4B33-11D7-B391-02BBFE4396CE"/>
@@ -26098,37 +25516,6 @@ specially for Gaphor</val>
 <ref refid="DCE:DB2CD0EE-509B-11D7-811E-AF5893A6470D"/>
 </specific>
 </Generalization>
-<Property id="DCE:BAEAACB2-65C6-11D7-89A9-9C62884CFFDE">
-<appliedStereotype>
-<reflist>
-<ref refid="176453e8-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</appliedStereotype>
-<association>
-<ref refid="DCE:BAEA7364-65C6-11D7-89A9-9C62884CFFDE"/>
-</association>
-<class_>
-<ref refid="DCE:D733DED0-65C5-11D7-89A9-9C62884CFFDE"/>
-</class_>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<name>
-<val>client</val>
-</name>
-<type>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</type>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-</Property>
 <Generalization id="DCE:4E6DB742-45D1-11D7-B5CA-613352B2821F">
 <general>
 <ref refid="DCE:38CB97A8-45CF-11D7-B5CA-613352B2821F"/>
@@ -37164,7 +36551,6 @@ swimlanes</val>
 <ref refid="1701fe82-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17023992-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17027326-fa90-11de-bd51-00224128e79d"/>
-<ref refid="17030db8-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1703ac0a-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17044c1e-fa90-11de-bd51-00224128e79d"/>
 <ref refid="170502e4-fa90-11de-bd51-00224128e79d"/>
@@ -37242,7 +36628,6 @@ swimlanes</val>
 <ref refid="172cd9a4-fa90-11de-bd51-00224128e79d"/>
 <ref refid="172d14a0-fa90-11de-bd51-00224128e79d"/>
 <ref refid="172d5258-fa90-11de-bd51-00224128e79d"/>
-<ref refid="172d8c14-fa90-11de-bd51-00224128e79d"/>
 <ref refid="172dc738-fa90-11de-bd51-00224128e79d"/>
 <ref refid="172e02ca-fa90-11de-bd51-00224128e79d"/>
 <ref refid="172f32f8-fa90-11de-bd51-00224128e79d"/>
@@ -37266,7 +36651,6 @@ swimlanes</val>
 <ref refid="17376f5e-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17381242-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1738b440-fa90-11de-bd51-00224128e79d"/>
-<ref refid="17395364-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17398e56-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1739ca42-fa90-11de-bd51-00224128e79d"/>
 <ref refid="173a05d4-fa90-11de-bd51-00224128e79d"/>
@@ -37317,7 +36701,6 @@ swimlanes</val>
 <ref refid="175163be-fa90-11de-bd51-00224128e79d"/>
 <ref refid="175204a4-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1752aa08-fa90-11de-bd51-00224128e79d"/>
-<ref refid="1753a732-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1753e74c-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17548332-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1754cae0-fa90-11de-bd51-00224128e79d"/>
@@ -37348,12 +36731,10 @@ swimlanes</val>
 <ref refid="175fc026-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17606742-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1760a1b2-fa90-11de-bd51-00224128e79d"/>
-<ref refid="17613dc0-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17622636-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17626056-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17630d8a-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1763b230-fa90-11de-bd51-00224128e79d"/>
-<ref refid="176453e8-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1764c990-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17691e28-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1769c206-fa90-11de-bd51-00224128e79d"/>
@@ -37483,7 +36864,6 @@ swimlanes</val>
 <ref refid="042a36f2-ec84-11ea-96dc-bf74f1f80424"/>
 <ref refid="549472ba-ec84-11ea-96dc-bf74f1f80424"/>
 <ref refid="5932a5bc-ec84-11ea-96dc-bf74f1f80424"/>
-<ref refid="c1bd2806-ec88-11ea-96dc-bf74f1f80424"/>
 <ref refid="3c94f390-ecfe-11ea-96dc-bf74f1f80424"/>
 <ref refid="4a28731a-ecfe-11ea-96dc-bf74f1f80424"/>
 <ref refid="1de265ac-00f1-11eb-8f71-7fd0147881a5"/>
@@ -37650,7 +37030,6 @@ swimlanes</val>
 <ref refid="17004a88-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1700e844-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1702b584-fa90-11de-bd51-00224128e79d"/>
-<ref refid="17034ff8-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1703ede6-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17049930-fa90-11de-bd51-00224128e79d"/>
 <ref refid="17055064-fa90-11de-bd51-00224128e79d"/>
@@ -37734,7 +37113,6 @@ swimlanes</val>
 <ref refid="175db9d4-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1760098c-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1760e55a-fa90-11de-bd51-00224128e79d"/>
-<ref refid="17618f0a-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1762acfa-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1763574a-fa90-11de-bd51-00224128e79d"/>
 <ref refid="1763f876-fa90-11de-bd51-00224128e79d"/>
@@ -37835,13 +37213,10 @@ swimlanes</val>
 <ref refid="08361ac2-ec84-11ea-96dc-bf74f1f80424"/>
 <ref refid="5768b71c-ec84-11ea-96dc-bf74f1f80424"/>
 <ref refid="5bbd170e-ec84-11ea-96dc-bf74f1f80424"/>
-<ref refid="cde17862-ec88-11ea-96dc-bf74f1f80424"/>
 <ref refid="b28c3610-ec8d-11ea-96dc-bf74f1f80424"/>
 <ref refid="481541c0-ecfe-11ea-96dc-bf74f1f80424"/>
 <ref refid="4c984e0e-ecfe-11ea-96dc-bf74f1f80424"/>
 <ref refid="691fc6bc-ed56-11ea-96dc-bf74f1f80424"/>
-<ref refid="c84b3eee-f9d8-11ea-b854-fb98adcb9438"/>
-<ref refid="cb489f42-f9d8-11ea-b854-fb98adcb9438"/>
 <ref refid="2037295a-00f1-11eb-8f71-7fd0147881a5"/>
 <ref refid="9adcb85e-62d1-11eb-9492-9757bcbe474b"/>
 <ref refid="7361575c-62d2-11eb-9492-9757bcbe474b"/>
@@ -37853,8 +37228,6 @@ swimlanes</val>
 <ref refid="8d2b539a-63c7-11eb-9492-9757bcbe474b"/>
 <ref refid="93f23af4-63c7-11eb-9492-9757bcbe474b"/>
 <ref refid="99332f14-63c7-11eb-9492-9757bcbe474b"/>
-<ref refid="d625de5a-64ba-11eb-9492-9757bcbe474b"/>
-<ref refid="dda913e0-64ba-11eb-9492-9757bcbe474b"/>
 <ref refid="34e2842a-6529-11eb-9492-9757bcbe474b"/>
 <ref refid="42a8be12-6529-11eb-9492-9757bcbe474b"/>
 <ref refid="7656921e-aa7c-11eb-ad49-8b526b5558f5"/>
@@ -37928,7 +37301,7 @@ swimlanes</val>
 <ref refid="16f98e50-fa90-11de-bd51-00224128e79d"/>
 </owningInstance>
 <value>
-<val>namespace, source</val>
+<val>namespace, relatedElement</val>
 </value>
 </Slot>
 <InstanceSpecification id="16fa3af8-fa90-11de-bd51-00224128e79d">
@@ -38312,34 +37685,6 @@ swimlanes</val>
 </owningInstance>
 <value>
 <val>members</val>
-</value>
-</Slot>
-<InstanceSpecification id="17030db8-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:522B7252-45D1-11D7-B5CA-613352B2821F"/>
-</reflist>
-</extended>
-<slot>
-<reflist>
-<ref refid="17034ff8-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</slot>
-</InstanceSpecification>
-<Slot id="17034ff8-fa90-11de-bd51-00224128e79d">
-<definingFeature>
-<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
-</definingFeature>
-<owningInstance>
-<ref refid="17030db8-fa90-11de-bd51-00224128e79d"/>
-</owningInstance>
-<value>
-<val>relatedElement</val>
 </value>
 </Slot>
 <InstanceSpecification id="1703ac0a-fa90-11de-bd51-00224128e79d">
@@ -38961,7 +38306,7 @@ swimlanes</val>
 <ref refid="17130f2e-fa90-11de-bd51-00224128e79d"/>
 </owningInstance>
 <value>
-<val>target</val>
+<val>relatedElement</val>
 </value>
 </Slot>
 <InstanceSpecification id="1713bbfe-fa90-11de-bd51-00224128e79d">
@@ -39597,7 +38942,7 @@ swimlanes</val>
 <ref refid="17245126-fa90-11de-bd51-00224128e79d"/>
 </owningInstance>
 <value>
-<val>namespace, source</val>
+<val>namespace, relatedElement</val>
 </value>
 </Slot>
 <InstanceSpecification id="1724f446-fa90-11de-bd51-00224128e79d">
@@ -39934,23 +39279,6 @@ swimlanes</val>
 <ref refid="DCE:3EEBFECC-6698-11D7-A84E-6C8643AD0CA4"/>
 </reflist>
 </extended>
-</InstanceSpecification>
-<InstanceSpecification id="172d8c14-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:B71C4ADE-65C6-11D7-89A9-9C62884CFFDE"/>
-</reflist>
-</extended>
-<slot>
-<reflist>
-<ref refid="dda913e0-64ba-11eb-9492-9757bcbe474b"/>
-</reflist>
-</slot>
 </InstanceSpecification>
 <InstanceSpecification id="172dc738-fa90-11de-bd51-00224128e79d">
 <classifier>
@@ -40454,23 +39782,6 @@ swimlanes</val>
 <val>packagedElement</val>
 </value>
 </Slot>
-<InstanceSpecification id="17395364-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:BAEADF3E-65C6-11D7-89A9-9C62884CFFDE"/>
-</reflist>
-</extended>
-<slot>
-<reflist>
-<ref refid="c84b3eee-f9d8-11ea-b854-fb98adcb9438"/>
-</reflist>
-</slot>
-</InstanceSpecification>
 <InstanceSpecification id="17398e56-fa90-11de-bd51-00224128e79d">
 <classifier>
 <reflist>
@@ -41519,23 +40830,6 @@ swimlanes</val>
 <val>ownedElement</val>
 </value>
 </Slot>
-<InstanceSpecification id="1753a732-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:B71C181E-65C6-11D7-89A9-9C62884CFFDE"/>
-</reflist>
-</extended>
-<slot>
-<reflist>
-<ref refid="d625de5a-64ba-11eb-9492-9757bcbe474b"/>
-</reflist>
-</slot>
-</InstanceSpecification>
 <InstanceSpecification id="1753e74c-fa90-11de-bd51-00224128e79d">
 <classifier>
 <reflist>
@@ -42078,34 +41372,6 @@ swimlanes</val>
 <val>owner, memberNamespace</val>
 </value>
 </Slot>
-<InstanceSpecification id="17613dc0-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:5C694A28-45D1-11D7-B5CA-613352B2821F"/>
-</reflist>
-</extended>
-<slot>
-<reflist>
-<ref refid="17618f0a-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</slot>
-</InstanceSpecification>
-<Slot id="17618f0a-fa90-11de-bd51-00224128e79d">
-<definingFeature>
-<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
-</definingFeature>
-<owningInstance>
-<ref refid="17613dc0-fa90-11de-bd51-00224128e79d"/>
-</owningInstance>
-<value>
-<val>relatedElement</val>
-</value>
-</Slot>
 <InstanceSpecification id="17622636-fa90-11de-bd51-00224128e79d">
 <classifier>
 <reflist>
@@ -42192,23 +41458,6 @@ swimlanes</val>
 <val>namespace</val>
 </value>
 </Slot>
-<InstanceSpecification id="176453e8-fa90-11de-bd51-00224128e79d">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:BAEAACB2-65C6-11D7-89A9-9C62884CFFDE"/>
-</reflist>
-</extended>
-<slot>
-<reflist>
-<ref refid="cb489f42-f9d8-11ea-b854-fb98adcb9438"/>
-</reflist>
-</slot>
-</InstanceSpecification>
 <InstanceSpecification id="1764c990-fa90-11de-bd51-00224128e79d">
 <classifier>
 <reflist>
@@ -52552,7 +51801,7 @@ association:not([memberEnd.navigability*=true]) {
 <ref refid="17490174-fa90-11de-bd51-00224128e79d"/>
 </owningInstance>
 <value>
-<val>directedRelationship, ownedMember</val>
+<val>relationship, ownedMember</val>
 </value>
 </Slot>
 <Slot id="0533bcb8-ea08-11ea-96dc-bf74f1f80424">
@@ -52563,7 +51812,7 @@ association:not([memberEnd.navigability*=true]) {
 <ref refid="17437cc2-fa90-11de-bd51-00224128e79d"/>
 </owningInstance>
 <value>
-<val>directedRelationship, ownedMember</val>
+<val>relationship, ownedMember</val>
 </value>
 </Slot>
 <InstanceSpecification id="042a36f2-ec84-11ea-96dc-bf74f1f80424">
@@ -52725,34 +51974,6 @@ association:not([memberEnd.navigability*=true]) {
 <val>ownedMember</val>
 </value>
 </Slot>
-<InstanceSpecification id="c1bd2806-ec88-11ea-96dc-bf74f1f80424">
-<classifier>
-<reflist>
-<ref refid="16f6b5f4-fa90-11de-bd51-00224128e79d"/>
-</reflist>
-</classifier>
-<extended>
-<reflist>
-<ref refid="DCE:522B4098-45D1-11D7-B5CA-613352B2821F"/>
-</reflist>
-</extended>
-<slot>
-<reflist>
-<ref refid="cde17862-ec88-11ea-96dc-bf74f1f80424"/>
-</reflist>
-</slot>
-</InstanceSpecification>
-<Slot id="cde17862-ec88-11ea-96dc-bf74f1f80424">
-<definingFeature>
-<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
-</definingFeature>
-<owningInstance>
-<ref refid="c1bd2806-ec88-11ea-96dc-bf74f1f80424"/>
-</owningInstance>
-<value>
-<val>relationship</val>
-</value>
-</Slot>
 <InstanceSpecification id="b2d601cc-ec89-11ea-96dc-bf74f1f80424">
 <classifier>
 <reflist>
@@ -52780,7 +52001,7 @@ association:not([memberEnd.navigability*=true]) {
 <Comment id="e993ec74-ec89-11ea-96dc-bf74f1f80424">
 <annotatedElement>
 <reflist>
-<ref refid="DCE:5C68DFBE-45D1-11D7-B5CA-613352B2821F"/>
+<ref refid="DCE:3F0B9972-45D1-11D7-B5CA-613352B2821F"/>
 </reflist>
 </annotatedElement>
 <body>
@@ -52890,28 +52111,6 @@ have an opposite end.
 <ref refid="DCE:22B3AA56-4B32-11D7-B391-02BBFE4396CE"/>
 </specific>
 </Generalization>
-<Slot id="c84b3eee-f9d8-11ea-b854-fb98adcb9438">
-<definingFeature>
-<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
-</definingFeature>
-<owningInstance>
-<ref refid="17395364-fa90-11de-bd51-00224128e79d"/>
-</owningInstance>
-<value>
-<val>ownedElement, directedRelationship</val>
-</value>
-</Slot>
-<Slot id="cb489f42-f9d8-11ea-b854-fb98adcb9438">
-<definingFeature>
-<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
-</definingFeature>
-<owningInstance>
-<ref refid="176453e8-fa90-11de-bd51-00224128e79d"/>
-</owningInstance>
-<value>
-<val>owner, target</val>
-</value>
-</Slot>
 <InstanceSpecification id="1de265ac-00f1-11eb-8f71-7fd0147881a5">
 <classifier>
 <reflist>
@@ -53455,28 +52654,6 @@ have an opposite end.
 </reflist>
 </presentation>
 </Comment>
-<Slot id="d625de5a-64ba-11eb-9492-9757bcbe474b">
-<definingFeature>
-<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
-</definingFeature>
-<owningInstance>
-<ref refid="1753a732-fa90-11de-bd51-00224128e79d"/>
-</owningInstance>
-<value>
-<val>target</val>
-</value>
-</Slot>
-<Slot id="dda913e0-64ba-11eb-9492-9757bcbe474b">
-<definingFeature>
-<ref refid="16f8dfbe-fa90-11de-bd51-00224128e79d"/>
-</definingFeature>
-<owningInstance>
-<ref refid="172d8c14-fa90-11de-bd51-00224128e79d"/>
-</owningInstance>
-<value>
-<val>directedRelationship</val>
-</value>
-</Slot>
 <Class id="d778d11e-6527-11eb-9492-9757bcbe474b">
 <generalization>
 <reflist>
@@ -55165,7 +54342,7 @@ have an opposite end.
 <ref refid="911142dc-4c90-11ec-8c4e-0456e5e540ed"/>
 </owningInstance>
 <value>
-<val>directedRelationship</val>
+<val>relationship</val>
 </value>
 </Slot>
 <Generalization id="bce01f32-4c90-11ec-8c4e-0456e5e540ed">
@@ -57612,5 +56789,63 @@ have an opposite end.
 <head-connection>
 <ref refid="DCE:38CAFEF6-45CF-11D7-B5CA-613352B2821F"/>
 </head-connection>
+</CommentLineItem>
+<Comment id="1579ed2a-3236-11ef-8506-be7f4daace40">
+<annotatedElement>
+<reflist>
+<ref refid="DCE:D733DED0-65C5-11D7-89A9-9C62884CFFDE"/>
+</reflist>
+</annotatedElement>
+<body>
+<val>From Core.</val>
+</body>
+<presentation>
+<reflist>
+<ref refid="1579f356-3236-11ef-8506-be7f4daace40"/>
+</reflist>
+</presentation>
+</Comment>
+<CommentItem id="1579f356-3236-11ef-8506-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 883.632530120482, 233.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>50.0</val>
+</height>
+<diagram>
+<ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
+</diagram>
+<subject>
+<ref refid="1579ed2a-3236-11ef-8506-be7f4daace40"/>
+</subject>
+</CommentItem>
+<CommentLineItem id="1be63344-3236-11ef-8506-be7f4daace40">
+<diagram>
+<ref refid="DCE:4E445586-50A4-11D7-807A-302CB4EF44FD"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 832.632530120482, 246.0)</val>
+</matrix>
+<points>
+<val>[(11.367469879518012, 2.5601549053356223), (51.0, 9.242857142857144)]</val>
+</points>
+<head-connection>
+<ref refid="DCE:D7075AD6-65C5-11D7-89A9-9C62884CFFDE"/>
+</head-connection>
+<tail-connection>
+<ref refid="1579f356-3236-11ef-8506-be7f4daace40"/>
+</tail-connection>
 </CommentLineItem>
 </gaphor>

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -5181,8 +5181,8 @@
 <ownedAttribute>
 <reflist>
 <ref refid="DCE:67C4FC98-4B35-11D7-B391-02BBFE4396CE"/>
-<ref refid="DCE:B0D30324-4B35-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:99FB75E6-4B35-11D7-B391-02BBFE4396CE"/>
+<ref refid="DCE:B0D30324-4B35-11D7-B391-02BBFE4396CE"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -6044,8 +6044,6 @@
 <ownedAttribute>
 <reflist>
 <ref refid="DCE:D33A9738-4694-11D7-B567-379CA7034986"/>
-<ref refid="90a6d158-b9b1-11eb-93ad-535118859f0b"/>
-<ref refid="98bdb712-b9b1-11eb-93ad-535118859f0b"/>
 <ref refid="aa8a8fb0-e185-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="DCE:B7B7E77C-4694-11D7-B567-379CA7034986"/>
 </reflist>
@@ -17290,6 +17288,7 @@
 <ref refid="DCE:BCEBC220-4B32-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:2889D960-6693-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:F1CF4FA4-4B33-11D7-B391-02BBFE4396CE"/>
+<ref refid="DCE:99FBA804-4B35-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:B0388110-4B34-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:00ED6378-4B35-11D7-B391-02BBFE4396CE"/>
 <ref refid="DCE:38A9AE44-4B54-11D7-A5E6-6257AF3C5118"/>
@@ -17297,7 +17296,6 @@
 <ref refid="DCE:3EEBCC18-6698-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="e9507590-e962-11ea-87d1-cbf2d1fcaed0"/>
 <ref refid="DCE:BFC7B66E-4B37-11D7-B391-02BBFE4396CE"/>
-<ref refid="DCE:99FBA804-4B35-11D7-B391-02BBFE4396CE"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -22656,10 +22654,10 @@ specially for Gaphor</val>
 </name>
 <ownedAttribute>
 <reflist>
+<ref refid="DCE:068AFED0-6692-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:B7523644-6691-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:54F98BE0-6692-11D7-A84E-6C8643AD0CA4"/>
 <ref refid="DCE:FE7634AE-6690-11D7-A84E-6C8643AD0CA4"/>
-<ref refid="DCE:068AFED0-6692-11D7-A84E-6C8643AD0CA4"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -49170,29 +49168,6 @@ association:not([memberEnd.navigability*=true]) {
 <val>owner</val>
 </value>
 </Slot>
-<Property id="aa8a8fb0-e185-11ea-b7ab-f5b4c130f24e">
-<class_>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<name>
-<val>visibility</val>
-</name>
-<typeValue>
-<val>VisibilityKind</val>
-</typeValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-</Property>
 <InstanceSpecification id="2de9d91e-e187-11ea-b7ab-f5b4c130f24e">
 <classifier>
 <reflist>
@@ -52818,55 +52793,6 @@ have an opposite end.
 <val>memberNamespace</val>
 </value>
 </Slot>
-<Property id="90a6d158-b9b1-11eb-93ad-535118859f0b">
-<class_>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<isDerived>
-<val>1</val>
-</isDerived>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<name>
-<val>qualifiedName</val>
-</name>
-<typeValue>
-<val>String</val>
-</typeValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-</Property>
-<Property id="98bdb712-b9b1-11eb-93ad-535118859f0b">
-<class_>
-<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
-</class_>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<lowerValue>
-<val>0</val>
-</lowerValue>
-<name>
-<val>name</val>
-</name>
-<typeValue>
-<val>String</val>
-</typeValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-<upperValue>
-<val>1</val>
-</upperValue>
-</Property>
 <Package id="34985146-ebea-11eb-8d68-2d4b211d5079">
 <name>
 <val>14. Information Flows</val>
@@ -56848,4 +56774,27 @@ have an opposite end.
 <ref refid="1579f356-3236-11ef-8506-be7f4daace40"/>
 </tail-connection>
 </CommentLineItem>
+<Property id="aa8a8fb0-e185-11ea-b7ab-f5b4c130f24e">
+<class_>
+<ref refid="DCE:FF594BE0-464C-11D7-AA08-1B85D5275D8A"/>
+</class_>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<lowerValue>
+<val>0</val>
+</lowerValue>
+<name>
+<val>visibility</val>
+</name>
+<typeValue>
+<val>VisibilityKind</val>
+</typeValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+<upperValue>
+<val>1</val>
+</upperValue>
+</Property>
 </gaphor>

--- a/models/UML.override
+++ b/models/UML.override
@@ -65,18 +65,6 @@ Property.isComposite = derived('isComposite', bool, 0, 1, lambda obj: [obj.aggre
 override Constraint.context: derivedunion[Namespace]
 Constraint.context = derivedunion('context', Namespace, 0, 1)
 %%
-override NamedElement.qualifiedName: derived[list[str]]
-
-from gaphor.core.modeling import qualifiedName
-
-NamedElement.qualifiedName = derived(
-    "qualifiedName",
-    list[str],
-    0,
-    1,
-    lambda obj: [qualifiedName(obj)],
-)
-%%
 override Property.navigability(Property.opposite, Property.association): derived[bool | None]
 # defined in umloverrides.py
 %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,9 @@ raaml.script = """gaphor.codegen.coder:main(
 c4model.script = """gaphor.codegen.coder:main(
     modelfile='models/C4Model.gaphor',
     outfile='gaphor/C4Model/c4model.py',
-    supermodelfiles=[('UML', 'models/UML.gaphor')]
+    supermodelfiles=[
+        ('Core', 'models/Core.gaphor'),
+        ('UML', 'models/UML.gaphor')]
     )"""
 lint = "pre-commit run --all-files"
 docs = { "cwd" = "docs", "shell" = "sphinx-build -W -b html . _build/html" }

--- a/test-models/all-elements.gaphor
+++ b/test-models/all-elements.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.8.2">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.25.1">
 <Package id="a80225e6-8a24-11e9-94a9-784f435640ba">
 <name>
 <val>New model</val>
@@ -36,6 +36,9 @@
 <ref refid="3c3e0f26-dcdf-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="8d674d1e-dce0-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="99fb9418-6961-11ec-a267-0456e5e540ed"/>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+<ref refid="ec968bb0-3457-11ef-8774-be7f4daace40"/>
+<ref refid="581e5002-3458-11ef-8774-be7f4daace40"/>
 </reflist>
 </ownedType>
 </Package>
@@ -58,27 +61,12 @@
 <ref refid="da3e9d1e-8a24-11e9-94a9-784f435640ba"/>
 <ref refid="dbb2da3e-8a24-11e9-94a9-784f435640ba"/>
 <ref refid="dd85bdfe-8a24-11e9-94a9-784f435640ba"/>
-<ref refid="fd30ea2a-8a24-11e9-94a9-784f435640ba"/>
-<ref refid="007a1a30-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="02313516-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="0a5bbe64-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="18562bd0-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="19e0db4e-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="1b5eff1e-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="1d309140-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="23fba4c4-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="25c79240-8a25-11e9-94a9-784f435640ba"/>
 <ref refid="588dd09a-8a25-11e9-94a9-784f435640ba"/>
 <ref refid="2e456ff6-dce0-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="545ff0de-8a25-11e9-94a9-784f435640ba"/>
 <ref refid="57b28a40-dce0-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="6f896e19-dce0-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="5cc961d4-dce0-11ea-b7ab-f5b4c130f24e"/>
-<ref refid="5de2c596-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="684d717a-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="6ae17ada-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="6ca26064-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="6e1580c0-8a25-11e9-94a9-784f435640ba"/>
 <ref refid="0c325d6e-8a26-11e9-bbea-784f435640ba"/>
 <ref refid="102891cc-8a26-11e9-bbea-784f435640ba"/>
 <ref refid="11bc3610-8a26-11e9-bbea-784f435640ba"/>
@@ -94,6 +82,21 @@
 <ref refid="19d7f847-8dda-11ea-9685-03ae027faeeb"/>
 <ref refid="33e08034-dcdf-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="3c3e0f27-dcdf-11ea-b7ab-f5b4c130f24e"/>
+<ref refid="c4d4c45c-3457-11ef-8774-be7f4daace40"/>
+<ref refid="18562bd0-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="19e0db4e-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="1b5eff1e-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="25c79240-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="23fba4c4-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="1d309140-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="0a5bbe64-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="02313516-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="007a1a30-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="ec9727e6-3457-11ef-8774-be7f4daace40"/>
+<ref refid="6ca26064-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="6e1580c0-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="684d717a-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="6ae17ada-8a25-11e9-94a9-784f435640ba"/>
 <ref refid="55de9488-8a25-11e9-94a9-784f435640ba"/>
 <ref refid="6ad9c93f-dce0-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="c892e296-8a24-11e9-94a9-784f435640ba"/>
@@ -121,6 +124,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 73.0, 62.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>725.0</val>
 </width>
@@ -140,6 +146,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 95.0, 90.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -149,12 +158,6 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
-<show_operations>
-<val>1</val>
-</show_operations>
 <show_stereotypes>
 <val>0</val>
 </show_stereotypes>
@@ -166,6 +169,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 95.0, 218.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>114.0</val>
 </width>
@@ -175,12 +181,6 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
-<show_operations>
-<val>1</val>
-</show_operations>
 <show_stereotypes>
 <val>0</val>
 </show_stereotypes>
@@ -195,6 +195,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 240.0, 90.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>125.0</val>
 </width>
@@ -221,9 +224,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="0495b7c8-8dda-11ea-9685-03ae027faeeb"/>
 </subject>
@@ -268,9 +268,6 @@
 <tail-connection>
 <ref refid="e38cbc98-8dd9-11ea-9685-03ae027faeeb"/>
 </tail-connection>
-<auto_dependency>
-<val>1</val>
-</auto_dependency>
 </DependencyItem>
 <GeneralizationItem id="cd5d43b6-8a24-11e9-94a9-784f435640ba">
 <diagram>
@@ -328,6 +325,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 73.0, 347.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>725.0</val>
 </width>
@@ -342,6 +342,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 102.0, 381.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>163.0</val>
 </width>
@@ -362,6 +365,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 277.5, 381.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>135.0</val>
 </width>
@@ -382,6 +388,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 435.5, 385.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>120.0</val>
 </width>
@@ -402,11 +411,14 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 582.75, 385.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>120.0</val>
 </width>
 <height>
-<val>50.0</val>
+<val>54.0</val>
 </height>
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
@@ -435,24 +447,13 @@
 <val>[(0.0, 0.0), (37.0, -58.0)]</val>
 </points>
 </ConnectorItem>
-<Box id="fd30ea2a-8a24-11e9-94a9-784f435640ba">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 73.0, 503.0)</val>
-</matrix>
-<width>
-<val>725.0</val>
-</width>
-<height>
-<val>163.0</val>
-</height>
-<diagram>
-<ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
-</diagram>
-</Box>
 <ActionItem id="007a1a30-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 230.0, 531.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 152.51557327905073, 27.2325434550184)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>101.0</val>
 </width>
@@ -462,14 +463,20 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="c4d4c45c-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="007a17b0-8a25-11e9-94a9-784f435640ba"/>
 </subject>
 </ActionItem>
 <InitialNodeItem id="02313516-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 135.0, 536.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 54.51557327905073, 29.2325434550184)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>20.0</val>
 </width>
@@ -479,6 +486,9 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="c4d4c45c-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="02313228-8a25-11e9-94a9-784f435640ba"/>
 </subject>
@@ -494,13 +504,13 @@
 <val>0</val>
 </orthogonal>
 <subject>
-<ref refid="04a6079a-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="45d9a37e-3458-11ef-8774-be7f4daace40"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 155.0, 547.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 158.0, 545.5)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (75.0, -1.0)]</val>
+<val>[(-6.0, 4.0), (72.0, 4.0)]</val>
 </points>
 <head-connection>
 <ref refid="02313516-8a25-11e9-94a9-784f435640ba"/>
@@ -511,8 +521,11 @@
 </ControlFlowItem>
 <ActivityFinalNodeItem id="0a5bbe64-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 373.0, 531.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 295.5155732790507, 24.2325434550184)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>30.0</val>
 </width>
@@ -522,6 +535,9 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="c4d4c45c-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="0a5bbb9e-8a25-11e9-94a9-784f435640ba"/>
 </subject>
@@ -537,13 +553,13 @@
 <val>0</val>
 </orthogonal>
 <subject>
-<ref refid="0c9b68e6-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="48c48d56-3458-11ef-8774-be7f4daace40"/>
 </subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 327.0, 544.5)</val>
 </matrix>
 <points>
-<val>[(4.0, 0.0), (46.0, -1.0)]</val>
+<val>[(4.0, 3.0), (46.0, 2.0)]</val>
 </points>
 <head-connection>
 <ref refid="007a1a30-8a25-11e9-94a9-784f435640ba"/>
@@ -554,8 +570,11 @@
 </ControlFlowItem>
 <FlowFinalNodeItem id="18562bd0-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 135.0, 584.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 55.01557327905073, 77.2325434550184)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>20.0</val>
 </width>
@@ -565,14 +584,20 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="c4d4c45c-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="185628ec-8a25-11e9-94a9-784f435640ba"/>
 </subject>
 </FlowFinalNodeItem>
 <DecisionNodeItem id="19e0db4e-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 175.0, 579.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 96.51557327905073, 72.2325434550184)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>20.0</val>
 </width>
@@ -582,13 +607,16 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="c4d4c45c-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="19e0d928-8a25-11e9-94a9-784f435640ba"/>
 </subject>
 </DecisionNodeItem>
 <ForkNodeItem id="1b5eff1e-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 214.0, 581.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 135.51557327905073, 75.2325434550184)</val>
 </matrix>
 <height>
 <val>30.0</val>
@@ -596,14 +624,20 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="c4d4c45c-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="1b5efc30-8a25-11e9-94a9-784f435640ba"/>
 </subject>
 </ForkNodeItem>
 <ObjectNodeItem id="1d309140-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 440.4522705078125, 531.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 367.5155732790507, 24.2325434550184)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>139.0</val>
 </width>
@@ -613,9 +647,9 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
-<show_ordering>
-<val>0</val>
-</show_ordering>
+<parent>
+<ref refid="c4d4c45c-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="1d308ec0-8a25-11e9-94a9-784f435640ba"/>
 </subject>
@@ -639,8 +673,11 @@
 </ControlFlowItem>
 <SendSignalActionItem id="23fba4c4-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 255.0, 599.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 174.51557327905073, 92.2325434550184)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>193.0</val>
 </width>
@@ -650,14 +687,20 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="c4d4c45c-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="23fba17c-8a25-11e9-94a9-784f435640ba"/>
 </subject>
 </SendSignalActionItem>
 <AcceptEventActionItem id="25c79240-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 440.4522705078125, 599.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 362.9678437868632, 92.2325434550184)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>203.0</val>
 </width>
@@ -667,6 +710,9 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="c4d4c45c-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="25c79006-8a25-11e9-94a9-784f435640ba"/>
 </subject>
@@ -704,6 +750,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 73.0, 696.544367758903)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>725.0</val>
 </width>
@@ -712,11 +761,11 @@
 </height>
 <children>
 <reflist>
+<ref refid="55de9488-8a25-11e9-94a9-784f435640ba"/>
 <ref refid="2e456ff6-dce0-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="545ff0de-8a25-11e9-94a9-784f435640ba"/>
 <ref refid="57b28a40-dce0-11ea-b7ab-f5b4c130f24e"/>
 <ref refid="5cc961d4-dce0-11ea-b7ab-f5b4c130f24e"/>
-<ref refid="55de9488-8a25-11e9-94a9-784f435640ba"/>
 <ref refid="6ad9c93f-dce0-11ea-b7ab-f5b4c130f24e"/>
 </reflist>
 </children>
@@ -731,6 +780,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 182.0, 36.455632241096964)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -746,14 +798,17 @@
 <subject>
 <ref refid="2e456ff5-dce0-11ea-b7ab-f5b4c130f24e"/>
 </subject>
-<lifetime-length>
-<val>10.0</val>
-</lifetime-length>
+<lifetime-y>
+<val>60.0</val>
+</lifetime-y>
 </LifelineItem>
 <LifelineItem id="545ff0de-8a25-11e9-94a9-784f435640ba">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 19.5, 36.455632241096964)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -769,14 +824,17 @@
 <subject>
 <ref refid="545fee04-8a25-11e9-94a9-784f435640ba"/>
 </subject>
-<lifetime-length>
-<val>10.0</val>
-</lifetime-length>
+<lifetime-y>
+<val>60.0</val>
+</lifetime-y>
 </LifelineItem>
 <LifelineItem id="57b28a40-dce0-11ea-b7ab-f5b4c130f24e">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 390.0, 11.455632241096964)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -797,9 +855,9 @@
 <subject>
 <ref refid="57b28a3f-dce0-11ea-b7ab-f5b4c130f24e"/>
 </subject>
-<lifetime-length>
-<val>42.0</val>
-</lifetime-length>
+<lifetime-y>
+<val>92.0</val>
+</lifetime-y>
 </LifelineItem>
 <ExecutionSpecificationItem id="6f896e19-dce0-11ea-b7ab-f5b4c130f24e">
 <matrix>
@@ -825,6 +883,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 557.5, 11.455632241096964)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -840,45 +901,40 @@
 <subject>
 <ref refid="5cc961d3-dce0-11ea-b7ab-f5b4c130f24e"/>
 </subject>
-<lifetime-length>
-<val>31.91126448219387</val>
-</lifetime-length>
+<lifetime-y>
+<val>81.91126448219387</val>
+</lifetime-y>
 </LifelineItem>
-<Box id="5de2c596-8a25-11e9-94a9-784f435640ba">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 73.0, 844.5)</val>
-</matrix>
-<width>
-<val>725.0</val>
-</width>
-<height>
-<val>93.0</val>
-</height>
-<diagram>
-<ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
-</diagram>
-</Box>
 <StateItem id="684d717a-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 174.0, 884.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 119.50000000000001, 79.40444929894807)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>78.0</val>
 </width>
 <height>
-<val>30.0</val>
+<val>31.0</val>
 </height>
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="ec9727e6-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="684d6c98-8a25-11e9-94a9-784f435640ba"/>
 </subject>
 </StateItem>
 <PseudostateItem id="6ae17ada-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 104.0, 889.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 22.000000000000014, 82.12920704270687)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>20.0</val>
 </width>
@@ -888,14 +944,20 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="ec9727e6-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="6ae176f2-8a25-11e9-94a9-784f435640ba"/>
 </subject>
 </PseudostateItem>
 <FinalStateItem id="6ca26064-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 325.0, 884.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 275.5, 78.53365634165493)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>30.0</val>
 </width>
@@ -905,14 +967,20 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="ec9727e6-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="6ca25c22-8a25-11e9-94a9-784f435640ba"/>
 </subject>
 </FinalStateItem>
 <PseudostateItem id="6e1580c0-8a25-11e9-94a9-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 435.5, 880.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 382.0, 79.40444929894807)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>30.0</val>
 </width>
@@ -922,6 +990,9 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
+<parent>
+<ref refid="ec9727e6-3457-11ef-8774-be7f4daace40"/>
+</parent>
 <subject>
 <ref refid="6e157b7a-8a25-11e9-94a9-784f435640ba"/>
 </subject>
@@ -940,10 +1011,10 @@
 <ref refid="c8a75e0c-dd42-11ea-b7ab-f5b4c130f24e"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 124.0, 899.6292070427069)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 130.0, 905.685683078191)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (50.0, -1.0)]</val>
+<val>[(-14.999999999999986, 10.880985328125917), (62.5, 12.156227584367116)]</val>
 </points>
 <head-connection>
 <ref refid="6ae17ada-8a25-11e9-94a9-784f435640ba"/>
@@ -954,8 +1025,11 @@
 </TransitionItem>
 <Box id="0c325d6e-8a26-11e9-bbea-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 73.0, 965.125)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 73.0, 1010.765625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>725.0</val>
 </width>
@@ -968,8 +1042,11 @@
 </Box>
 <UseCaseItem id="102891cc-8a26-11e9-bbea-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 104.0, 1006.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 105.0, 1052.140625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>104.0</val>
 </width>
@@ -985,8 +1062,11 @@
 </UseCaseItem>
 <ActorItem id="11bc3610-8a26-11e9-bbea-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 305.0, 991.6292070427069)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 305.0, 1037.2698320427069)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>38.0</val>
 </width>
@@ -1013,9 +1093,6 @@
 <orthogonal>
 <val>0</val>
 </orthogonal>
-<show_direction>
-<val>0</val>
-</show_direction>
 <subject>
 <ref refid="8d674d1e-dce0-11ea-b7ab-f5b4c130f24e"/>
 </subject>
@@ -1023,10 +1100,10 @@
 <ref refid="8d674d20-dce0-11ea-b7ab-f5b4c130f24e"/>
 </tail_subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 305.0, 1025.2584140854137)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 307.0, 1070.8990390854137)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (-97.0, -3.6292070427068666)]</val>
+<val>[(-2.0, 0.0), (-98.0, -3.6292070427068666)]</val>
 </points>
 <head-connection>
 <ref refid="11bc3610-8a26-11e9-bbea-784f435640ba"/>
@@ -1049,10 +1126,10 @@
 <ref refid="4d14005a-dcdf-11ea-b7ab-f5b4c130f24e"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 593.28, 1040.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 595.6640625, 1086.140625)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (21.782500000000027, -33.87079295729313)]</val>
+<val>[(-2.3840625000000273, 0.0), (19.3984375, -33.87079295729313)]</val>
 </points>
 <head-connection>
 <ref refid="3c3e0f27-dcdf-11ea-b7ab-f5b4c130f24e"/>
@@ -1075,10 +1152,10 @@
 <ref refid="47767218-dcdf-11ea-b7ab-f5b4c130f24e"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 695.4, 1040.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 694.5640625, 1086.140625)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (19.899999999999977, -33.87079295729313)]</val>
+<val>[(0.8359375, 0.0), (20.735937499999977, -33.87079295729313)]</val>
 </points>
 <head-connection>
 <ref refid="3c3e0f27-dcdf-11ea-b7ab-f5b4c130f24e"/>
@@ -1089,8 +1166,11 @@
 </ExtendItem>
 <Box id="23b4bde2-8a26-11e9-bbea-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 73.0, 1107.125)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 73.0, 1152.765625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>725.0</val>
 </width>
@@ -1103,8 +1183,11 @@
 </Box>
 <PackageItem id="2cb86966-8a26-11e9-bbea-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 108.0, 1132.6292070427069)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 105.0, 1178.2698320427069)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>109.0</val>
 </width>
@@ -1120,8 +1203,11 @@
 </PackageItem>
 <ClassItem id="2e4737bc-8a26-11e9-bbea-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 260.5, 1134.8771035213535)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 263.5, 1180.5177285213535)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1146,8 +1232,11 @@
 </ClassItem>
 <ClassItem id="31a607ee-8a26-11e9-bbea-784f435640ba">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 421.5, 1126.8771035213535)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 420.5, 1172.5177285213535)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>129.0</val>
 </width>
@@ -1157,12 +1246,6 @@
 <diagram>
 <ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
 </diagram>
-<show_attributes>
-<val>1</val>
-</show_attributes>
-<show_operations>
-<val>1</val>
-</show_operations>
 <show_stereotypes>
 <val>0</val>
 </show_stereotypes>
@@ -1181,13 +1264,13 @@
 <val>0</val>
 </orthogonal>
 <subject>
-<ref refid="5c70f828-dcdf-11ea-b7ab-f5b4c130f24e"/>
+<ref refid="581e5002-3458-11ef-8774-be7f4daace40"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 360.5, 1168.1292070427069)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 363.5, 1213.7698320427069)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (61.0, 0.5)]</val>
+<val>[(0.0, 0.5), (57.0, 0.5)]</val>
 </points>
 <head-connection>
 <ref refid="2e4737bc-8a26-11e9-bbea-784f435640ba"/>
@@ -1200,6 +1283,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 73.0, -27.625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1214,6 +1300,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 201.0, -23.625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1245,6 +1334,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 405.0, -17.625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -1279,6 +1371,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 474.5, 86.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>216.5</val>
 </width>
@@ -1302,6 +1397,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 475.0, 234.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>143.5</val>
 </width>
@@ -1325,6 +1423,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 626.5, 234.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>106.5</val>
 </width>
@@ -1349,8 +1450,11 @@
 </InterfaceItem>
 <UseCaseItem id="33e08034-dcdf-11ea-b7ab-f5b4c130f24e">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 596.5, 976.6292070427069)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 596.5, 1022.2698320427069)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>148.5</val>
 </width>
@@ -1366,8 +1470,11 @@
 </UseCaseItem>
 <UseCaseItem id="3c3e0f27-dcdf-11ea-b7ab-f5b4c130f24e">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 577.0, 1040.5)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 577.0, 1086.140625)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>148.0</val>
 </width>
@@ -1424,10 +1531,10 @@
 <ref refid="dc41f3a0-dd42-11ea-b7ab-f5b4c130f24e"/>
 </subject>
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 252.0, 900.6292070427069)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 252.0, 865.5174013699163)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (73.0, 0.0)]</val>
+<val>[(18.5, 54.32450929264178), (96.5, 53.453716335348645)]</val>
 </points>
 <head-connection>
 <ref refid="684d717a-8a25-11e9-94a9-784f435640ba"/>
@@ -1538,9 +1645,12 @@
 </presentation>
 </Device>
 <Action id="007a17b0-8a25-11e9-94a9-784f435640ba">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
 <incoming>
 <reflist>
-<ref refid="04a6079a-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="45d9a37e-3458-11ef-8774-be7f4daace40"/>
 </reflist>
 </incoming>
 <name>
@@ -1548,7 +1658,7 @@
 </name>
 <outgoing>
 <reflist>
-<ref refid="0c9b68e6-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="48c48d56-3458-11ef-8774-be7f4daace40"/>
 </reflist>
 </outgoing>
 <presentation>
@@ -1558,12 +1668,15 @@
 </presentation>
 </Action>
 <InitialNode id="02313228-8a25-11e9-94a9-784f435640ba">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
 <name>
 <val>start</val>
 </name>
 <outgoing>
 <reflist>
-<ref refid="04a6079a-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="45d9a37e-3458-11ef-8774-be7f4daace40"/>
 </reflist>
 </outgoing>
 <presentation>
@@ -1572,27 +1685,14 @@
 </reflist>
 </presentation>
 </InitialNode>
-<ControlFlow id="04a6079a-8a25-11e9-94a9-784f435640ba">
-<name>
-<val>flow</val>
-</name>
-<presentation>
-<reflist>
-<ref refid="03e0cb38-8a25-11e9-94a9-784f435640ba"/>
-</reflist>
-</presentation>
-<source>
-<ref refid="02313228-8a25-11e9-94a9-784f435640ba"/>
-</source>
-<target>
-<ref refid="007a17b0-8a25-11e9-94a9-784f435640ba"/>
-</target>
-</ControlFlow>
 <ActivityFinalNode id="0a5bbb9e-8a25-11e9-94a9-784f435640ba">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
 <incoming>
 <reflist>
-<ref refid="0c9b68e6-8a25-11e9-94a9-784f435640ba"/>
-<ref refid="6b0176f4-8ce9-11ec-ad28-0456e5e540ed"/>
+<ref refid="48c48d56-3458-11ef-8774-be7f4daace40"/>
+<ref refid="509e4b20-3458-11ef-8774-be7f4daace40"/>
 </reflist>
 </incoming>
 <name>
@@ -1604,23 +1704,10 @@
 </reflist>
 </presentation>
 </ActivityFinalNode>
-<ControlFlow id="0c9b68e6-8a25-11e9-94a9-784f435640ba">
-<name>
-<val>flow</val>
-</name>
-<presentation>
-<reflist>
-<ref refid="0bfe92d2-8a25-11e9-94a9-784f435640ba"/>
-</reflist>
-</presentation>
-<source>
-<ref refid="007a17b0-8a25-11e9-94a9-784f435640ba"/>
-</source>
-<target>
-<ref refid="0a5bbb9e-8a25-11e9-94a9-784f435640ba"/>
-</target>
-</ControlFlow>
 <FlowFinalNode id="185628ec-8a25-11e9-94a9-784f435640ba">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
 <name>
 <val>delete</val>
 </name>
@@ -1631,6 +1718,9 @@
 </presentation>
 </FlowFinalNode>
 <DecisionNode id="19e0d928-8a25-11e9-94a9-784f435640ba">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
 <name>
 <val>fork</val>
 </name>
@@ -1641,6 +1731,9 @@
 </presentation>
 </DecisionNode>
 <JoinNode id="1b5efc30-8a25-11e9-94a9-784f435640ba">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
 <name>
 <val>join node</val>
 </name>
@@ -1651,12 +1744,15 @@
 </presentation>
 </JoinNode>
 <ObjectNode id="1d308ec0-8a25-11e9-94a9-784f435640ba">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
 <name>
 <val>NewObjectNode</val>
 </name>
 <outgoing>
 <reflist>
-<ref refid="6b0176f4-8ce9-11ec-ad28-0456e5e540ed"/>
+<ref refid="509e4b20-3458-11ef-8774-be7f4daace40"/>
 </reflist>
 </outgoing>
 <presentation>
@@ -1666,6 +1762,9 @@
 </presentation>
 </ObjectNode>
 <SendSignalAction id="23fba17c-8a25-11e9-94a9-784f435640ba">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
 <name>
 <val>NewSendSignalAction</val>
 </name>
@@ -1676,6 +1775,9 @@
 </presentation>
 </SendSignalAction>
 <AcceptEventAction id="25c79006-8a25-11e9-94a9-784f435640ba">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
 <name>
 <val>NewAcceptEventAction</val>
 </name>
@@ -1736,6 +1838,9 @@
 </presentation>
 </Interaction>
 <State id="684d6c98-8a25-11e9-94a9-784f435640ba">
+<container>
+<ref refid="f03d0ce4-3457-11ef-8774-be7f4daace40"/>
+</container>
 <incoming>
 <reflist>
 <ref refid="c8a75e0c-dd42-11ea-b7ab-f5b4c130f24e"/>
@@ -1756,6 +1861,9 @@
 </presentation>
 </State>
 <Pseudostate id="6ae176f2-8a25-11e9-94a9-784f435640ba">
+<container>
+<ref refid="f03d0ce4-3457-11ef-8774-be7f4daace40"/>
+</container>
 <name>
 <val>start</val>
 </name>
@@ -1771,6 +1879,9 @@
 </presentation>
 </Pseudostate>
 <FinalState id="6ca25c22-8a25-11e9-94a9-784f435640ba">
+<container>
+<ref refid="f03d0ce4-3457-11ef-8774-be7f4daace40"/>
+</container>
 <incoming>
 <reflist>
 <ref refid="dc41f3a0-dd42-11ea-b7ab-f5b4c130f24e"/>
@@ -1786,6 +1897,9 @@
 </presentation>
 </FinalState>
 <Pseudostate id="6e157b7a-8a25-11e9-94a9-784f435640ba">
+<container>
+<ref refid="f03d0ce4-3457-11ef-8774-be7f4daace40"/>
+</container>
 <kind>
 <val>shallowHistory</val>
 </kind>
@@ -1843,7 +1957,7 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="5c70f82a-dcdf-11ea-b7ab-f5b4c130f24e"/>
+<ref refid="581f2fe0-3458-11ef-8774-be7f4daace40"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -1861,7 +1975,7 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="5c70f829-dcdf-11ea-b7ab-f5b4c130f24e"/>
+<ref refid="581eef76-3458-11ef-8774-be7f4daace40"/>
 </reflist>
 </ownedAttribute>
 <package>
@@ -2155,53 +2269,6 @@
 </reflist>
 </presentation>
 </Include>
-<Extension id="5c70f828-dcdf-11ea-b7ab-f5b4c130f24e">
-<memberEnd>
-<reflist>
-<ref refid="5c70f829-dcdf-11ea-b7ab-f5b4c130f24e"/>
-<ref refid="5c70f82a-dcdf-11ea-b7ab-f5b4c130f24e"/>
-</reflist>
-</memberEnd>
-<name>
-<val>extension</val>
-</name>
-<ownedEnd>
-<ref refid="5c70f82a-dcdf-11ea-b7ab-f5b4c130f24e"/>
-</ownedEnd>
-<presentation>
-<reflist>
-<ref refid="3557fc26-8a26-11e9-bbea-784f435640ba"/>
-</reflist>
-</presentation>
-</Extension>
-<Property id="5c70f829-dcdf-11ea-b7ab-f5b4c130f24e">
-<association>
-<ref refid="5c70f828-dcdf-11ea-b7ab-f5b4c130f24e"/>
-</association>
-<class_>
-<ref refid="31a5fc90-8a26-11e9-bbea-784f435640ba"/>
-</class_>
-<name>
-<val>baseClass</val>
-</name>
-<type>
-<ref refid="2e472c7c-8a26-11e9-bbea-784f435640ba"/>
-</type>
-</Property>
-<ExtensionEnd id="5c70f82a-dcdf-11ea-b7ab-f5b4c130f24e">
-<aggregation>
-<val>composite</val>
-</aggregation>
-<association>
-<ref refid="5c70f828-dcdf-11ea-b7ab-f5b4c130f24e"/>
-</association>
-<class_>
-<ref refid="2e472c7c-8a26-11e9-bbea-784f435640ba"/>
-</class_>
-<type>
-<ref refid="31a5fc90-8a26-11e9-bbea-784f435640ba"/>
-</type>
-</ExtensionEnd>
 <Lifeline id="2e456ff5-dce0-11ea-b7ab-f5b4c130f24e">
 <coveredBy>
 <reflist>
@@ -2408,6 +2475,9 @@
 </type>
 </Property>
 <Transition id="c8a75e0c-dd42-11ea-b7ab-f5b4c130f24e">
+<container>
+<ref refid="f03d0ce4-3457-11ef-8774-be7f4daace40"/>
+</container>
 <guard>
 <ref refid="c8a75e0d-dd42-11ea-b7ab-f5b4c130f24e"/>
 </guard>
@@ -2429,6 +2499,9 @@
 </transition>
 </Constraint>
 <Transition id="dc41f3a0-dd42-11ea-b7ab-f5b4c130f24e">
+<container>
+<ref refid="f03d0ce4-3457-11ef-8774-be7f4daace40"/>
+</container>
 <guard>
 <ref refid="dc41f3a1-dd42-11ea-b7ab-f5b4c130f24e"/>
 </guard>
@@ -2466,6 +2539,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 167.0, 148.5)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>148.0</val>
 </width>
@@ -2489,14 +2565,17 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
-<ref refid="6b0176f4-8ce9-11ec-ad28-0456e5e540ed"/>
+<ref refid="509e4b20-3458-11ef-8774-be7f4daace40"/>
 </subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 627.0, 570.0)</val>
 </matrix>
 <points>
-<val>[(-186.5477294921875, -22.5), (-224.0, -22.5)]</val>
+<val>[(-182.0, -22.5), (-224.0, -23.5)]</val>
 </points>
 <head-connection>
 <ref refid="1d309140-8a25-11e9-94a9-784f435640ba"/>
@@ -2505,7 +2584,190 @@
 <ref refid="0a5bbe64-8a25-11e9-94a9-784f435640ba"/>
 </tail-connection>
 </ObjectFlowItem>
-<ObjectFlow id="6b0176f4-8ce9-11ec-ad28-0456e5e540ed">
+<ObjectFlowItem id="706b4e1c-8ce9-11ec-ad28-0456e5e540ed">
+<diagram>
+<ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 647.0, 580.0)</val>
+</matrix>
+<points>
+<val>[(4.0, -4.5), (41.39999999999998, -43.5)]</val>
+</points>
+</ObjectFlowItem>
+<Activity id="c4d3f4c8-3457-11ef-8774-be7f4daace40">
+<edge>
+<reflist>
+<ref refid="45d9a37e-3458-11ef-8774-be7f4daace40"/>
+<ref refid="48c48d56-3458-11ef-8774-be7f4daace40"/>
+<ref refid="509e4b20-3458-11ef-8774-be7f4daace40"/>
+</reflist>
+</edge>
+<name>
+<val>New Activity</val>
+</name>
+<node>
+<reflist>
+<ref refid="007a17b0-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="02313228-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="0a5bbb9e-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="1d308ec0-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="23fba17c-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="25c79006-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="1b5efc30-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="19e0d928-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="185628ec-8a25-11e9-94a9-784f435640ba"/>
+</reflist>
+</node>
+<package>
+<ref refid="a80225e6-8a24-11e9-94a9-784f435640ba"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="c4d4c45c-3457-11ef-8774-be7f4daace40"/>
+</reflist>
+</presentation>
+</Activity>
+<ActivityItem id="c4d4c45c-3457-11ef-8774-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 77.48442672094927, 507.2674565449816)</val>
+</matrix>
+<top-left>
+<val>(-4.484426720949273, 0.0)</val>
+</top-left>
+<width>
+<val>725.0</val>
+</width>
+<height>
+<val>153.22272754196257</val>
+</height>
+<children>
+<reflist>
+<ref refid="007a1a30-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="02313516-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="0a5bbe64-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="1d309140-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="23fba4c4-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="25c79240-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="1b5eff1e-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="19e0db4e-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="18562bd0-8a25-11e9-94a9-784f435640ba"/>
+</reflist>
+</children>
+<diagram>
+<ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
+</diagram>
+<subject>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</subject>
+</ActivityItem>
+<StateMachine id="ec968bb0-3457-11ef-8774-be7f4daace40">
+<name>
+<val>New StateMachine</val>
+</name>
+<package>
+<ref refid="a80225e6-8a24-11e9-94a9-784f435640ba"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="ec9727e6-3457-11ef-8774-be7f4daace40"/>
+</reflist>
+</presentation>
+<region>
+<reflist>
+<ref refid="f03d0ce4-3457-11ef-8774-be7f4daace40"/>
+</reflist>
+</region>
+</StateMachine>
+<StateMachineItem id="ec9727e6-3457-11ef-8774-be7f4daace40">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 73.0, 824.3082543209032)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>528.2187238050384</val>
+</width>
+<height>
+<val>162.0</val>
+</height>
+<children>
+<reflist>
+<ref refid="6ae17ada-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="684d717a-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="6e1580c0-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="6ca26064-8a25-11e9-94a9-784f435640ba"/>
+</reflist>
+</children>
+<diagram>
+<ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
+</diagram>
+<subject>
+<ref refid="ec968bb0-3457-11ef-8774-be7f4daace40"/>
+</subject>
+</StateMachineItem>
+<Region id="f03d0ce4-3457-11ef-8774-be7f4daace40">
+<stateMachine>
+<ref refid="ec968bb0-3457-11ef-8774-be7f4daace40"/>
+</stateMachine>
+<subvertex>
+<reflist>
+<ref refid="6ae176f2-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="684d6c98-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="6e157b7a-8a25-11e9-94a9-784f435640ba"/>
+<ref refid="6ca25c22-8a25-11e9-94a9-784f435640ba"/>
+</reflist>
+</subvertex>
+</Region>
+<ControlFlow id="45d9a37e-3458-11ef-8774-be7f4daace40">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
+<name>
+<val>flow</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="03e0cb38-8a25-11e9-94a9-784f435640ba"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="02313228-8a25-11e9-94a9-784f435640ba"/>
+</source>
+<target>
+<ref refid="007a17b0-8a25-11e9-94a9-784f435640ba"/>
+</target>
+</ControlFlow>
+<ControlFlow id="48c48d56-3458-11ef-8774-be7f4daace40">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
+<name>
+<val>flow</val>
+</name>
+<presentation>
+<reflist>
+<ref refid="0bfe92d2-8a25-11e9-94a9-784f435640ba"/>
+</reflist>
+</presentation>
+<source>
+<ref refid="007a17b0-8a25-11e9-94a9-784f435640ba"/>
+</source>
+<target>
+<ref refid="0a5bbb9e-8a25-11e9-94a9-784f435640ba"/>
+</target>
+</ControlFlow>
+<ObjectFlow id="509e4b20-3458-11ef-8774-be7f4daace40">
+<activity>
+<ref refid="c4d3f4c8-3457-11ef-8774-be7f4daace40"/>
+</activity>
 <presentation>
 <reflist>
 <ref refid="5f9e926a-8ce9-11ec-ad28-0456e5e540ed"/>
@@ -2518,18 +2780,54 @@
 <ref refid="0a5bbb9e-8a25-11e9-94a9-784f435640ba"/>
 </target>
 </ObjectFlow>
-<ObjectFlowItem id="706b4e1c-8ce9-11ec-ad28-0456e5e540ed">
-<diagram>
-<ref refid="a8022870-8a24-11e9-94a9-784f435640ba"/>
-</diagram>
-<horizontal>
-<val>0</val>
-</horizontal>
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 647.0, 580.0)</val>
-</matrix>
-<points>
-<val>[(4.0, -4.5), (41.39999999999998, -43.5)]</val>
-</points>
-</ObjectFlowItem>
+<Extension id="581e5002-3458-11ef-8774-be7f4daace40">
+<memberEnd>
+<reflist>
+<ref refid="581eef76-3458-11ef-8774-be7f4daace40"/>
+<ref refid="581f2fe0-3458-11ef-8774-be7f4daace40"/>
+</reflist>
+</memberEnd>
+<name>
+<val>extension</val>
+</name>
+<ownedEnd>
+<ref refid="581f2fe0-3458-11ef-8774-be7f4daace40"/>
+</ownedEnd>
+<package>
+<ref refid="a80225e6-8a24-11e9-94a9-784f435640ba"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="3557fc26-8a26-11e9-bbea-784f435640ba"/>
+</reflist>
+</presentation>
+</Extension>
+<Property id="581eef76-3458-11ef-8774-be7f4daace40">
+<association>
+<ref refid="581e5002-3458-11ef-8774-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="31a5fc90-8a26-11e9-bbea-784f435640ba"/>
+</class_>
+<name>
+<val>baseClass</val>
+</name>
+<type>
+<ref refid="2e472c7c-8a26-11e9-bbea-784f435640ba"/>
+</type>
+</Property>
+<ExtensionEnd id="581f2fe0-3458-11ef-8774-be7f4daace40">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="581e5002-3458-11ef-8774-be7f4daace40"/>
+</association>
+<class_>
+<ref refid="2e472c7c-8a26-11e9-bbea-784f435640ba"/>
+</class_>
+<type>
+<ref refid="31a5fc90-8a26-11e9-bbea-784f435640ba"/>
+</type>
+</ExtensionEnd>
 </gaphor>

--- a/tests/test_models_up_to_date.py
+++ b/tests/test_models_up_to_date.py
@@ -53,7 +53,7 @@ def test_c4model_model(tmp_path):
     outfile = tmp_path / "c4model.py"
     main(
         modelfile="models/C4Model.gaphor",
-        supermodelfiles=[("UML", "models/UML.gaphor")],
+        supermodelfiles=[("Core", "models/Core.gaphor"), ("UML", "models/UML.gaphor")],
         outfile=outfile,
     )
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is new?

Gaphor has a minimal core model.

This PR implements (part of) the KerML spec for the core model. I think this is a nice stepping stone to implementing, as KerML is the basis got SysML v2.

The idea is to slowly migrate to the KerML metamodel as a basis for Gaphor.

The new model can be viewed in the readthedocs build.

Issue Number: #2584

### Other information

- [x] Move `Relationship` to core model
- [x] Move `Dependency` to core model
- [x] Move `name` to `Element` (as is, not as a derived property)
- [ ] ~Remove use of `NamedElement`, once `name` is moved to `Element`~ `NamedElement` is used all over the place
- [x] Move `Namespace` to core model
- [ ] ~Move `DependencyItem` to diagram package?~ Hard, since it still depends on UML elements too.
- [ ] ~Deal with `Relationship.abstraction`. It's not part of the core model.~ Leave as exception for now. We also have some properties for `Namespace`, but it looks like we do not use those (MyPy is not complaining at least).
- [x] Restore `Named` interface again on `DirectedRelationshipPropertyPathItem`, `DependencyItem`, and `InterfaceRealizationItem`.

Review notes:

This PR has become pretty big.

A lot of files changed due to `name` and `namespace` now being part of the `Element` class: no casting is required in `watch()` operations

I tried to remove NamedElement. So far I got it out of the Model Browser, but there's some other places that depend on it still. Although NamedElement only contains a visibility attribute (not sure if we even use that).

I think we need a base type for Element at some point, so Element can be used for "normal" model elements and we can derive "gaphor-internal" types like Presentation and StyleSheet from the base type. This way Element can more easily replace NamedElement.

I tried to change the semantics of the model as little as possible. E.g. I did not implement the `Membership` and `OwnedMembership` relations.