### PR TITLE
Highlight drop zone during DnD operation

### DIFF
--- a/gaphor/SysML/drop.py
+++ b/gaphor/SysML/drop.py
@@ -1,9 +1,35 @@
-from gaphor.core.modeling import Diagram
+from gaphor.core.modeling import Diagram, Presentation
 from gaphor.diagram.drop import drop
 from gaphor.diagram.presentation import connect
 from gaphor.diagram.support import get_diagram_item
+from gaphor.SysML.diagramframe import DiagramFrameItem
 from gaphor.SysML.sysml import Block, ProxyPort
-from gaphor.UML.uml import Property
+from gaphor.UML.uml import Element, Property
+
+
+@drop.register(Element, DiagramFrameItem)
+def drop_element_on_diagram_frame(
+    element: Element, diagram_frame: DiagramFrameItem, x, y
+):
+    if item := drop(element, diagram_frame.diagram, x, y):
+        item.parent = diagram_frame
+        item.request_update()
+
+    return item
+
+
+@drop.register(Presentation, DiagramFrameItem)
+def drop_presentation_on_diagram_frame(
+    item: Presentation, diagram_frame: DiagramFrameItem, x, y
+):
+    """When dropped on a diagram frame, change item ownership.
+
+    Do not change model element ownership.
+    """
+    item.change_parent(diagram_frame)
+    item.request_update()
+
+    return item
 
 
 @drop.register(ProxyPort, Diagram)

--- a/gaphor/UML/compartments.py
+++ b/gaphor/UML/compartments.py
@@ -55,8 +55,7 @@ def from_package_str(item):
     namespace = subject.namespace
     parent = item.parent
 
-    # if there is a parent (i.e. interaction)
-    if parent and parent.subject and parent.subject.namespace is not namespace:
+    if parent and parent.subject and parent.subject is namespace:
         return False
 
     return (

--- a/gaphor/UML/tests/test_drop.py
+++ b/gaphor/UML/tests/test_drop.py
@@ -1,5 +1,6 @@
 from gaphor import UML
 from gaphor.diagram.drop import drop
+from gaphor.UML.classes import PackageItem
 from gaphor.UML.interactions import MessageItem
 from gaphor.UML.interactions.interactionsconnect import connect_lifelines
 from gaphor.UML.recipes import (
@@ -153,3 +154,27 @@ def test_drop_pin(diagram, element_factory):
     assert ouput_item
     assert ouput_item.subject is output_pin
     assert ouput_item.parent.subject is action
+
+
+def test_drop_element_on_presentation(diagram, element_factory):
+    package_item = diagram.create(
+        PackageItem, subject=element_factory.create(UML.Package)
+    )
+    cls = element_factory.create(UML.Class)
+
+    drop(cls, package_item, 0, 0)
+    class_item = cls.presentation[0]
+
+    assert class_item.parent is package_item
+
+
+def test_drop_element_on_presentation_that_cannot_be_owned(diagram, element_factory):
+    package_item = diagram.create(
+        PackageItem, subject=element_factory.create(UML.Package)
+    )
+    action = element_factory.create(UML.Action)
+
+    drop(action, package_item, 0, 0)
+    class_item = action.presentation[0]
+
+    assert class_item.parent is None

--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -5,7 +5,7 @@
   background-color: transparent;
 }
 
-:drop {
+:not(diagramframe):drop {
   color: #1a5fb4;
   line-width: 3;
 }

--- a/gaphor/diagram/drop.py
+++ b/gaphor/diagram/drop.py
@@ -19,9 +19,13 @@ def no_drop(element: Base, diagram: Diagram, x: float, y: float):
     return None
 
 
-drop: FunctionDispatcher[Callable[[Base, Base], Presentation | None]] = multidispatch(
-    Base, Diagram
-)(no_drop)
+drop: FunctionDispatcher[Callable[[Base, Base, float, float], Presentation | None]] = (
+    multidispatch(Base, Diagram)(no_drop)
+)
+"""Drop an element on a diagram or presentation
+
+The position (x, y) is in parent element coordinates.
+"""
 
 
 @drop.register(Presentation, Diagram)
@@ -40,7 +44,7 @@ def drop_presentation(item: Presentation, diagram: Diagram, x: float, y: float):
 def drop_on_presentation(
     item: Presentation, new_parent: Presentation, x: float, y: float
 ):
-    """Place :obj:`item`, with position :obj:`pos` relative to :obj:`new_parent`."""
+    """Place :obj:`item`, with position (:obj:`x`, :obj:`y`) relative to :obj:`new_parent`."""
     assert item.diagram is new_parent.diagram
 
     old_parent = item.parent

--- a/gaphor/diagram/group.py
+++ b/gaphor/diagram/group.py
@@ -37,7 +37,8 @@ def change_owner(new_parent: Base | None, element: Base) -> bool:
         o = None
 
     if new_parent and o is new_parent:
-        return False
+        # idempotency
+        return True
 
     if new_parent and element in self_and_owners(new_parent):
         return False

--- a/gaphor/diagram/tools/dnd.py
+++ b/gaphor/diagram/tools/dnd.py
@@ -33,6 +33,7 @@ def on_motion(
 ) -> Gdk.DragAction:
     view = target.get_widget()
     source_value = target.get_value()
+
     if view.selection.dropzone_item:
         view.model.request_update(view.selection.dropzone_item)
 
@@ -66,10 +67,13 @@ def on_drop(target, source_value, x, y, modeling_language, event_manager):
     view = target.get_widget()
     if isinstance(source_value, ElementDragData):
         elements = source_value.elements
+        new_parent = view.selection.dropzone_item
+        view.selection.dropzone_item = None
+
         with Transaction(event_manager):
             items = []
             for element in elements:
-                if item := _drop(view, element, x, y):
+                if item := _drop(view, element, new_parent, x, y):
                     x += 20
                     y += 20
                     items.append(item)
@@ -86,7 +90,6 @@ def on_drop(target, source_value, x, y, modeling_language, event_manager):
                 event_manager.handle(
                     Notification(gettext("Element can’t be represented on a diagram."))
                 )
-        view.selection.dropzone_item = None
         return True
     elif isinstance(source_value, ToolboxActionDragData):
         tool_def = get_tool_def(modeling_language, source_value.action)
@@ -97,8 +100,7 @@ def on_drop(target, source_value, x, y, modeling_language, event_manager):
     return False
 
 
-def _drop(view, item, x, y):
-    new_parent = view.selection.dropzone_item
+def _drop(view, item, new_parent, x, y):
     return (
         drop(
             item,

--- a/gaphor/diagram/tools/dnd.py
+++ b/gaphor/diagram/tools/dnd.py
@@ -1,7 +1,9 @@
+from gaphas.tool.itemtool import item_at_point
 from gi.repository import Gdk, GObject, Gtk
 
 from gaphor.diagram.diagramtoolbox import get_tool_def
 from gaphor.diagram.drop import drop
+from gaphor.diagram.group import can_group
 from gaphor.diagram.tools.placement import create_item
 from gaphor.event import Notification
 from gaphor.i18n import gettext
@@ -20,19 +22,54 @@ def drop_target_tool(modeling_language, event_manager) -> Gtk.EventController:
     """DropTarget tool."""
     drop_target = Gtk.DropTarget.new(GObject.TYPE_NONE, Gdk.DragAction.COPY)
     drop_target.set_gtypes([ElementDragData.__gtype__, ToolboxActionDragData.__gtype__])
+    drop_target.set_preload(True)
+    drop_target.connect("motion", on_motion, modeling_language)
     drop_target.connect("drop", on_drop, modeling_language, event_manager)
     return drop_target
+
+
+def on_motion(
+    target: Gtk.DropTarget, x: float, y: float, modeling_language
+) -> Gdk.DragAction:
+    view = target.get_widget()
+    source_value = target.get_value()
+    if view.selection.dropzone_item:
+        view.model.request_update(view.selection.dropzone_item)
+
+    if not (
+        (parent_item := next(item_at_point(view, (x, y)), None)) and parent_item.subject
+    ):
+        view.selection.dropzone_item = None
+        return Gdk.DragAction.COPY
+
+    if (
+        isinstance(source_value, ElementDragData)
+        and (len(source_value.elements) == 1)
+        and can_group(parent_item.subject, source_value.elements[0])
+    ):
+        view.selection.dropzone_item = parent_item
+        view.model.request_update(parent_item)
+    elif (
+        isinstance(source_value, ToolboxActionDragData)
+        and (tool_def := get_tool_def(modeling_language, source_value.action))
+        and can_group(parent_item.subject, tool_def.item_factory.subject_class)
+    ):
+        view.selection.dropzone_item = parent_item
+        view.model.request_update(parent_item)
+    else:
+        view.selection.dropzone_item = None
+
+    return Gdk.DragAction.COPY
 
 
 def on_drop(target, source_value, x, y, modeling_language, event_manager):
     view = target.get_widget()
     if isinstance(source_value, ElementDragData):
         elements = source_value.elements
-        x, y = view.matrix.inverse().transform_point(x, y)
         with Transaction(event_manager):
             items = []
             for element in elements:
-                if item := drop(element, view.model, x, y):
+                if item := _drop(view, element, x, y):
                     x += 20
                     y += 20
                     items.append(item)
@@ -49,7 +86,8 @@ def on_drop(target, source_value, x, y, modeling_language, event_manager):
                 event_manager.handle(
                     Notification(gettext("Element can’t be represented on a diagram."))
                 )
-        return
+        view.selection.dropzone_item = None
+        return True
     elif isinstance(source_value, ToolboxActionDragData):
         tool_def = get_tool_def(modeling_language, source_value.action)
         with Transaction(event_manager):
@@ -57,3 +95,20 @@ def on_drop(target, source_value, x, y, modeling_language, event_manager):
         return True
 
     return False
+
+
+def _drop(view, item, x, y):
+    new_parent = view.selection.dropzone_item
+    return (
+        drop(
+            item,
+            new_parent,
+            *view.get_matrix_v2i(new_parent).transform_point(x, y),
+        )
+        if new_parent
+        else drop(
+            item,
+            view.model,
+            *view.matrix.inverse().transform_point(x, y),
+        )
+    )

--- a/gaphor/diagram/tools/placement.py
+++ b/gaphor/diagram/tools/placement.py
@@ -51,13 +51,13 @@ def on_drag_begin(gesture, start_x, start_y, placement_state: PlacementState):
     else:
         placement_state.event_manager.handle(DiagramItemPlaced(item))
 
-    view.selection.dropzone_item = None
     view.model.update({item})
 
 
 def create_item(view, factory, event_manager, x, y):
     selection = view.selection
     parent = selection.dropzone_item
+    selection.dropzone_item = None
     item = factory(view.model, parent)
     x, y = view.get_matrix_v2i(item).transform_point(x, y)
     item.matrix.translate(x, y)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Grouping didn't work when dragging elements from Model Browser or Toolbox.

Issue Number: fixes #3769, fixes #3750

### What is the new behavior?

Grouping works, with drop zone support.

To test, drop an element from the model browser on another element in a diagram (e.g. drop one class on either of 2 packages).

Diagram frames will no longer change ownership of elements dragged onto them.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Maybe iterate items at a point, instead of only looking at the topmost one?
