### PR TITLE
Minimum macOS system version is 10.15

### DIFF
--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -137,7 +137,7 @@ app = BUNDLE(  # type: ignore
     info_plist={
         "CFBundleVersion": str(get_version()),
         "NSHumanReadableCopyright": COPYRIGHT,
-        "LSMinimumSystemVersion": "10.13",
+        "LSMinimumSystemVersion": "10.15",
         "NSHighResolutionCapable": True,
         "LSApplicationCategoryType": "public.app-category.developer-tools",
         "NSPrincipalClass": "NSApplication",


### PR DESCRIPTION
That's the minimum version of (the next) GTK version.

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Minimum macOS version is set to 10.13

Issue Number: N/A

### What is the new behavior?

GTK4 will require macOS 10.15 or newer.

https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7881

### Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
