### PR TITLE
Fix undo order

### DIFF
--- a/gaphor/core/modeling/presentation.py
+++ b/gaphor/core/modeling/presentation.py
@@ -121,10 +121,15 @@ class Presentation(Matrices, Base, Generic[S]):
 
         if diagram := self._original_diagram:
             diagram.connections.remove_connections_to_item(self)
-            self._original_diagram = None
+
+            # First unlink subject, allowing sanitizer service can remove model elements.
+            # This will ensure that diagrams are always removed after presentations.
+            type(self).subject.unlink(self)  # type: ignore[attr-defined]
 
             for prop in self.__properties__:
                 prop.unlink(self)
+
+            self._original_diagram = None
 
             log.debug("unlinking %s", self)
             self.handle(UnlinkEvent(self, diagram=diagram))

--- a/gaphor/services/undomanager.py
+++ b/gaphor/services/undomanager.py
@@ -41,7 +41,6 @@ from gaphor.event import (
     TransactionRollback,
 )
 from gaphor.transaction import Transaction
-from gaphor.UML.uml import Diagram
 
 logger = logging.getLogger(__name__)
 
@@ -347,18 +346,12 @@ class UndoManager(Service, ActionProvider):
             event.element.save(save_func)
 
             def undo_delete_event():
-                # If diagram is not there, for some reason, recreate it.
-                # It's probably removed in the same transaction.
-                try:
-                    diagram: Diagram = self.lookup(diagram_id)  # type: ignore[assignment]
-                except ValueError:
-                    diagram = self.element_factory.create_as(Diagram, diagram_id)
+                diagram = self.lookup(diagram_id)
+                element = diagram.create_as(element_type, element_id)  # type: ignore[attr-defined]
 
-                element = diagram.create_as(element_type, element_id)
                 for name, ser in data.items():
                     for value in deserialize(ser, lambda ref: None):
                         element.load(name, value)
-
         else:
 
             def undo_delete_event():

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest_archon import archrule
 
 import gaphor
@@ -79,7 +78,6 @@ def test_diagram_package():
     )
 
 
-@pytest.mark.xfail(reason="Undo manager imports gaphor.UML")
 def test_services_package():
     (
         archrule("Services only depend on core functionality")


### PR DESCRIPTION
This PR builds on #3582

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The undo order is not always right for presentation elements.

Issue Number: #3577

### What is the new behavior?

Diagrams will always be removed after all presentations are removed. This way the undo order is maintained.

### Other information

This opens the opportunity to have different types of diagrams. It could be that we create separate `ClassDiagram`, `SequenceDiagram`, etc. types, instead of using the diagramType objects we currently use.