### PR TITLE
Allow spaces in string attribute value

### DIFF
--- a/gaphor/UML/tests/test_umllex.py
+++ b/gaphor/UML/tests/test_umllex.py
@@ -54,7 +54,7 @@ def test_parse_property_simple(factory):
     assert a.defaultValue is None, a.defaultValue
 
 
-def test_parse_property_complex(factory):
+def test_parse_property_complex_1(factory):
     """Test complex property parsing."""
     a = factory.create(UML.Property)
 
@@ -66,6 +66,21 @@ def test_parse_property_complex(factory):
     assert "0" == a.lowerValue
     assert "*" == a.upperValue
     assert '"aap"' == a.defaultValue
+    assert "and a note" == a.note
+
+
+def test_parse_property_complex_2(factory):
+    """Test complex property parsing."""
+    a = factory.create(UML.Property)
+
+    parse(a, '+ / name : str[0..*] = "aap bbq" { static }# and a note')
+    assert "public" == a.visibility
+    assert a.isDerived
+    assert "name" == a.name
+    assert "str" == a.typeValue
+    assert "0" == a.lowerValue
+    assert "*" == a.upperValue
+    assert '"aap bbq"' == a.defaultValue
     assert "and a note" == a.note
 
 

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -33,7 +33,9 @@ multa_subpat = r"\s*(\[?((?P<mult_l>[0-9]+)\s*\.\.)?\s*(?P<mult_u>([0-9]+|\*))\]
 type_subpat = r"\s*(:\s*(?P<type>[a-zA-Z_]\w*( +\w+| *\| *\w+| *<[\w\| ]*>)*))?"
 
 # default value (optional) ::= '=' default
-default_subpat = r"\s*(=\s*(?P<default>\S+))?"
+default_subpat = (
+    r"\s*(=\s*(?P<default>((?P<oq>[\"'])(?:(?=(?P<ec>\\?))(?P=ec).)*?(?P=oq))|(\S+)))?"
+)
 
 # tagged values (optional) ::= '{' tags '}'
 tags_subpat = r"\s*(\{\s*(?P<tags>.*?)\s*\})?"

--- a/gaphor/codegen/coder.py
+++ b/gaphor/codegen/coder.py
@@ -305,7 +305,12 @@ def default_value(a):
         if a.typeValue == "int":
             defaultValue = a.defaultValue.title()
         elif a.typeValue == "str":
-            defaultValue = f'"{a.defaultValue}"'
+            if (a.defaultValue[0] == a.defaultValue[-1]) and (
+                a.defaultValue[0] in ['"', "'"]
+            ):
+                defaultValue = a.defaultValue
+            else:
+                defaultValue = f'"{a.defaultValue}"'
         else:
             raise ValueError(
                 f"Unknown default value type: {a.owner.name}.{a.name}: {a.typeValue} = {a.defaultValue}"


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->

Modify regex

https://github.com/gaphor/gaphor/blob/6fee35e8a9413b28c3b32e5d3a1a0697dc244605/gaphor/UML/umllex.py#L36

to treat differently the `default` match in case the text is sorrounded by either `"` or `` ` ``.  In this latter case regex 

    (?P<oq>[\"'])(?:(?=(?P<ec>\\?))(?P=ec).)*?(?P=oq)

applies (it should allow for escaped quotes between quotes. 

Also, fixes the generation of code from the model. In the following snippet `coder.py` applies double quotes regardless if `a.defaultValue` is already quoted or not. In the former case the generated Python code is not valid.

https://github.com/gaphor/gaphor/blob/62b2fa0d0719362e6d644a332cc55ec3b66daa46/gaphor/codegen/coder.py#L307-L308

### PR Checklist

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Issue Number: Fixes #3432

See the issue for more information

### What is the new behavior?

See the issue expected behavior.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

### Other information
