### PR TITLE
Prepare for native window controls (macOS)

### DIFF
--- a/gaphor/diagram/styleeditor.ui
+++ b/gaphor/diagram/styleeditor.ui
@@ -6,7 +6,7 @@
     <property name="resizable">false</property>
 
     <child type="titlebar">
-      <object class="GtkHeaderBar">
+      <object class="AdwHeaderBar">
         <property name="decoration-layout">:close</property>
       </object>
     </child>

--- a/gaphor/plugins/console/consolewindow.py
+++ b/gaphor/plugins/console/consolewindow.py
@@ -65,7 +65,8 @@ class ConsoleWindow(UIComponent, ActionProvider):
             }
         )
         box = Gtk.Box(orientation="vertical")
-        header_bar = Gtk.HeaderBar()
+        header_bar = Adw.HeaderBar()
+
         box.append(header_bar)
         box.append(console)
         window.set_content(box)

--- a/gaphor/plugins/errorreports/errorreports.ui
+++ b/gaphor/plugins/errorreports/errorreports.ui
@@ -7,7 +7,7 @@
     <property name="default-width">600</property>
     <property name="default-height">400</property>
     <child type="titlebar">
-      <object class="GtkHeaderBar">
+      <object class="AdwHeaderBar">
         <property name="decoration-layout">:close</property>
       </object>
     </child>

--- a/gaphor/ui/greeter.ui
+++ b/gaphor/ui/greeter.ui
@@ -35,7 +35,8 @@
     <property name="content">
       <object class="AdwToolbarView">
         <child type="top">
-          <object class="GtkHeaderBar">
+          <object class="AdwHeaderBar">
+            <property name="decoration-layout">:close</property>
             <child type="title">
               <object class="GtkBox">
                 <property name="orientation">vertical</property>

--- a/gaphor/ui/styling.py
+++ b/gaphor/ui/styling.py
@@ -10,8 +10,6 @@ class Styling(Service):
     def __init__(self):
         self.style_provider = init_styling()
         init_icon_theme()
-        if sys.platform == "darwin":
-            init_macos_settings()
 
     def shutdown(self):
         Gtk.StyleContext.remove_provider_for_display(
@@ -50,11 +48,3 @@ def init_icon_theme():
     path = importlib.resources.files("gaphor.ui") / "icons"
     if icon_theme:
         icon_theme.add_search_path(str(path))
-
-
-def init_macos_settings():
-    """Tweak settings, so Gaphor on macOS looks alike Linux.
-
-    Adwaita styling only requires a close button.
-    """
-    Gtk.Settings.get_default().set_property("gtk-decoration-layout", ":close")


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

On macOS, the window looks a bit off, since it does not contain the signature window controls.

### What is the new behavior?

This is an implementation of native window controls, which will hopefully make it in GTK 4.18.

See https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/8071

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

This PR requires GTK 4.18, or the latest development version with MR.

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/fd3c4c63-6cd9-4527-8dd5-2ba9d70bd111" />
