### PR TITLE
Make model browsers ownership concept extendible

### DIFF
--- a/gaphor/core/format.py
+++ b/gaphor/core/format.py
@@ -6,17 +6,17 @@
 
 from functools import singledispatch
 
-from gaphor.core.modeling import Diagram, Element
+from gaphor.core.modeling import Base, Diagram, Element
 
 
 @singledispatch
-def format(el: Element, **kwargs) -> str:
+def format(el: Base, **kwargs) -> str:
     """Format an element."""
     raise TypeError(f"Format routine for type {type(el)} not implemented yet")
 
 
 @singledispatch
-def parse(el: Element, text: str) -> None:
+def parse(el: Base, text: str) -> None:
     """Parse text and update `el` accordingly."""
     raise TypeError(f"Parsing routine for type {type(el)} not implemented yet")
 

--- a/gaphor/diagram/deletable.py
+++ b/gaphor/diagram/deletable.py
@@ -1,9 +1,9 @@
 from functools import singledispatch
 
-from gaphor.core.modeling import Element
+from gaphor.core.modeling import Base
 
 
 @singledispatch
-def deletable(element: Element) -> bool:
+def deletable(_element: Base) -> bool:
     """Determine if a single element can safely be deleted."""
     return True

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -7,6 +7,7 @@ from gaphor.abc import ActionProvider
 from gaphor.action import action
 from gaphor.core import event_handler
 from gaphor.core.modeling import (
+    Base,
     DerivedAdded,
     DerivedDeleted,
     DerivedSet,
@@ -34,10 +35,12 @@ from gaphor.ui.event import (
 )
 from gaphor.ui.treemodel import (
     RelationshipItem,
+    Root,
+    RootType,
     TreeItem,
     TreeModel,
+    owner,
     tree_item_sort,
-    visible,
 )
 from gaphor.ui.treesearch import search, sorted_tree_walker
 
@@ -135,7 +138,7 @@ class ModelBrowser(UIComponent, ActionProvider):
         self.event_manager.unsubscribe(self.on_model_ready)
         self.event_manager.unsubscribe(self.on_diagram_selection_changed)
 
-    def select_element(self, element: Element) -> int | None:
+    def select_element(self, element: Base) -> int | None:
         return select_element(self.tree_view, element)
 
     def select_element_quietly(self, element):
@@ -146,11 +149,11 @@ class ModelBrowser(UIComponent, ActionProvider):
         finally:
             self.selection.handler_unblock(self._selection_changed_id)
 
-    def get_selected_elements(self) -> list[Element]:
+    def get_selected_elements(self) -> list[Base]:
         assert self.model
         return get_selected_elements(self.selection)
 
-    def get_selected_element(self) -> Element | None:
+    def get_selected_element(self) -> Base | None:
         assert self.model
         return next(iter(self.get_selected_elements()), None)
 
@@ -185,16 +188,18 @@ class ModelBrowser(UIComponent, ActionProvider):
 
     @action(name="win.create-diagram")
     def tree_view_create_diagram(self, diagram_kind: str):
-        element = self.get_selected_element()
-        while element and not isinstance(element, UML.NamedElement):
-            element = element.owner
+        element: Base | RootType | None = self.get_selected_element()
+        while isinstance(element, Base) and not isinstance(element, UML.NamedElement):
+            element = owner(element)
 
         with Transaction(self.event_manager):
             diagram_type = self._diagram_type_or(
                 diagram_kind, DiagramType(diagram_kind, "New Diagram", ())
             )
             try:
-                diagram = diagram_type.create(self.element_factory, element)
+                diagram = diagram_type.create(
+                    self.element_factory, None if element is Root else element
+                )
                 diagram.name = diagram.gettext("New Diagram")
             except TypeError as e:
                 self.event_manager.handle(Notification(str(e)))
@@ -212,14 +217,14 @@ class ModelBrowser(UIComponent, ActionProvider):
 
     @action(name="tree-view.create-element")
     def tree_view_create_element(self, id: str):
-        owner = self.get_selected_element()
+        own = self.get_selected_element()
         element_def = self.element_type(id)
 
         with Transaction(self.event_manager):
             element = self.element_factory.create(element_def.element_type)
             element.name = element_def.name
-            if owner:
-                change_owner(owner, element)
+            if own:
+                change_owner(own, element)
 
             self.select_element(element)
             self.tree_view_rename_selected()
@@ -273,13 +278,12 @@ class ModelBrowser(UIComponent, ActionProvider):
         # Should check on ownedElement as well, since it may not have been updated
         # before this thing triggers
         if (
-            event.property not in (Element.owner, UML.NamedElement.memberNamespace)
-        ) or not visible(event.element):
-            return
-        element = event.element
-        self.model.remove_element(element)
-        self.model.add_element(element)
-        self.select_element_quietly(element)
+            event.property in (Element.owner, UML.NamedElement.memberNamespace)
+        ) and owner(event.element):
+            element = event.element
+            self.model.remove_element(element)
+            self.model.add_element(element)
+            self.select_element_quietly(element)
 
     @event_handler(ElementUpdated)
     def on_attribute_changed(self, event: ElementUpdated):
@@ -291,9 +295,7 @@ class ModelBrowser(UIComponent, ActionProvider):
         model = self.model
         model.clear()
 
-        for element in self.element_factory.select(
-            lambda e: isinstance(e, Element) and (e.owner is None) and visible(e)
-        ):
+        for element in self.element_factory.select(owner):
             model.add_element(element)
 
     @event_handler(DiagramSelectionChanged)
@@ -335,7 +337,7 @@ class SearchEngine:
             select_element(self.tree_view, next_item.element)
 
 
-def get_selected_elements(selection: Gtk.SelectionModel) -> list[Element]:
+def get_selected_elements(selection: Gtk.SelectionModel) -> list[Base]:
     bitset = selection.get_selection()
     return [
         e
@@ -351,12 +353,12 @@ def get_first_selected_item(selection):
 
 
 def select_element(
-    tree_view: Gtk.ListView, element: Element, unselect_rest=True
+    tree_view: Gtk.ListView, element: Base, unselect_rest=True
 ) -> int | None:
     def expand_up_to_element(element, expand=False) -> int | None:
-        if not element:
+        if element in (Root, None):
             return 0
-        if (n := expand_up_to_element(element.owner, expand=True)) is None:
+        if (n := expand_up_to_element(owner(element), expand=True)) is None:
             return None
         is_relationship = isinstance(element, UML.Relationship)
         while row := selection.get_item(n):
@@ -585,7 +587,7 @@ def list_item_drop_drop(
     tree_item = list_item.get_item().get_item()
     dest_element = tree_item.element
     if y < 4:
-        dest_element = dest_element.owner
+        dest_element = owner(dest_element)
 
     with Transaction(event_manager) as tx:
         # This view is concerned with owner relationships.

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -277,7 +277,7 @@ class ModelBrowser(UIComponent, ActionProvider):
         ) or not visible(event.element):
             return
         element = event.element
-        self.model.remove_element(element, former_owner=event.old_value)
+        self.model.remove_element(element)
         self.model.add_element(element)
         self.select_element_quietly(element)
 

--- a/gaphor/ui/tests/test_modelbrowser.py
+++ b/gaphor/ui/tests/test_modelbrowser.py
@@ -222,6 +222,39 @@ def test_delete_element(model_browser, element_factory):
     assert not element_factory.lselect()
 
 
+def test_association_end(model_browser: ModelBrowser, element_factory):
+    tree_model = model_browser.model
+    head_class = element_factory.create(UML.Class)
+    tail_class = element_factory.create(UML.Class)
+    association = recipes.create_association(head_class, tail_class)
+
+    recipes.set_navigability(association, association.memberEnd[0], True)
+    recipes.set_navigability(association, association.memberEnd[0], None)
+
+    association_item = tree_model.tree_item_for_element(association)
+    association_children = tree_model.child_model(association_item)
+
+    assert association.memberEnd[0] in (t.element for t in association_children)
+    assert association.memberEnd[1] in (t.element for t in association_children)
+
+
+def test_navigable_association_end(model_browser: ModelBrowser, element_factory):
+    tree_model = model_browser.model
+    head_class = element_factory.create(UML.Class)
+    tail_class = element_factory.create(UML.Class)
+    association = recipes.create_association(head_class, tail_class)
+
+    recipes.set_navigability(association, association.memberEnd[0], True)
+
+    association_item = tree_model.tree_item_for_element(association)
+    tail_class_item = tree_model.tree_item_for_element(tail_class)
+    association_children = tree_model.child_model(association_item)
+    tail_class_children = tree_model.child_model(tail_class_item)
+
+    assert association.memberEnd[0] not in (t.element for t in association_children)
+    assert association.memberEnd[0] in (t.element for t in tail_class_children)
+
+
 def test_search_next(model_browser, element_factory):
     class_a = element_factory.create(UML.Class)
     class_a.name = "a"

--- a/gaphor/ui/tests/test_treemodel.py
+++ b/gaphor/ui/tests/test_treemodel.py
@@ -3,6 +3,7 @@ from gaphor.i18n import gettext
 from gaphor.ui.treemodel import (
     Branch,
     RelationshipItem,
+    Root,
     TreeItem,
     TreeModel,
     tree_item_sort,
@@ -123,7 +124,7 @@ def test_tree_model_remove_nested_element(element_factory):
     tree_model.remove_element(class_)
 
     assert len(tree_model.branches) == 1
-    assert None in tree_model.branches
+    assert Root in tree_model.branches
     assert tree_model.tree_item_for_element(package) is not None
     assert tree_model.tree_item_for_element(class_) is None
 
@@ -140,7 +141,7 @@ def test_tree_model_remove_package_with_nested_element(element_factory):
 
     assert tree_model.tree_item_for_element(package) is None
     assert len(tree_model.branches) == 1
-    assert None in tree_model.branches
+    assert Root in tree_model.branches
     assert tree_model.tree_item_for_element(package) is None
     assert tree_model.tree_item_for_element(class_) is None
 
@@ -153,7 +154,7 @@ def test_tree_model_remove_from_different_owner(element_factory):
     tree_model.add_element(package)
     tree_model.add_element(class_)
     class_.package = package
-    tree_model.remove_element(class_, former_owner=None)
+    tree_model.remove_element(class_)
 
     assert tree_model.tree_item_for_element(package) is not None
     assert len(tree_model.root) == 1
@@ -167,7 +168,7 @@ def test_tree_model_change_owner(element_factory):
     tree_model.add_element(package)
     tree_model.add_element(class_)
     class_.package = package
-    tree_model.remove_element(class_, former_owner=None)
+    tree_model.remove_element(class_)
     tree_model.add_element(class_)
     package_item = tree_model.tree_item_for_element(package)
     tree_model.child_model(package_item)

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -269,16 +269,10 @@ class TreeModel:
         for child in owns(element):
             self.remove_element(child)
 
-        if (
-            owner_branch := next(
-                (
-                    b
-                    for b in self.branches.values()
-                    if element in (i.element for i in b)
-                ),
-                None,
-            )
-        ) is not None:
+        if owner_branch := next(
+            (b for b in self.branches.values() if element in (i.element for i in b)),
+            None,
+        ):
             owner_branch.remove(element)
 
             if not len(owner_branch):

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import singledispatch
 from unicodedata import normalize
 
 from gi.repository import Gio, GObject, Pango
@@ -7,10 +8,9 @@ from gi.repository import Gio, GObject, Pango
 from gaphor import UML
 from gaphor.core.format import format
 from gaphor.core.modeling import (
+    Base,
     Diagram,
     Element,
-    Presentation,
-    StyleSheet,
 )
 from gaphor.diagram.iconname import icon_name
 from gaphor.i18n import gettext
@@ -133,13 +133,18 @@ class Branch:
         yield from self.relationships
 
 
-def visible(element: Element) -> bool:
+@singledispatch
+def visible(base: Base) -> bool:
+    return False
+
+
+# Only UML elements:
+@visible.register
+def _(element: Element) -> bool:
     return not (
         isinstance(
             element,
-            Presentation
-            | StyleSheet
-            | UML.Comment
+            UML.Comment
             | UML.InstanceSpecification
             | UML.OccurrenceSpecification
             | UML.Slot,

--- a/gaphor/ui/treemodel.py
+++ b/gaphor/ui/treemodel.py
@@ -153,18 +153,26 @@ def _(element: Element):
 
 
 @owner.register
-def _(_element: UML.Slot):
-    return None
+def _(element: UML.NamedElement):
+    return element.owner or element.memberNamespace or Root
 
 
 @owner.register
-def _(element: UML.NamedElement):
-    if isinstance(
-        element, UML.Comment | UML.InstanceSpecification | UML.OccurrenceSpecification
-    ):
+def _(element: UML.StructuralFeature):
+    if not (element.owner or element.memberNamespace):
         return None
 
-    return element.owner or element.memberNamespace or Root
+    return element.owner or element.memberNamespace
+
+
+@owner.register
+def _(
+    _element: UML.Slot
+    | UML.Comment
+    | UML.InstanceSpecification
+    | UML.OccurrenceSpecification,
+):
+    return None
 
 
 @singledispatch


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The model browser mainly depends on the `Element.owner/ownedElement` relationship for ownership.
 It also supports `memberNamespace`, mainly for association ends without owner.

Builds on #3568.

Issue Number: #3540

Fixes #3557

### What is the new behavior?

Separate the concept of ownership out of the model browser, so it can be extended. 

The `owner()` dispatch method tells who's the owner of an element: another element, `Root`, or `None`. In case of `None`, the element is not supposed to be shown in the model browser.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

A separate element ownership function.

### Other information

The only issue is that event handling (in `ModelBrowser`) still checks for the properties used. This should change at some point, but I think this is already a nice simplification.

I do love to get rid of the `owns()` dispatch function -- basically the counterpart of `owner()` -- but I have no idea how, yet.