### PR TITLE
Prepare for RTD migration to Addons

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,3 +232,6 @@ intersphinx_mapping = {
     "gaphas": ("https://gaphas.readthedocs.io/en/stable", None),
     "python": ("https://docs.python.org/3", None),
 }
+
+# Canonical URL required for custom domain with RTD Addons enabled
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -228,7 +228,7 @@ epub_exclude_files = ["search.html"]
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "gnome": ("https://amolenaar.pages.gitlab.gnome.org/pygobject-docs", None),
-    "pygobject": ("https://gnome.pages.gitlab.gnome.org/pygobject", None),
+    "pygobject": ("https://pygobject.gnome.org", None),
     "gaphas": ("https://gaphas.readthedocs.io/en/stable", None),
     "python": ("https://docs.python.org/3", None),
 }


### PR DESCRIPTION
On 2024-10-07, RTD will enable RTD Addons by default on all projects. This PR ensures that the html baseurl is injected in order to use our custom domain.

Everyone can read more about this here:
https://about.readthedocs.com/blog/2024/07/addons-by-default/

Once this is merged, I should be able to enable addons ahead of time by following these steps: https://docs.readthedocs.io/en/stable/addons.html#enabling-read-the-docs-addons