### PR TITLE
macos: Fix Gaphor model file conformance

### DIFF
--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -156,7 +156,7 @@ app = BUNDLE(  # type: ignore
         "UTExportedTypeDeclarations": [
             {
                 "UTTypeIdentifier": "org.gaphor.model",
-                "UTTypeConformsTo": ["gaphor.model"],
+                "UTTypeConformsTo": ["public.xml"],
                 "UTTypeDescription": "Gaphor Model",
                 "UTTypeIconFile": "gaphor.icns",
                 "UTTypeReferenceURL": "https://gaphor.org",


### PR DESCRIPTION


### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the new behavior?

According to the apple docs, the conformance type should be some sort of super-type for our Gaphor model.

Since our models are saved as XML, I suppose `public.xml` is the most approprate.

https://developer.apple.com/documentation/uniformtypeidentifiers/defining-file-and-data-types-for-your-app?language=objc

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
