### PR TITLE
Message name align

### DIFF
--- a/gaphor/UML/interactions/interactionsconnect.py
+++ b/gaphor/UML/interactions/interactionsconnect.py
@@ -13,7 +13,7 @@ from gaphor.UML.interactions.message import MessageItem
 def get_connected(item, handle) -> Presentation[UML.Element] | None:
     """Get item connected to a handle."""
     if cinfo := item.diagram.connections.get_connection(handle):
-        return cinfo.connected  # type: ignore[no-any-return] # noqa: F723
+        return cinfo.connected  # type: ignore[no-any-return]
     return None
 
 

--- a/gaphor/UML/interactions/message.py
+++ b/gaphor/UML/interactions/message.py
@@ -57,7 +57,7 @@ from gaphor.diagram.presentation import (
     get_center_pos,
     text_name,
 )
-from gaphor.diagram.shapes import Box, cairo_state, stroke
+from gaphor.diagram.shapes import Box, VerticalAlign, cairo_state, stroke
 from gaphor.diagram.support import represents
 from gaphor.UML.compartments import text_stereotypes
 from gaphor.UML.interactions.lifeline import LifelineItem
@@ -89,6 +89,7 @@ class MessageItem(Named, LinePresentation[UML.Message]):
                 text_stereotypes(self),
                 text_name(self),
             ),
+            middle_valign=VerticalAlign.TOP,
         )
         self.handles()[1].pos = (40, 0)
 

--- a/gaphor/UML/umllex.py
+++ b/gaphor/UML/umllex.py
@@ -136,7 +136,7 @@ parameters_pat = compile(
 )
 
 # Lifeline:
-#  [name] [: type]  # noqa: E800
+#  [name] [: type]
 lifeline_pat = compile(f"^{name_subpat}{type_subpat}{mult_subpat}{garbage_subpat}")
 
 
@@ -356,7 +356,7 @@ def parse_lifeline(el: uml.Lifeline, s: str) -> None:
         if t := g("type"):
             el.name += f": {t}"
         # In the near future the data model should be extended with
-        # Lifeline.represents: ConnectableElement  # noqa: E800
+        # Lifeline.represents: ConnectableElement
 
 
 def render_lifeline(el: uml.Lifeline) -> str:

--- a/gaphor/UML/umloverrides.py
+++ b/gaphor/UML/umloverrides.py
@@ -38,8 +38,8 @@ def extension_metaclass(self):
 
 
 # Don't use derived() now, it can not deal with a [0..1] property derived from a [0..*] property.
-# Extension.metaclass = derived(Extension, 'metaclass', Class, 0, 1, Extension.ownedEnd, Association.memberEnd)  # noqa: E800
-# Extension.metaclass.filter = extension_metaclass  # noqa: E800
+# Extension.metaclass = derived(Extension, 'metaclass', Class, 0, 1, Extension.ownedEnd, Association.memberEnd)
+# Extension.metaclass.filter = extension_metaclass
 uml.Extension.metaclass = property(extension_metaclass, doc=extension_metaclass.__doc__)
 
 

--- a/gaphor/diagram/connectors.py
+++ b/gaphor/diagram/connectors.py
@@ -71,7 +71,7 @@ class BaseConnector:
     def get_connected(self, handle: Handle) -> Presentation[Base] | None:
         """Get item connected to a handle."""
         if cinfo := self.diagram.connections.get_connection(handle):
-            return cinfo.connected  # type: ignore[no-any-return] # noqa: F723
+            return cinfo.connected  # type: ignore[no-any-return]
         return None
 
     def allow(self, handle: Handle, port: Port) -> bool:

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -267,7 +267,7 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
         self.update_orthogonal_constraints()
 
     def update_shape_bounds(self, context):
-        def shape_bounds(shape, align):
+        def shape_bounds(shape: Shape | None, align: TextAlign):
             if shape:
                 size = shape.size(context)
                 x, y = text_point_at_line(points, size, align)

--- a/gaphor/diagram/presentation.py
+++ b/gaphor/diagram/presentation.py
@@ -16,7 +16,12 @@ from gaphor.core.modeling.event import AttributeUpdated, RevertibleEvent
 from gaphor.core.modeling.presentation import Presentation, S, literal_eval
 from gaphor.core.modeling.properties import attribute
 from gaphor.diagram.shapes import CssNode, Shape, Text, stroke, traverse_css_nodes
-from gaphor.diagram.text import TextAlign, middle_segment, text_point_at_line
+from gaphor.diagram.text import (
+    TextAlign,
+    VerticalAlign,
+    middle_segment,
+    text_point_at_line,
+)
 
 DEFAULT_HEIGHT = 50
 DEFAULT_WIDTH = 100
@@ -214,12 +219,14 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
         shape_head: Shape | None = None,
         shape_middle: Shape | None = None,
         shape_tail: Shape | None = None,
+        middle_valign: VerticalAlign | None = None,
     ):
         super().__init__(connections=diagram.connections, diagram=diagram, id=id)  # type: ignore[call-arg]
 
         self._shape_head = shape_head
         self._shape_middle = shape_middle
         self._shape_tail = shape_tail
+        self._middle_valign = middle_valign
 
         self.fuzziness = 4
         self._shape_head_rect = None
@@ -267,16 +274,20 @@ class LinePresentation(gaphas.Line, HandlePositionUpdate, Presentation[S]):
         self.update_orthogonal_constraints()
 
     def update_shape_bounds(self, context):
-        def shape_bounds(shape: Shape | None, align: TextAlign):
+        def shape_bounds(
+            shape: Shape | None, align: TextAlign, valign: VerticalAlign | None
+        ):
             if shape:
                 size = shape.size(context)
-                x, y = text_point_at_line(points, size, align)
+                x, y = text_point_at_line(points, size, align, valign)
                 return Rectangle(x, y, *size)
 
         points = [h.pos for h in self.handles()]
-        self._shape_head_rect = shape_bounds(self._shape_head, TextAlign.LEFT)
-        self._shape_middle_rect = shape_bounds(self._shape_middle, TextAlign.CENTER)
-        self._shape_tail_rect = shape_bounds(self._shape_tail, TextAlign.RIGHT)
+        self._shape_head_rect = shape_bounds(self._shape_head, TextAlign.LEFT, None)
+        self._shape_middle_rect = shape_bounds(
+            self._shape_middle, TextAlign.CENTER, self._middle_valign
+        )
+        self._shape_tail_rect = shape_bounds(self._shape_tail, TextAlign.RIGHT, None)
 
     def css_nodes(self) -> Iterator[CssNode]:
         if self._shape_head:

--- a/gaphor/diagram/shapes.py
+++ b/gaphor/diagram/shapes.py
@@ -519,8 +519,6 @@ class Text:
     def draw(self, context: DrawContext, bounding_box: Rectangle):
         """Draw the text, return the location and size."""
         style = context.style
-        min_w = max(style.get("min-width", 0), bounding_box.width)
-        min_h = max(style.get("min-height", 0), bounding_box.height)
         text_box = rectangle_shrink(bounding_box, style.get("padding", DEFAULT_PADDING))
 
         with cairo_state(context.cairo) as cr:
@@ -532,7 +530,7 @@ class Text:
             layout = self._layout
             cr.move_to(text_box.x, text_box.y)
             layout.set(font=style)
-            layout.show_layout(cr, text_box.width, default_size=(min_w, min_h))
+            layout.show_layout(cr, text_box.width)
 
 
 class CssNode:

--- a/gaphor/diagram/tests/fixtures.py
+++ b/gaphor/diagram/tests/fixtures.py
@@ -34,7 +34,7 @@ def disconnect(line, handle):
 def get_connected(item, handle):
     assert handle in item.handles()
     if cinfo := item.diagram.connections.get_connection(handle):
-        return cinfo.connected  # type: ignore[no-any-return] # noqa: F723
+        return cinfo.connected  # type: ignore[no-any-return]
     return None
 
 

--- a/gaphor/diagram/tests/test_text.py
+++ b/gaphor/diagram/tests/test_text.py
@@ -20,7 +20,7 @@ from gaphor.diagram.text import (
     ],
 )
 def test_point_at_left_top(points, point_at_line):
-    x, y = text_point_at_line(points, (10, 5), TextAlign.LEFT)
+    x, y = text_point_at_line(points, (10, 5), TextAlign.LEFT, None)
 
     assert x == point_at_line[0]
     assert y == point_at_line[1]
@@ -36,7 +36,7 @@ def test_point_at_left_top(points, point_at_line):
     ],
 )
 def test_point_at_right_top(points, point_at_line):
-    x, y = text_point_at_line(points, (10, 5), TextAlign.RIGHT)
+    x, y = text_point_at_line(points, (10, 5), TextAlign.RIGHT, None)
 
     assert x == point_at_line[0]
     assert y == point_at_line[1]
@@ -61,7 +61,7 @@ def test_point_at_right_top(points, point_at_line):
 )
 def test_point_at_center_bottom(points, point_at_line):
     """Test aligned at the line text position calculation, horizontal mode."""
-    x, y = text_point_at_line(points, (10, 5), TextAlign.CENTER)
+    x, y = text_point_at_line(points, (10, 5), TextAlign.CENTER, None)
 
     assert x == pytest.approx(point_at_line[0])
     assert y == pytest.approx(point_at_line[1])

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -15,6 +15,7 @@ from gaphor.core.styling import (
     Style,
     TextAlign,
     TextDecoration,
+    VerticalAlign,
 )
 
 Size = tuple[Number, Number]
@@ -136,13 +137,19 @@ class Layout:
             PangoCairo.show_layout(cr, layout)
 
 
-def text_point_at_line(points: list[Pos], size: Size, text_align: TextAlign) -> Pos:
+def text_point_at_line(
+    points: list[Pos],
+    size: Size,
+    text_align: TextAlign,
+    vertial_align: VerticalAlign | None,
+) -> Pos:
     """Provide a position (x, y) to draw a text close to a line.
 
     Parameters:
      - points:  the line points, a list of (x, y) points
      - size:    size of the text, a (width, height) tuple
      - text_align: alignment to the line: left, beginning of the line, center, middle and right: end of the line
+     - vertical_align: Vertical alignment, only applicable for a center aligned text
     """
 
     if text_align == TextAlign.LEFT:
@@ -151,7 +158,7 @@ def text_point_at_line(points: list[Pos], size: Size, text_align: TextAlign) -> 
         x, y = _text_point_at_line_end(size, p0, p1)
     elif text_align == TextAlign.CENTER:
         p0, p1 = middle_segment(points)
-        x, y = _text_point_at_line_center(size, p0, p1)
+        x, y = _text_point_at_line_center(size, p0, p1, vertial_align)
     elif text_align == TextAlign.RIGHT:
         p0 = points[-1]
         p1 = points[-2]
@@ -214,7 +221,9 @@ PADDING_HINT = (1, 1, -1)
 EPSILON = 1e-6
 
 
-def _text_point_at_line_center(size: Size, p1: Pos, p2: Pos) -> Pos:
+def _text_point_at_line_center(
+    size: Size, p1: Pos, p2: Pos, vertical_align: VerticalAlign | None
+) -> Pos:
     """Calculate position of the text relative to a line defined by points p1
     and p2.
 
@@ -249,6 +258,11 @@ def _text_point_at_line_center(size: Size, p1: Pos, p2: Pos) -> Pos:
 
         x = x0 - w2
         y = y0 + hint + ofs
+        y = (
+            (y0 - hint - ofs - height)
+            if vertical_align == VerticalAlign.TOP
+            else (y0 + hint + ofs)
+        )
     else:
         # much better in case of vertical lines
 

--- a/gaphor/diagram/text.py
+++ b/gaphor/diagram/text.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
+from cairo import Context as CairoContext
 from gaphas.canvas import instant_cairo_context
 from gaphas.painter.freehand import FreeHandCairoContext
+from gaphas.types import Pos
 from gi.repository import Pango, PangoCairo
 
-from gaphor.core.styling import FontStyle, FontWeight, Style, TextAlign, TextDecoration
+from gaphor.core.styling import (
+    FontStyle,
+    FontWeight,
+    Number,
+    Style,
+    TextAlign,
+    TextDecoration,
+)
+
+Size = tuple[Number, Number]
 
 
 class Layout:
@@ -14,7 +25,7 @@ class Layout:
         self,
         text: str = "",
         font: Style | None = None,
-        width: int | None = None,
+        width: Number | None = None,
         text_align: TextAlign = TextAlign.CENTER,
         default_size: tuple[int, int] = (0, 0),
     ):
@@ -23,7 +34,7 @@ class Layout:
             tuple[str, float | str, FontWeight | None, FontStyle | None] | None
         ) = None
         self.text = ""
-        self.width = -1
+        self.width: Number = -1
         self.default_size = default_size
 
         if text:
@@ -34,10 +45,16 @@ class Layout:
             self.set_font(font)
         self.set_alignment(text_align)
 
-    def set(self, text=None, font=None, width=None, text_align=None):
+    def set(
+        self,
+        text: str | None = None,
+        font: Style | None = None,
+        width: Number | None = None,
+        text_align: TextAlign | None = None,
+    ) -> None:
         # Since text expressions can return False, we should also accommodate for that
         if text not in (None, False):
-            self.set_text(text)
+            self.set_text(text)  # type: ignore[arg-type]
         if font:
             self.set_font(font)
         if width is not None:
@@ -89,7 +106,7 @@ class Layout:
             self.text = text
             self.layout.set_text(self.text, length=-1)
 
-    def set_width(self, width: int) -> None:
+    def set_width(self, width: Number) -> None:
         self.width = width
         if width == -1:
             self.layout.set_width(-1)
@@ -105,10 +122,11 @@ class Layout:
         self.set_width(self.width)
         return self.layout.get_pixel_size()  # type: ignore[no-any-return]
 
-    def show_layout(self, cr, width=None, default_size=None):
-        layout = self.layout
+    def show_layout(self, cr: CairoContext, width: Number | None = None) -> None:
         if not self.text:
-            return default_size or self.default_size
+            return None
+
+        layout = self.layout
         if width is not None:
             layout.set_width(min(int(width * Pango.SCALE), 2147483647))
 
@@ -118,7 +136,7 @@ class Layout:
             PangoCairo.show_layout(cr, layout)
 
 
-def text_point_at_line(points, size, text_align):
+def text_point_at_line(points: list[Pos], size: Size, text_align: TextAlign) -> Pos:
     """Provide a position (x, y) to draw a text close to a line.
 
     Parameters:
@@ -142,14 +160,14 @@ def text_point_at_line(points, size, text_align):
     return x, y
 
 
-def middle_segment(points):
+def middle_segment(points: list[Pos]) -> Pos:
     """Get middle line segment."""
     m = len(points) // 2
     assert m >= 1 and m < len(points)
     return points[m - 1], points[m]
 
 
-def _text_point_at_line_end(size, p1, p2):
+def _text_point_at_line_end(size: Size, p1: Pos, p2: Pos) -> Pos:
     """Calculate position of the text relative to a line defined by points p1
     and p2.
 
@@ -196,7 +214,7 @@ PADDING_HINT = (1, 1, -1)
 EPSILON = 1e-6
 
 
-def _text_point_at_line_center(size, p1, p2):
+def _text_point_at_line_center(size: Size, p1: Pos, p2: Pos) -> Pos:
     """Calculate position of the text relative to a line defined by points p1
     and p2.
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Issue Number: fixes #3909 

### What is the new behavior?

Label for sequence diagram messages are now drawn above the message.

![image](https://github.com/user-attachments/assets/1e4eb4d8-0376-4ba4-998d-40ac2ae8840a)

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Also added some extra type information and removed some unused code.

BTW. The image was copied straight out of Gaphor into the browser. Works like a charm 😄 