### PR TITLE
Remove workaround for opening links on macOS

### DIFF
--- a/gaphor/ui/help/__init__.py
+++ b/gaphor/ui/help/__init__.py
@@ -4,9 +4,8 @@
 """
 import logging
 import sys
-import webbrowser
 
-from gi.repository import Adw, GObject, Gtk
+from gi.repository import Adw, Gtk
 
 from gaphor.abc import ActionProvider, Service
 from gaphor.application import distribution
@@ -42,7 +41,6 @@ class HelpService(Service, ActionProvider):
 
         about.set_version(distribution().version)
         about.set_transient_for(self.window)
-        about.connect("activate-link", activate_link)
         about.set_modal(True)
         about.set_visible(True)
 
@@ -102,10 +100,3 @@ class HelpService(Service, ActionProvider):
 
         self.preferences_window.set_visible(True)
         return self.preferences_window
-
-
-def activate_link(window, uri):
-    """D-Bus does not work on macOS, so we open URL's ourselves."""
-    if sys.platform == "darwin":
-        GObject.signal_stop_emission_by_name(window, "activate-link")
-        webbrowser.open(uri)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

About dialog has a workaround for opening links on Darwin. It did not work before.

Issue Number: N/A

### What is the new behavior?

Links work in a (to be released) GLib version, not to far in the future, I hope.

See https://gitlab.gnome.org/GNOME/glib/-/issues/3484.