### PR TITLE
Fix InterfaceRealization.implementingClassifier name

### DIFF
--- a/gaphor/UML/classes/interfacerealization.py
+++ b/gaphor/UML/classes/interfacerealization.py
@@ -13,7 +13,7 @@ from gaphor.UML.compartments import text_stereotypes
 @represents(
     UML.InterfaceRealization,
     head=UML.InterfaceRealization.contract,
-    tail=UML.InterfaceRealization.implementatingClassifier,
+    tail=UML.InterfaceRealization.implementingClassifier,
 )
 class InterfaceRealizationItem(Named, LinePresentation):
     def __init__(self, diagram, id=None):

--- a/gaphor/UML/classes/tests/test_realizationconnect.py
+++ b/gaphor/UML/classes/tests/test_realizationconnect.py
@@ -51,7 +51,7 @@ def test_connection(create):
     assert ct is iface
     assert impl.subject is not None
     assert impl.subject.contract is iface.subject
-    assert impl.subject.implementatingClassifier is clazz.subject
+    assert impl.subject.implementingClassifier is clazz.subject
 
 
 def test_reconnection(create):
@@ -72,5 +72,5 @@ def test_reconnection(create):
 
     assert s is not impl.subject
     assert iface.subject is impl.subject.contract
-    assert c2.subject is impl.subject.implementatingClassifier
-    assert c1.subject is not impl.subject.implementatingClassifier
+    assert c2.subject is impl.subject.implementingClassifier
+    assert c1.subject is not impl.subject.implementingClassifier

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -374,7 +374,7 @@ class Activity(Behavior):
 
 class InterfaceRealization(Realization):
     contract: relation_many[Interface]
-    implementatingClassifier: relation_one[BehavioredClassifier]
+    implementingClassifier: relation_one[BehavioredClassifier]
 
 
 class Parameter(ConnectableElement, MultiplicityElement):
@@ -1025,7 +1025,7 @@ Element.ownedElement.add(Activity.group)  # type: ignore[attr-defined]
 Element.ownedElement.add(Activity.edge)  # type: ignore[attr-defined]
 Element.ownedElement.add(Activity.node)  # type: ignore[attr-defined]
 InterfaceRealization.contract = redefine(InterfaceRealization, "contract", Interface, Dependency.supplier)
-InterfaceRealization.implementatingClassifier = redefine(InterfaceRealization, "implementatingClassifier", BehavioredClassifier, Dependency.client)
+InterfaceRealization.implementingClassifier = redefine(InterfaceRealization, "implementingClassifier", BehavioredClassifier, Dependency.client)
 Parameter.owningNode = association("owningNode", ActivityParameterNode, upper=1, opposite="parameter")
 Parameter.parameterSet = association("parameterSet", ParameterSet, opposite="parameter")
 Parameter.ownerFormalParam = association("ownerFormalParam", BehavioralFeature, upper=1, opposite="ownedParameter")

--- a/gaphor/storage/tests/test_storage_uml_2_5_upgrade.py
+++ b/gaphor/storage/tests/test_storage_uml_2_5_upgrade.py
@@ -45,7 +45,7 @@ def test_implementation_to_interface_realization(loader):
 
     interface_realization, clazz = loader(i, c)
     assert interface_realization in clazz.interfaceRealization
-    assert interface_realization.implementatingClassifier is clazz
+    assert interface_realization.implementingClassifier is clazz
 
 
 def test_formal_parameter_to_owned_parameter(loader):

--- a/gaphor/storage/tests/test_storage_upgrades.py
+++ b/gaphor/storage/tests/test_storage_upgrades.py
@@ -111,7 +111,7 @@ def test_upgrade_flow_item_to_object_flow_item(element_factory, modeling_languag
     assert element_factory.lselect(diagramitems.ObjectFlowItem)
 
 
-def test_upgradedecision_node_item_show_type(loader):
+def test_upgrade_decision_node_item_show_type(loader):
     parsed_item = element(id="2", type="DecisionNodeItem")
     parsed_item.values["show_type"] = "1"
     item = loader(parsed_item)[0]

--- a/models/UML.gaphor
+++ b/models/UML.gaphor
@@ -17074,7 +17074,7 @@
 <ref refid="DCE:882D4230-A35C-11D8-9D85-00C00C03A405"/>
 </class_>
 <name>
-<val>implementatingClassifier</val>
+<val>implementingClassifier</val>
 </name>
 <type>
 <ref refid="DCE:555F3576-6679-11D7-A84E-6C8643AD0CA4"/>


### PR DESCRIPTION

<!-- Please add an overview of the PR here -->


### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Misspelled property in UML model

Issue Number: Fixes #3455 

### What is the new behavior?

Proper name: `implementingClassifier`.

### Other information

There's no need to an upgrade in the storage module, since `InterfaceRealization.implementatingClassifier` is a redefined property.
