### PR TITLE
Fix nestedPackage error when exporting all diagrams to PDF

### DIFF
--- a/gaphor/plugins/diagramexport/exportall.py
+++ b/gaphor/plugins/diagramexport/exportall.py
@@ -12,7 +12,7 @@ def pkg2dir(package):
     name: list[str] = []
     while package:
         name.insert(0, package.name)
-        package = package.nestingPackage
+        package = package.owningPackage
     return "/".join(name)
 
 


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->
L15 of exportAll.py refered to nestedPackage not owningPackage

### PR Checklist

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [ ] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3825

### What is the new behavior?
Diagrams now export as expected. 

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
