### PR TITLE
Fix VirusTotal Action is Failing Release Build

### DIFF
--- a/.github/actions/macos_dmg/action.yml
+++ b/.github/actions/macos_dmg/action.yml
@@ -113,7 +113,7 @@ runs:
       run: security delete-keychain temp.keychain
       shell: bash
     - name: Upload Gaphor-${{ inputs.version }}.dmg
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: Gaphor-${{ inputs.version }}.dmg
         path: _packaging/dist/Gaphor-${{ inputs.version }}.dmg

--- a/.github/actions/windows_executables/action.yml
+++ b/.github/actions/windows_executables/action.yml
@@ -64,12 +64,12 @@ runs:
         }
       shell: PowerShell
     - name: Upload gaphor-${{ inputs.version }}-installer.exe
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: gaphor-${{ inputs.version }}-installer.exe
         path: _packaging/dist/gaphor-${{ inputs.version }}-installer.exe
     - name: Upload gaphor-${{ inputs.version }}-portable.exe
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: gaphor-${{ inputs.version }}-portable.exe
         path: _packaging/dist/gaphor-${{ inputs.version }}-portable.exe

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -1,5 +1,8 @@
 name: Full Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -177,7 +177,7 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: >
           brew update && brew install gtksourceview5 libadwaita
-          adwaita-icon-theme gobject-introspection graphviz create-dmg upx
+          adwaita-icon-theme gobject-introspection graphviz create-dmg
       - name: Set up Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -313,18 +313,21 @@ jobs:
     runs-on: windows-latest
     continue-on-error: true
     timeout-minutes: 15
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{ needs.windows.outputs.installer }}
           path: .
       - name: VirusTotal Scan
-        uses: crazy-max/ghaction-virustotal@v4
+        uses: crazy-max/ghaction-virustotal@92a6081d9aab8f8ef3d9081e8bb264aaccc9e74d # v4.0.0
         if: env.mainline_build == 'true'
         with:
           vt_api_key: ${{ secrets.VIRUSTOTAL_API_KEY }}
           request_rate: 4
           update_release_body: true
+          github_token: ${{ github.token }}
           files: |
             ${{ needs.windows.outputs.installer }}
 


### PR DESCRIPTION
This PR fixes a build issue with the VirusTotal action trying to write to the release. It also cleans up some of the other actions to pin hashes and add a top level permission.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Build is failing for release

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
