### PR TITLE
Add option to export all diagrams from UI (same as CLI)

### DIFF
--- a/gaphor/plugins/diagramexport/__init__.py
+++ b/gaphor/plugins/diagramexport/__init__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from gi.repository import Gtk
+
 from gaphor.abc import ActionProvider, Service
 from gaphor.core import action, gettext
 from gaphor.diagram.export import (
@@ -11,19 +13,23 @@ from gaphor.diagram.export import (
     save_png,
     save_svg,
 )
+from gaphor.plugins.diagramexport.exportall import export_all
 from gaphor.ui.filedialog import save_file_dialog
 
 
 class DiagramExport(Service, ActionProvider):
     """Service for exporting diagrams as images (SVG, PNG, PDF)."""
 
-    def __init__(self, diagrams=None, export_menu=None, main_window=None):
+    def __init__(
+        self, diagrams=None, export_menu=None, main_window=None, element_factory=None
+    ):
         self.diagrams = diagrams
         self.export_menu = export_menu
         self.main_window = main_window
         if export_menu:
             export_menu.add_actions(self)
         self.filename: Path = Path("export").absolute()
+        self.factory = element_factory
 
     def shutdown(self):
         if self.export_menu:
@@ -100,3 +106,83 @@ class DiagramExport(Service, ActionProvider):
             "application/postscript",
             save_eps,
         )
+
+    @action(
+        name="all-export-svg",
+        label=gettext("Export all diagrams as SVG"),
+        tooltip=gettext(
+            "Export all diagrams as SVG diagrams in a specified" "directory"
+        ),
+    )
+    def export_all_svg_action(self):
+        dialog = Gtk.FileDialog.new()
+        dialog.set_title(gettext("Export all diagrams"))
+
+        def response(dialog, result):
+            if result.had_error():
+                return
+
+            folder = dialog.select_folder_finish(result).get_path()
+            export_all(self.factory, folder, save_svg, "svg")
+
+        dialog.select_folder(callback=response)
+
+    @action(
+        name="all-export-png",
+        label=gettext("Export all diagrams as PNG"),
+        tooltip=gettext(
+            "Export all diagrams as PNG diagrams in a specified" "directory"
+        ),
+    )
+    def export_all_png_action(self):
+        dialog = Gtk.FileDialog.new()
+        dialog.set_title(gettext("Export all diagrams"))
+
+        def response(dialog, result):
+            if result.had_error():
+                return
+
+            folder = dialog.select_folder_finish(result).get_path()
+            export_all(self.factory, folder, save_png, "png")
+
+        dialog.select_folder(callback=response)
+
+    @action(
+        name="all-export-pdf",
+        label=gettext("Export all diagrams as PDF"),
+        tooltip=gettext(
+            "Export all diagrams as PDF diagrams in a specified" "directory"
+        ),
+    )
+    def export_all_pdf_action(self):
+        dialog = Gtk.FileDialog.new()
+        dialog.set_title(gettext("Export all diagrams"))
+
+        def response(dialog, result):
+            if result.had_error():
+                return
+
+            folder = dialog.select_folder_finish(result).get_path()
+            export_all(self.factory, folder, save_pdf, "pdf")
+
+        dialog.select_folder(callback=response)
+
+    @action(
+        name="all-export-eps",
+        label=gettext("Export all diagrams as EPS"),
+        tooltip=gettext(
+            "Export all diagrams as EPS diagrams in a specified" "directory"
+        ),
+    )
+    def export_all_eps_action(self):
+        dialog = Gtk.FileDialog.new()
+        dialog.set_title(gettext("Export all diagrams"))
+
+        def response(dialog, result):
+            if result.had_error():
+                return
+
+            folder = dialog.select_folder_finish(result).get_path()
+            export_all(self.factory, folder, save_eps, "eps")
+
+        dialog.select_folder(callback=response)

--- a/gaphor/plugins/diagramexport/exportall.py
+++ b/gaphor/plugins/diagramexport/exportall.py
@@ -1,0 +1,45 @@
+import logging
+from pathlib import Path
+from typing import List
+
+from gaphor.core.modeling import Diagram
+from gaphor.diagram.export import escape_filename
+
+log = logging.getLogger(__name__)
+
+
+def pkg2dir(package):
+    """Return directory path from package class."""
+    name: List[str] = []
+    while package:
+        name.insert(0, package.name)
+        package = package.package
+    return "/".join(name)
+
+
+def export_all(factory, path, save_fn, suffix, name_re=None, underscore=None):
+    for diagram in factory.select(Diagram):
+        odir = f"{path}/{pkg2dir(diagram.owner)}"
+        # just diagram name
+        dname = escape_filename(diagram.name)
+        # full diagram name including package path
+        pname = f"{odir}/{dname}"
+
+        if underscore:
+            log.info("replacing underscores")
+            odir = odir.replace(" ", "_")
+            dname = dname.replace(" ", "_")
+
+        if name_re and not name_re.search(pname):
+            log.debug("skipping %s", pname)
+            continue
+
+        outfilename = f"{odir}/{dname}.{suffix}"
+
+        if not Path(odir).exists():
+            log.debug("creating dir %s", odir)
+            Path(odir).mkdir(parents=True)
+
+        log.info("rendering: %s -> %s...", pname, outfilename)
+
+        save_fn(outfilename, diagram)

--- a/gaphor/plugins/diagramexport/exportcli.py
+++ b/gaphor/plugins/diagramexport/exportcli.py
@@ -5,7 +5,7 @@ import logging
 import re
 
 from gaphor.application import Session
-from gaphor.diagram.export import save_pdf, save_png, save_svg
+from gaphor.diagram.export import save_eps, save_pdf, save_png, save_svg
 from gaphor.plugins.diagramexport.exportall import export_all
 from gaphor.storage import storage
 
@@ -31,7 +31,7 @@ def export_parser():
         metavar="format",
         help="output file format, default pdf",
         default="pdf",
-        choices=["pdf", "svg", "png"],
+        choices=["pdf", "svg", "png", "eps"],
     )
     parser.add_argument(
         "-r",
@@ -75,6 +75,8 @@ def export_command(args):
             out_fn = save_svg
         elif args.format == "png":
             out_fn = save_png
+        elif args.format == "eps":
+            out_fn = save_eps
         else:
             raise RuntimeError(f"Unknown file format: {args.format}")
 


### PR DESCRIPTION
Creating a full export of all diagrams in a model was already possible from the command-line. This can be intimidating for people who are less used to working in a CLI environment. I encountered this issue at my work where some system engineers were going through their model and manually exporting diagrams one-by-one, which is not a good use of their time. I quickly whipped up a plugin for them to do a dump to PNG. This PR is the cleaned up version of that plugin with support for all 4 formats that Gaphor currently supports.

Additionally this also adds support for EPS export on the CLI which was missing before.


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Export is only available for a single diagram in the UI

Issue Number: N/A

### What is the new behavior?

Menu options exist to export all diagrams in the model to a specific format

![image](https://github.com/user-attachments/assets/b52cd837-4079-4f47-ac1b-b91e52b205f8)


### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
