### PR TITLE
Show/hide tips with a smooth cross fade and styling fixes

### DIFF
--- a/gaphor/ui/elementeditor.py
+++ b/gaphor/ui/elementeditor.py
@@ -241,12 +241,10 @@ class EditorStack:
         self.vbox.append(builder.get_object("no-item-selected"))
 
         tips = builder.get_object("tips")
-        cta = builder.get_object("cta")
 
         def on_show_tips_changed(checkbox, gparam):
             active = checkbox.get_active()
-            tips.set_visible(active)
-            cta.set_visible(active)
+            tips.set_visible_child_name("tips" if active else "empty")
             self.properties.set("show-tips", active)
 
         show_tips = builder.get_object("show-tips")

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -35,93 +35,110 @@
       </object>
     </child>
     <child>
-      <object class="GtkBox" id="tips">
-        <property name="orientation">vertical</property>
+      <object class="GtkStack" id="tips">
+        <property name="transition-type">crossfade</property>
         <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Add a model element from the tool box (bottom left) to the diagram. Here you will see its properties appear.</property>
-            <property name="use_markup">1</property>
-            <property name="wrap">1</property>
-            <property name="xalign">0</property>
+          <object class="GtkStackPage">
+            <property name="name">tips</property>
+            <property name="child">
+
+              <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <property name="vexpand">1</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">Add a model element from the tool box (bottom left) to the diagram. Here you will see its properties appear.</property>
+                    <property name="use_markup">1</property>
+                    <property name="wrap">1</property>
+                    <property name="xalign">0</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">This pane can be hidden by clicking the pane icon in the header.</property>
+                    <property name="use_markup">1</property>
+                    <property name="wrap">1</property>
+                    <property name="xalign">0</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">&lt;b&gt;Tip:&lt;/b&gt; Most elements in the toolbox have a keyboard shortcut (e.g. &quot;c&quot; for Class). Tool selection only works from the diagram. If a tool does not get selected, click on the diagram once (so it&apos;s focused) and then hit the shortcut key.</property>
+                    <property name="use_markup">1</property>
+                    <property name="wrap">1</property>
+                    <property name="xalign">0</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">&lt;b&gt;Tip:&lt;/b&gt; To search for an element in the model browser (top left), select an element in the model browser and start typing. A search box will automatically appear.</property>
+                    <property name="use_markup">1</property>
+                    <property name="wrap">1</property>
+                    <property name="xalign">0</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox" id="cta">
+                    <property name="orientation">vertical</property>
+                    <property name="vexpand">1</property>
+                    <property name="valign">end</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">Help improve Gaphor</property>
+                        <property name="xalign">0</property>
+                        <style>
+                          <class name="title" />
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">Gaphor is free and open source software, written by devoted volunteers.</property>
+                        <property name="use_markup">1</property>
+                        <property name="wrap">1</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">There are many ways to help make Gaphor better: write a blog post, translate Gaphor into your language, report bugs, or suggest new features. Join us in improving Gaphor!</property>
+                        <property name="use_markup">1</property>
+                        <property name="wrap">1</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">Visit &lt;a href=&quot;https://gaphor.org/contribute/&quot;&gt;gaphor.org&lt;/a&gt; for more information.</property>
+                        <property name="use_markup">1</property>
+                        <property name="wrap">1</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <style>
+                      <class name="cta" />
+                    </style>
+                  </object>
+                </child>
+                <style>
+                  <class name="tips" />
+                </style>
+              </object>
+
+            </property>
           </object>
         </child>
         <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">This pane can be hidden by clicking the pane icon in the header.</property>
-            <property name="use_markup">1</property>
-            <property name="wrap">1</property>
-            <property name="xalign">0</property>
+          <object class="GtkStackPage">
+            <property name="name">empty</property>
+            <property name="child">
+              <object class="GtkBox"/>
+            </property>
           </object>
         </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">&lt;b&gt;Tip:&lt;/b&gt; Most elements in the toolbox have a keyboard shortcut (e.g. &quot;c&quot; for Class). Tool selection only works from the diagram. If a tool does not get selected, click on the diagram once (so it&apos;s focused) and then hit the shortcut key.</property>
-            <property name="use_markup">1</property>
-            <property name="wrap">1</property>
-            <property name="xalign">0</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">&lt;b&gt;Tip:&lt;/b&gt; To search for an element in the model browser (top left), select an element in the model browser and start typing. A search box will automatically appear.</property>
-            <property name="use_markup">1</property>
-            <property name="wrap">1</property>
-            <property name="xalign">0</property>
-          </object>
-        </child>
-        <style>
-          <class name="tips" />
-        </style>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="vexpand">1</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox" id="cta">
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Help improve Gaphor</property>
-            <property name="xalign">0</property>
-            <style>
-              <class name="title" />
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Gaphor is free and open source software, written by devoted volunteers.</property>
-            <property name="use_markup">1</property>
-            <property name="wrap">1</property>
-            <property name="xalign">0</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">There are many ways to help make Gaphor better: write a blog post, translate Gaphor into your language, report bugs, or suggest new features. Join us in improving Gaphor!</property>
-            <property name="use_markup">1</property>
-            <property name="wrap">1</property>
-            <property name="xalign">0</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Visit &lt;a href=&quot;https://gaphor.org/contribute/&quot;&gt;gaphor.org&lt;/a&gt; for more information.</property>
-            <property name="use_markup">1</property>
-            <property name="wrap">1</property>
-            <property name="xalign">0</property>
-          </object>
-        </child>
-        <style>
-          <class name="cta" />
-        </style>
       </object>
     </child>
   </object>
-
   <object class="GtkSourceBuffer" id="style-sheet-buffer"/>
 
   <object class="GtkBox" id="elementeditor">

--- a/gaphor/ui/styling-macos.css
+++ b/gaphor/ui/styling-macos.css
@@ -17,3 +17,7 @@
 .csd:backdrop {
   box-shadow: none;
 }
+
+.monospace {
+  font-family: monospace;
+}

--- a/gaphor/ui/styling-windows.css
+++ b/gaphor/ui/styling-windows.css
@@ -22,3 +22,7 @@
               0 2px 6px 2px alpha(black, 0.1),
               0 0 0 1px alpha(black, 0.06);
 }
+
+.monospace {
+  font-family: monospace;
+}

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -184,11 +184,11 @@ flowboxchild:active {
 }
 
 
-.tips label {
+.tips > label {
   margin: 0px 0px 6px;
 }
 
-.tips label:first-child {
+.tips > label:first-child {
   margin-top: 6px;
 }
 
@@ -209,5 +209,5 @@ flowboxchild:active {
   background-color: var(--blue-4);
   color: white;
   margin: 0;
-  padding: 6px 6px;
+  padding: 6px;
 }

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -1,6 +1,6 @@
 
 #toolbox expander {
-  border-top: 1px solid @unfocused_borders;
+  border-top: 1px solid var(--unfocused-borders);
   margin-top: 6px;
   padding-top: 6px;
   padding-bottom: 6px;
@@ -24,9 +24,9 @@ diagramview {
   margin: 12px;
   padding: 6px;
   border-radius: 12px;
-  background-color: alpha(@window_bg_color, 0.95);
-  border: 1px solid @borders;
-  box-shadow: 0px 3px 6px @shade_color;
+  background-color: alpha(var(--window-bg-color), 0.95);
+  border: 1px solid var(--border-color);
+  box-shadow: 0px 3px 6px var(--shade-color);
 }
 
 .status-window box {
@@ -101,13 +101,13 @@ row {
 }
 
 textfield text {
-  background-color: @theme_bg_color;
-  color: @theme_fg_color;
-  border: 1px solid @theme_bg_color;
+  background-color: var(--window-bg-color);
+  color: var(--window-fg-color);
+  border: 1px solid var(--window-bg-color);
 }
 
 textfield text selection {
-  background-color: alpha(@theme_selected_bg_color, 0.3);
+  background-color: alpha(var(--accent-bg-color), 0.3);
 }
 
 .info {
@@ -117,7 +117,7 @@ textfield text selection {
 }
 
 .info:hover {
-  background-color: @shade_color;
+  background-color: var(--shade-color);
 }
 
 .info-popover {
@@ -129,7 +129,7 @@ textfield text selection {
 }
 
 #model_browser .row {
-  border-top: 0 solid @shade_color;
+  border-top: 0 solid var(--shade-color);
   transition: border 200ms;
 }
 
@@ -147,8 +147,8 @@ tabbar > revealer > box,
 }
 
 .pseudo-sidebar-pane {
-  background-color: @sidebar_bg_color;
-  color: @sidebar_fg_color;
+  background-color: var(--sidebar-bg-color);
+  color: var(--sidebar-fg-color);
 }
 
 #element_editor {
@@ -164,11 +164,11 @@ tabbar > revealer > box,
 }
 
 flowboxchild:hover {
-  background-color: @shade_color;
+  background-color: var(--shade-color);
 }
 
 flowboxchild:active {
-  background-color: alpha(@shade_color, 2);
+  background-color: alpha(var(--shade-color), 2);
 }
 
 .mono {

--- a/gaphor/ui/styling.css
+++ b/gaphor/ui/styling.css
@@ -209,5 +209,5 @@ flowboxchild:active {
   background-color: var(--blue-4);
   color: white;
   margin: 0;
-  padding: 6px;
+  padding: 3px 6px 6px 6px;
 }


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Tips are shown/hidden instantly.

Issue Number: N/A

### What is the new behavior?

Create a smooth cross fade effect for showing/hiding the tips. I think this fits better in the overall application.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

* A few styling updates: replace `@`-colors with `var()`iables.
* small styling fix for CTA block
* Restore monospace font on macOS and Windows (changed in libadwaita 1.7)