### PR TITLE
Align text vertically if package is contained

### DIFF
--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -249,6 +249,7 @@ state compartment:first-child {
 
 :has(compartment + compartment),
 :has(regions),
+:has(package),
 :not([children=""]):has(compartment),
 :not([children=""]) > compartment {
   justify-content: start;


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: issue #3906 

### What is the new behavior?

Parent package name is vertically aligned at the top:

![image](https://github.com/user-attachments/assets/1c2caf8b-dd8b-423a-8dba-cd5e0df87d09)

### Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

This is a quick fix in the CSS. I'm considering to give all elements an "element" class, so we can easily find out if an element is contained: the diagram structure for CSS also includes name and stereotype elements, which should be excluded if we want to see if an element contains another element.
