### PR TITLE
3806 - forced upper limits that are strings to take value '*'

### DIFF
--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -587,8 +587,8 @@ def upgrade_simple_properties_to_value_specifications(
                     )
                     if type is not None and isinstance(value, str):
                         upperValue = element_factory.create(type)
-                        #upperValue.value = "*" if value == "*" else int(value)
-                        upperValue.value = '*' if isinstance(value, str) else int(value)
+                        #Overwrite any string value that is not '*'
+                        upperValue.value = "*" if isinstance(value, str) else int(value)
                         upperValue.name = value
                         elem.values["upperValue"] = upperValue
                         homeless_literals[upperValue.id] = (elem.id, name)

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -587,8 +587,11 @@ def upgrade_simple_properties_to_value_specifications(
                     )
                     if type is not None and isinstance(value, str):
                         upperValue = element_factory.create(type)
+                        try:
                         # Overwrite any string value that is not '*'
-                        upperValue.value = "*" if isinstance(value, str) else int(value)
+                            upperValue.value = int(value)
+                        except ValueError:
+                            upperValue.value = "*"
                         upperValue.name = value
                         elem.values["upperValue"] = upperValue
                         homeless_literals[upperValue.id] = (elem.id, name)

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -587,7 +587,8 @@ def upgrade_simple_properties_to_value_specifications(
                     )
                     if type is not None and isinstance(value, str):
                         upperValue = element_factory.create(type)
-                        upperValue.value = "*" if value == "*" else int(value)
+                        #upperValue.value = "*" if value == "*" else int(value)
+                        upperValue.value = '*' if isinstance(value, str) else int(value)
                         upperValue.name = value
                         elem.values["upperValue"] = upperValue
                         homeless_literals[upperValue.id] = (elem.id, name)

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -588,7 +588,7 @@ def upgrade_simple_properties_to_value_specifications(
                     if type is not None and isinstance(value, str):
                         upperValue = element_factory.create(type)
                         try:
-                        # Overwrite any string value that is not '*'
+                            # Overwrite any string value that is not '*'
                             upperValue.value = int(value)
                         except ValueError:
                             upperValue.value = "*"

--- a/gaphor/storage/storage.py
+++ b/gaphor/storage/storage.py
@@ -587,7 +587,7 @@ def upgrade_simple_properties_to_value_specifications(
                     )
                     if type is not None and isinstance(value, str):
                         upperValue = element_factory.create(type)
-                        #Overwrite any string value that is not '*'
+                        # Overwrite any string value that is not '*'
                         upperValue.value = "*" if isinstance(value, str) else int(value)
                         upperValue.name = value
                         elem.values["upperValue"] = upperValue


### PR DESCRIPTION
Forces upper limits to take the value '*' if they are strings hence overwriting values like 'N' or 'max_items'
Allows model to load, but may not be a thorough solution.  

### PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [ x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
If associations have upper limits defined as any string othe than '*' the model fails to load.
Issue Number: 3806

### What is the new behavior?
Overwirte string with '*'

### Does this PR introduce a breaking change?
- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
