### PR TITLE
Allow to move properties and operations around in the Model Browser

### DIFF
--- a/gaphor/UML/group.py
+++ b/gaphor/UML/group.py
@@ -136,3 +136,61 @@ def behavior_ungroup(parent, element) -> bool:
         del element.behavioredClassifier
         return True
     return False
+
+
+@group.register(UML.Artifact, UML.Property)
+@group.register(UML.Class, UML.Property)
+@group.register(UML.DataType, UML.Property)
+@group.register(UML.Interface, UML.Property)
+def property_group(
+    parent: UML.Artifact | UML.Class | UML.DataType | UML.Interface,
+    element: UML.Property,
+) -> bool:
+    if element.owner:
+        ungroup(element.owner, element)
+
+    parent.ownedAttribute = element
+    return True
+
+
+@ungroup.register(UML.Artifact, UML.Property)
+@ungroup.register(UML.Class, UML.Property)
+@ungroup.register(UML.DataType, UML.Property)
+@ungroup.register(UML.Interface, UML.Property)
+def property_ungroup(
+    parent: UML.Artifact | UML.Class | UML.DataType | UML.Interface,
+    element: UML.Property,
+) -> bool:
+    if element in parent.ownedAttribute:
+        del parent.ownedAttribute[element]
+        return True
+    return False
+
+
+@group.register(UML.Artifact, UML.Operation)
+@group.register(UML.Class, UML.Operation)
+@group.register(UML.DataType, UML.Operation)
+@group.register(UML.Interface, UML.Operation)
+def operation_group(
+    parent: UML.Artifact | UML.Class | UML.DataType | UML.Interface,
+    element: UML.Operation,
+) -> bool:
+    if element.owner:
+        ungroup(element.owner, element)
+
+    parent.ownedOperation = element
+    return True
+
+
+@ungroup.register(UML.Artifact, UML.Operation)
+@ungroup.register(UML.Class, UML.Operation)
+@ungroup.register(UML.DataType, UML.Operation)
+@ungroup.register(UML.Interface, UML.Operation)
+def operation_ungroup(
+    parent: UML.Artifact | UML.Class | UML.DataType | UML.Interface,
+    element: UML.Operation,
+) -> bool:
+    if element in parent.ownedOperation:
+        del parent.ownedOperation[element]
+        return True
+    return False

--- a/gaphor/UML/group.py
+++ b/gaphor/UML/group.py
@@ -146,6 +146,9 @@ def property_group(
     parent: UML.Artifact | UML.Class | UML.DataType | UML.Interface,
     element: UML.Property,
 ) -> bool:
+    if element.association:
+        return False
+
     if element.owner:
         ungroup(element.owner, element)
 
@@ -161,7 +164,7 @@ def property_ungroup(
     parent: UML.Artifact | UML.Class | UML.DataType | UML.Interface,
     element: UML.Property,
 ) -> bool:
-    if element in parent.ownedAttribute:
+    if not element.association and element in parent.ownedAttribute:
         del parent.ownedAttribute[element]
         return True
     return False

--- a/gaphor/UML/tests/test_group.py
+++ b/gaphor/UML/tests/test_group.py
@@ -101,6 +101,30 @@ def test_ungroup_class_and_activity(element_factory):
 
 
 @pytest.mark.parametrize(
+    "classifier_type,feature_type",
+    [
+        (UML.Artifact, UML.Operation),
+        (UML.Class, UML.Operation),
+        (UML.DataType, UML.Operation),
+        (UML.Interface, UML.Operation),
+        (UML.Artifact, UML.Property),
+        (UML.Class, UML.Property),
+        (UML.DataType, UML.Property),
+        (UML.Interface, UML.Property),
+    ],
+)
+def test_group_classifier_and_feature(classifier_type, feature_type, element_factory):
+    classifier = element_factory.create(classifier_type)
+    feature = element_factory.create(feature_type)
+    classifier2 = element_factory.create(classifier_type)
+
+    assert group(classifier, feature)
+    assert group(classifier2, feature)
+
+    assert feature.owner is classifier2
+
+
+@pytest.mark.parametrize(
     "element_type",
     [
         UML.Slot,
@@ -112,6 +136,7 @@ def test_ungroup_class_and_activity(element_factory):
         UML.ConnectorEnd,
         UML.Parameter,
         UML.Pin,
+        UML.Property,
         UML.StructuralFeature,
     ],
 )

--- a/gaphor/UML/tests/test_group.py
+++ b/gaphor/UML/tests/test_group.py
@@ -2,6 +2,7 @@ import pytest
 
 import gaphor.UML.uml as UML
 from gaphor.diagram.group import can_group, group, owner, ungroup
+from gaphor.UML.recipes import create_association, set_navigability
 
 
 def test_can_group_package_and_class(element_factory):
@@ -122,6 +123,18 @@ def test_group_classifier_and_feature(classifier_type, feature_type, element_fac
     assert group(classifier2, feature)
 
     assert feature.owner is classifier2
+
+
+def test_should_not_group_association_end(element_factory):
+    head_class = element_factory.create(UML.Class)
+    tail_class = element_factory.create(UML.Class)
+    association = create_association(head_class, tail_class)
+    set_navigability(association, association.memberEnd[0], True)
+    other_class = element_factory.create(UML.Class)
+    end = association.memberEnd[0]
+
+    assert not group(other_class, end)
+    assert not ungroup(end.owner, end)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Properties and Operations can not be moved to another owner.

Issue Number: fixes #3572 

### What is the new behavior?

Properties and Operations can be moved to another owner.

Association ends (properties attached to an association) *cannot* be moved, since that could create inconsistencies between model and diagram.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
