### PR TITLE
Add reference to UML.recipes in Scripting docs

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -297,8 +297,8 @@ with open(model_filename, "w") as out:
 What else is there to know…
 
 * Gaphor supports derived associations. For example, `element.owner` points to the owner element. For an attribute that would be its containing class.
-* The module `gaphor.UML.recipes` contains several helper functions for manipulating elements and their associations.
-* The tests for a given modelling language are a good place to find reference examples of element creation and modification.  
+* The module `gaphor.UML.recipes` contains several functions for manipulating elements and their associations.
+* The tests for a given modelling language are a good place to find reference examples of element creation and modification.
 * All data models are described in the `Modeling Languages` section of the docs.
 * If you use Gaphor’s Console, you’ll need to apply all changes in a transaction, or they will result in an error.
 * If you want a comprehensive example of a code generator, have a look at [Gaphor’s `coder` module](https://github.com/gaphor/gaphor/blob/main/gaphor/codegen/coder.py). This module is used to generate the code for the data models used by Gaphor.

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -297,6 +297,8 @@ with open(model_filename, "w") as out:
 What else is there to know…
 
 * Gaphor supports derived associations. For example, `element.owner` points to the owner element. For an attribute that would be its containing class.
+* The module `gaphor.UML.recipes` contains several helper functions for manipulating elements and their associations.
+* The tests for a given modelling language are a good place to find reference examples of element creation and modification.  
 * All data models are described in the `Modeling Languages` section of the docs.
 * If you use Gaphor’s Console, you’ll need to apply all changes in a transaction, or they will result in an error.
 * If you want a comprehensive example of a code generator, have a look at [Gaphor’s `coder` module](https://github.com/gaphor/gaphor/blob/main/gaphor/codegen/coder.py). This module is used to generate the code for the data models used by Gaphor.


### PR DESCRIPTION
Updated docs to reference UML.recipes which has some handy functions for model creation and editing. And also added reference to modelling language tests cases which illustrate behaviour of the elements. 

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [ ] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [X] Documentation content changes

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
