### PR TITLE
Resolve warnings of Logger library

### DIFF
--- a/gaphor/core/modeling/diagram.py
+++ b/gaphor/core/modeling/diagram.py
@@ -110,7 +110,7 @@ def attrstr(obj):
         return "true" if obj else ""
     elif isinstance(obj, Base):
         return obj.__class__.__name__.lower()
-    log.warn(
+    log.warning(
         f'Can not make a string out of {obj}, returning "". Please raise an issue.'
     )
     return ""

--- a/gaphor/entrypoint.py
+++ b/gaphor/entrypoint.py
@@ -54,7 +54,7 @@ def init_entry_points(
                 if depcls:
                     kwargs[param_name] = init(param_name, depcls)
                 elif param.default is inspect.Parameter.empty:
-                    logger.warn(
+                    logger.warning(
                         "Entrypoint %s parameter %s does not reference a resolved dependency",
                         name,
                         param_name,


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
The `logger.warn()` method is deprecated:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

Issue Number: N/A

### What is the new behavior?
This PR resolves the deprecation warnings of the `logger` library.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
