### PR TITLE
Fix quit behavior for greeter

### DIFF
--- a/gaphor/application.py
+++ b/gaphor/application.py
@@ -124,10 +124,10 @@ class Application(Service, ActionProvider):
             self._active_session = session
 
         @event_handler(SessionShutdown)
-        def on_session_shutdown(_event):
+        def on_session_shutdown(event: SessionShutdown):
             self.shutdown_session(session)
-            if not self._sessions and not (
-                self._gtk_app and self._gtk_app.get_windows()
+            if not self._sessions and (
+                event.quitting or not (self._gtk_app and self._gtk_app.get_windows())
             ):
                 self.shutdown()
 
@@ -174,9 +174,9 @@ class Application(Service, ActionProvider):
         for session in list(self._sessions):
             self._active_session = session
             event_manager = session.get_service("event_manager")
-            event_manager.handle(SessionShutdownRequested())
+            event_manager.handle(SessionShutdownRequested(quitting=True))
 
-        if not self._sessions and not (self._gtk_app and self._gtk_app.get_windows()):
+        if not self._sessions:
             self.shutdown()
 
     def all(self, base: type[T]) -> Iterator[tuple[str, T]]:

--- a/gaphor/event.py
+++ b/gaphor/event.py
@@ -64,15 +64,21 @@ class ActiveSessionChanged:
     service: Service
 
 
+@dataclass
 class SessionShutdownRequested:
     """When the application is asked to terminate, it will inform all sessions.
 
     The user can then save his/her work.
     """
 
+    quitting: bool
 
+
+@dataclass
 class SessionShutdown:
     """The session is emitting this event when it's ready to shut down."""
+
+    quitting: bool
 
 
 @dataclass

--- a/gaphor/ui/filemanager.py
+++ b/gaphor/ui/filemanager.py
@@ -210,7 +210,7 @@ class FileManager(Service, ActionProvider):
                 ),
                 window=self.parent_window,
             )
-            self.event_manager.handle(SessionShutdown())
+            self.event_manager.handle(SessionShutdown(quitting=False))
 
     async def resolve_merge_conflict(self, filename: Path):
         temp_dir = tempfile.TemporaryDirectory()
@@ -229,7 +229,7 @@ class FileManager(Service, ActionProvider):
         if split:
             answer = await resolve_merge_conflict_dialog(self.parent_window)
             if answer == "cancel":
-                self.event_manager.handle(SessionShutdown())
+                self.event_manager.handle(SessionShutdown(quitting=False))
             elif answer == "current":
                 await self.load(current_filename)
             elif answer == "incoming":
@@ -254,7 +254,7 @@ class FileManager(Service, ActionProvider):
                 ),
                 window=self.parent_window,
             )
-            self.event_manager.handle(SessionShutdown())
+            self.event_manager.handle(SessionShutdown(quitting=False))
 
     async def save(self, filename):
         """Save the current model to the specified file name.
@@ -343,7 +343,7 @@ class FileManager(Service, ActionProvider):
 
     @event_handler(SessionShutdownRequested)
     async def _on_session_shutdown_request(
-        self, _event: SessionShutdownRequested
+        self, event: SessionShutdownRequested
     ) -> None:
         """Ask user to close window if the model has changed.
 
@@ -352,7 +352,7 @@ class FileManager(Service, ActionProvider):
         """
 
         def confirm_shutdown():
-            self.event_manager.handle(SessionShutdown())
+            self.event_manager.handle(SessionShutdown(quitting=event.quitting))
 
         if self.main_window.model_changed:
             answer = await save_changes_before_close_dialog(self.parent_window)

--- a/gaphor/ui/mainwindow.py
+++ b/gaphor/ui/mainwindow.py
@@ -328,7 +328,7 @@ class MainWindow(Service, ActionProvider):
         self.event_manager.handle(TransactionClosed())
 
     def _on_window_close_request(self, _window, _event=None):
-        self.event_manager.handle(SessionShutdownRequested())
+        self.event_manager.handle(SessionShutdownRequested(quitting=False))
         return True
 
     def _on_window_size_changed(self, window, _gspec):

--- a/gaphor/ui/tests/test_lifecycle.py
+++ b/gaphor/ui/tests/test_lifecycle.py
@@ -41,7 +41,7 @@ def test_active_window_changed(application):
 def test_session_shutdown(application):
     session1, session2 = two_sessions(application)
 
-    session2.get_service("event_manager").handle(SessionShutdown())
+    session2.get_service("event_manager").handle(SessionShutdown(quitting=False))
 
     assert len(application.sessions) == 1
     assert session1 in application.sessions
@@ -58,8 +58,8 @@ def test_all_sessions_shut_down(application):
 
     session1, session2 = two_sessions(application)
 
-    session1.get_service("event_manager").handle(SessionShutdown())
-    session2.get_service("event_manager").handle(SessionShutdown())
+    session1.get_service("event_manager").handle(SessionShutdown(quitting=False))
+    session2.get_service("event_manager").handle(SessionShutdown(quitting=False))
 
     assert len(application.sessions) == 0
     assert quit_events

--- a/tests/test_session_recovery.py
+++ b/tests/test_session_recovery.py
@@ -158,7 +158,7 @@ async def test_no_recovery_for_properly_closed_session(
     with Transaction(event_manager):
         diagram = element_factory.create(Diagram)
 
-    event_manager.handle(SessionShutdown())
+    event_manager.handle(SessionShutdown(quitting=False))
 
     new_session = application.recover_session(
         session_id=session.session_id, filename=model_file


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Ctrl-Q didn't work when the greeter window was opened. The quit logic checked of there were any non-session windows opened and then refused to quit.

Issue Number: N/A

### What is the new behavior?

It has been fixed by providing a bit more context to session shutdown events. They can now tell the event is intended to quit the application.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
