### PR TITLE
Rename new-model action to new-window

### DIFF
--- a/gaphor/ui/greeter.py
+++ b/gaphor/ui/greeter.py
@@ -154,7 +154,7 @@ class Greeter(Service, ActionProvider):
             self.greeter.destroy()
             self.greeter = None
 
-    @action(name="app.new-model", shortcut="<Primary>n")
+    @action(name="app.new-window", shortcut="<Primary>n")
     def new_model(self):
         self.open()
 

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -44,7 +44,7 @@ def create_hamburger_model(export_menu, tools_menu):
     model = Gio.Menu.new()
 
     part = Gio.Menu.new()
-    part.append(gettext("New Model…"), "app.new-model")
+    part.append(gettext("New Model…"), "app.new-window")
     part.append(gettext("Open Model…"), "app.file-open")
     model.append_section(None, part)
 


### PR DESCRIPTION
GNOME Shell uses the "new-window" action to open new main windows for an application. Renaming that action to this common name allows application launchers to use it.

<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
GNOME Shell does not provide a "New Window" option for Gaphor, because the "new-window" action is not implemented.

Issue Number: N/A

### What is the new behavior?
GNOME Shell provides a "New Window" action for Gaphor that opens a new greeter window if not already present.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
