### PR TITLE
Add a special C4 Dependency with a technology field

### DIFF
--- a/gaphor/C4Model/c4model.py
+++ b/gaphor/C4Model/c4model.py
@@ -36,6 +36,11 @@ class C4Database(C4Container):
     pass
 
 
+from gaphor.core.modeling.coremodel import Dependency
+class C4Dependency(Dependency):
+    technology: _attribute[str] = _attribute("technology", str)
+
+
 
 C4Container.ownerContainer = association("ownerContainer", C4Container, upper=1, opposite="owningContainer")
 C4Container.owningContainer = association("owningContainer", C4Container, composite=True, opposite="ownerContainer")

--- a/gaphor/C4Model/diagramitems/__init__.py
+++ b/gaphor/C4Model/diagramitems/__init__.py
@@ -2,4 +2,5 @@
 
 from gaphor.C4Model.diagramitems.container import C4ContainerItem
 from gaphor.C4Model.diagramitems.database import C4DatabaseItem
+from gaphor.C4Model.diagramitems.dependency import C4DependencyItem
 from gaphor.C4Model.diagramitems.person import C4PersonItem

--- a/gaphor/C4Model/diagramitems/dependency.py
+++ b/gaphor/C4Model/diagramitems/dependency.py
@@ -1,0 +1,46 @@
+from gaphor.C4Model import c4model
+from gaphor.diagram.presentation import LinePresentation, Named, text_name
+from gaphor.diagram.shapes import Box, CssNode, Text, draw_arrow_head
+from gaphor.diagram.support import represents
+from gaphor.UML.compartments import text_stereotypes
+
+
+@represents(
+    c4model.C4Dependency,
+    head=c4model.C4Dependency.supplier,
+    tail=c4model.C4Dependency.client,
+)
+class C4DependencyItem(Named, LinePresentation[c4model.C4Dependency]):
+    def __init__(self, diagram, id=None):
+        super().__init__(
+            diagram,
+            id,
+            shape_middle=Box(
+                text_stereotypes(self),
+                text_name(self),
+                text_technology(self),
+            ),
+        )
+
+        self._handles[0].pos = (30, 20)
+        self._handles[1].pos = (0, 0)
+
+        self.watch("subject")
+        self.watch("subject.name")
+        self.watch("subject[C4Dependency].technology")
+        self.watch("subject.appliedStereotype.classifier.name")
+
+        self.draw_head = draw_arrow_head
+
+
+def text_technology(item: C4DependencyItem):
+    return CssNode(
+        "technology",
+        item.subject,
+        Text(
+            text=lambda: item.subject
+            and item.subject.technology
+            and f"[{item.subject.technology}]"
+            or ""
+        ),
+    )

--- a/gaphor/C4Model/iconname.py
+++ b/gaphor/C4Model/iconname.py
@@ -1,4 +1,4 @@
-from gaphor.C4Model.c4model import C4Container, C4Database
+from gaphor.C4Model.c4model import C4Container, C4Database, C4Dependency
 from gaphor.diagram.iconname import get_default_icon_name, icon_name
 
 
@@ -14,3 +14,8 @@ def get_name_for_class(element):
 @icon_name.register(C4Database)
 def get_database_name(element):
     return get_default_icon_name(element)
+
+
+@icon_name.register(C4Dependency)
+def get_dependency_name(element):
+    return "gaphor-dependency-symbolic"

--- a/gaphor/C4Model/propertypages.py
+++ b/gaphor/C4Model/propertypages.py
@@ -3,6 +3,7 @@ from typing import Union
 from gaphor.C4Model import c4model
 from gaphor.core import Transaction
 from gaphor.diagram.propertypages import (
+    NamePropertyPage,
     PropertyPageBase,
     PropertyPages,
     handler_blocking,
@@ -11,6 +12,9 @@ from gaphor.diagram.propertypages import (
 )
 
 new_builder = new_resource_builder("gaphor.C4Model")
+
+
+PropertyPages.register(c4model.C4Dependency, NamePropertyPage)
 
 
 @PropertyPages.register(c4model.C4Container)
@@ -59,10 +63,13 @@ class DescriptionPropertyPage(PropertyPageBase):
 
 
 @PropertyPages.register(c4model.C4Container)
+@PropertyPages.register(c4model.C4Dependency)
 class TechnologyPropertyPage(PropertyPageBase):
     order = 15
 
-    def __init__(self, subject: c4model.C4Container, event_manager):
+    def __init__(
+        self, subject: c4model.C4Container | c4model.C4Dependency, event_manager
+    ):
         super().__init__()
         assert subject
         self.subject = subject

--- a/gaphor/C4Model/toolbox.py
+++ b/gaphor/C4Model/toolbox.py
@@ -15,7 +15,6 @@ from gaphor.diagram.diagramtoolbox import (
     new_item_factory,
 )
 from gaphor.i18n import gettext, i18nize
-from gaphor.UML import diagramitems as uml_items
 from gaphor.UML.actions.actionstoolbox import actions
 from gaphor.UML.classes.classestoolbox import classes
 from gaphor.UML.interactions.interactionstoolbox import interactions
@@ -131,7 +130,7 @@ c4 = ToolSection(
             gettext("Dependency"),
             "gaphor-dependency-symbolic",
             "d",
-            new_item_factory(uml_items.DependencyItem),
+            new_item_factory(diagramitems.C4DependencyItem),
             handle_index=0,
         ),
     ),

--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -233,10 +233,16 @@ class StyledItem:
         )
 
     def attribute(self, name: str) -> str | None:
-        a = lookup_attribute(self.item, name)
-        if a in (None, "") and self.item.subject:
-            a = lookup_attribute(self.item.subject, name)
-        return a
+        if item_value := lookup_attribute(self.item, name):
+            return item_value
+
+        if (
+            self.item.subject
+            and (subject_value := lookup_attribute(self.item.subject, name)) is not None
+        ):
+            return subject_value
+
+        return item_value
 
     def state(self) -> Sequence[str]:
         return self._state

--- a/gaphor/core/modeling/tests/test_style_attributes.py
+++ b/gaphor/core/modeling/tests/test_style_attributes.py
@@ -125,3 +125,13 @@ def test_attrname_diagram_subject():
 def test_attrname_collection_subject(diagram):
     collection1 = collection(None, None, int)
     assert attrname(collection1, "subject") == "subject"
+
+
+def test_attribute_on_item_and_not_on_subject(diagram, element_factory):
+    class_ = element_factory.create(UML.Class)
+    classitem = diagram.create(ClassItem, subject=class_)
+
+    node = StyledItem(classitem)
+
+    assert node.attribute("children") == ""
+    assert node.attribute("does_not_exist") is None

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -60,6 +60,7 @@
 /* Relationships */
 
 commentline,
+c4dependency,
 dependency,
 interfacerealization,
 include,
@@ -366,7 +367,7 @@ c4database {
   text-align: left;
 }
 
-:is(c4container, c4database, c4person) technology {
+:is(c4container, c4database, c4dependency, c4person) technology {
   font-size: x-small;
 }
 

--- a/models/C4Model.gaphor
+++ b/models/C4Model.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.6.5">
+<gaphor xmlns="http://gaphor.sourceforge.net/model" version="3.0" gaphor-version="2.26.0">
 <StyleSheet id="2e656716-6cae-11eb-aee1-750f3fed8beb"/>
 <Package id="2e656717-6cae-11eb-aee1-750f3fed8beb">
 <name>
@@ -18,6 +18,9 @@
 <ref refid="6e5e9410-6faf-11eb-bdd8-859c1b7b5447"/>
 <ref refid="2b94e4ac-4bc0-11ec-aa3d-0456e5e540ed"/>
 <ref refid="30f4593c-4bc0-11ec-aa3d-0456e5e540ed"/>
+<ref refid="abb942dc-4932-11ef-8312-be7f4daace3f"/>
+<ref refid="cfe5e55c-4932-11ef-8312-be7f4daace3f"/>
+<ref refid="f3942770-4932-11ef-8312-be7f4daace3f"/>
 </reflist>
 </ownedType>
 <presentation>
@@ -40,26 +43,35 @@
 <ref refid="b680213b-6d81-11eb-bdd8-859c1b7b5447"/>
 <ref refid="d7d28eb9-6d81-11eb-bdd8-859c1b7b5447"/>
 <ref refid="6e5e9411-6faf-11eb-bdd8-859c1b7b5447"/>
+<ref refid="abb9e6f6-4932-11ef-8312-be7f4daace3f"/>
+<ref refid="cfe61a40-4932-11ef-8312-be7f4daace3f"/>
 <ref refid="96f0c884-6cae-11eb-aee1-750f3fed8beb"/>
 <ref refid="ca16bf74-6d81-11eb-bdd8-859c1b7b5447"/>
 <ref refid="2daf9a4a-6dde-11eb-bdd8-859c1b7b5447"/>
 <ref refid="5630b2f6-6faf-11eb-bdd8-859c1b7b5447"/>
+<ref refid="c8097bb4-4932-11ef-8312-be7f4daace3f"/>
 </reflist>
 </ownedPresentation>
 </Diagram>
 <ClassItem id="872907b9-6cae-11eb-aee1-750f3fed8beb">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 87.0, 278.28205128205127)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 87.0, 278.2820512820512)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
-<val>182.0</val>
+<val>180.973664042013</val>
 </width>
 <height>
-<val>100.0</val>
+<val>92.0</val>
 </height>
 <diagram>
 <ref refid="2e656718-6cae-11eb-aee1-750f3fed8beb"/>
 </diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
 <subject>
 <ref refid="872907b8-6cae-11eb-aee1-750f3fed8beb"/>
 </subject>
@@ -68,6 +80,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 128.0, 100.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
@@ -94,6 +109,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="2b94e4ac-4bc0-11ec-aa3d-0456e5e540ed"/>
 </subject>
@@ -101,7 +119,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 80.0, 281.0)</val>
 </matrix>
 <points>
-<val>[(96.0, -110.0), (96.0, -2.7179487179487296)]</val>
+<val>[(96.0, -110.0), (95.49811043812724, -2.7179487179487296)]</val>
 </points>
 <head-connection>
 <ref refid="905056c1-6cae-11eb-aee1-750f3fed8beb"/>
@@ -114,6 +132,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 349.0, 100.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>128.0</val>
 </width>
@@ -123,6 +144,12 @@
 <diagram>
 <ref refid="2e656718-6cae-11eb-aee1-750f3fed8beb"/>
 </diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
 <subject>
 <ref refid="b680213a-6d81-11eb-bdd8-859c1b7b5447"/>
 </subject>
@@ -134,6 +161,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="30f4593c-4bc0-11ec-aa3d-0456e5e540ed"/>
 </subject>
@@ -152,17 +182,23 @@
 </ExtensionItem>
 <ClassItem id="d7d28eb9-6d81-11eb-bdd8-859c1b7b5447">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 347.0, 278.28205128205127)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 347.0, 278.2820512820512)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>130.0</val>
 </width>
 <height>
-<val>134.0</val>
+<val>128.42527336722765</val>
 </height>
 <diagram>
 <ref refid="2e656718-6cae-11eb-aee1-750f3fed8beb"/>
 </diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
 <subject>
 <ref refid="d7d28eb8-6d81-11eb-bdd8-859c1b7b5447"/>
 </subject>
@@ -190,7 +226,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 195.0, 500.046875)</val>
 </matrix>
 <points>
-<val>[(282.0, -191.046875), (475.0, -191.046875), (475.0, -119.046875), (282.0, -119.046875)]</val>
+<val>[(282.0, -192.32481654344838), (475.0, -192.32481654344838), (475.0, -123.32019204762463), (282.0, -123.32019204762463)]</val>
 </points>
 <head-connection>
 <ref refid="d7d28eb9-6d81-11eb-bdd8-859c1b7b5447"/>
@@ -206,6 +242,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="34af0e8c-4bc0-11ec-aa3d-0456e5e540ed"/>
 </subject>
@@ -213,7 +252,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 375.0, 354.0)</val>
 </matrix>
 <points>
-<val>[(35.721649621102245, 135.0), (35.721649621102245, 58.28205128205127)]</val>
+<val>[(35.721649621102245, 135.0), (35.721649621102245, 52.70732464927886)]</val>
 </points>
 <head-connection>
 <ref refid="6e5e9411-6faf-11eb-bdd8-859c1b7b5447"/>
@@ -226,15 +265,21 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 349.0, 489.0)</val>
 </matrix>
+<top-left>
+<val>(-2.0, 0.0)</val>
+</top-left>
 <width>
-<val>128.0</val>
+<val>130.0</val>
 </width>
 <height>
-<val>91.0</val>
+<val>62.73857464927886</val>
 </height>
 <diagram>
 <ref refid="2e656718-6cae-11eb-aee1-750f3fed8beb"/>
 </diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
 <subject>
 <ref refid="6e5e9410-6faf-11eb-bdd8-859c1b7b5447"/>
 </subject>
@@ -334,6 +379,11 @@
 <ref refid="d7d28eb9-6d81-11eb-bdd8-859c1b7b5447"/>
 </reflist>
 </presentation>
+<specialization>
+<reflist>
+<ref refid="34af0e8c-4bc0-11ec-aa3d-0456e5e540ed"/>
+</reflist>
+</specialization>
 </Stereotype>
 <Property id="dff5b962-6d81-11eb-bdd8-859c1b7b5447">
 <class_>
@@ -384,6 +434,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 143.0, 117.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>131.0</val>
 </width>
@@ -401,6 +454,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 425.0, 117.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>137.0</val>
 </width>
@@ -418,6 +474,9 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 377.0, 259.0)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>138.0</val>
 </width>
@@ -472,11 +531,14 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 233.44921875, 186.61328125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>129.0</val>
 </width>
 <height>
-<val>83.0</val>
+<val>85.0</val>
 </height>
 <diagram>
 <ref refid="e93225c2-6ddd-11eb-bdd8-859c1b7b5447"/>
@@ -489,11 +551,14 @@
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 247.94921875, 32.61328125)</val>
 </matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
 <width>
 <val>100.0</val>
 </width>
 <height>
-<val>58.0</val>
+<val>70.0</val>
 </height>
 <diagram>
 <ref refid="e93225c2-6ddd-11eb-bdd8-859c1b7b5447"/>
@@ -509,6 +574,9 @@
 <horizontal>
 <val>0</val>
 </horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
 <subject>
 <ref refid="8fa07206-6dde-11eb-bdd8-859c1b7b5447"/>
 </subject>
@@ -516,7 +584,7 @@
 <val>(1.0, 0.0, 0.0, 1.0, 295.44921875, 60.61328125)</val>
 </matrix>
 <points>
-<val>[(1.1373015873015788, 30.0), (3.6500000000000057, 126.0)]</val>
+<val>[(1.1373015873015788, 42.0), (3.6500000000000057, 126.0)]</val>
 </points>
 <head-connection>
 <ref refid="8b905b0f-6dde-11eb-bdd8-859c1b7b5447"/>
@@ -601,6 +669,12 @@
 </upperValue>
 </Property>
 <Stereotype id="86a99614-6dde-11eb-bdd8-859c1b7b5447">
+<instanceSpecification>
+<reflist>
+<ref refid="b5fb0092-6dde-11eb-bdd8-859c1b7b5447"/>
+<ref refid="bffddfa6-6dde-11eb-bdd8-859c1b7b5447"/>
+</reflist>
+</instanceSpecification>
 <name>
 <val>Tagged</val>
 </name>
@@ -915,4 +989,174 @@
 <ref refid="6e5e9410-6faf-11eb-bdd8-859c1b7b5447"/>
 </specific>
 </Generalization>
+<Class id="abb942dc-4932-11ef-8312-be7f4daace3f">
+<name>
+<val>Dependency</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="f394b596-4932-11ef-8312-be7f4daace3f"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="2e656717-6cae-11eb-aee1-750f3fed8beb"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="abb9e6f6-4932-11ef-8312-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Class>
+<ClassItem id="abb9e6f6-4932-11ef-8312-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 735.02734375, 100.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>114.8430282995684</val>
+</width>
+<height>
+<val>71.0</val>
+</height>
+<diagram>
+<ref refid="2e656718-6cae-11eb-aee1-750f3fed8beb"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="abb942dc-4932-11ef-8312-be7f4daace3f"/>
+</subject>
+</ClassItem>
+<ExtensionItem id="c8097bb4-4932-11ef-8312-be7f4daace3f">
+<diagram>
+<ref refid="2e656718-6cae-11eb-aee1-750f3fed8beb"/>
+</diagram>
+<horizontal>
+<val>0</val>
+</horizontal>
+<orthogonal>
+<val>0</val>
+</orthogonal>
+<subject>
+<ref refid="f3942770-4932-11ef-8312-be7f4daace3f"/>
+</subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 788.3352157995685, 164.0688764068343)</val>
+</matrix>
+<points>
+<val>[(4.1136421002157135, 6.931123593165694), (4.1136421002157135, 114.21317487521696)]</val>
+</points>
+<head-connection>
+<ref refid="abb9e6f6-4932-11ef-8312-be7f4daace3f"/>
+</head-connection>
+<tail-connection>
+<ref refid="cfe61a40-4932-11ef-8312-be7f4daace3f"/>
+</tail-connection>
+</ExtensionItem>
+<Stereotype id="cfe5e55c-4932-11ef-8312-be7f4daace3f">
+<name>
+<val>C4Dependency</val>
+</name>
+<ownedAttribute>
+<reflist>
+<ref refid="dfc6da9e-4932-11ef-8312-be7f4daace3f"/>
+<ref refid="f39484a4-4932-11ef-8312-be7f4daace3f"/>
+</reflist>
+</ownedAttribute>
+<package>
+<ref refid="2e656717-6cae-11eb-aee1-750f3fed8beb"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="cfe61a40-4932-11ef-8312-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Stereotype>
+<ClassItem id="cfe61a40-4932-11ef-8312-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 738.3352157995685, 278.28205128205127)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>113.0</val>
+</width>
+<height>
+<val>85.0</val>
+</height>
+<diagram>
+<ref refid="2e656718-6cae-11eb-aee1-750f3fed8beb"/>
+</diagram>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="cfe5e55c-4932-11ef-8312-be7f4daace3f"/>
+</subject>
+</ClassItem>
+<Property id="dfc6da9e-4932-11ef-8312-be7f4daace3f">
+<class_>
+<ref refid="cfe5e55c-4932-11ef-8312-be7f4daace3f"/>
+</class_>
+<name>
+<val>technology</val>
+</name>
+<typeValue>
+<val>str</val>
+</typeValue>
+</Property>
+<Extension id="f3942770-4932-11ef-8312-be7f4daace3f">
+<memberEnd>
+<reflist>
+<ref refid="f39484a4-4932-11ef-8312-be7f4daace3f"/>
+<ref refid="f394b596-4932-11ef-8312-be7f4daace3f"/>
+</reflist>
+</memberEnd>
+<ownedEnd>
+<ref refid="f394b596-4932-11ef-8312-be7f4daace3f"/>
+</ownedEnd>
+<package>
+<ref refid="2e656717-6cae-11eb-aee1-750f3fed8beb"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="c8097bb4-4932-11ef-8312-be7f4daace3f"/>
+</reflist>
+</presentation>
+</Extension>
+<Property id="f39484a4-4932-11ef-8312-be7f4daace3f">
+<association>
+<ref refid="f3942770-4932-11ef-8312-be7f4daace3f"/>
+</association>
+<class_>
+<ref refid="cfe5e55c-4932-11ef-8312-be7f4daace3f"/>
+</class_>
+<name>
+<val>baseClass</val>
+</name>
+<type>
+<ref refid="abb942dc-4932-11ef-8312-be7f4daace3f"/>
+</type>
+</Property>
+<ExtensionEnd id="f394b596-4932-11ef-8312-be7f4daace3f">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="f3942770-4932-11ef-8312-be7f4daace3f"/>
+</association>
+<class_>
+<ref refid="abb942dc-4932-11ef-8312-be7f4daace3f"/>
+</class_>
+<type>
+<ref refid="cfe5e55c-4932-11ef-8312-be7f4daace3f"/>
+</type>
+</ExtensionEnd>
 </gaphor>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes #3381

### What is the new behavior?

A special type of dependency can be used in C4 models, where the technology can be specified.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Also fixed how item attributes are fetched, so now the `[children=""]` expression in our CSS works again.

<img width="1172" alt="image" src="https://github.com/user-attachments/assets/f2c6b80a-8971-4203-8019-a48b23e34d35">
