### PR TITLE
Initialize model specific diagram types

### DIFF
--- a/gaphor/UML/general/diagramitem.py
+++ b/gaphor/UML/general/diagramitem.py
@@ -32,7 +32,7 @@ class DiagramItem(ElementPresentation, Named):
             text_name(self),
         )
 
-        self.watch("subject[Core:Diagram].name")
+        self.watch("subject[UML:Diagram].name")
         self.watch("subject[Core:Diagram].diagramType")
         self.watch("subject[UML:Element].appliedStereotype.classifier.name")
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

We now have different diagram types, instead of one diagram type with a `diagramType` property.

However, the mapping from diagram type to diagram item was not loaded.

Issue Number: fixes #3698

### What is the new behavior?

Diagram type mappings (representations) are loaded.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
