### PR TITLE
Fix unowned elements

### DIFF
--- a/gaphor/SysML/blocks/connectors.py
+++ b/gaphor/SysML/blocks/connectors.py
@@ -91,4 +91,6 @@ class PropertyConnectorConnector(RelationshipConnect):
             assert isinstance(c2.subject, UML.ConnectableElement)
             connector = UML.recipes.create_connector(c1.subject, c2.subject)
             line.subject = connector
-            connector.structuredClassifier = c1.subject.owner or c2.subject.owner
+            owner = c1.subject.owner or c2.subject.owner
+            assert isinstance(owner, UML.StructuredClassifier)
+            connector.structuredClassifier = owner

--- a/gaphor/UML/recipes.py
+++ b/gaphor/UML/recipes.py
@@ -248,7 +248,9 @@ def create_association(type_a: Type, type_b: Type):
     return assoc
 
 
-def create_connector(type_a: ConnectableElement, type_b: ConnectableElement):
+def create_connector(
+    type_a: ConnectableElement, type_b: ConnectableElement
+) -> Connector:
     """Create a connector between two items.
 
     Depending on the ends, the connector kind may be "assembly" or

--- a/gaphor/UML/tests/test_recipes.py
+++ b/gaphor/UML/tests/test_recipes.py
@@ -297,3 +297,14 @@ def test_interaction_messages_cloning(element_factory):
 
     assert m2.sendEvent.covered is rl
     assert m2.receiveEvent.covered is sl
+
+
+def test_connector_ends(element_factory):
+    port = element_factory.create(UML.Port)
+    prop = element_factory.create(UML.Property)
+    connector = UML.recipes.create_connector(port, prop)
+
+    assert port in connector.end[:].role
+    assert prop in connector.end[:].role
+
+    assert all(e in connector.ownedElement for e in connector.end)

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -286,7 +286,7 @@ class ModelBrowser(UIComponent, ActionProvider):
         self.sorter.changed(Gtk.SorterChange.DIFFERENT)
 
     @event_handler(ModelReady, ModelFlushed)
-    def on_model_ready(self, event=None):
+    def on_model_ready(self, _event=None):
         model = self.model
         model.clear()
 

--- a/gaphor/ui/tests/test_modelbrowser.py
+++ b/gaphor/ui/tests/test_modelbrowser.py
@@ -311,6 +311,17 @@ def test_unlink_element_should_not_collapse_branch(
     assert model_browser.selection.get_item(1).get_item().element is class_b
 
 
+def test_multiplicity_element_should_not_end_up_in_root(model_browser, element_factory):
+    port = element_factory.create(UML.Port)
+    prop = element_factory.create(UML.Property)
+    connector = UML.recipes.create_connector(port, prop)
+
+    model_browser.on_model_ready()
+    model = model_browser.model
+
+    assert model.tree_item_for_element(connector.end[0]) is None
+
+
 def test_stereotype_base_class_should_not_end_up_in_root(
     model_browser, element_factory
 ):

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -131,18 +131,25 @@ class Branch:
         yield from self.relationships
 
 
-def visible(element):
-    return not isinstance(
-        element,
-        (
-            Comment,
-            Presentation,
-            StyleSheet,
-            UML.InstanceSpecification,
-            UML.OccurrenceSpecification,
-            UML.Slot,
-        ),
-    ) or (not element.owner and isinstance(element, UML.MultiplicityElement))
+def visible(element: Element) -> bool:
+    return not (
+        isinstance(
+            element,
+            (
+                Comment,
+                Presentation,
+                StyleSheet,
+                UML.InstanceSpecification,
+                UML.OccurrenceSpecification,
+                UML.Slot,
+            ),
+        )
+        or (
+            # Some types we want to show, except at top level
+            (not (element.owner or element.memberNamespace))
+            and isinstance(element, UML.MultiplicityElement)
+        )
+    )
 
 
 def tree_item_sort(a, b, _user_data=None):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

`ConnectorEnd`s show in the model root after a model is loaded.

Issue Number: Fixes #3445

### What is the new behavior?

`ConnectorEnd`, or any `MultiplicityElement` are no longer shown at top level.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
