### PR TITLE
Windows: add tree of files expected in docs

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -98,6 +98,18 @@ Unzip the `GTK4_Gvsbuild_VERSION_x64.zip` file to `C:\gtk`. For example with 7Zi
 7z x GTK4_Gvsbuild_*.zip  -oC:\gtk -y
 ```
 
+The resulting directory structure should look like:
+
+```
+C:\gtk
+├── bin
+├── include
+├── lib
+├── python
+├── share
+└── wheels
+```
+
 ### Setup Gaphor
 
 In the same PowerShell terminal, clone the repository:


### PR DESCRIPTION
Based on discussion on matrix, improving the documentation to ensure that the tree structure is present after unziping the Gvsbuild files.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [X] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
