### PR TITLE
Fix Gvsbuild automation and Windows tests

### DIFF
--- a/.github/workflows/gvsbuild-updater.yml
+++ b/.github/workflows/gvsbuild-updater.yml
@@ -75,7 +75,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git checkout $COMMIT_SHA
           git switch -c gvsbuild-updates-${{ github.run_id }}
+          git checkout origin/main -- ${ROOT_DIR}/.github/workflows
           git add ${{ env.file }}
           git commit -m "Bump Gvsbuild to version $LATEST"
           git push origin gvsbuild-updates-${{ github.run_id }}

--- a/gaphor/ui/tests/test_filedialog.py
+++ b/gaphor/ui/tests/test_filedialog.py
@@ -1,5 +1,5 @@
 import os
-from pathlib import Path, PosixPath
+from pathlib import Path
 
 import pytest
 from gi.repository import Gio, Gtk
@@ -188,7 +188,7 @@ def test_open_dialog_one_file_single(file_dialog):
 
     assert file_dialog.calls["open"] == 1
     assert file_dialog.calls["open_finish"] == 1
-    assert isinstance(selected_file, PosixPath)
+    assert isinstance(selected_file, Path)
     assert selected_file.parts == (os.path.sep, "test", "path", "file")
 
 
@@ -228,7 +228,7 @@ def test_open_dialog_one_file_multiple(file_dialog):
     assert file_dialog.calls["open_multiple_finish"] == 1
     assert isinstance(selected_file, list)
     assert len(selected_file) == 1
-    assert isinstance(selected_file[0], PosixPath)
+    assert isinstance(selected_file[0], Path)
     assert selected_file[0].parts == (os.path.sep, "test", "path", "file")
 
 


### PR DESCRIPTION
Fixes two issues:
- Fixes a permissions issue when trying to push during a workflow dispatch introduced in #3389
- Fixes usage of PosixPath in tests since this isn't cross platform for Windows introduced in #3430 

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
