### PR TITLE
Select single image file and avoid accessing image attributes after close

### DIFF
--- a/gaphor/diagram/general/generalpropertypages.py
+++ b/gaphor/diagram/general/generalpropertypages.py
@@ -127,33 +127,33 @@ class PicturePropertyPage(PropertyPageBase):
     def _on_select_picture_clicked(self, button):
         open_file_dialog(
             gettext("Select a picture..."),
-            self.open_files,
+            self.open_file,
             image_filter=True,
             parent=button.get_root(),
+            multiple=False,
         )
 
-    def open_files(self, filenames):
-        for filename in filenames:
-            with open(filename, "rb") as file:
-                try:
-                    image_data = file.read()
-                    with Image.open(io.BytesIO(image_data)) as image:
-                        image.verify()
+    def open_file(self, filename):
+        with open(filename, "rb") as file:
+            try:
+                image_data = file.read()
+                with Image.open(io.BytesIO(image_data)) as image:
+                    image.verify()
 
-                        base64_encoded_data = base64.b64encode(image_data)
+                    base64_encoded_data = base64.b64encode(image_data)
 
-                        with Transaction(self.event_manager):
-                            self.subject.subject.content = base64_encoded_data.decode(
-                                "ascii"
-                            )
-                            self.subject.width = image.width
-                            self.subject.height = image.height
-                except Exception:
-                    error_handler(
-                        message=gettext("Unable to parse picture “{filename}”.").format(
-                            filename=filename
+                    with Transaction(self.event_manager):
+                        self.subject.subject.content = base64_encoded_data.decode(
+                            "ascii"
                         )
+                        self.subject.width = image.width
+                        self.subject.height = image.height
+            except Exception:
+                error_handler(
+                    message=gettext("Unable to parse picture “{filename}”.").format(
+                        filename=filename
                     )
+                )
 
     def _on_default_size_clicked(self, button):
         if self.subject and self.subject.subject and self.subject.subject.content:

--- a/gaphor/diagram/general/generalpropertypages.py
+++ b/gaphor/diagram/general/generalpropertypages.py
@@ -137,18 +137,17 @@ class PicturePropertyPage(PropertyPageBase):
             with open(filename, "rb") as file:
                 try:
                     image_data = file.read()
-                    image = Image.open(io.BytesIO(image_data))
-                    image.verify()
-                    image.close()
+                    with Image.open(io.BytesIO(image_data)) as image:
+                        image.verify()
 
-                    base64_encoded_data = base64.b64encode(image_data)
+                        base64_encoded_data = base64.b64encode(image_data)
 
-                    with Transaction(self.event_manager):
-                        self.subject.subject.content = base64_encoded_data.decode(
-                            "ascii"
-                        )
-                        self.subject.width = image.width
-                        self.subject.height = image.height
+                        with Transaction(self.event_manager):
+                            self.subject.subject.content = base64_encoded_data.decode(
+                                "ascii"
+                            )
+                            self.subject.width = image.width
+                            self.subject.height = image.height
                 except Exception:
                     error_handler(
                         message=gettext("Unable to parse picture “{filename}”.").format(

--- a/gaphor/ui/tests/test_filedialog.py
+++ b/gaphor/ui/tests/test_filedialog.py
@@ -1,31 +1,71 @@
 import os
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import pytest
 from gi.repository import Gio, Gtk
 
-from gaphor.ui.filedialog import pretty_path, save_file_dialog
+from gaphor.ui.filedialog import open_file_dialog, pretty_path, save_file_dialog
 
 
 class TaskMock:
+    def __init__(self, error=False):
+        self._error = error
+
     def had_error(self):
-        return False
+        return self._error
 
 
 class FileDialogMock(Gtk.FileDialog):
     def __init__(self):
         super().__init__()
         self._save_response = Gio.File.parse_name("/unset")
+        self._error = False
+        self.calls = {
+            "save": 0,
+            "save_finish": 0,
+            "open": 0,
+            "open_finish": 0,
+            "open_multiple": 0,
+            "open_multiple_finish": 0,
+        }
 
     def save(self, parent, cancellable, callback):
+        self.calls["save"] += 1
         self.save_callback = callback
-        callback(self, TaskMock())
+        callback(self, TaskMock(self._error))
 
     def save_finish(self, result):
+        self.calls["save_finish"] += 1
+        return self._save_response
+
+    def open(self, parent, cancellable, callback):
+        self.calls["open"] += 1
+        self.save_callback = callback
+        callback(self, TaskMock(self._error))
+
+    def open_finish(self, result):
+        self.calls["open_finish"] += 1
+        return self._save_response
+
+    def open_multiple(self, parent, cancellable, callback):
+        self.calls["open_multiple"] += 1
+        self.save_callback = callback
+        callback(self, TaskMock(self._error))
+
+    def open_multiple_finish(self, result):
+        self.calls["open_multiple_finish"] += 1
         return self._save_response
 
     def define_response(self, response):
-        self._save_response = Gio.File.parse_name(response)
+        if isinstance(response, list):
+            self._save_response = Gio.ListStore(item_type=Gio.File)
+            for r in response:
+                self._save_response.append(Gio.File.parse_name(r))
+        else:
+            self._save_response = Gio.File.parse_name(response)
+
+    def define_error(self, error):
+        self._error = error
 
 
 @pytest.fixture
@@ -37,6 +77,27 @@ def file_dialog(monkeypatch):
 
     monkeypatch.setattr("gi.repository.Gtk.FileDialog.new", new_file_dialog)
     return stub
+
+
+def test_save_dialog_cancelled(file_dialog):
+    file_dialog.define_response("/test/path/model.gaphor")
+    file_dialog.define_error(True)
+    selected_file = None
+
+    def save_handler(f):
+        nonlocal selected_file
+        selected_file = f
+
+    save_file_dialog(
+        "title",
+        Path("testfile.gaphor"),
+        save_handler,
+        filters=[],
+    )
+
+    assert file_dialog.calls["save"] == 1
+    assert file_dialog.calls["save_finish"] == 0
+    assert selected_file is None
 
 
 def test_save_dialog(file_dialog):
@@ -54,6 +115,8 @@ def test_save_dialog(file_dialog):
         filters=[],
     )
 
+    assert file_dialog.calls["save"] == 1
+    assert file_dialog.calls["save_finish"] == 1
     assert selected_file.parts == (os.path.sep, "test", "path", "model.gaphor")
 
 
@@ -91,6 +154,82 @@ def test_save_dialog_filename_without_extension(file_dialog):
     )
 
     assert selected_file.parts == (os.path.sep, "test", "path", "model")
+
+
+def test_open_dialog_single_cancelled(file_dialog):
+    file_dialog.define_response("/test/path/file")
+    file_dialog.define_error(True)
+    selected_file = None
+
+    def open_handler(f):
+        nonlocal selected_file
+        selected_file = f
+
+    open_file_dialog("title", open_handler, multiple=False)
+
+    assert file_dialog.calls["open"] == 1
+    assert file_dialog.calls["open_finish"] == 0
+    assert selected_file is None
+
+
+def test_open_dialog_one_file_single(file_dialog):
+    file_dialog.define_response("/test/path/file")
+    selected_file = None
+
+    def open_handler(f):
+        nonlocal selected_file
+        selected_file = f
+
+    open_file_dialog(
+        "title",
+        open_handler,
+        multiple=False,
+    )
+
+    assert file_dialog.calls["open"] == 1
+    assert file_dialog.calls["open_finish"] == 1
+    assert isinstance(selected_file, PosixPath)
+    assert selected_file.parts == (os.path.sep, "test", "path", "file")
+
+
+def test_open_dialog_multiple_cancelled(file_dialog):
+    file_dialog.define_response(["/test/path/file"])
+    file_dialog.define_error(True)
+    selected_file = None
+
+    def open_handler(f):
+        nonlocal selected_file
+        selected_file = f
+
+    open_file_dialog(
+        "title",
+        open_handler,
+    )
+
+    assert file_dialog.calls["open_multiple"] == 1
+    assert file_dialog.calls["open_multiple_finish"] == 0
+    assert selected_file is None
+
+
+def test_open_dialog_one_file_multiple(file_dialog):
+    file_dialog.define_response(["/test/path/file"])
+    selected_file = None
+
+    def open_handler(f):
+        nonlocal selected_file
+        selected_file = f
+
+    open_file_dialog(
+        "title",
+        open_handler,
+    )
+
+    assert file_dialog.calls["open_multiple"] == 1
+    assert file_dialog.calls["open_multiple_finish"] == 1
+    assert isinstance(selected_file, list)
+    assert len(selected_file) == 1
+    assert isinstance(selected_file[0], PosixPath)
+    assert selected_file[0].parts == (os.path.sep, "test", "path", "file")
 
 
 def test_format_home_folder():


### PR DESCRIPTION
While playing on #3428 I noticed how in [gaphor/diagram/general/generalpropertypages.py](https://github.com/gaphor/gaphor/blob/48b4ef6862f99d223ca5605614216f81c65cc621/gaphor/diagram/general/generalpropertypages.py) attributes of the `image` object are accessed after its `close()`.

https://github.com/gaphor/gaphor/blob/48b4ef6862f99d223ca5605614216f81c65cc621/gaphor/diagram/general/generalpropertypages.py#L140-L151

Moreover, in current implementation the user is allowed to select multiple image files:

https://github.com/gaphor/gaphor/blob/48b4ef6862f99d223ca5605614216f81c65cc621/gaphor/diagram/general/generalpropertypages.py#L135-L137 

Todo:

- [x] Run regression tests
- [x] Add test

### PR Checklist

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type

- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

1. Add a `Picture` to a diagram;
2. `Select picture...`
3. The user is allowed to select more than one file

![image-1](https://github.com/user-attachments/assets/a9068508-2f1a-45d4-80bb-df8d197955e6)

### What is the new behavior?

1. Add a `Picture` to a diagram;
2. `Select picture...`
3. The user is allowed to select only one file

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

The change adds a new `multiple` argument to  

https://github.com/gaphor/gaphor/blob/48b4ef6862f99d223ca5605614216f81c65cc621/gaphor/ui/filedialog.py#L45-L52

in order to retrieve a single element instead of a list. This should not break other behaviours, although there do not seem to be many scenarios where the application would need to select multiple files. 