### PR TITLE
Update diagram frame styling

### DIFF
--- a/gaphor/C4Model/iconname.py
+++ b/gaphor/C4Model/iconname.py
@@ -1,5 +1,5 @@
-from gaphor.C4Model.c4model import Container, Database, Dependency
-from gaphor.diagram.iconname import get_default_icon_name, icon_name
+from gaphor.C4Model.c4model import Container, Database, Dependency, Person
+from gaphor.diagram.iconname import icon_name
 
 
 @icon_name.register(Container)
@@ -8,14 +8,19 @@ def get_name_for_class(element):
         return "gaphor-c4-software-system-symbolic"
     elif element.type == "Component":
         return "gaphor-c4-component-symbolic"
-    return get_default_icon_name(element)
+    return "gaphor-c4-container-symbolic"
 
 
 @icon_name.register(Database)
-def get_database_name(element):
-    return get_default_icon_name(element)
+def get_database_name(_element):
+    return "gaphor-c4-database-symbolic"
 
 
 @icon_name.register(Dependency)
-def get_dependency_name(element):
+def get_dependency_name(_element):
     return "gaphor-dependency-symbolic"
+
+
+@icon_name.register(Person)
+def get_person_name(_element):
+    return "gaphor-c4-person-symbolic"

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -40,7 +40,6 @@
 }
 
 diagramframe {
-  text-align: left;
   justify-content: start;
 }
 
@@ -128,6 +127,7 @@ metadata heading {
 pentagon {
   padding: 4;
   justify-content: start;
+  text-align: left;
 }
 
 /* UML */
@@ -318,7 +318,6 @@ from {
   font-size: x-small;
 }
 
-interaction > pentagon,
 activity > :is(name, stereotypes) {
   text-align: left;
 }


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Elements contained in a diagram frame have left aligned text.

<img width="430" alt="image" src="https://github.com/user-attachments/assets/9a8d38e7-c77f-4199-9570-d55a56bdcae9" />

### What is the new behavior?

<img width="432" alt="image" src="https://github.com/user-attachments/assets/a8b9c7b2-bf82-49df-b746-df89e6b778f0" />

Also fixed the mapping from C4 elements to their icons.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
