### PR TITLE
Improve text undo

### DIFF
--- a/gaphor/C4Model/propertypages.py
+++ b/gaphor/C4Model/propertypages.py
@@ -47,7 +47,7 @@ class DescriptionPropertyPage(PropertyPageBase):
         )
 
     def _on_description_changed(self, buffer):
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             self.subject.description = buffer.get_text(
                 buffer.get_start_iter(), buffer.get_end_iter(), False
             )
@@ -78,5 +78,5 @@ class TechnologyPropertyPage(PropertyPageBase):
         return builder.get_object("technology-editor")
 
     def _on_technology_changed(self, entry):
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             self.subject.technology = entry.get_text()

--- a/gaphor/C4Model/propertypages.py
+++ b/gaphor/C4Model/propertypages.py
@@ -38,7 +38,7 @@ class DescriptionPropertyPage(PropertyPageBase):
         @handler_blocking(buffer, "changed", self._on_description_changed)
         def text_handler(event):
             if not description.props.has_focus:
-                buffer.set_text(event.new_value)
+                buffer.set_text(event.new_value or "")
 
         self.watcher.watch("description", text_handler)
 

--- a/gaphor/C4Model/propertypages.ui
+++ b/gaphor/C4Model/propertypages.ui
@@ -43,9 +43,7 @@
       </object>
     </child>
     <child>
-      <object class="GtkEntry" id="technology">
-        <signal name="changed" handler="technology-changed" swapped="no"/>
-      </object>
+      <object class="GtkEntry" id="technology" />
     </child>
     <style>
       <class name="propertypage"/>

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -71,11 +71,11 @@ class RequirementPropertyPage(PropertyPageBase):
         )
 
     def _on_id_changed(self, entry):
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             self.subject.externalId = entry.get_text()
 
     def _on_text_changed(self, buffer):
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             self.subject.text = buffer.get_text(
                 buffer.get_start_iter(), buffer.get_end_iter(), False
             )
@@ -324,7 +324,7 @@ class ItemFlowPropertyPage(PropertyPageBase):
             return
 
         assert isinstance(iflow, sysml.ItemFlow)
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             iflow.itemProperty.name = entry.get_text()
 
     def _on_item_flow_type_changed(self, dropdown, _pspec):

--- a/gaphor/UML/actions/actionseditors.py
+++ b/gaphor/UML/actions/actionseditors.py
@@ -18,7 +18,7 @@ def fork_node_item_editor(item, view, event_manager, pos=None) -> bool:
     entry = popup_entry(join_spec)
 
     def update_text():
-        with Transaction(event_manager):
+        with Transaction(event_manager, context="editing"):
             item.subject.joinSpec = entry.get_buffer().get_text()
 
     show_popover(entry, view, box, update_text)
@@ -38,7 +38,7 @@ def activity_parameter_node_item_editor(
     entry = popup_entry(name)
 
     def update_text():
-        with Transaction(event_manager):
+        with Transaction(event_manager, context="editing"):
             item.subject.parameter.name = entry.get_buffer().get_text()
 
     show_popover(entry, view, box, update_text)

--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -59,7 +59,7 @@ class ObjectNodePropertyPage(PropertyPageBase):
 
     def _on_upper_bound_change(self, entry):
         value = entry.get_text().strip()
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             if value == "":
                 self.subject.upperBound = None
             else:
@@ -123,7 +123,7 @@ class ValueSpecificationActionPropertyPage(PropertyPageBase):
         return builder.get_object("value-specifiation-action-editor")
 
     def _on_value_change(self, entry):
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             value = entry.get_text()
             self.subject.value = value
 
@@ -263,7 +263,7 @@ class JoinNodePropertyPage(PropertyPageBase):
 
     def _on_join_spec_change(self, entry):
         value = entry.get_text().strip()
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             if (
                 self.subject.joinSpec is None
                 or UML.recipes.get_literal_value_as_string(self.subject.joinSpec)
@@ -316,7 +316,7 @@ class FlowPropertyPageAbstract(PropertyPageBase):
 
     def _on_guard_change(self, entry):
         value = entry.get_text().strip()
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             if (
                 self.subject.guard is None
                 or UML.recipes.get_literal_value_as_string(self.subject.guard) != value
@@ -397,10 +397,10 @@ class PinPropertyPage(PropertyPageBase):
 
     def _on_multiplicity_lower_change(self, entry):
         value = entry.get_text().strip()
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             self.subject.lowerValue = value
 
     def _on_multiplicity_upper_change(self, entry):
         value = entry.get_text().strip()
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             self.subject.upperValue = value

--- a/gaphor/UML/actions/activitypropertypage.py
+++ b/gaphor/UML/actions/activitypropertypage.py
@@ -217,7 +217,7 @@ class ActivityParameterNodeNamePropertyPage(PropertyPageBase):
 
     def _on_name_changed(self, entry):
         if self.subject.parameter.name != entry.get_text():
-            with Transaction(self.event_manager):
+            with Transaction(self.event_manager, context="editing"):
                 self.subject.parameter.name = entry.get_text()
 
 

--- a/gaphor/UML/actions/partitionpage.py
+++ b/gaphor/UML/actions/partitionpage.py
@@ -88,7 +88,7 @@ class PartitionPropertyPage(PropertyPageBase):
 
     def _on_partition_name_changed(self, entry, partition):
         """Event handler for editing partition names."""
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             partition.name = entry.get_text()
 
     def _on_partition_type_changed(self, combo, _pspec, partition):

--- a/gaphor/UML/classes/associationpropertypages.py
+++ b/gaphor/UML/classes/associationpropertypages.py
@@ -162,7 +162,7 @@ class AssociationPropertyPage(PropertyPageBase):
     @blockable
     def _on_end_name_change(self, entry, subject):
         with self.update_end_name.block():
-            with Transaction(self.event_manager):
+            with Transaction(self.event_manager, context="editing"):
                 parse(subject, entry.get_text())
 
     @blockable

--- a/gaphor/UML/classes/classeseditors.py
+++ b/gaphor/UML/classes/classeseditors.py
@@ -37,7 +37,7 @@ def association_item_editor(item, view, event_manager, pos=None) -> bool:
 
         def update_text():
             assert end_item
-            with Transaction(event_manager):
+            with Transaction(event_manager, context="editing"):
                 parse(end_item.subject, entry.get_buffer().get_text())
 
         bb = end_item.name_bounds
@@ -49,7 +49,7 @@ def association_item_editor(item, view, event_manager, pos=None) -> bool:
         entry = popup_entry(text)
 
         def update_text():
-            with Transaction(event_manager):
+            with Transaction(event_manager, context="editing"):
                 item.subject.name = entry.get_buffer().get_text()
 
         box = item.middle_shape_size

--- a/gaphor/UML/general/commenteditor.py
+++ b/gaphor/UML/general/commenteditor.py
@@ -11,7 +11,7 @@ def comment_item_editor(item, view, event_manager, pos=None) -> bool:
         text = buffer.get_text(
             buffer.get_start_iter(), buffer.get_end_iter(), include_hidden_chars=True
         )
-        with Transaction(event_manager):
+        with Transaction(event_manager, context="editing"):
             item.subject.body = text
 
     subject = item.subject

--- a/gaphor/UML/states/propertypages.py
+++ b/gaphor/UML/states/propertypages.py
@@ -86,7 +86,7 @@ class TransitionPropertyPage(PropertyPageBase):
 
     def _on_guard_change(self, entry):
         value = entry.get_text().strip()
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             if not self.subject.guard:
                 self.subject.guard = self.subject.model.create(UML.Constraint)
             specification = self.subject.model.create(UML.LiteralString)
@@ -96,14 +96,14 @@ class TransitionPropertyPage(PropertyPageBase):
 
     def _on_trigger_change(self, entry):
         value = entry.get_text().strip()
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             if not self.subject.trigger:
                 self.subject.trigger = self.subject.model.create(UML.Behavior)
             self.subject.trigger.name = value
 
     def _on_action_change(self, entry):
         value = entry.get_text().strip()
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             if not self.subject.action:
                 self.subject.action = self.subject.model.create(UML.Behavior)
             self.subject.action.name = value

--- a/gaphor/diagram/general/generalpropertypages.py
+++ b/gaphor/diagram/general/generalpropertypages.py
@@ -41,6 +41,6 @@ class MetadataPropertyPage(PropertyPageBase):
         return builder.get_object("metadata-editor")
 
     def _on_field_change(self, entry, field_name):
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             text = entry.get_text()
             setattr(self.item, field_name, text)

--- a/gaphor/diagram/instanteditors.py
+++ b/gaphor/diagram/instanteditors.py
@@ -43,7 +43,7 @@ def named_item_editor(item, view, event_manager, pos=None) -> bool:
     entry = popup_entry(name)
 
     def update_text():
-        with Transaction(event_manager):
+        with Transaction(event_manager, context="editing"):
             item.subject.name = entry.get_buffer().get_text()
 
     show_popover(entry, view, box, update_text)
@@ -71,7 +71,7 @@ def valued_item_editor(item, view, event_manager, pos=None) -> bool:
     entry = popup_entry(value)
 
     def update_text():
-        with Transaction(event_manager):
+        with Transaction(event_manager, context="editing"):
             item.subject.value = entry.get_buffer().get_text()
 
     show_popover(entry, view, box, update_text)

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -188,7 +188,7 @@ class NamePropertyPage(PropertyPageBase):
 
         @handler_blocking(entry, "changed", self._on_name_changed)
         def handler(event):
-            if event.element is subject and event.new_value != entry.get_text():
+            if event.element is subject and (event.new_value or "") != entry.get_text():
                 entry.set_text(event.new_value or "")
 
         self.watcher.watch("name", handler)
@@ -198,9 +198,8 @@ class NamePropertyPage(PropertyPageBase):
         )
 
     def _on_name_changed(self, entry):
-        with Transaction(self.event_manager):
-            if self.subject.name != entry.get_text():
-                self.subject.name = entry.get_text()
+        with Transaction(self.event_manager, context="editing"):
+            self.subject.name = entry.get_text()
 
 
 @PropertyPages.register(gaphas.item.Line)

--- a/gaphor/diagram/propertypages.py
+++ b/gaphor/diagram/propertypages.py
@@ -285,7 +285,7 @@ class NotePropertyPage(PropertyPageBase):
         return builder.get_object("note-editor")
 
     def _on_body_change(self, buffer):
-        with Transaction(self.event_manager):
+        with Transaction(self.event_manager, context="editing"):
             self.subject.note = buffer.get_text(
                 buffer.get_start_iter(), buffer.get_end_iter(), False
             )

--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -109,6 +109,15 @@ class TransactionRollback:
         self.context = context
 
 
+class TransactionClosed:
+    """Close an amendable transaction.
+
+    In some transaction contexts (notably "editing") changes can be
+    added to an existing transaction. This event closes those transactions
+    for new changes.
+    """
+
+
 class ActionEnabled:
     """Signal if an action can be activated or not."""
 

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -19,6 +19,7 @@ from gaphor.event import (
     Notification,
     SessionCreated,
     SessionShutdownRequested,
+    TransactionClosed,
 )
 from gaphor.i18n import translated_ui_string
 from gaphor.services.modelinglanguage import ModelingLanguageChanged
@@ -224,6 +225,7 @@ class MainWindow(Service, ActionProvider):
         window.connect("notify::maximized", self._on_window_mode_changed)
         window.connect("notify::fullscreened", self._on_window_mode_changed)
         window.connect("notify::is-active", self._on_window_active)
+        window.connect("notify::focus-widget", self._on_window_focus_widget)
         window.present()
 
         for handler in self._ui_updates:
@@ -323,10 +325,13 @@ class MainWindow(Service, ActionProvider):
 
         self.in_app_notifier.handle(event)
 
-    def _on_window_active(self, window, prop):
+    def _on_window_active(self, _window, _prop):
         self.event_manager.handle(ActiveSessionChanged(self))
 
-    def _on_window_close_request(self, window, event=None):
+    def _on_window_focus_widget(self, _window, _prop):
+        self.event_manager.handle(TransactionClosed())
+
+    def _on_window_close_request(self, _window, _event=None):
         self.event_manager.handle(SessionShutdownRequested())
         return True
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Currently, when undoing text via the central undo option, text is undone one character at a time.

Transactions are closed for amending when focus changes on the window.

Issue Number: N/A

### What is the new behavior?

Text edit actions are amended to an existing transaction (`context="editing"`).

This means that if you undo one edit action, the text is changes to what it was before.


### Other information

* It could be that bogus undo transactions are created if a user changes something in a text field and the reverts it by itself.
* amendable transactions (edit transactions) are closed when the user switches focus to another widget.
