### PR TITLE
Show main window first when loading model from command line

### DIFF
--- a/gaphor/application.py
+++ b/gaphor/application.py
@@ -136,7 +136,9 @@ class Application(Service, ActionProvider):
 
         self._sessions.add(session)
 
-        session_created = SessionCreated(self, session, filename, template, force)
+        session_created = SessionCreated(
+            self, session, filename, template, force, interactive=bool(self._gtk_app)
+        )
         event_manager.handle(session_created)
         self.event_manager.handle(session_created)
         session.foreground()

--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -49,6 +49,7 @@ class SessionCreated(ServiceEvent):
         filename: Path | None,
         template: Path | None = None,
         force: bool = False,
+        interactive: bool = False,
     ):
         super().__init__(application)
         self.application = application
@@ -56,6 +57,7 @@ class SessionCreated(ServiceEvent):
         self.filename = Path(filename) if filename else None
         self.template = template
         self.force = force
+        self.interactive = interactive
 
 
 class ActiveSessionChanged(ServiceEvent):

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Callable
 
 from gaphas.decorators import g_async
-from gi.repository import Adw, Gio, Gtk
+from gi.repository import Adw, Gio, GLib, Gtk
 
 from gaphor import UML
 from gaphor.abc import ActionProvider, Service
@@ -395,7 +395,12 @@ class FileManager(Service, ActionProvider):
     @event_handler(SessionCreated)
     def _on_session_created(self, event: SessionCreated) -> None:
         if event.filename:
-            self.load(event.filename)
+            if event.interactive:
+                # Load new model once the main loop started,
+                # so we can show the main window first.
+                GLib.idle_add(self.load, event.filename)
+            else:
+                self.load(event.filename)
         elif event.template:
             self.load_template(event.template)
         else:

--- a/gaphor/ui/greeter.py
+++ b/gaphor/ui/greeter.py
@@ -189,25 +189,17 @@ class Greeter(Service, ActionProvider):
         self.close()
 
     def _on_recent_file_activated(self, row):
-        def load():
-            self.application.new_session(filename=filename)
-            self.close()
-
         filename = row.filename
         self.greeter.set_sensitive(False)
-        GLib.idle_add(load, priority=GLib.PRIORITY_LOW)
+        self.application.new_session(filename=filename)
+        self.close()
 
     def _on_template_activated(self, child):
-        def load():
-            filename = (
-                importlib.resources.files("gaphor") / "templates" / child.filename
-            )
-            session = self.application.new_session(template=filename)
-            session.get_service("properties").set("modeling-language", child.lang)
-            self.close()
-
         self.greeter.set_sensitive(False)
-        GLib.idle_add(load, priority=GLib.PRIORITY_LOW)
+        filename = importlib.resources.files("gaphor") / "templates" / child.filename
+        session = self.application.new_session(template=filename)
+        session.get_service("properties").set("modeling-language", child.lang)
+        self.close()
 
     def _on_window_close_request(self, window, event=None):
         self.close()


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When a large model is loaded (e.g. `models/UML.gaphor`), it looks like nothing happens for a while.

Issue Number: fixes #3392

### What is the new behavior?

Postpone model loading until the main window is present. This has the additional advantage that dialogs are always placed over a window (no more warnings).

