### PR TITLE
Copy PNG and SVG to the clipboard

### DIFF
--- a/gaphor/diagram/export.py
+++ b/gaphor/diagram/export.py
@@ -1,5 +1,6 @@
 """Service dedicated to exporting diagrams to a variety of file formats."""
 
+import contextlib
 import re
 
 import cairo
@@ -14,15 +15,22 @@ def escape_filename(diagram_name):
     return re.sub("\\W+", "_", diagram_name)
 
 
-def render(diagram, new_surface, padding=8, write_to_png=None) -> None:
+def render(diagram, new_surface, items=None, with_diagram_type=True, padding=8) -> None:
+    if items is None:
+        items = list(diagram.get_all_items())
+
     diagram.update(diagram.ownedPresentation)
 
     painter = new_painter(diagram)
+    if with_diagram_type:
+        painter.append(DiagramTypePainter(diagram))
+        type_padding = diagram_type_height(diagram)
+    else:
+        type_padding = 0
 
     # Update bounding boxes with a temporary Cairo Context
     # (used for stuff like calculating font metrics)
-    bounding_box = calc_bounding_box(diagram, painter)
-    type_padding = diagram_type_height(diagram)
+    bounding_box = calc_bounding_box(items, painter)
 
     w, h = (
         bounding_box.width + 2 * padding,
@@ -41,26 +49,26 @@ def render(diagram, new_surface, padding=8, write_to_png=None) -> None:
         cr.translate(
             -bounding_box.x + padding, -bounding_box.y + padding + type_padding
         )
-        painter.paint(diagram.get_all_items(), cr)
+        painter.paint(items, cr)
         cr.show_page()
-
-        if write_to_png:
-            surface.write_to_png(write_to_png)
+        surface.flush()
 
 
 def diagram_type_height(diagram):
     if not diagram.diagramType:
         return 0
 
-    bounding_box = calc_bounding_box(diagram, DiagramTypePainter(diagram))
+    bounding_box = calc_bounding_box(
+        diagram.get_all_items(), DiagramTypePainter(diagram)
+    )
 
     return bounding_box.height
 
 
-def calc_bounding_box(diagram, painter):
+def calc_bounding_box(items, painter):
     surface = cairo.RecordingSurface(cairo.Content.COLOR_ALPHA, None)
     cr = cairo.Context(surface)
-    painter.paint(diagram.get_all_items(), cr)
+    painter.paint(items, cr)
     return Rectangle(*surface.ink_extents())
 
 
@@ -69,10 +77,15 @@ def save_svg(filename, diagram):
 
 
 def save_png(filename, diagram):
+    @contextlib.contextmanager
+    def new_png_surface(w, h):
+        with cairo.ImageSurface(cairo.FORMAT_ARGB32, int(w + 1), int(h + 1)) as surface:
+            yield surface
+            surface.write_to_png(filename)
+
     render(
         diagram,
-        lambda w, h: cairo.ImageSurface(cairo.FORMAT_ARGB32, int(w + 1), int(h + 1)),
-        write_to_png=filename,
+        new_png_surface,
     )
 
 
@@ -95,4 +108,4 @@ def new_painter(diagram):
     item_painter = (
         FreeHandPainter(ItemPainter(), sloppiness) if sloppiness else ItemPainter()
     )
-    return PainterChain().append(item_painter).append(DiagramTypePainter(diagram))
+    return PainterChain().append(item_painter)

--- a/gaphor/ui/clipboard.py
+++ b/gaphor/ui/clipboard.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
 from collections.abc import Collection
 
+import cairo
 from gi.repository import Gdk, GLib, GObject
 
+from gaphor.asyncio import TaskOwner
 from gaphor.core import Transaction
 from gaphor.core.modeling import Presentation
 from gaphor.diagram.copypaste import copy_full, paste_full, paste_link
+from gaphor.diagram.export import render
 
 
 class CopyBuffer(GObject.Object):
@@ -19,10 +24,11 @@ class CopyBuffer(GObject.Object):
     buffer = GObject.Property(type=object)
 
 
-class Clipboard:
+class Clipboard(TaskOwner):
     """Copy/Cut/Paste functionality for diagrams."""
 
     def __init__(self, event_manager, element_factory, clipboard=None):
+        super().__init__()
         self.event_manager = event_manager
         self.element_factory = element_factory
 
@@ -30,58 +36,89 @@ class Clipboard:
 
     def copy(self, view):
         if items := view.selection.selected_items:
-            self._copy(items)
+            self._copy(view.model, items)
 
     def cut(self, view):
         items = view.selection.selected_items
         if not items:
             return
 
-        self._copy(items)
+        self._copy(view.model, items)
 
         with Transaction(self.event_manager):
             for i in list(items):
                 i.unlink()
 
     def paste_link(self, view):
-        self._paste(view, paste_link)
+        self.create_background_task(self._paste(view, paste_link))
 
     def paste_full(self, view):
-        self._paste(view, paste_full)
+        self.create_background_task(self._paste(view, paste_full))
 
-    def _copy(self, items: Collection[Presentation]) -> None:
+    def _copy(self, diagram, items: Collection[Presentation]) -> None:
         if items:
             copy_buffer = copy_full(items, self.element_factory.lookup)
-            v = GObject.Value(CopyBuffer.__gtype__, CopyBuffer(buffer=copy_buffer))
-            self.clipboard.set_content(Gdk.ContentProvider.new_for_value(v))
+            svg_data = GLib.Bytes.new(render_svg(diagram, items))
+            png_data = GLib.Bytes.new(render_png(diagram, items))
 
-    def _paste(self, view, paster):
+            self.clipboard.set_content(
+                Gdk.ContentProvider.new_union(
+                    [
+                        Gdk.ContentProvider.new_for_value(
+                            GObject.Value(
+                                CopyBuffer.__gtype__, CopyBuffer(buffer=copy_buffer)
+                            )
+                        ),
+                        Gdk.ContentProvider.new_for_bytes("image/svg", svg_data),
+                        Gdk.ContentProvider.new_for_bytes("image/png", png_data),
+                    ]
+                )
+            )
+
+    async def _paste(self, view, paster):
         diagram = view.model
 
-        def on_paste(_source_object, result):
-            try:
-                copy_buffer = self.clipboard.read_value_finish(result)
-            except GLib.GError as e:
-                if str(e).startswith("g-io-error-quark:"):
-                    return
-                raise
+        try:
+            copy_buffer = await self.clipboard.read_value_async(
+                CopyBuffer.__gtype__, io_priority=GLib.PRIORITY_DEFAULT
+            )
+        except GLib.GError as e:
+            if str(e).startswith("g-io-error-quark:"):
+                return
+            raise
 
-            with Transaction(self.event_manager):
-                # Create new id's that have to be used to create the items:
-                new_items = paster(copy_buffer.buffer, diagram)
+        with Transaction(self.event_manager):
+            # Create new id's that have to be used to create the items:
+            new_items = paster(copy_buffer.buffer, diagram)
 
-                # move pasted items a bit, so user can see result of his action :)
-                for item in new_items:
-                    if item.parent not in new_items:
-                        item.matrix.translate(10, 10)
+            # move pasted items a bit, so user can see result of his action :)
+            for item in new_items:
+                if item.parent not in new_items:
+                    item.matrix.translate(10, 10)
 
-            selection = view.selection
-            selection.unselect_all()
-            selection.select_items(*new_items)
+        selection = view.selection
+        selection.unselect_all()
+        selection.select_items(*new_items)
 
-        self.clipboard.read_value_async(
-            CopyBuffer.__gtype__,
-            io_priority=GLib.PRIORITY_DEFAULT,
-            cancellable=None,
-            callback=on_paste,
-        )
+
+def render_svg(diagram, items) -> bytes:
+    buffer = io.BytesIO()
+    render(
+        diagram,
+        lambda w, h: cairo.SVGSurface(buffer, w, h),
+        items=items,
+        with_diagram_type=False,
+    )
+    return buffer.getbuffer()
+
+
+def render_png(diagram, items) -> bytes:
+    @contextlib.contextmanager
+    def new_png_surface(w, h):
+        with cairo.ImageSurface(cairo.FORMAT_ARGB32, int(w + 1), int(h + 1)) as surface:
+            yield surface
+            surface.write_to_png(buffer)
+
+    buffer = io.BytesIO()
+    render(diagram, new_png_surface, items=items, with_diagram_type=False)
+    return buffer.getbuffer()

--- a/gaphor/ui/tests/test_clipboard.py
+++ b/gaphor/ui/tests/test_clipboard.py
@@ -13,21 +13,20 @@ class MockSystemClipboard:
     def set_content(self, content_provider):
         self.copy_buffer = content_provider.get_value()
 
-    def read_value_async(self, gtype, io_priority, cancellable, callback):
-        callback(None, self.copy_buffer)
-
-    def read_value_finish(self, result):
-        return result
+    async def read_value_async(self, gtype, io_priority):
+        return self.copy_buffer
 
 
 @pytest.fixture
 def clipboard(event_manager, element_factory, monkeypatch):
+    monkeypatch.setattr("gi.repository.Gdk.ContentProvider.new_union", lambda v: v[0])
     monkeypatch.setattr("gi.repository.Gdk.ContentProvider.new_for_value", lambda v: v)
 
     return Clipboard(event_manager, element_factory, MockSystemClipboard())
 
 
-def test_copy_link(clipboard, diagram, view, element_factory):
+@pytest.mark.asyncio
+async def test_copy_link(clipboard, diagram, view, element_factory):
     ci = diagram.create(CommentItem, subject=element_factory.create(UML.Comment))
     view.selection.select_items(ci)
 
@@ -35,12 +34,14 @@ def test_copy_link(clipboard, diagram, view, element_factory):
     assert list(diagram.get_all_items()) == [ci]
 
     clipboard.paste_link(view)
+    await clipboard.gather_background_task()
 
     assert ci in diagram.get_all_items()
     assert len(list(diagram.get_all_items())) == 2, list(diagram.get_all_items())
 
 
-def test_copy_full_with_owned_element(clipboard, diagram, view, element_factory):
+@pytest.mark.asyncio
+async def test_copy_full_with_owned_element(clipboard, diagram, view, element_factory):
     package_item = diagram.create(
         PackageItem, subject=element_factory.create(UML.Package)
     )
@@ -50,5 +51,6 @@ def test_copy_full_with_owned_element(clipboard, diagram, view, element_factory)
     clipboard.copy(view)
 
     clipboard.paste_full(view)
+    await clipboard.gather_background_task()
 
     assert len(element_factory.lselect(UML.Package)) == 4


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Diagram data can't be copied to other apps.

Issue Number: #3664

### What is the new behavior?

Apart from the (internal) copy buffer, also provide PNG and SVG images, so diagrams can be copied in other apps.

### Other information

* Paste function is now async/await instead of callbacks.

