### PR TITLE
Fix build error on macOS

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -206,6 +206,15 @@ jobs:
           # https://github.com/actions/runner-images/issues/9966
           brew install --overwrite python@${python_version}
           brew install gtksourceview5 libadwaita adwaita-icon-theme gobject-introspection graphviz create-dmg
+      - name: Workaround for broken svg pixbuf loader
+        # Force SVG loader to the gdk-pixbuf loader cache. This is broken on Homebrew (July 2nd 2025)
+        # See https://gitlab.gnome.org/GNOME/librsvg/-/issues/1161, https://github.com/Homebrew/brew/pull/9102
+        run: >
+          test ! -d /opt/homebrew/lib || {
+            install_name_tool -change @rpath/librsvg-2.2.dylib /opt/homebrew/opt/librsvg/lib/librsvg-2.2.dylib /opt/homebrew/opt/librsvg/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader_svg.so
+            codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime /opt/homebrew/opt/librsvg/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader_svg.so
+            GDK_PIXBUF_MODULEDIR=/opt/homebrew/lib/gdk-pixbuf-2.0/2.10.0/loaders gdk-pixbuf-query-loaders --update-cache
+          }
       - name: Ensure Homebrew Library Path
         run: test ! -d /opt/homebrew/lib || echo "DYLD_LIBRARY_PATH=/opt/homebrew/lib" >> $GITHUB_ENV
         shell: bash


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

The self-test on macOS also shows something seemingly related:

```
(gaphor:9836): Gtk-WARNING **: 12:53:06.960: Theme parser error: (null): Error loading image 
                                             'resource:///org/gnome/Adwaita/styles/assets/devel-symbolic.svg': 
(gaphor:9836): Gtk-CRITICAL **: 12:53:07.504: gtk_css_section_get_bytes: assertion 'section != NULL' failed
```

Something's off with the produced app as well:

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/3fc29ce7-1195-4a11-a197-226caf5b6382" />

Icons are bundled, though:

```
./Resources/gaphor/ui/icons/hicolor/scalable/actions/gaphor-abstract-operational-situation-symbolic.svg
./Resources/gaphor/ui/icons/hicolor/scalable/actions/gaphor-accept-event-action-symbolic.svg
...
./Resources/share/icons/Adwaita/symbolic/actions/format-indent-more-symbolic.svg
./Resources/share/icons/Adwaita/symbolic/actions/format-justify-center-symbolic.svg
```

It looks like GdkPixbuf is not picking up the rsvg loader. I updated gdkpixbuf's cache and now I can reproduce it on my machine as well (`/opt/homebrew/opt/gdk-pixbuf/bin/gdk-pixbuf-query-loaders --update-cache`).
It's taking it from `LoaderDir = /opt/homebrew/Cellar/gdk-pixbuf/2.42.12_1/lib/gdk-pixbuf-2.0/2.10.0/loaders`, which only contains the standard loaders, but not svg, since that's provided by librsvg.

Related PR's on Homebrew have been merged beginning of March 🤷 