### PR TITLE
Update Toolbox pane color to match Property Editor

### DIFF
--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -137,7 +137,7 @@ tabbar > revealer > box,
 }
 
 .pseudo-sidebar-pane {
-  background-color: @sidebar_bg_color;
+  background-color: @sidebar_backdrop_color;
   color: @sidebar_fg_color;
 }
 


### PR DESCRIPTION
As pointed out by the research on [User interfaces of MBSE tools and their impact on neurodivergent system architects](https://madoc.bib.uni-mannheim.de/66242/1/Benutzeroberfl%C3%A4chen%20von%20MBSE-Tools%20und%20deren%20Auswirkung%20auf%20neurodivergente%20Systemarchitekten.pdf) by Mareike Victoria Keil and Oliver Bleisinger, Gaphor was using different gray colors on our Property Editor than on the Toolbox and Model Browser pane.

This PR updates the Toolbox pane to use the same color as Property Editor by setting the color to the sidebar backdrop instead of background color.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
The gray colors are slightly different

Issue Number: N/A

### What is the new behavior?
The gray colors match

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
