### PR TITLE
Do not upload development flatpak artifact

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-22.04
-      - uses: flatpak/flatpak-github-actions/flatpak-builder@df610e76bc0eabff41ffaa7953f6d03123e9e26a # v6.3
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@d6ddccb268e43e87b19ca0112b83de26fb83b215 # master
         with:
           bundle: gaphor.flatpak
           manifest-path: org.gaphor.Gaphor.json

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -153,6 +153,7 @@ jobs:
           manifest-path: org.gaphor.Gaphor.json
           run-tests: true
           cache-key: flatpak-builder-${{ github.sha }}
+          upload-artifact: false
 
   macos:
     strategy:


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

An artifact with a funny name (`gaphor-x86_64`) is uploaded as artifact.

It looks like the flatpak-builder action now uploads artifacts. We do not need that.

