### PR TITLE
Fix exception when dragging with touch

### DIFF
--- a/gaphor/ui/diagrampage.py
+++ b/gaphor/ui/diagrampage.py
@@ -333,6 +333,7 @@ def context_menu_controller(context_menu, diagram):
     def on_show_popup(ctrl, n_press, x, y):
         if (
             Transaction.in_transaction()
+            or ctrl.get_last_event() is None
             or not ctrl.get_last_event().triggers_context_menu()
         ):
             return


### PR DESCRIPTION
Fixes #3741

This doesn't improve touch interaction much, just avoids the context menu code erroring out.

### PR Checklist

Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type

- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Issue Number: #3741 

### What is the new behavior?

Doesn't error.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

It would be nice to improve touch inut overall, like allowing box selection, draging elements and not preserving as much scroll momentum when dragging. I don't have a touch-enabled developing machine, so testing code changes requires a bit of work. Maybe I'll take a stab at it in the future.