### PR TITLE
Fix variable expansion during notarization

### DIFF
--- a/.github/actions/macos_dmg/action.yml
+++ b/.github/actions/macos_dmg/action.yml
@@ -109,7 +109,7 @@ runs:
       env:
         PRODUCT_PATH: "_packaging/dist/Gaphor-${{ inputs.version }}-${{ inputs.arch }}.dmg"
       run: |
-        ditto -c -k --keepParent "${.PRODUCT_PATH}" "notarization.zip"
+        ditto -c -k --keepParent "${PRODUCT_PATH}" "notarization.zip"
         xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
       shell: bash
     - name: Staple .dmg

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -196,7 +196,6 @@ jobs:
           # Pre-installed Python conflicts with Homebrew Python
           # https://github.com/actions/runner-images/issues/9966
           brew install --overwrite python@${python_version}
-          brew unlink pkg-config@0.29.2 || true
           brew install gtksourceview5 libadwaita adwaita-icon-theme gobject-introspection graphviz create-dmg
       - name: Set up Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0


### PR DESCRIPTION
During mainline builds, we were getting a build failure during notarization caused by a typo in one of the variable expansions.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
