### PR TITLE
Read-only attributes

### DIFF
--- a/gaphor/UML/classes/classespropertypages.py
+++ b/gaphor/UML/classes/classespropertypages.py
@@ -165,6 +165,18 @@ class AttributeView(GObject.Object):
         with Transaction(self.event_manager):
             self.attr.isStatic = value
 
+    @GObject.Property(type=bool, default=False)
+    def read_only(self):
+        return self.attr.isReadOnly if self.attr else False
+
+    @read_only.setter  # type: ignore[no-redef]
+    def read_only(self, value):
+        if not self.attr:
+            return
+
+        with Transaction(self.event_manager):
+            self.attr.isReadOnly = value
+
     editing = GObject.Property(type=bool, default=False)
 
     def empty(self):
@@ -250,6 +262,12 @@ class AttributesPage(PropertyPageBase):
                     attribute=AttributeView.attribute,
                     placeholder_text=gettext("New Attribute…"),
                     signal_handlers=text_field_handlers("attribute"),
+                ),
+                list_item_factory(
+                    "check-button-cell.ui",
+                    klass=AttributeView,
+                    attribute=AttributeView.read_only,
+                    signal_handlers=check_button_handlers("read_only"),
                 ),
                 list_item_factory(
                     "check-button-cell.ui",

--- a/gaphor/UML/classes/klass.py
+++ b/gaphor/UML/classes/klass.py
@@ -76,6 +76,8 @@ def attribute_watches(presentation, cast):
         f"subject[{cast}].ownedAttribute.association", presentation.update_shapes
     ).watch(f"subject[{cast}].ownedAttribute.name").watch(
         f"subject[{cast}].ownedAttribute.isStatic", presentation.update_shapes
+    ).watch(
+        f"subject[{cast}].ownedAttribute.isReadOnly", presentation.update_shapes
     ).watch(f"subject[{cast}].ownedAttribute.isDerived").watch(
         f"subject[{cast}].ownedAttribute.visibility"
     ).watch(f"subject[{cast}].ownedAttribute.lowerValue").watch(
@@ -106,7 +108,7 @@ def operation_watches(presentation, cast):
 def attributes_compartment(subject):
     # We need to scope the attribute value, since the for loop changes it.
     def lazy_format(attribute):
-        return lambda: format(attribute)
+        return lambda: format(attribute, tags=True)
 
     return CssNode(
         "compartment",

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -342,6 +342,11 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             </child>
             <child>
               <object class="GtkColumnViewColumn">
+                <property name="title" translatable="yes">ReadOnly</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkColumnViewColumn">
                 <property name="title" translatable="yes">Static</property>
               </object>
             </child>

--- a/gaphor/UML/tests/test_umlfmt.py
+++ b/gaphor/UML/tests/test_umlfmt.py
@@ -51,6 +51,14 @@ def test_attribute(factory, text, formatted_text):
     assert formatted_text == format(a, note=True)
 
 
+def test_read_only_attribute(factory):
+    a = factory.create(UML.Property)
+    a.name = "myattr"
+    a.isReadOnly = True
+
+    assert "+ myattr { readOnly }" == format(a, tags=True)
+
+
 def test_attribute_with_applied_stereotype(factory):
     a = factory.create(UML.Property)
     parse(a, "myattr: int")

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -12,9 +12,9 @@ no_render_pat = re.compile(r"^\s*[+#-]", re.MULTILINE | re.DOTALL)
 vis_map = {"public": "+", "protected": "#", "package": "~", "private": "-"}
 
 
-@format.register(UML.Property)
+@format.register
 def format_property(
-    el,
+    el: UML.Property,
     visibility=False,
     is_derived=False,
     type=False,
@@ -63,10 +63,14 @@ def format_property(
     if default and el.defaultValue:
         s.append(f" = {el.defaultValue}")
 
-    if tags and (
-        slots := [format(slot) for slot in el.appliedStereotype[:].slot if slot]
-    ):
-        s.append(" { %s }" % ", ".join(slots))
+    if tags:
+        tag_vals = []
+        if el.isReadOnly:
+            tag_vals.append(gettext("readOnly"))
+        tag_vals.extend(format(slot) for slot in el.appliedStereotype[:].slot if slot)
+
+        if tag_vals:
+            s.append(" { %s }" % ", ".join(tag_vals))
 
     if note and el.note:
         s.append(f" # {el.note}")


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?



Issue Number: Fixes #3327

### What is the new behavior?

Added a checkbox ("readOnly") to the attributes editor. Setting the `readOnly` property will make it visible in the class.

<img width="946" alt="image" src="https://github.com/gaphor/gaphor/assets/96249/fe60b5f6-4131-4c07-b340-f742d2337ca3">

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

I considered editing tags/modifiers directly, but it's hard to keep those up to date. Also, there are a couple of. specific modifiers, and we can't expect users to know those by heart.
