### PR TITLE
No longer need to set up key bindings on macos for GTK 4.16

### DIFF
--- a/gaphor/ui/macosshim.py
+++ b/gaphor/ui/macosshim.py
@@ -4,6 +4,10 @@ from gi.repository import GLib, Gtk
 def init_macos_shortcuts():
     """Add <Cmd>-<..> shortcuts for macOS."""
 
+    if Gtk.get_minor_version() >= 16:
+        # GTK 4.16 contains proper key mappings for macOS
+        return
+
     def new_shortcut_with_args(shortcut, signal, *args):
         shortcut = Gtk.Shortcut.new(
             trigger=Gtk.ShortcutTrigger.parse_string(shortcut),


### PR DESCRIPTION

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

See https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7260.

We no longer have to set up the keybindings by ourselves.

