### PR TITLE
Remove use of deprecated Gtk.StyleContext

### DIFF
--- a/gaphor/ui/greeter.py
+++ b/gaphor/ui/greeter.py
@@ -120,7 +120,7 @@ class Greeter(Service, ActionProvider):
         self.greeter = builder.get_object("greeter")
         self.greeter.set_application(self.gtk_app)
         if ".dev" in distribution().version:
-            self.greeter.get_style_context().add_class("devel")
+            self.greeter.add_css_class("devel")
 
         listbox = builder.get_object("recent-files")
         templates = builder.get_object("templates")

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -170,7 +170,7 @@ class MainWindow(Service, ActionProvider):
         window = self.window
         window.set_application(gtk_app)
         if ".dev" in distribution().version:
-            window.get_style_context().add_class("devel")
+            window.add_css_class("devel")
 
         select_modeling_language = builder.get_object("select-modeling-language")
         select_modeling_language.set_menu_model(

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -554,11 +554,10 @@ def list_item_drop_motion(
     target: Gtk.DropTarget, x: int, y: int, list_item: Gtk.ListItem
 ) -> Gdk.DragAction:
     widget = target.get_widget()
-    style_context = widget.get_style_context()
     if y < 4:
-        style_context.add_class("move-element-above")
+        widget.add_css_class("move-element-above")
     else:
-        style_context.remove_class("move-element-above")
+        widget.remove_css_class("move-element-above")
 
     return Gdk.DragAction.COPY
 
@@ -567,8 +566,7 @@ def list_item_drop_leave(
     target: Gtk.DropTarget, list_item: Gtk.ListItem
 ) -> Gdk.DragAction:
     widget = target.get_widget()
-    style_context = widget.get_style_context()
-    style_context.remove_class("move-element-above")
+    widget.remove_css_class("move-element-above")
 
 
 def list_item_drop_drop(

--- a/gaphor/ui/tests/test_modelbrowser.py
+++ b/gaphor/ui/tests/test_modelbrowser.py
@@ -364,11 +364,7 @@ class MockRowItem:
 class MockDropTarget:
     def get_widget(self):
         class Widget:
-            def get_style_context(self):
-                return StyleContext()
-
-        class StyleContext:
-            def remove_class(self, _):
+            def remove_css_class(self, _):
                 pass
 
         return Widget()


### PR DESCRIPTION

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

`Gtk.StyleContext`, and `Gtk.Widget.get_style_context()` are deprecated since GTK 4.10.

### What is the new behavior?

Instead, set style classes on widgets directly.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
