### PR TITLE
Fix macOS release upload

### DIFF
--- a/.github/actions/macos_dmg/action.yml
+++ b/.github/actions/macos_dmg/action.yml
@@ -4,6 +4,9 @@ inputs:
   version:
     description: 'Gaphor version number'
     required: true
+  arch:
+    description: 'macOS architecture'
+    required: true
   base64_encoded_p12:
     description: 'base64_encoded_p12'
     required: true
@@ -93,18 +96,18 @@ runs:
         # https://github.com/actions/runner-images/issues/7522#issuecomment-1556766641
         echo killing...; sudo pkill -9 XProtect >/dev/null || true;
         echo waiting...; while pgrep XProtect; do sleep 3; done;
-        create-dmg --hdiutil-verbose --volname "Gaphor ${{ inputs.version }}" \
+        create-dmg --hdiutil-verbose --volname "Gaphor ${{ inputs.version }}-${{ inputs.arch }}" \
         --background "macos/background.png" \
         --window-pos 200 120 --window-size 700 400 --icon-size 100 \
         --icon "Gaphor.app" 200 240 --hide-extension "Gaphor.app" \
-        --app-drop-link 500 240 "dist/Gaphor-${{ inputs.version }}.dmg" \
+        --app-drop-link 500 240 "dist/Gaphor-${{ inputs.version }}-${{ inputs.arch }}.dmg" \
         "dist/Gaphor.app"
-        echo "artifact=Gaphor-${{ inputs.version }}.dmg" >> $GITHUB_OUTPUT
+        echo "artifact=Gaphor-${{ inputs.version }}-${{ inputs.arch }}.dmg" >> $GITHUB_OUTPUT
       shell: bash
     - name: Notarize dmg
       if: inputs.sign_app == 'true'
       env:
-        PRODUCT_PATH: "_packaging/dist/Gaphor-${{ inputs.version }}.dmg"
+        PRODUCT_PATH: "_packaging/dist/Gaphor-${{ inputs.version }}-${{ inputs.arch }}.dmg"
       run: |
         ditto -c -k --keepParent "${{ env.PRODUCT_PATH }}" "notarization.zip"
         xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
@@ -112,21 +115,21 @@ runs:
     - name: Staple .dmg
       if: inputs.sign_app == 'true'
       env:
-        PRODUCT_PATH: "_packaging/dist/Gaphor-${{ inputs.version }}.dmg"
+        PRODUCT_PATH: "_packaging/dist/Gaphor-${{ inputs.version }}-${{ inputs.arch }}.dmg"
       run: xcrun stapler staple ${{ env.PRODUCT_PATH }}
       shell: bash
     - name: Delete temporary keychain
       if: inputs.sign_app == 'true'
       run: security delete-keychain temp.keychain
       shell: bash
-    - name: Upload Gaphor-${{ inputs.version }}.dmg
+    - name: Upload Gaphor-${{ inputs.version }}-${{ inputs.arch }}.dmg
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
-        name: Gaphor-${{ inputs.version }}.dmg
-        path: _packaging/dist/Gaphor-${{ inputs.version }}.dmg
+        name: Gaphor-${{ inputs.version }}-${{ inputs.arch }}.dmg
+        path: _packaging/dist/Gaphor-${{ inputs.version }}-${{ inputs.arch }}.dmg
     - name: Upload Assets (release only)
       if: github.event_name == 'release'
       env:
         GH_TOKEN: ${{ github.token }}
-      run: gh release upload ${{ inputs.version }} "_packaging/dist/Gaphor-${{ inputs.version }}.dmg"
+      run: gh release upload ${{ inputs.version }} "_packaging/dist/Gaphor-${{ inputs.version }}-${{ inputs.arch }}.dmg"
       shell: bash

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -160,9 +160,9 @@ jobs:
       matrix:
         target:
           - runner: macos-13
-            suffix: -intel
+            suffix: intel
           - runner: macos-15
-            suffix: -arm
+            suffix: arm
     name: macOS
     needs: lint
     runs-on: ${{ matrix.target.runner }}
@@ -206,7 +206,8 @@ jobs:
         uses: ./.github/actions/macos_dmg
         with:
           sign_app: ${{ env.mainline_build }}
-          version: ${{ steps.install.outputs.version }}${{ matrix.target.suffix }}
+          version: ${{ steps.install.outputs.version }}
+          arch: ${{ matrix.target.suffix }}
           base64_encoded_p12: ${{ secrets.BASE64_ENCODED_P12 }}
           certpassword_p12: ${{ secrets.CERTPASSWORD_P12 }}
           notary_username:  ${{ secrets.APPLE_NOTARY_USER }}
@@ -214,7 +215,7 @@ jobs:
           notary_team_id: ${{ secrets.APPLE_TEAM_ID }}
       - name: Output
         id: output
-        run: echo "artifact${{ matrix.target.suffix }}=${{ steps.create.outputs.artifact }}" >> $GITHUB_OUTPUT
+        run: echo "artifact-${{ matrix.target.suffix }}=${{ steps.create.outputs.artifact }}" >> $GITHUB_OUTPUT
 
   check-macos-app:
     name: Check macOS App

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -160,9 +160,9 @@ jobs:
       matrix:
         target:
           - runner: macos-13
-            suffix: intel
+            arch: intel
           - runner: macos-15
-            suffix: arm
+            arch: arm
     name: macOS
     needs: lint
     runs-on: ${{ matrix.target.runner }}
@@ -207,7 +207,7 @@ jobs:
         with:
           sign_app: ${{ env.mainline_build }}
           version: ${{ steps.install.outputs.version }}
-          arch: ${{ matrix.target.suffix }}
+          arch: ${{ matrix.target.arch }}
           base64_encoded_p12: ${{ secrets.BASE64_ENCODED_P12 }}
           certpassword_p12: ${{ secrets.CERTPASSWORD_P12 }}
           notary_username:  ${{ secrets.APPLE_NOTARY_USER }}
@@ -215,7 +215,7 @@ jobs:
           notary_team_id: ${{ secrets.APPLE_TEAM_ID }}
       - name: Output
         id: output
-        run: echo "artifact-${{ matrix.target.suffix }}=${{ steps.create.outputs.artifact }}" >> $GITHUB_OUTPUT
+        run: echo "artifact-${{ matrix.target.arch }}=${{ steps.create.outputs.artifact }}" >> $GITHUB_OUTPUT
 
   check-macos-app:
     name: Check macOS App

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -223,9 +223,9 @@ jobs:
     strategy:
       matrix:
         target:
-          - runner: macos-12
+          - runner: macos-13
             artifact: ${{ needs.macos.outputs.artifact-intel }}
-          - runner: macos-14
+          - runner: macos-15
             artifact: ${{ needs.macos.outputs.artifact-arm }}
     runs-on: ${{ matrix.target.runner }}
     timeout-minutes: 10


### PR DESCRIPTION
When trying to release version 2.27.0, we are getting an error when trying to upload the macOS release assets to the release. This is because we need to pass the release version to the `gh upload` command, but the version is currently mixed with the architecture suffix. This PR splits the version and the arch to two separate inputs so that we can keep the version to the actual version number and use the arch as a separate suffix where needed.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
