### PR TITLE
When double-clicking on a model element, select it in diagram

### DIFF
--- a/gaphor/ui/event.py
+++ b/gaphor/ui/event.py
@@ -1,6 +1,11 @@
 """UI related events."""
 
 
+class ElementFocused:
+    def __init__(self, element):
+        self.element = element
+
+
 class ElementOpened:
     def __init__(self, element):
         self.element = element

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -17,7 +17,11 @@ from gaphor.services.modelinglanguage import ModelingLanguageChanged
 from gaphor.transaction import Transaction
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.actiongroup import create_action_group
-from gaphor.ui.event import ElementOpened, ModelSelectionChanged
+from gaphor.ui.event import (
+    ElementFocused,
+    ElementOpened,
+    ModelSelectionChanged,
+)
 from gaphor.ui.treesearch import search, sorted_tree_walker
 
 START_EDIT_DELAY = 100  # ms
@@ -86,7 +90,7 @@ class ModelBrowser(UIComponent, ActionProvider):
 
         def list_view_activate(list_view, position):
             if element := self.selection.get_item(position).get_item().element:  # type: ignore[union-attr]
-                self.open_element(element)
+                self.focus_element(element)
 
         self.tree_view.connect("activate", list_view_activate)
 
@@ -150,6 +154,13 @@ class ModelBrowser(UIComponent, ActionProvider):
     def get_selected_element(self) -> Base | None:
         assert self.model
         return next(iter(self.get_selected_elements()), None)
+
+    def focus_element(self, element):
+        assert element
+        if isinstance(element, Diagram):
+            self.event_manager.handle(DiagramOpened(element))
+        else:
+            self.event_manager.handle(ElementFocused(element))
 
     def open_element(self, element):
         assert element


### PR DESCRIPTION

<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Double-click adds a model element to the active diagram. This is perceived as confusing.

Issue Number: Fixed #3262

### What is the new behavior?

Do not add a new presentation to the diagram, instead select the element if it's in the diagram. Show a message if it's not in the diagram.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
