### PR TITLE
Be more lenient with association end multiplicity

### DIFF
--- a/gaphor/UML/tests/test_umllex.py
+++ b/gaphor/UML/tests/test_umllex.py
@@ -171,6 +171,21 @@ def test_parse_association_end_multiplicity2(factory):
     assert not p.defaultValue
 
 
+@pytest.mark.parametrize("text", ["-0..2", "-[0..2]"])
+def test_parse_association_end_visibility_multiplicity_no_name(text, factory):
+    """Test parsing of multiplicity with multiline constraints."""
+    a = factory.create(UML.Association)
+    p = factory.create(UML.Property)
+    p.association = a
+    parse(p, text)
+    assert not p.name
+    assert not p.typeValue
+    assert p.visibility == "private"
+    assert "0" == p.lowerValue
+    assert "2" == p.upperValue
+    assert not p.defaultValue
+
+
 def test_parse_association_end_derived_end(factory):
     """Test parsing derived association end."""
     a = factory.create(UML.Association)

--- a/gaphor/UML/tests/test_umllex.py
+++ b/gaphor/UML/tests/test_umllex.py
@@ -201,6 +201,21 @@ def test_parse_association_end_derived_end(factory):
     assert not p.defaultValue
 
 
+def test_parse_association_end_derived_end_without_name(factory):
+    """Test parsing derived association end without name."""
+    a = factory.create(UML.Association)
+    p = factory.create(UML.Property)
+    p.association = a
+    parse(p, "-/*")
+    assert "private" == p.visibility
+    assert p.isDerived
+    assert not p.name
+    assert not p.typeValue
+    assert not p.lowerValue
+    assert "*" == p.upperValue
+    assert not p.defaultValue
+
+
 def test_parse_association_end_with_type(factory):
     """Test parsing of association end, type is ignored."""
     a = factory.create(UML.Association)

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -91,7 +91,9 @@ association_end_name_pat = compile(
 
 # Association end multiplicity:
 #   [mult] [{ tagged values }]
-association_end_mult_pat = compile(f"^{multa_subpat}{tags_subpat}{garbage_subpat}")
+association_end_mult_pat = compile(
+    f"^{vis_subpat}{multa_subpat}{tags_subpat}{garbage_subpat}"
+)
 
 
 # Operation:
@@ -205,6 +207,7 @@ def parse_association_end(el: uml.Property, s: str) -> None:
 
     if m and m.group("mult_u") or m.group("tags"):
         g = m.group
+        _set_visibility(el, g("vis"))
         el.lowerValue = g("mult_l")
         el.upperValue = g("mult_u")
     else:

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -92,7 +92,7 @@ association_end_name_pat = compile(
 # Association end multiplicity:
 #   [mult] [{ tagged values }]
 association_end_mult_pat = compile(
-    f"^{vis_subpat}{multa_subpat}{tags_subpat}{garbage_subpat}"
+    f"^{vis_subpat}{derived_subpat}{multa_subpat}{tags_subpat}{garbage_subpat}"
 )
 
 
@@ -177,7 +177,7 @@ def parse_attribute(el: uml.Property, s: str) -> None:
     else:
         g = m.group
         _set_visibility(el, g("vis"))
-        el.isDerived = g("derived") and True or False
+        el.isDerived = bool(g("derived"))
         el.name = g("name")
         el.typeValue = g("type")
         el.lowerValue = g("mult_l")
@@ -208,6 +208,7 @@ def parse_association_end(el: uml.Property, s: str) -> None:
     if m and m.group("mult_u") or m.group("tags"):
         g = m.group
         _set_visibility(el, g("vis"))
+        el.isDerived = bool(g("derived"))
         el.lowerValue = g("mult_l")
         el.upperValue = g("mult_u")
     else:
@@ -220,7 +221,7 @@ def parse_association_end(el: uml.Property, s: str) -> None:
             del el.note
         else:
             _set_visibility(el, g("vis"))
-            el.isDerived = g("derived") and True or False
+            el.isDerived = bool(g("derived"))
             el.name = g("name")
             el.note = g("note")
             # Optionally, the multiplicity and tagged values may be defined:


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

You cannot define a combination of visibilitity (and derived) and multiplicity, without providing an association end name.

### What is the new behavior?

Be more lenient with what to accept. Parse visibility and derived properties too.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
