### PR TITLE
Styling tweaks

### DIFF
--- a/gaphor/ui/diagramview.py
+++ b/gaphor/ui/diagramview.py
@@ -62,6 +62,7 @@ def _trigger_signal(signal_name):
 
 
 if hasattr(DiagramView, "install_action"):
+    DiagramView.set_css_name("diagramview")
     # Deal with Gtk being mocked when generating docs
     DiagramView.install_action("clipboard.cut", None, _trigger_signal("cut-clipboard"))
     DiagramView.install_action(

--- a/gaphor/ui/elementeditor.ui
+++ b/gaphor/ui/elementeditor.ui
@@ -36,7 +36,6 @@
     </child>
     <child>
       <object class="GtkStack" id="tips">
-        <property name="transition-type">crossfade</property>
         <child>
           <object class="GtkStackPage">
             <property name="name">tips</property>

--- a/gaphor/ui/styling-macos.css
+++ b/gaphor/ui/styling-macos.css
@@ -9,6 +9,10 @@
  * See: https://gitlab.gnome.org/GNOME/gtk/-/issues/6255
  */
 
+:root {
+  font-size: 13pt;
+}
+
 .csd {
   box-shadow: none;
   border-radius: 0;


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When tips are not shown, unselecting all elements fades out the tips text (again).

The font for labels and such on macOS is too small: 12pt (user) vs 13pt (system) font size. See https://developer.apple.com/design/human-interface-guidelines/typography#macOS.

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

