### PR TITLE
Move editing settings to global preferences window

### DIFF
--- a/gaphor/UML/sanitizerservice.py
+++ b/gaphor/UML/sanitizerservice.py
@@ -16,6 +16,7 @@ from gaphor.core.modeling.event import (
 from gaphor.diagram.deletable import deletable
 from gaphor.event import Notification
 from gaphor.i18n import gettext
+from gaphor.settings import settings
 from gaphor.transaction import TransactionBegin, TransactionCommit, TransactionRollback
 from gaphor.UML.general.comment import CommentLineItem
 
@@ -89,7 +90,7 @@ class SanitizerService(Service):
         `item`'s subject or the deleted item was the only item currently
         linked."""
         if (
-            not self.properties.get("remove-unused-elements", True)
+            not settings.remove_unused_elements
             or event.property is not Presentation.subject  # type: ignore[misc]
         ):
             return

--- a/gaphor/settings.py
+++ b/gaphor/settings.py
@@ -102,10 +102,33 @@ class Settings:
         )
 
     def bind_use_english(self, target, prop):
+        self._bind_propery("use-english", target, prop)
+
+    @property
+    def reset_tool_after_create(self):
+        return (
+            self._gio_settings.get_boolean("reset-tool-after-create")
+            if self._gio_settings
+            else True
+        )
+
+    def bind_reset_tool_after_create(self, target, prop):
+        self._bind_propery("reset-tool-after-create", target, prop)
+
+    @property
+    def remove_unused_elements(self):
+        return (
+            self._gio_settings.get_boolean("remove-unused-elements")
+            if self._gio_settings
+            else True
+        )
+
+    def bind_remove_unused_elements(self, target, prop):
+        self._bind_propery("remove-unused-elements", target, prop)
+
+    def _bind_propery(self, name, target, prop):
         if self._gio_settings:
-            self._gio_settings.bind(
-                "use-english", target, prop, Gio.SettingsBindFlags.DEFAULT
-            )
+            self._gio_settings.bind(name, target, prop, Gio.SettingsBindFlags.DEFAULT)
 
 
 settings = Settings()

--- a/gaphor/settings.py
+++ b/gaphor/settings.py
@@ -50,13 +50,23 @@ class StyleVariant(Enum):
 class Settings:
     """Gaphor settings."""
 
+    _required_keys = [
+        "use-english",
+        "style-variant",
+        "reset-tool-after-create",
+        "remove-unused-elements",
+    ]
+
     def __init__(self):
-        schema_source = Gio.SettingsSchemaSource.get_default()
         self._gio_settings = (
             Gio.Settings.new(APPLICATION_ID)
-            if schema_source and schema_source.lookup(APPLICATION_ID, False)
+            if (schema_source := Gio.SettingsSchemaSource.get_default())
+            and (schema := schema_source.lookup(APPLICATION_ID, False))
+            and (schema_keys := schema.list_keys())
+            and all(key in schema_keys for key in self._required_keys)
             else None
         )
+
         if not self._gio_settings:
             # Workaround: do not show this message if we're installing schemas
             if "install-schemas" not in sys.argv:

--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -143,20 +143,6 @@ class ElementEditor(UIComponent, ActionProvider):
         if not self.editor_stack.get_mapped():
             self.editor_stack.activate_action("win.show-editors", None)
 
-    @action(
-        name="reset-tool-after-create",
-        state=lambda self: self.properties.get("reset-tool-after-create", True),
-    )
-    def reset_tool_after_create(self, active):
-        self.properties.set("reset-tool-after-create", active)
-
-    @action(
-        name="remove-unused-elements",
-        state=lambda self: self.properties.get("remove-unused-elements", True),
-    )
-    def remove_unused_elements(self, active):
-        self.properties.set("remove-unused-elements", active)
-
 
 class EditorStack:
     def __init__(self, event_manager, component_registry, diagrams, properties):

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -124,49 +124,11 @@
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel">
-                    <property name="label" translatable="yes">Preferences</property>
+                    <property name="label" translatable="yes">Style Sheet</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"></attribute>
                     </attributes>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkBox">
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Reset Tool Automatically</property>
-                        <property name="xalign">0</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSwitch">
-                        <property name="halign">center</property>
-                        <property name="action_name">win.reset-tool-after-create</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkBox">
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Remove Unused Elements</property>
-                        <property name="xalign">0</property>
-                        <property name="tooltip-text" translatable="yes">Automatically remove elements no longer in use in any diagram.</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSwitch">
-                        <property name="halign">center</property>
-                        <property name="action_name">win.remove-unused-elements</property>
-                        <property name="tooltip-text" translatable="yes">Automatically remove elements no longer in use in any diagram.</property>
-                      </object>
-                    </child>
                   </object>
                 </child>
                 <child>
@@ -193,7 +155,7 @@
                 <child>
                   <object class="GtkLabel">
                     <property name="margin_top">6</property>
-                    <property name="label" translatable="yes">Style Sheet</property>
+                    <property name="label" translatable="yes">CSS Editor</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"></attribute>

--- a/gaphor/ui/help/__init__.py
+++ b/gaphor/ui/help/__init__.py
@@ -92,12 +92,21 @@ class HelpService(Service, ActionProvider):
 
         style_variant: Adw.ComboRow = builder.get_object("style_variant")
         use_english: Adw.SwitchRow = builder.get_object("use_english")
+        reset_tool_after_create: Adw.SwitchRow = builder.get_object(
+            "reset_tool_after_create"
+        )
+        remove_unused_elements: Adw.SwitchRow = builder.get_object(
+            "remove_unused_elements"
+        )
 
         settings.bind_use_english(use_english, "active")
         use_english.connect("notify::active", self._on_use_english_selected)
 
         settings.bind_style_variant(style_variant, "selected")
         style_variant.connect("notify::selected-item", self._on_style_variant_selected)
+
+        settings.bind_reset_tool_after_create(reset_tool_after_create, "active")
+        settings.bind_remove_unused_elements(remove_unused_elements, "active")
 
         self.preferences_window.set_visible(True)
         return self.preferences_window

--- a/gaphor/ui/help/preferences.ui
+++ b/gaphor/ui/help/preferences.ui
@@ -37,6 +37,23 @@
                         </child>
                     </object>
                 </child>
+                <child>
+                    <object class="AdwPreferencesGroup">
+                        <property name="title" translatable="yes">Editing</property>
+                        <child>
+                            <object class="AdwSwitchRow" id="reset_tool_after_create">
+                                <property name="title" translatable="yes">Reset Tool Automatically</property>
+                                <property name="subtitle" translatable="yes">After an element is created, switch back to the pointer tool.</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="AdwSwitchRow" id="remove_unused_elements">
+                                <property name="title" translatable="yes">Remove Unused Elements</property>
+                                <property name="subtitle" translatable="yes">Automatically remove elements no longer in use in any diagram.</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
             </object>
         </child>
     </object>

--- a/gaphor/ui/installschemas/org.gaphor.Gaphor.gschema.xml
+++ b/gaphor/ui/installschemas/org.gaphor.Gaphor.gschema.xml
@@ -16,5 +16,15 @@
             <summary>Use English</summary>
             <description>Override language to English.</description>
         </key>
+        <key name="reset-tool-after-create" type="b">
+            <default>true</default>
+            <summary>Reset Tool Automatically</summary>
+            <description>After an element is created, switch back to the pointer tool.</description>
+        </key>
+        <key name="remove-unused-elements" type="b">
+            <default>true</default>
+            <summary>Remove Unused Elements</summary>
+            <description>Automatically remove elements no longer in use in any diagram.</description>
+        </key>
     </schema>
 </schemalist>

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -17,6 +17,7 @@ from gaphor.services.modelinglanguage import (
     ModelingLanguageService,
 )
 from gaphor.services.properties import Properties
+from gaphor.settings import settings
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.event import CurrentDiagramChanged, ToolSelected
 
@@ -159,7 +160,7 @@ class Toolbox(UIComponent):
 
     @event_handler(ToolCompleted)
     def _on_diagram_item_placed(self, event) -> None:
-        if self.properties.get("reset-tool-after-create", True):
+        if settings.reset_tool_after_create:
             # Select tool from an idle handler, so the original tool can complete properly.
             GLib.idle_add(self.select_tool, "toolbox-pointer")
 

--- a/tests/test_remove_unused_elements.py
+++ b/tests/test_remove_unused_elements.py
@@ -1,5 +1,6 @@
 import pytest
 
+import gaphor.UML.sanitizerservice
 from gaphor import UML
 from gaphor.application import Session
 from gaphor.core import Transaction
@@ -53,6 +54,15 @@ def classes_and_association(diagram, event_manager, element_factory):
     return c1.subject, c2.subject, a.subject
 
 
+class MockSettings:
+    def __init__(self, value):
+        self._value = value
+
+    @property
+    def remove_unused_elements(self):
+        return self._value
+
+
 @pytest.mark.parametrize(
     ["remove_unused_elements", "comparator"],
     [
@@ -65,11 +75,13 @@ def test_delete_diagram(
     diagram,
     event_manager,
     element_factory,
-    properties,
+    monkeypatch,
     remove_unused_elements,
     comparator,
 ):
-    properties.set("remove-unused-elements", remove_unused_elements)
+    monkeypatch.setattr(
+        gaphor.UML.sanitizerservice, "settings", MockSettings(remove_unused_elements)
+    )
 
     c1, c2, a = classes_and_association
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Settings for tool reset and automatic model maintenance used to be configured on a per-model basis.

Issue Number: N/A

### What is the new behavior?

Settings moved from a model-based to global settings. This should make our settings story more consistent. Now all we have

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

I think we discussed this idea a while back as part of Mareike's study on MBSE tooling for neurodivergent people.

NB. Do not forget to run `gaphor install-schemas`.
