### PR TITLE
Fix Sphinx extension relative image path for out of source builds

### DIFF
--- a/gaphor/extensions/sphinx.py
+++ b/gaphor/extensions/sphinx.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import os
 from pathlib import Path
 
 import sphinx.util.docutils
@@ -95,7 +96,9 @@ class DiagramDirective(sphinx.util.docutils.SphinxDirective):
         save_pdf(outfile.with_suffix(".pdf"), diagram)
 
         # Image needs a relative path. Make our outfile path relative to the doc
-        outdir = outdir.relative_to(self.env.srcdir)
+        # os.path.relpath is used because Path.relative_to doesn't support going up
+        # to a common parent directory before Python 3.12 with the walk_up option
+        outdir = Path(os.path.relpath(outdir, self.env.srcdir))
         outfile = outdir / f"{diagram.id}"
 
         for _ in Path(self.env.docname).parts[:-1]:


### PR DESCRIPTION
The use of `relative_to` causes a failure when building Sphinx documentation using an out of source build because it cannot create a relative path by walking up through parent directories prior to the `walk_up` option available in Python 3.12

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Failure to include generated images when using out of source Sphinx builds.

### What is the new behavior?
Out of source Sphinx builds are supported.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
