### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/org.gaphor.Gaphor.desktop
+++ b/data/org.gaphor.Gaphor.desktop
@@ -11,6 +11,7 @@ Comment[ru]=Простой инструмент моделирования
 Comment[it]=Lo strumento di modellazione semplice
 Exec=gaphor %f
 Icon=org.gaphor.Gaphor
+DBusActivatable=true
 Terminal=false
 Type=Application
 Categories=GTK;GNOME;Development;ProjectManagement;

--- a/data/org.gaphor.Gaphor.service
+++ b/data/org.gaphor.Gaphor.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.gaphor.Gaphor
+Exec=/usr/bin/gaphor --gapplication-service


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

<!-- Please add an overview of the PR here -->
Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Gaphor is not launchable via D-Bus, so application launchers could able to launch it only by executing the launcher script.

Issue Number: N/A

### What is the new behavior?
Application launchers that support activating apps via D-Bus are able to do that for Gaphor.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The file needs to be installed into the following path, otherwise the desktop launcher won't work:
/usr/share/dbus-1/services/org.gaphor.Gaphor.service

### Other information
