### PR TITLE
Fix Ctrl+q: retrieve shortcuts from Application class

### DIFF
--- a/gaphor/ui/__init__.py
+++ b/gaphor/ui/__init__.py
@@ -62,7 +62,9 @@ def run(argv: list[str], *, launch_service="greeter", recover=False) -> int:
         def on_quit(_event: ApplicationShutdown):
             gtk_app.quit()
 
-        apply_shortcuts_from_entry_point("gaphor.appservices", "app", gtk_app)
+        apply_shortcuts_from_entry_point(
+            "gaphor.appservices", "app", gtk_app, extra=[Application]
+        )
         apply_shortcuts_from_entry_point("gaphor.services", "win", gtk_app)
         apply_shortcuts_from_entry_point("gaphor.services", "text", gtk_app)
 

--- a/gaphor/ui/actiongroup.py
+++ b/gaphor/ui/actiongroup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from itertools import chain
 
 from gi.repository import Gio, GLib, Gtk
 
@@ -17,8 +18,10 @@ def apply_application_actions(component_registry, gtk_app) -> None:
             gtk_app.add_action(a)
 
 
-def apply_shortcuts_from_entry_point(entry_point, scope, gtk_app) -> None:
-    for provider_class in load_entry_points(entry_point).values():
+def apply_shortcuts_from_entry_point(
+    entry_point, scope, gtk_app, *, extra=None
+) -> None:
+    for provider_class in chain(load_entry_points(entry_point).values(), extra or []):
         if not issubclass(provider_class, ActionProvider):
             continue
         for _attrname, act in iter_actions(provider_class, scope):


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Ctrl+q doesn't work on Linux (and probably also not on Windows).

Issue Number: #3821 

### What is the new behavior?

Ctrl+q works again.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
