### PR TITLE
Only show status window on save for big files

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -58,6 +58,12 @@ sudo apt-get install -y python3-dev python3-gi python3-gi-cairo
 gir1.2-gtk-4.0 libgirepository1.0-dev libcairo2-dev libgtksourceview-5-dev
 ```
 
+For Redhat/RPM/Fedora based systems:
+
+```bash
+sudo dnf install python3-devel cairo-gobject-devel gobject-introspection-devel
+```
+
 Install [Poetry](https://python-poetry.org) using [pipx](https://pypa.github.io/pipx/):
 ```bash
 pipx install poetry

--- a/gaphor/ui/statuswindow.py
+++ b/gaphor/ui/statuswindow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from gi.repository import Adw, Gtk, Pango
+from gi.repository import Adw, GLib, Gtk, Pango
 
 
 class StatusWindow:
@@ -43,5 +43,11 @@ class StatusWindow:
     def done(self):
         """Close the status window."""
         if self.window:
-            self.window.close()
+            if GLib.main_depth() > 0:
+                # If we close the status window to quick it will stay around
+                # See https://gitlab.gnome.org/GNOME/libadwaita/-/issues/970
+                window = self.window
+                GLib.idle_add(window.close, priority=GLib.PRIORITY_LOW)
+            else:
+                self.window.close()
             self.window = None

--- a/gaphor/ui/tests/test_main.py
+++ b/gaphor/ui/tests/test_main.py
@@ -21,9 +21,9 @@ def fake_run(monkeypatch):
 
     def fake_run(self, args):
         run.extend(args)
-        idle = GLib.Idle(GLib.PRIORITY_LOW + GLib.PRIORITY_LOW)
-        idle.set_callback(lambda *a: self.quit())
-        idle.attach()
+        # NB. Priority used to be GLib.PRIORITY_LOW + GLib.PRIORITY_LOW,
+        # but that makes the tests hang. Is an idle loop blocking us?
+        GLib.idle_add(self.quit, priority=GLib.PRIORITY_LOW)
         app_run(self, args)
 
     app_run = Gtk.Application.run


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

An issue arose with the Adwaita dialogs: if a dialog is closed to quickly, the close call is ignored and the dialog remains visible. 

Issue Number: N/A

### What is the new behavior?

This avoids flicker when smaller files are saved.

A workaround is in place for issue https://gitlab.gnome.org/GNOME/libadwaita/-/issues/970.

Small update for setting up a local Gaphor dev environment on Fedora.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
