### PR TITLE
Add a small teaser text for Gaphor

### DIFF
--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -241,10 +241,12 @@ class EditorStack:
         self.vbox.append(builder.get_object("no-item-selected"))
 
         tips = builder.get_object("tips")
+        cta = builder.get_object("cta")
 
         def on_show_tips_changed(checkbox, gparam):
             active = checkbox.get_active()
             tips.set_visible(active)
+            cta.set_visible(active)
             self.properties.set("show-tips", active)
 
         show_tips = builder.get_object("show-tips")

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -101,7 +101,7 @@
         </child>
         <child>
           <object class="GtkLabel">
-            <property name="label" translatable="yes">There's many ways you can help make Gaphor better: write a blog post, help translate Gaphor to your language, reporting bugs, suggesting features. Help make Gaphor better!</property>
+            <property name="label" translatable="yes">There are many ways to help make Gaphor better: write a blog post, translate Gaphor into your language, report bugs, or suggest new features. Join us in improving Gaphor!</property>
             <property name="use_markup">1</property>
             <property name="wrap">1</property>
             <property name="xalign">0</property>

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -36,9 +36,6 @@
     </child>
     <child>
       <object class="GtkBox" id="tips">
-        <property name="margin_top">12</property>
-        <property name="margin_bottom">12</property>
-        <property name="spacing">12</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkLabel">
@@ -72,6 +69,55 @@
             <property name="xalign">0</property>
           </object>
         </child>
+        <style>
+          <class name="tips" />
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="vexpand">1</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox" id="cta">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Help improve Gaphor</property>
+            <property name="xalign">0</property>
+            <style>
+              <class name="title" />
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Gaphor is free and open source software, written by devoted volunteers.</property>
+            <property name="use_markup">1</property>
+            <property name="wrap">1</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">There's many ways you can help make Gaphor better: write a blog post, help translate Gaphor to your language, reporting bugs, suggesting features. Help make Gaphor better!</property>
+            <property name="use_markup">1</property>
+            <property name="wrap">1</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Visit &lt;a href=&quot;https://gaphor.org/contribute/&quot;&gt;gaphor.org&lt;/a&gt; for more information.</property>
+            <property name="use_markup">1</property>
+            <property name="wrap">1</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <style>
+          <class name="cta" />
+        </style>
       </object>
     </child>
   </object>

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -182,3 +182,32 @@ flowboxchild:active {
 .style-editor-content > button {
   margin-top: 12px;
 }
+
+
+.tips label {
+  margin: 0px 0px 6px;
+}
+
+.tips label:first-child {
+  margin-top: 6px;
+}
+
+.cta {
+  border: 3px solid var(--blue-4);
+  border-radius: 6px;
+}
+
+.cta label {
+  margin: 0px 6px 6px;
+}
+
+.cta label:nth-child(2) {
+  margin-top: 6px;
+}
+
+.cta .title {
+  background-color: var(--blue-4);
+  color: white;
+  margin: 0;
+  padding: 6px 6px;
+}


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?


Issue Number: N/A

### What is the new behavior?

Add a little section to the property editor to make people aware that Gaphor is free and open source.

Not sure if it should still show if the "Show Tips" switch is disabled.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

* Improved CSS for tips section.


<img width="992" alt="image" src="https://github.com/user-attachments/assets/20eae919-082c-491f-8793-8648f2ca5d88" />
