### PR TITLE
Fix Gvsbuild and Pre-commit PR updates

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,8 @@ jobs:
         allowed-endpoints: >
           api.github.com:443
           github.com:443
-          objects.githubusercontent.com:443
+          *.githubusercontent.com:443
+          ghcr.io
           uploads.github.com:443
           azure.archive.ubuntu.com:80
           esm.ubuntu.com:443

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
@@ -46,7 +46,7 @@ jobs:
     - name: Install Linux Dependencies
       run: >
         sudo apt-get update -qq && sudo apt-get install -qq --no-install-recommends
-        libgirepository1.0-dev
+        libgirepository1.0-dev libcairo2-dev
     - name: Install Poetry
       run: python${{ env.python_version }} -m pip install --constraint=.github/constraints.txt poetry
     - name: Configure Poetry

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,6 +25,8 @@ jobs:
             api.github.com:443
             api.securityscorecards.dev:443
             github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
 
       - name: 'Checkout Repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -42,8 +42,8 @@ jobs:
             pypi.org:443
             github.com:443
             api.github.com:443
-            objects.githubusercontent.com:443
-            raw.githubusercontent.com:443
+            *.githubusercontent.com:443
+            ghcr.io
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   lint:
     name: 🕵️ Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
@@ -66,7 +66,7 @@ jobs:
   linux-wheel:
     name:  🐧 Linux (Wheel) with Python ${{ matrix.python_version }}
     needs: lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: fedora:39
     timeout-minutes: 30
     if: "!contains(github.event.head_commit.message, 'skip ci')"
@@ -131,7 +131,7 @@ jobs:
   linux-flatpak-devel:
     name: 📦 Linux (Devel Flatpak)
     needs: lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: bilelmoussaoui/flatpak-github-actions:gnome-45
       options: --privileged
@@ -354,7 +354,7 @@ jobs:
   publish-to-pypi:
     name: 🧀 Publish to PyPI (release only)
     needs: [ linux-wheel, linux-flatpak-devel, check-macos-app, check-windows-installer ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
     if: github.event_name == 'release'
@@ -380,7 +380,7 @@ jobs:
   trigger-website-version-update:
     name: ⏩ gaphor.org version update
     needs: [ publish-to-pypi ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
@@ -398,7 +398,7 @@ jobs:
   trigger-flatpak-version-update:
     name: ⏩ Flathub version update
     needs: [ publish-to-pypi ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2

--- a/.github/workflows/gvsbuild-updater.yml
+++ b/.github/workflows/gvsbuild-updater.yml
@@ -23,10 +23,12 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
-            api.github.com:443
             files.pythonhosted.org:443
-            github.com:443
             pypi.org:443
+            github.com:443
+            api.github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
@@ -62,6 +64,8 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main

--- a/.github/workflows/gvsbuild-updater.yml
+++ b/.github/workflows/gvsbuild-updater.yml
@@ -71,10 +71,16 @@ jobs:
           ref: main
       - name: Update version
         run: sed -i "$(yq '${{ env.yaml_key }} | line' "${{ env.file }}")s/$CURRENT/$LATEST/" "${{ env.file }}"
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.GAPHOR_UPDATER_APP_ID }}
+          private-key: ${{ secrets.GAPHOR_UPDATER_APP_PRIVATE_KEY }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
-          token: ${{ secrets.PR_CREATOR }}
+          token: ${{ steps.generate-token.outputs.token }}
           commit-message: Bump Gvsbuild to version ${{ env.LATEST }}
           branch: gvsbuild-update
           delete-branch: true

--- a/.github/workflows/gvsbuild-updater.yml
+++ b/.github/workflows/gvsbuild-updater.yml
@@ -12,7 +12,7 @@ env:
 jobs:
 
   check-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       current_version: ${{ steps.current-version.outputs.current_version }}
       latest_version: ${{ steps.latest-version.outputs.latest_version }}
@@ -46,7 +46,7 @@ jobs:
           echo "latest_version=$(python -m lastversion gvsbuild)" >> "$GITHUB_OUTPUT"
 
   update-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ check-version ]
     if: ${{ needs.check-version.outputs.current_version != needs.check-version.outputs.latest_version }}
     permissions:

--- a/.github/workflows/hypothesis-test.yml
+++ b/.github/workflows/hypothesis-test.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
 
   hypothesis:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: fedora:39
     timeout-minutes: 60
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,6 +19,8 @@ jobs:
         egress-policy: block
         allowed-endpoints: >
           api.github.com:443
+          *.githubusercontent.com:443
+          ghcr.io
 
     - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
       with:

--- a/.github/workflows/pre-commit-updater.yml
+++ b/.github/workflows/pre-commit-updater.yml
@@ -22,8 +22,9 @@ jobs:
             files.pythonhosted.org:443
             pypi.org:443
             github.com:443
-            objects.githubusercontent.com:443
-            raw.githubusercontent.com:443
+            api.github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main

--- a/.github/workflows/pre-commit-updater.yml
+++ b/.github/workflows/pre-commit-updater.yml
@@ -39,10 +39,16 @@ jobs:
         run: pre-commit autoupdate --freeze
       - name: Run pre-commit hooks
         run: pre-commit run --all-files
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.GAPHOR_UPDATER_APP_ID }}
+          private-key: ${{ secrets.GAPHOR_UPDATER_APP_PRIVATE_KEY }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
-          token: ${{ secrets.PR_CREATOR }}
+          token: ${{ steps.generate-token.outputs.token }}
           commit-message: Update pre-commit hooks
           branch: pre-commit-update
           delete-branch: true

--- a/.github/workflows/pre-commit-updater.yml
+++ b/.github/workflows/pre-commit-updater.yml
@@ -11,7 +11,7 @@ jobs:
 
   updater:
     name: Update
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write  # for release-drafter/release-drafter to create a github release
       pull-requests: write  # for release-drafter/release-drafter to add label to PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,6 +23,8 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
       - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,13 +29,15 @@ jobs:
           allowed-endpoints: >
             api.deps.dev:443
             api.github.com:443
+            github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
             api.osv.dev:443
             api.scorecard.dev:443
             api.securityscorecards.dev:443
             auth.docker.io:443
             cdn.fwupd.org:443
             fulcio.sigstore.dev:443
-            github.com:443
             index.docker.io:443
             oss-fuzz-build-logs.storage.googleapis.com:443
             rekor.sigstore.dev:443


### PR DESCRIPTION
1. We were getting permission errors when pushing a branch using my account PAT. I added a GitHub App to the Gaphor org, and this PR makes use of it to make the PR updates instead.
2. Updates Linux runners to Ubuntu 24.04
3. Enables network access for Immutable Actions per the [breaking change](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#updates-to-the-network-allow-list-for-self-hosted-runners-and-azure-private-networking) announcement

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
