### PR TITLE
Ellipsize long class names in association property editor

### DIFF
--- a/gaphor/UML/classes/propertypages.ui
+++ b/gaphor/UML/classes/propertypages.ui
@@ -52,6 +52,7 @@
         <child>
           <object class="GtkLabel" id="head-title">
             <property name="label" translatable="yes">Head:</property>
+            <property name="ellipsize">end</property>
             <property name="xalign">0</property>
             <property name="hexpand">1</property>
             <style>
@@ -164,6 +165,7 @@ Use &lt;b&gt;-&lt;/b&gt;/&lt;b&gt;=&lt;/b&gt; to move items up or down.</propert
         <child>
           <object class="GtkLabel" id="tail-title">
             <property name="label" translatable="yes">Tail:</property>
+            <property name="ellipsize">end</property>
             <property name="xalign">0</property>
             <property name="hexpand">1</property>
             <style>


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Fixes #3745

### What is the new behavior?

Association member end names are ellipsized, so long names do not make the property editor unnecessary wide.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

<img width="1307" alt="image" src="https://github.com/user-attachments/assets/a42a3fc5-edbe-45ef-9f43-914e8f265e19" />

@tompkins-ct This is the fix, right?