### PR TITLE
Update activity parameter node name and types in Model browser 

### DIFF
--- a/gaphor/UML/tests/test_treemodel.py
+++ b/gaphor/UML/tests/test_treemodel.py
@@ -266,34 +266,3 @@ def test_element_with_member_and_no_owner(tree_model, element_factory):
     association_model = tree_model.branches.get(association_item)
 
     assert property_item in association_model.elements
-
-
-def test_parameter_alone_displays(tree_model, element_factory):
-    element = element_factory.create(UML.Operation)
-    parameter = element_factory.create(UML.Parameter)
-    element.ownedParameter.append(parameter)
-
-    tree_model.add_element(element)
-    element_item = tree_model.tree_item_for_element(element)
-    tree_model.child_model(element_item)
-    property_item = tree_model.tree_item_for_element(parameter)
-
-    assert property_item.element is parameter
-
-
-def test_parameter_with_activity_node_hidden(tree_model, element_factory):
-    element = element_factory.create(UML.Activity)
-    parameter = element_factory.create(UML.Parameter)
-    act_param_node = element_factory.create(UML.ActivityParameterNode)
-    act_param_node.parameter = parameter
-    element.ownedParameter.append(parameter)
-    element.node.append(act_param_node)
-
-    assert len(element.ownedElement.items) == 2
-
-    tree_model.add_element(element)
-    element_item = tree_model.tree_item_for_element(element)
-    tree_model.child_model(element_item)
-    property_item = tree_model.tree_item_for_element(parameter)
-
-    assert property_item is None

--- a/gaphor/UML/tests/test_treemodel.py
+++ b/gaphor/UML/tests/test_treemodel.py
@@ -266,3 +266,34 @@ def test_element_with_member_and_no_owner(tree_model, element_factory):
     association_model = tree_model.branches.get(association_item)
 
     assert property_item in association_model.elements
+
+
+def test_parameter_alone_displays(tree_model, element_factory):
+    element = element_factory.create(UML.Operation)
+    parameter = element_factory.create(UML.Parameter)
+    element.ownedParameter.append(parameter)
+
+    tree_model.add_element(element)
+    element_item = tree_model.tree_item_for_element(element)
+    tree_model.child_model(element_item)
+    property_item = tree_model.tree_item_for_element(parameter)
+
+    assert property_item.element is parameter
+
+
+def test_parameter_with_activity_node_hidden(tree_model, element_factory):
+    element = element_factory.create(UML.Activity)
+    parameter = element_factory.create(UML.Parameter)
+    act_param_node = element_factory.create(UML.ActivityParameterNode)
+    act_param_node.parameter = parameter
+    element.ownedParameter.append(parameter)
+    element.node.append(act_param_node)
+
+    assert len(element.ownedElement.items) == 2
+
+    tree_model.add_element(element)
+    element_item = tree_model.tree_item_for_element(element)
+    tree_model.child_model(element_item)
+    property_item = tree_model.tree_item_for_element(parameter)
+
+    assert property_item is None

--- a/gaphor/UML/tests/test_umlfmt.py
+++ b/gaphor/UML/tests/test_umlfmt.py
@@ -170,3 +170,22 @@ def test_pin(factory):
     recipes.set_multiplicity_upper_value(pin, "*")
 
     assert format(pin) == "foo: MyClass[1..*]"
+
+
+@pytest.mark.parametrize(
+    "text,formatted_text",
+    [
+        ("", ""),
+        ("param", "in param"),
+        ("in param: str", "in param: str"),
+        ("param = val", "in param = val"),
+    ],
+)
+def test_activity_parameter_node(factory, text, formatted_text):
+    """Test simple operation formatting."""
+    p = factory.create(UML.Parameter)
+    n = factory.create(UML.ActivityParameterNode)
+    n.parameter = p
+    parse(p, text)
+
+    assert formatted_text == format(n)

--- a/gaphor/UML/treemodel.py
+++ b/gaphor/UML/treemodel.py
@@ -205,12 +205,18 @@ class TreeModel:
             new_branch = Branch()
             self.branches[item] = new_branch
             for e in owned_elements:
-                new_branch.append(e)
+                if self.should_show(e):
+                    new_branch.append(e)
             return new_branch.elements
         return None
 
     def tree_item_sort(self, a, b) -> int:
         return tree_item_sort(a, b)
+
+    def should_show(self, element: Base) -> bool:
+        if isinstance(element, UML.Parameter):
+            return element.activityParameterNode.isEmpty() is True
+        return True
 
     def should_expand(self, item: TreeItem, element: Base) -> bool:
         return isinstance(element, UML.Relationship) and isinstance(

--- a/gaphor/UML/treemodel.py
+++ b/gaphor/UML/treemodel.py
@@ -186,17 +186,33 @@ class TreeModel:
     def root(self) -> Gio.ListStore:
         return self.branches[Root].elements
 
-    def sync(self, element):
-        if owner(element) and (tree_item := self.tree_item_for_element(element)):
-            tree_item.sync()
-            if self._on_sync:
-                self._on_sync()
-            if own := owner(element):
-                self.sync(own)
-            if isinstance(element, UML.Parameter) and element.activityParameterNode:
-                for node in element.activityParameterNode:
-                    self.sync(node)
-            # TODO: sync type
+    def sync(self, element, seen=None):
+        if seen is None:
+            seen = set()
+
+        if (
+            element in seen
+            or not owner(element)
+            or not (tree_item := self.tree_item_for_element(element))
+        ):
+            return
+
+        seen.add(element)
+        tree_item.sync()
+        if self._on_sync:
+            self._on_sync()
+
+        if own := owner(element):
+            self.sync(own, seen)
+
+        if isinstance(element, UML.Parameter) and element.activityParameterNode:
+            for node in element.activityParameterNode:
+                self.sync(node, seen)
+
+        if isinstance(element, UML.Type):
+            for e in self.element_factory.select(UML.TypedElement):
+                if e.type is element:
+                    self.sync(e, seen)
 
     def child_model(self, item: TreeItem) -> Gio.ListStore | None:
         """This method will create branches on demand (lazy)."""

--- a/gaphor/UML/umlfmt.py
+++ b/gaphor/UML/umlfmt.py
@@ -259,3 +259,12 @@ def format_include(el):
 def format_call_behavior_action_name(el):
     """Name conforms to UML2.5.1 16.3.4.1 naming description"""
     return el.behavior.name if el.behavior and not el.name else el.name or ""
+
+
+@format.register(UML.ActivityParameterNode)
+def format_activity_parameter_node_name(
+    el, direction=False, type=False, multiplicity=False, default=False
+):
+    if el.parameter is None:
+        return ""
+    return format_parameter(el.parameter, direction, type, multiplicity, default)


### PR DESCRIPTION
This feature builds on #3827.

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Related names in the model browser are not updated.

Issue Number: Fixes #3791, #2852. Closes #3827.

### What is the new behavior?

Synchronize related elements in the Model browser, so everything looks up to date.

I took @mvinca's PR and simplified it a bit. It now works for ActivityParameterNode's and Properties (any Typed Element).

This makes the UI behave more consistently. If I missed a case, I think it's best to just add it to `TreeModel.sync()`.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Thanks again @mvinca for your work. It helped a lot in shaping this solution.
