### PR TITLE
Capture all button presses for popup menus

### DIFF
--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -303,6 +303,7 @@ def context_menu_controller(context_menu, diagram):
         context_menu.popup()
 
     ctrl = Gtk.GestureClick.new()
+    ctrl.set_button(0)
     ctrl.connect("pressed", on_show_popup)
     return ctrl
 

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -428,6 +428,7 @@ def create_popup_controller(tree_view, selection, modeling_language):
         menu.popup()
 
     ctrl = Gtk.GestureClick.new()
+    ctrl.set_button(0)
     ctrl.connect("pressed", on_show_popup)
     return ctrl
 
@@ -481,6 +482,7 @@ def list_item_factory_setup(
         row.menu.popup()
 
     ctrl = Gtk.GestureClick.new()
+    ctrl.set_button(0)
     ctrl.connect("pressed", on_show_popup)
     row.add_controller(ctrl)
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the new behavior?

Fix broken popups introduced by #3415.

By default [Gtk.GestureClick](https://docs.gtk.org/gtk4/class.GestureSingle.html) only triggers on the primary mouse button.


@tompkins-ct this should fix the issue you're facing.