### PR TITLE
Decouple UML concepts from model browser

### DIFF
--- a/gaphor/C4Model/modelinglanguage.py
+++ b/gaphor/C4Model/modelinglanguage.py
@@ -15,6 +15,7 @@ from gaphor.diagram.diagramtoolbox import (
     ElementCreateInfo,
     ToolboxDefinition,
 )
+from gaphor.UML.treemodel import TreeModel
 
 
 class C4ModelLanguage(ModelingLanguage):
@@ -33,6 +34,10 @@ class C4ModelLanguage(ModelingLanguage):
     @property
     def element_types(self) -> Iterable[ElementCreateInfo]:
         yield from c4model_element_types
+
+    @property
+    def model_browser_model(self) -> type[TreeModel]:
+        return TreeModel
 
     def lookup_element(self, name, ns=None):
         assert ns in ("C4Model", None)

--- a/gaphor/C4Model/toolbox.py
+++ b/gaphor/C4Model/toolbox.py
@@ -156,6 +156,7 @@ c4model_diagram_types: DiagramTypes = (
 )
 
 c4model_element_types = (
+    ElementCreateInfo("package", i18nize("New Package"), Package, (Package,)),
     ElementCreateInfo("activity", i18nize("New Activity"), Activity, (Package,)),
     ElementCreateInfo(
         "interaction", i18nize("New Interaction"), Interaction, (Package,)

--- a/gaphor/RAAML/modelinglanguage.py
+++ b/gaphor/RAAML/modelinglanguage.py
@@ -16,6 +16,7 @@ from gaphor.RAAML.toolbox import (
     raaml_element_types,
     raaml_toolbox_actions,
 )
+from gaphor.UML.treemodel import TreeModel
 
 
 class RAAMLModelingLanguage(ModelingLanguage):
@@ -34,6 +35,10 @@ class RAAMLModelingLanguage(ModelingLanguage):
     @property
     def element_types(self) -> Iterable[ElementCreateInfo]:
         yield from raaml_element_types
+
+    @property
+    def model_browser_model(self) -> type[TreeModel]:
+        return TreeModel
 
     def lookup_element(self, name, ns=None):
         assert ns in ("RAAML", None)

--- a/gaphor/RAAML/toolbox.py
+++ b/gaphor/RAAML/toolbox.py
@@ -25,6 +25,7 @@ raaml_diagram_types: DiagramTypes = (
 )
 
 raaml_element_types = (
+    ElementCreateInfo("package", i18nize("New Package"), Package, (Package,)),
     ElementCreateInfo("topevent", i18nize("New Top Event"), TopEvent, (Package,)),
     ElementCreateInfo("loss", i18nize("New Loss"), Loss, (Package,)),
     ElementCreateInfo("hazard", i18nize("New Hazard"), Hazard, (Package,)),

--- a/gaphor/SysML/modelinglanguage.py
+++ b/gaphor/SysML/modelinglanguage.py
@@ -16,6 +16,7 @@ from gaphor.SysML.toolbox import (
     sysml_element_types,
     sysml_toolbox_actions,
 )
+from gaphor.UML.treemodel import TreeModel
 
 
 class SysMLModelingLanguage(ModelingLanguage):
@@ -34,6 +35,10 @@ class SysMLModelingLanguage(ModelingLanguage):
     @property
     def element_types(self) -> Iterable[ElementCreateInfo]:
         yield from sysml_element_types
+
+    @property
+    def model_browser_model(self) -> type[TreeModel]:
+        return TreeModel
 
     def lookup_element(self, name, ns=None):
         assert ns in ("SysML", None)

--- a/gaphor/SysML/toolbox.py
+++ b/gaphor/SysML/toolbox.py
@@ -169,6 +169,7 @@ sysml_diagram_types: DiagramTypes = (
 )
 
 sysml_element_types = (
+    ElementCreateInfo("package", i18nize("New Package"), Package, (Package,)),
     ElementCreateInfo("activity", i18nize("New Activity"), Activity, (Package,)),
     ElementCreateInfo("actor", i18nize("New Actor"), Actor, (Package,)),
     ElementCreateInfo("block", i18nize("New Block"), Block, (Package,)),

--- a/gaphor/UML/actions/propertypages.ui
+++ b/gaphor/UML/actions/propertypages.ui
@@ -322,6 +322,7 @@
             <property name="halign">end</property>
             <property name="valign">end</property>
             <property name="label" translatable="yes">ⓘ Help</property>
+            <property name="accessible-role">button</property>
             <child>
               <object class="GtkPopover" id="parameters-info">
                 <property name="visible">0</property>

--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -64,6 +64,7 @@
             <property name="halign">end</property>
             <property name="valign">end</property>
             <property name="label" translatable="yes">ⓘ Help</property>
+            <property name="accessible-role">button</property>
             <child>
               <object class="GtkPopover" id="head-info">
                 <property name="visible">0</property>
@@ -175,6 +176,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <property name="halign">end</property>
             <property name="valign">end</property>
             <property name="label" translatable="yes">ⓘ Help</property>
+            <property name="accessible-role">button</property>
             <child>
               <object class="GtkPopover" id="tail-info">
                 <property name="visible">0</property>
@@ -293,7 +295,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <property name="halign">end</property>
             <property name="valign">end</property>
             <property name="label" translatable="yes">ⓘ Help</property>
-
+            <property name="accessible-role">button</property>
             <child>
               <object class="GtkPopover" id="attributes-info">
                 <property name="visible">0</property>
@@ -577,6 +579,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <property name="halign">end</property>
             <property name="valign">end</property>
             <property name="label" translatable="yes">ⓘ Help</property>
+            <property name="accessible-role">button</property>
             <child>
               <object class="GtkPopover" id="operations-info">
                 <property name="visible">0</property>
@@ -689,7 +692,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
             <property name="halign">end</property>
             <property name="valign">end</property>
             <property name="label" translatable="yes">ⓘ Help</property>
-
+            <property name="accessible-role">button</property>
             <child>
               <object class="GtkPopover" id="enumerations-info">
                 <property name="position">top</property>

--- a/gaphor/UML/modelinglanguage.py
+++ b/gaphor/UML/modelinglanguage.py
@@ -12,6 +12,7 @@ from gaphor.diagram.diagramtoolbox import (
 )
 from gaphor.UML import diagramitems, uml
 from gaphor.UML.toolbox import uml_diagram_types, uml_element_types, uml_toolbox_actions
+from gaphor.UML.treemodel import TreeModel
 
 
 class UMLModelingLanguage(ModelingLanguage):
@@ -31,6 +32,10 @@ class UMLModelingLanguage(ModelingLanguage):
     @property
     def element_types(self) -> Iterable[ElementCreateInfo]:
         yield from uml_element_types
+
+    @property
+    def model_browser_model(self) -> type[TreeModel]:
+        return TreeModel
 
     def lookup_element(self, name, ns=None):
         assert ns in ("UML", None)

--- a/gaphor/UML/tests/test_treemodel.py
+++ b/gaphor/UML/tests/test_treemodel.py
@@ -1,3 +1,5 @@
+import pytest
+
 from gaphor import UML
 from gaphor.i18n import gettext
 from gaphor.UML.treemodel import (
@@ -8,6 +10,11 @@ from gaphor.UML.treemodel import (
     TreeModel,
     tree_item_sort,
 )
+
+
+@pytest.fixture
+def tree_model(event_manager, element_factory):
+    return TreeModel(event_manager, element_factory)
 
 
 class ItemChangedHandler:
@@ -57,8 +64,7 @@ def test_branch_add_relationship(element_factory):
     assert branch.relationships[0].element is element
 
 
-def test_tree_model_add_element(element_factory):
-    tree_model = TreeModel()
+def test_tree_model_add_element(tree_model, element_factory):
     element = element_factory.create(UML.Class)
 
     tree_model.add_element(element)
@@ -67,8 +73,7 @@ def test_tree_model_add_element(element_factory):
     assert tree_item.element is element
 
 
-def test_tree_model_add_nested_element(element_factory):
-    tree_model = TreeModel()
+def test_tree_model_add_nested_element(tree_model, element_factory):
     class_ = element_factory.create(UML.Class)
     package = element_factory.create(UML.Package)
 
@@ -84,8 +89,7 @@ def test_tree_model_add_nested_element(element_factory):
     assert tree_model.branches.get(class_item) is None
 
 
-def test_tree_model_add_nested_element_in_reverse_order(element_factory):
-    tree_model = TreeModel()
+def test_tree_model_add_nested_element_in_reverse_order(tree_model, element_factory):
     class_ = element_factory.create(UML.Class)
     package = element_factory.create(UML.Package)
 
@@ -101,8 +105,7 @@ def test_tree_model_add_nested_element_in_reverse_order(element_factory):
     assert tree_model.branches.get(class_item) is None
 
 
-def test_tree_model_remove_element(element_factory):
-    tree_model = TreeModel()
+def test_tree_model_remove_element(tree_model, element_factory):
     element = element_factory.create(UML.Class)
     tree_model.add_element(element)
 
@@ -112,8 +115,7 @@ def test_tree_model_remove_element(element_factory):
     assert tree_item is None
 
 
-def test_tree_model_remove_nested_element(element_factory):
-    tree_model = TreeModel()
+def test_tree_model_remove_nested_element(tree_model, element_factory):
     class_ = element_factory.create(UML.Class)
     package = element_factory.create(UML.Package)
 
@@ -129,8 +131,7 @@ def test_tree_model_remove_nested_element(element_factory):
     assert tree_model.tree_item_for_element(class_) is None
 
 
-def test_tree_model_remove_package_with_nested_element(element_factory):
-    tree_model = TreeModel()
+def test_tree_model_remove_package_with_nested_element(tree_model, element_factory):
     class_ = element_factory.create(UML.Class)
     package = element_factory.create(UML.Package)
 
@@ -146,8 +147,7 @@ def test_tree_model_remove_package_with_nested_element(element_factory):
     assert tree_model.tree_item_for_element(class_) is None
 
 
-def test_tree_model_remove_from_different_owner(element_factory):
-    tree_model = TreeModel()
+def test_tree_model_remove_from_different_owner(tree_model, element_factory):
     class_ = element_factory.create(UML.Class)
     package = element_factory.create(UML.Package)
 
@@ -160,8 +160,7 @@ def test_tree_model_remove_from_different_owner(element_factory):
     assert len(tree_model.root) == 1
 
 
-def test_tree_model_change_owner(element_factory):
-    tree_model = TreeModel()
+def test_tree_model_change_owner(tree_model, element_factory):
     class_ = element_factory.create(UML.Class)
     package = element_factory.create(UML.Package)
 
@@ -180,8 +179,7 @@ def test_tree_model_change_owner(element_factory):
     assert class_item in package_model
 
 
-def test_tree_model_relationship_subtree(element_factory):
-    tree_model = TreeModel()
+def test_tree_model_relationship_subtree(tree_model, element_factory):
     package = element_factory.create(UML.Package)
     association = element_factory.create(UML.Association)
     association.package = package
@@ -202,8 +200,7 @@ def test_tree_model_relationship_subtree(element_factory):
     assert association_item is relationship_model.get_item(0)
 
 
-def test_tree_model_second_relationship(element_factory):
-    tree_model = TreeModel()
+def test_tree_model_second_relationship(tree_model, element_factory):
     package = element_factory.create(UML.Package)
     association = element_factory.create(UML.Association)
     association.package = package
@@ -228,8 +225,7 @@ def test_tree_model_second_relationship(element_factory):
     assert new_association_item is relationship_model[1]
 
 
-def test_tree_model_remove_relationship(element_factory):
-    tree_model = TreeModel()
+def test_tree_model_remove_relationship(tree_model, element_factory):
     package = element_factory.create(UML.Package)
     association = element_factory.create(UML.Association)
     association.package = package
@@ -244,7 +240,7 @@ def test_tree_model_remove_relationship(element_factory):
     assert not package_model
 
 
-def test_tree_model_sort_relationship_item_first(element_factory):
+def test_tree_model_sort_relationship_item_first():
     a = TreeItem(UML.Package())
     a.readonly_text = "a"
     b = TreeItem(UML.Package())
@@ -257,8 +253,7 @@ def test_tree_model_sort_relationship_item_first(element_factory):
     assert tree_item_sort(b, a) == 1
 
 
-def test_element_with_member_and_no_owner(element_factory):
-    tree_model = TreeModel()
+def test_element_with_member_and_no_owner(tree_model, element_factory):
     property = element_factory.create(UML.Property)
     association = element_factory.create(UML.Association)
     association.memberEnd = property

--- a/gaphor/UML/tests/test_treemodel.py
+++ b/gaphor/UML/tests/test_treemodel.py
@@ -1,6 +1,6 @@
 from gaphor import UML
 from gaphor.i18n import gettext
-from gaphor.ui.treemodel import (
+from gaphor.UML.treemodel import (
     Branch,
     RelationshipItem,
     Root,
@@ -23,7 +23,7 @@ class ItemChangedHandler:
 
 
 def test_tree_item_gtype():
-    assert TreeItem.__gtype__.name == "gaphor+ui+treemodel+TreeItem"
+    assert TreeItem.__gtype__.name == "gaphor+UML+treemodel+TreeItem"
 
 
 def test_branch_add_element(element_factory):

--- a/gaphor/UML/toolbox.py
+++ b/gaphor/UML/toolbox.py
@@ -60,6 +60,7 @@ uml_diagram_types: DiagramTypes = (
 )
 
 uml_element_types = (
+    ElementCreateInfo("package", i18nize("New Package"), Package, (Package,)),
     ElementCreateInfo("activity", i18nize("New Activity"), Activity, (Package,)),
     ElementCreateInfo("actor", i18nize("New Actor"), Actor, (Package,)),
     ElementCreateInfo("artifact", i18nize("New Artifact"), Artifact, (Package,)),

--- a/gaphor/UML/treeitem.ui
+++ b/gaphor/UML/treeitem.ui
@@ -17,12 +17,12 @@
             <child>
               <object class="GtkImage">
                 <binding name="icon-name">
-                  <lookup name="icon" type="gaphor+ui+treemodel+TreeItem">
+                  <lookup name="icon" type="gaphor+UML+treemodel+TreeItem">
                     <lookup name="item">expander</lookup>
                   </lookup>
                 </binding>
                 <binding name="visible">
-                  <lookup name="icon_visible" type="gaphor+ui+treemodel+TreeItem">
+                  <lookup name="icon_visible" type="gaphor+UML+treemodel+TreeItem">
                     <lookup name="item">expander</lookup>
                   </lookup>
                 </binding>
@@ -31,27 +31,27 @@
             <child>
               <object class="TextField" id="text">
                 <binding name="readonly-text">
-                  <lookup name="readonly-text" type="gaphor+ui+treemodel+TreeItem">
+                  <lookup name="readonly-text" type="gaphor+UML+treemodel+TreeItem">
                     <lookup name="item">expander</lookup>
                   </lookup>
                 </binding>
                 <binding name="editable-text">
-                  <lookup name="editable-text" type="gaphor+ui+treemodel+TreeItem">
+                  <lookup name="editable-text" type="gaphor+UML+treemodel+TreeItem">
                     <lookup name="item">expander</lookup>
                   </lookup>
                 </binding>
                 <binding name="attributes">
-                  <lookup name="attributes" type="gaphor+ui+treemodel+TreeItem">
+                  <lookup name="attributes" type="gaphor+UML+treemodel+TreeItem">
                     <lookup name="item">expander</lookup>
                   </lookup>
                 </binding>
                 <binding name="editing">
-                  <lookup name="editing" type="gaphor+ui+treemodel+TreeItem">
+                  <lookup name="editing" type="gaphor+UML+treemodel+TreeItem">
                     <lookup name="item">expander</lookup>
                   </lookup>
                 </binding>
                 <binding name="can-edit">
-                  <lookup name="can-edit" type="gaphor+ui+treemodel+TreeItem">
+                  <lookup name="can-edit" type="gaphor+UML+treemodel+TreeItem">
                     <lookup name="item">expander</lookup>
                   </lookup>
                 </binding>

--- a/gaphor/UML/treemodel.py
+++ b/gaphor/UML/treemodel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.resources
 from unicodedata import normalize
 
 from gi.repository import Gio, GObject, Pango
@@ -141,6 +142,12 @@ class TreeModel:
     def __init__(self):
         super().__init__()
         self.branches: dict[TreeItem | RootType, Branch] = {Root: Branch()}
+
+    @property
+    def template(self) -> str:
+        return (importlib.resources.files("gaphor.UML") / "treeitem.ui").read_text(
+            encoding="utf-8"
+        )
 
     @property
     def root(self) -> Gio.ListStore:

--- a/gaphor/UML/treemodel.py
+++ b/gaphor/UML/treemodel.py
@@ -128,7 +128,7 @@ class Branch:
         yield from self.relationships
 
 
-def tree_item_sort(a, b, _user_data=None):
+def tree_item_sort(a, b):
     if isinstance(a, RelationshipItem):
         return -1
     if isinstance(b, RelationshipItem):
@@ -173,6 +173,9 @@ class TreeModel:
                 new_branch.append(e)
             return new_branch.elements
         return None
+
+    def tree_item_sort(self, a, b):
+        return tree_item_sort(a, b)
 
     def owner_branch_for_element(self, element: Base) -> Branch | None:
         if (own := owner(element)) is Root:

--- a/gaphor/UML/treemodel.py
+++ b/gaphor/UML/treemodel.py
@@ -29,8 +29,7 @@ class TreeItem(GObject.Object):
     def __init__(self, element: Base | None):
         super().__init__()
         self.element = element
-        if element:
-            self.sync()
+        self.sync()
 
     icon = GObject.Property(type=str)
     icon_visible = GObject.Property(type=bool, default=False)

--- a/gaphor/UML/treemodel.py
+++ b/gaphor/UML/treemodel.py
@@ -139,7 +139,7 @@ class Branch:
         yield from self.relationships
 
 
-def tree_item_sort(a, b):
+def tree_item_sort(a: TreeItem, b: TreeItem) -> int:
     if isinstance(a, RelationshipItem):
         return -1
     if isinstance(b, RelationshipItem):
@@ -167,7 +167,7 @@ class TreeModel:
 
         self.on_model_ready()
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         self.event_manager.unsubscribe(self.on_element_created)
         self.event_manager.unsubscribe(self.on_element_deleted)
         self.event_manager.unsubscribe(self.on_owner_changed)
@@ -191,7 +191,7 @@ class TreeModel:
             if self._on_sync:
                 self._on_sync()
 
-    def child_model(self, item: TreeItem, _user_data=None) -> Gio.ListStore | None:
+    def child_model(self, item: TreeItem) -> Gio.ListStore | None:
         """This method will create branches on demand (lazy)."""
         branches = self.branches
         if item in branches:
@@ -208,12 +208,12 @@ class TreeModel:
             return new_branch.elements
         return None
 
-    def tree_item_sort(self, a, b):
+    def tree_item_sort(self, a, b) -> int:
         return tree_item_sort(a, b)
 
-    def should_expand(self, tree_item: TreeItem, element: Base):
+    def should_expand(self, item: TreeItem, element: Base) -> bool:
         return isinstance(element, UML.Relationship) and isinstance(
-            tree_item, RelationshipItem
+            item, RelationshipItem
         )
 
     def owner_branch_for_element(self, element: Base) -> Branch | None:

--- a/gaphor/UML/treemodel.py
+++ b/gaphor/UML/treemodel.py
@@ -211,6 +211,11 @@ class TreeModel:
     def tree_item_sort(self, a, b):
         return tree_item_sort(a, b)
 
+    def should_expand(self, tree_item: TreeItem, element: Base):
+        return isinstance(element, UML.Relationship) and isinstance(
+            tree_item, RelationshipItem
+        )
+
     def owner_branch_for_element(self, element: Base) -> Branch | None:
         if (own := owner(element)) is Root:
             return self.branches[Root]

--- a/gaphor/abc.py
+++ b/gaphor/abc.py
@@ -78,6 +78,8 @@ T = TypeVar("T", bound=TreeItem, contravariant=True)
 
 
 class TreeModel(Protocol[T]):
+    def __init__(self, *args, on_select=None, on_sync=None): ...
+
     @property
     def root(self) -> Gio.ListStore: ...
 

--- a/gaphor/core/modeling/modelinglanguage.py
+++ b/gaphor/core/modeling/modelinglanguage.py
@@ -46,19 +46,15 @@ class MockModelingLanguage(ModelingLanguage):
 
     @property
     def diagram_types(self):
-        return ()
+        raise ValueError("No diagram types for the mock model")
 
     @property
     def element_types(self):
-        return ()
+        raise ValueError("No element types for the mock model")
 
     @property
     def model_browser_model(self):
-        for lang in self._modeling_languages:
-            try:
-                return lang.model_browser_model
-            except ValueError:
-                continue
+        raise ValueError("No model browser model for the mock model")
 
     def lookup_element(self, name, ns=None):
         if ns:

--- a/gaphor/core/modeling/modelinglanguage.py
+++ b/gaphor/core/modeling/modelinglanguage.py
@@ -19,7 +19,11 @@ class CoreModelingLanguage(ModelingLanguage):
 
     @property
     def element_types(self):
-        return ValueError("No element types for the core model")
+        raise ValueError("No element types for the core model")
+
+    @property
+    def model_browser_model(self):
+        raise ValueError("No model browser model for the core model")
 
     def lookup_element(self, name, ns=None):
         assert ns in ("Core", None)
@@ -47,6 +51,14 @@ class MockModelingLanguage(ModelingLanguage):
     @property
     def element_types(self):
         return ()
+
+    @property
+    def model_browser_model(self):
+        for lang in self._modeling_languages:
+            try:
+                return lang.model_browser_model
+            except ValueError:
+                continue
 
     def lookup_element(self, name, ns=None):
         if ns:

--- a/gaphor/diagram/general/modelinglanguage.py
+++ b/gaphor/diagram/general/modelinglanguage.py
@@ -19,7 +19,11 @@ class GeneralModelingLanguage(ModelingLanguage):
 
     @property
     def element_types(self):
-        return ValueError("No element types for the core model")
+        raise ValueError("No element types for the core model")
+
+    @property
+    def model_browser_model(self):
+        raise ValueError("No model browser model for the core model")
 
     def lookup_element(self, name, ns=None):
         assert ns in ("general", None)

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -98,7 +98,6 @@ def help_link(builder, help_widget, popover):
         builder.get_object(popover).set_visible(True)
 
     help = builder.get_object(help_widget)
-    help.set_accessible_role(Gtk.AccessibleRole.BUTTON)
     click_handler = Gtk.GestureClick.new()
     click_handler.connect("released", on_activate)
     help.add_controller(click_handler)

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -1,5 +1,3 @@
-from gi.repository import Gtk
-
 from gaphor.diagram.connectors import Connector
 from gaphor.diagram.copypaste import copy_full, paste_link
 from gaphor.diagram.presentation import connect as _connect
@@ -70,9 +68,6 @@ def copy_clear_and_paste_link(items, diagram, element_factory, retain=None):
 def find(widget, name):
     if widget.get_buildable_id() == name:
         return widget
-    if isinstance(widget, Gtk.Expander):
-        # Iterating children will only iterate the label section
-        return find(widget.get_child(), name)
     if sibling := widget.get_next_sibling():
         if found := find(sibling, name):
             return found

--- a/gaphor/services/modelinglanguage.py
+++ b/gaphor/services/modelinglanguage.py
@@ -71,6 +71,10 @@ class ModelingLanguageService(Service, ActionProvider, ModelingLanguage):
     def element_types(self):
         return self._modeling_language().element_types
 
+    @property
+    def model_browser_model(self):
+        return self._modeling_language().model_browser_model
+
     def lookup_element(self, name, ns=None):
         if ns:
             if ns not in self._modeling_languages:

--- a/gaphor/templates/blank.gaphor
+++ b/gaphor/templates/blank.gaphor
@@ -16,7 +16,7 @@
 <ref refid="58d6c2e8-66f8-11ec-b4c8-0456e5e540ed"/>
 </element>
 <name>
-<val>New diagram</val>
+<val>New Diagram</val>
 </name>
 </Diagram>
 </gaphor>

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -24,7 +24,7 @@ from gaphor.diagram.event import DiagramOpened, DiagramSelectionChanged
 from gaphor.diagram.group import change_owner
 from gaphor.diagram.tools.dnd import ElementDragData
 from gaphor.event import Notification
-from gaphor.i18n import gettext, translated_ui_string
+from gaphor.i18n import gettext
 from gaphor.transaction import Transaction
 from gaphor.ui.abc import UIComponent
 from gaphor.ui.actiongroup import create_action_group
@@ -32,7 +32,8 @@ from gaphor.ui.event import (
     ElementOpened,
     ModelSelectionChanged,
 )
-from gaphor.ui.treemodel import (
+from gaphor.ui.treesearch import search, sorted_tree_walker
+from gaphor.UML.treemodel import (
     RelationshipItem,
     Root,
     RootType,
@@ -41,7 +42,6 @@ from gaphor.ui.treemodel import (
     owner,
     tree_item_sort,
 )
-from gaphor.ui.treesearch import search, sorted_tree_walker
 
 START_EDIT_DELAY = 100  # ms
 
@@ -84,6 +84,7 @@ class ModelBrowser(UIComponent, ActionProvider):
             self.selection,
             self.event_manager,
             self.modeling_language,
+            self.model.template,
         )
         self.tree_view = Gtk.ListView.new(self.selection, factory)
         self.tree_view.set_vexpand(True)
@@ -445,14 +446,14 @@ def toplevel_popup_model(modeling_language) -> Gio.Menu:
 
 
 def list_item_factory_setup(
-    _factory, list_item, selection, event_manager, modeling_language
+    _factory, list_item, selection, event_manager, modeling_language, template
 ):
     builder = Gtk.Builder()
     builder.set_current_object(list_item)
     builder.extend_with_template(
         list_item,
         type(list_item).__gtype__,
-        translated_ui_string("gaphor.ui", "treeitem.ui"),
+        template,
         -1,
     )
     row = builder.get_object("row")

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -569,9 +569,10 @@ def popup_model(element, modeling_language):
     model.append_section(None, part)
 
     part = Gio.Menu.new()
-    part.append_submenu(
-        gettext("New _Diagram"), create_diagram_types_model(modeling_language, element)
-    )
+    diagram_submenu = create_diagram_types_model(modeling_language, element)
+    if diagram_submenu.get_n_items():
+        part.append_submenu(gettext("New _Diagram"), diagram_submenu)
+
     if any(
         isinstance(element, element_type.allowed_owning_elements)
         for element_type in modeling_language.element_types
@@ -624,13 +625,17 @@ def create_diagram_types_model(modeling_language, element=None):
             )
             part.append_item(menu_item)
 
-    model.append_section(None, part)
+    if part.get_n_items():
+        model.append_section(None, part)
 
-    part = Gio.Menu.new()
-    menu_item = Gio.MenuItem.new(gettext("New Generic Diagram"), "win.create-diagram")
-    menu_item.set_attribute_value("target", GLib.Variant.new_string(""))
-    part.append_item(menu_item)
-    model.append_section(None, part)
+    if not isinstance(element, Diagram):
+        part = Gio.Menu.new()
+        menu_item = Gio.MenuItem.new(
+            gettext("New Generic Diagram"), "win.create-diagram"
+        )
+        menu_item.set_attribute_value("target", GLib.Variant.new_string(""))
+        part.append_item(menu_item)
+        model.append_section(None, part)
 
     return model
 

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -180,8 +180,6 @@ class ModelBrowser(UIComponent, ActionProvider):
     @action(name="win.create-diagram")
     def tree_view_create_diagram(self, diagram_kind: str):
         element: Base | RootType | None = self.get_selected_element()
-        while isinstance(element, Base) and not isinstance(element, UML.NamedElement):
-            element = owner(element)
 
         with Transaction(self.event_manager):
             diagram_type = self._diagram_type_or(
@@ -219,19 +217,6 @@ class ModelBrowser(UIComponent, ActionProvider):
 
             self.select_element(element)
             self.tree_view_rename_selected()
-
-    @action(name="tree-view.create-package")
-    def tree_view_create_package(self):
-        element = self.get_selected_element()
-        with Transaction(self.event_manager):
-            package = self.element_factory.create(UML.Package)
-            if isinstance(element, UML.Package):
-                package.package = element
-                package.name = gettext("{name} package").format(name=element.name)
-            else:
-                package.name = gettext("New package")
-        self.select_element(package)
-        self.tree_view_rename_selected()
 
     @action(name="tree-view.delete", shortcut="Delete")
     def tree_view_delete(self):
@@ -581,8 +566,6 @@ def popup_model(element, modeling_language):
             gettext("New _Element"),
             create_element_types_model(modeling_language, element),
         )
-    if isinstance(element, UML.Package):
-        part.append(gettext("New _Package"), "tree-view.create-package")
     model.append_section(None, part)
 
     part = Gio.Menu.new()

--- a/gaphor/ui/tests/test_modelbrowser.py
+++ b/gaphor/ui/tests/test_modelbrowser.py
@@ -350,7 +350,6 @@ def test_multiplicity_element_should_not_end_up_in_root(model_browser, element_f
     prop = element_factory.create(UML.Property)
     connector = UML.recipes.create_connector(port, prop)
 
-    model_browser.on_model_ready()
     model = model_browser.model
 
     assert model.tree_item_for_element(connector.end[0]) is None

--- a/gaphor/ui/tests/test_modelbrowser.py
+++ b/gaphor/ui/tests/test_modelbrowser.py
@@ -191,27 +191,6 @@ def test_create_diagram(model_browser, element_factory):
     assert diagram.diagramType == "my type"
 
 
-def test_create_package(model_browser, element_factory):
-    parent = element_factory.create(UML.Package)
-    parent.name = "root"
-    model_browser.select_element(parent)
-    model_browser.tree_view_create_package()
-
-    package = next(p for p in element_factory.select(UML.Package) if p.name != "root")
-
-    assert package
-    assert package.owner is parent
-
-
-def test_create_toplevel_package(model_browser, element_factory):
-    model_browser.tree_view_create_package()
-
-    package = next(p for p in element_factory.select(UML.Package) if p.name != "root")
-
-    assert package
-    assert package.owner is None
-
-
 def test_delete_element(model_browser, element_factory):
     klass = element_factory.create(UML.Class)
     model_browser.select_element(klass)

--- a/gaphor/ui/tests/test_treesearch.py
+++ b/gaphor/ui/tests/test_treesearch.py
@@ -1,8 +1,8 @@
 import pytest
 
 from gaphor import UML
-from gaphor.ui.treemodel import TreeModel
 from gaphor.ui.treesearch import search, sorted_tree_walker
+from gaphor.UML.treemodel import TreeModel
 
 
 @pytest.fixture

--- a/gaphor/ui/tests/test_treesearch.py
+++ b/gaphor/ui/tests/test_treesearch.py
@@ -6,8 +6,8 @@ from gaphor.UML.treemodel import TreeModel
 
 
 @pytest.fixture
-def tree_model():
-    return TreeModel()
+def tree_model(event_manager, element_factory):
+    return TreeModel(event_manager, element_factory)
 
 
 @pytest.fixture

--- a/gaphor/ui/treesearch.py
+++ b/gaphor/ui/treesearch.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import functools
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 from unicodedata import normalize
 
-from gaphor.UML.treemodel import TreeItem, tree_item_sort
+if TYPE_CHECKING:
+    from gaphor.UML.treemodel import TreeItem
 
 """
 Inputs:
@@ -36,7 +40,7 @@ def sorted_tree_walker(
     """The tree model as one stream, sorted."""
 
     def _flatten(list_store):
-        for tree_item in sorted_tree_items(list_store):
+        for tree_item in sorted_tree_items(model, list_store):
             yield tree_item
             if children := model.child_model(tree_item):
                 yield from _flatten(children)
@@ -60,8 +64,8 @@ def sorted_tree_walker(
                 break
 
 
-def sorted_tree_items(branch):
+def sorted_tree_items(model, branch):
     return sorted(
         branch,
-        key=functools.cmp_to_key(tree_item_sort),
+        key=functools.cmp_to_key(model.tree_item_sort),
     )

--- a/gaphor/ui/treesearch.py
+++ b/gaphor/ui/treesearch.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from unicodedata import normalize
 
 if TYPE_CHECKING:
-    from gaphor.UML.treemodel import TreeItem
+    from gaphor.ui.modelbrowser import TreeItem
 
 """
 Inputs:

--- a/gaphor/ui/treesearch.py
+++ b/gaphor/ui/treesearch.py
@@ -2,7 +2,7 @@ import functools
 from collections.abc import Iterable
 from unicodedata import normalize
 
-from gaphor.ui.treemodel import TreeItem, tree_item_sort
+from gaphor.UML.treemodel import TreeItem, tree_item_sort
 
 """
 Inputs:

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -17,6 +17,7 @@ GAPHOR_CORE = [
 
 GLIB = [
     "gi.repository.GLib",
+    "gi.repository.GObject",
     "gi.repository.Gio",
 ]
 
@@ -30,7 +31,6 @@ UI_LIBRARIES = [
     "gi.repository.Adw",
     "gi.repository.Gdk",
     "gi.repository.Gtk",
-    "gi.repository.GObject",
 ]
 
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Currently the model browser only works with UML (derived) modeling languages.

Issue Number: #3577 

### What is the new behavior?

The Model Browser model is now part of the model.

It can be exposed through the `ModelingLanguage` class. The tree model type is then instantiated via dependency injection.

Every modeling language now has an associated model class for the Model Browser. The model browser takes care to leave the model as is for modeling languages that use the same tree model type (all our current languages).

### Other information

* Improved new-diagram menu for diagrams.