### PR TITLE
Enable double click to edit stereotype values

### DIFF
--- a/gaphor/UML/profiles/propertypages.ui
+++ b/gaphor/UML/profiles/propertypages.ui
@@ -72,7 +72,6 @@
                 <signal name="key-pressed" handler="stereotype-key-pressed" />
               </object>
             </child>
-            <signal name="activate" handler="stereotype-activated" />
           </object>
         </property>
       </object>

--- a/gaphor/UML/profiles/stereotype-value-cell.ui
+++ b/gaphor/UML/profiles/stereotype-value-cell.ui
@@ -29,6 +29,11 @@
           </lookup>
         </binding>
         <signal name="done-editing" handler="on_done_editing" object="GtkColumnViewCell" swapped="no" />
+        <child>
+          <object class="GtkGestureClick">
+            <signal name="pressed" handler="stereotype-click-pressed" />
+          </object>
+        </child>
       </object>
     </property>
   </template>

--- a/gaphor/UML/profiles/stereotypepropertypages.py
+++ b/gaphor/UML/profiles/stereotypepropertypages.py
@@ -37,7 +37,6 @@ class StereotypePage(PropertyPageBase):
         builder = new_builder(
             "stereotypes-editor",
             signals={
-                "stereotype-activated": (stereotype_activated,),
                 "stereotype-key-pressed": (stereotype_key_handler,),
             },
         )
@@ -100,7 +99,10 @@ def stereotype_set_model_with_interaction(stereotype_list, model):
                 },
             ),
             value_list_item_factory(
-                signal_handlers=text_field_handlers("slot_value"),
+                signal_handlers={
+                    "stereotype-click-pressed": stereotype_click_handler,
+                    **text_field_handlers("slot_value"),
+                },
             ),
         ],
         strict=False,
@@ -257,14 +259,10 @@ def value_list_item_factory(signal_handlers=None):
     )
 
 
-def stereotype_activated(list_view, _row):
-    selection = list_view.get_model()
-    item = selection.get_selected_item()
-
-    if item.attr:
-        item.editing = True
-    else:
-        item.applied = not item.applied
+def stereotype_click_handler(ctrl, n_press, x, y):
+    if n_press == 2:
+        cell = ctrl.get_widget()
+        cell.editing = True
 
 
 def stereotype_key_handler(ctrl, keyval, _keycode, state):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

To edit a stereotype slot value you have to use `F2`.

Issue Number: N/A

### What is the new behavior?

Now double click also works, as with attribute and operations editors.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
