### PR TITLE
Explicitly set dmg size to improve hdiutil reliability

### DIFF
--- a/.github/actions/macos_dmg/action.yml
+++ b/.github/actions/macos_dmg/action.yml
@@ -101,6 +101,7 @@ runs:
         --window-pos 200 120 --window-size 700 400 --icon-size 100 \
         --icon "Gaphor.app" 200 240 --hide-extension "Gaphor.app" \
         --app-drop-link 500 240 "dist/Gaphor-${{ inputs.version }}-${{ inputs.arch }}.dmg" \
+        --disk-image-size 55 \
         "dist/Gaphor.app"
         echo "artifact=Gaphor-${{ inputs.version }}-${{ inputs.arch }}.dmg" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
We are continuing to see some issues with hdiutil reliability. This PR explicitly sets the dmg size to help prevent resize operations.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
