### PR TITLE
Enable the (New) Package menu item again

### DIFF
--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -401,7 +401,9 @@ def toplevel_popup_model(modeling_language) -> Gio.Menu:
     model = create_diagram_types_model(modeling_language)
 
     part = Gio.Menu.new()
-    part.append(gettext("New _Package"), "tree-view.create-package")
+    menu_item = Gio.MenuItem.new(gettext("Package"), "tree-view.create-element")
+    menu_item.set_attribute_value("target", GLib.Variant.new_string("package"))
+    part.append_item(menu_item)
     model.prepend_section(None, part)
     return model
 

--- a/gaphor/ui/modelbrowser.py
+++ b/gaphor/ui/modelbrowser.py
@@ -97,7 +97,6 @@ class ModelBrowser(UIComponent, ActionProvider):
         scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scrolled_window.set_child(self.tree_view)
 
-        apply_action_group(self, "tree-view", self.tree_view)
         apply_action_group(self, "selection", self.tree_view)
 
         self.tree_view.add_controller(
@@ -220,7 +219,7 @@ class ModelBrowser(UIComponent, ActionProvider):
             if el_type.id == id
         )
 
-    @action(name="tree-view.create-element")
+    @action(name="win.create-element")
     def tree_view_create_element(self, id: str):
         own = self.get_selected_element()
         element_def = self.element_type(id)
@@ -401,7 +400,7 @@ def toplevel_popup_model(modeling_language) -> Gio.Menu:
     model = create_diagram_types_model(modeling_language)
 
     part = Gio.Menu.new()
-    menu_item = Gio.MenuItem.new(gettext("Package"), "tree-view.create-element")
+    menu_item = Gio.MenuItem.new(gettext("Package"), "win.create-element")
     menu_item.set_attribute_value("target", GLib.Variant.new_string("package"))
     part.append_item(menu_item)
     model.prepend_section(None, part)
@@ -644,7 +643,7 @@ def create_element_types_model(modeling_language, element):
 
     for id, name, _, allowed_owning_elements in modeling_language.element_types:
         if isinstance(element, allowed_owning_elements):
-            menu_item = Gio.MenuItem.new(gettext(name), "tree-view.create-element")
+            menu_item = Gio.MenuItem.new(gettext(name), "win.create-element")
             menu_item.set_attribute_value("target", GLib.Variant.new_string(id))
             model.append_item(menu_item)
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The "New Package" popup menu item in the Model Browser is disabled.

Issue Number: fixes #3931

### What is the new behavior?

It works again. Dropped "New", as we did with all other items.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
