### PR TITLE
Only import classes from their authoritative model

### DIFF
--- a/gaphor/C4Model/c4model.py
+++ b/gaphor/C4Model/c4model.py
@@ -18,14 +18,14 @@ from gaphor.core.modeling.properties import (
 )
 
 
-from gaphor.UML.uml import Actor
-class Person(Actor):
+from gaphor.UML.uml import Actor as _Actor
+class Person(_Actor):
     description: _attribute[str] = _attribute("description", str)
     location: _attribute[str] = _attribute("location", str)
 
 
-from gaphor.UML.uml import Package
-class Container(Package):
+from gaphor.UML.uml import Package as _Package
+class Container(_Package):
     description: _attribute[str] = _attribute("description", str)
     location: _attribute[str] = _attribute("location", str)
     ownerContainer: relation_one[Container]
@@ -43,8 +43,8 @@ class Dependency(_Dependency):
     technology: _attribute[str] = _attribute("technology", str)
 
 
-from gaphor.UML.uml import Diagram
-class C4Diagram(Diagram):
+from gaphor.UML.uml import Diagram as _Diagram
+class C4Diagram(_Diagram):
     diagramType: _attribute[str] = _attribute("diagramType", str, default="c4")
 
 

--- a/gaphor/C4Model/c4model.py
+++ b/gaphor/C4Model/c4model.py
@@ -23,6 +23,7 @@ from gaphor.UML.uml import Package as _Package
 from gaphor.UML.uml import Dependency as _Dependency
 from gaphor.UML.uml import Diagram as _Diagram
 
+
 class Person(_Actor):
     description: _attribute[str] = _attribute("description", str)
     location: _attribute[str] = _attribute("location", str)

--- a/gaphor/C4Model/c4model.py
+++ b/gaphor/C4Model/c4model.py
@@ -19,12 +19,15 @@ from gaphor.core.modeling.properties import (
 
 
 from gaphor.UML.uml import Actor as _Actor
+from gaphor.UML.uml import Package as _Package
+from gaphor.UML.uml import Dependency as _Dependency
+from gaphor.UML.uml import Diagram as _Diagram
+
 class Person(_Actor):
     description: _attribute[str] = _attribute("description", str)
     location: _attribute[str] = _attribute("location", str)
 
 
-from gaphor.UML.uml import Package as _Package
 class Container(_Package):
     description: _attribute[str] = _attribute("description", str)
     location: _attribute[str] = _attribute("location", str)
@@ -38,12 +41,10 @@ class Database(Container):
     pass
 
 
-from gaphor.UML.uml import Dependency as _Dependency
 class Dependency(_Dependency):
     technology: _attribute[str] = _attribute("technology", str)
 
 
-from gaphor.UML.uml import Diagram as _Diagram
 class C4Diagram(_Diagram):
     diagramType: _attribute[str] = _attribute("diagramType", str, default="c4")
 

--- a/gaphor/C4Model/c4model.py
+++ b/gaphor/C4Model/c4model.py
@@ -53,7 +53,7 @@ class C4Diagram(_Diagram):
 
 Container.ownerContainer = association("ownerContainer", Container, upper=1, opposite="owningContainer")
 Container.owningContainer = association("owningContainer", Container, composite=True, opposite="ownerContainer")
-from gaphor.UML.uml import NamedElement
-NamedElement.namespace.add(Container.ownerContainer)  # type: ignore[attr-defined]
-from gaphor.UML.uml import Namespace
-Namespace.ownedMember.add(Container.owningContainer)  # type: ignore[attr-defined]
+from gaphor.UML.uml import NamedElement as _NamedElement
+_NamedElement.namespace.add(Container.ownerContainer)  # type: ignore[attr-defined]
+from gaphor.UML.uml import Namespace as _Namespace
+_Namespace.ownedMember.add(Container.owningContainer)  # type: ignore[attr-defined]

--- a/gaphor/RAAML/raaml.py
+++ b/gaphor/RAAML/raaml.py
@@ -18,23 +18,28 @@ from gaphor.core.modeling.properties import (
 )
 
 
-from gaphor.UML.uml import Class
-from gaphor.SysML.sysml import Block
-class Situation(Block, Class):
+from gaphor.UML.uml import Class as _Class
+from gaphor.SysML.sysml import Block as _Block
+from gaphor.SysML.sysml import DirectedRelationshipPropertyPath as _DirectedRelationshipPropertyPath
+from gaphor.UML.uml import Dependency as _Dependency
+from gaphor.UML.uml import State as _State
+from gaphor.UML.uml import Property as _Property
+from gaphor.UML.uml import DataType as _DataType
+from gaphor.UML.uml import Diagram as _Diagram
+
+class Situation(_Block, _Class):
     pass
 
 
-from gaphor.SysML.sysml import DirectedRelationshipPropertyPath
-from gaphor.UML.uml import Dependency
-class RelevantTo(Dependency, DirectedRelationshipPropertyPath):
+class RelevantTo(_Dependency, _DirectedRelationshipPropertyPath):
     pass
 
 
-class ControllingMeasure(Dependency, DirectedRelationshipPropertyPath):
-    affects: relation_many[Property]
+class ControllingMeasure(_Dependency, _DirectedRelationshipPropertyPath):
+    affects: relation_many[_Property]
 
 
-class Violates(Dependency):
+class Violates(_Dependency):
     pass
 
 
@@ -89,24 +94,23 @@ class AbstractRisk(Scenario):
     trigger: relation_many[AbstractEvent]
 
 
-class Detection(ControllingMeasure, Dependency):
+class Detection(ControllingMeasure, _Dependency):
     pass
 
 
-class Prevention(ControllingMeasure, Dependency):
+class Prevention(ControllingMeasure, _Dependency):
     pass
 
 
-class Mitigation(ControllingMeasure, Dependency):
+class Mitigation(ControllingMeasure, _Dependency):
     pass
 
 
-class Recommendation(ControllingMeasure, Dependency):
+class Recommendation(ControllingMeasure, _Dependency):
     pass
 
 
-from gaphor.UML.uml import State
-class FailureState(State):
+class FailureState(_State):
     pass
 
 
@@ -118,7 +122,7 @@ class FTATree(FTAElement, Scenario):
     topEvent: relation_one[EventDef]
 
 
-class Tree(Class):
+class Tree(_Class):
     pass
 
 
@@ -126,76 +130,75 @@ class EventDef(FTAElement):
     pass
 
 
-class Event(Class):
+class Event(_Class):
     pass
 
 
-class Gate(Class):
+class Gate(_Class):
     pass
 
 
-class DormantEvent(Class):
+class DormantEvent(_Class):
     pass
 
 
-class BasicEvent(Class):
+class BasicEvent(_Class):
     pass
 
 
-class ConditionalEvent(Class):
+class ConditionalEvent(_Class):
     pass
 
 
-class ZeroEvent(Class):
+class ZeroEvent(_Class):
     pass
 
 
-class HouseEvent(Class):
+class HouseEvent(_Class):
     pass
 
 
-class AND(Class):
+class AND(_Class):
     pass
 
 
-class OR(Class):
+class OR(_Class):
     pass
 
 
-class SEQ(Class):
+class SEQ(_Class):
     pass
 
 
-class XOR(Class):
+class XOR(_Class):
     pass
 
 
-class INHIBIT(Class):
+class INHIBIT(_Class):
     pass
 
 
-class MAJORITY_VOTE(Class):
+class MAJORITY_VOTE(_Class):
     pass
 
 
-class NOT(Class):
+class NOT(_Class):
     pass
 
 
-class IntermediateEvent(Class):
+class IntermediateEvent(_Class):
     pass
 
 
-class TopEvent(Class):
+class TopEvent(_Class):
     pass
 
 
-from gaphor.UML.uml import Property
-class TransferIn(Property):
+class TransferIn(_Property):
     pass
 
 
-class TransferOut(Class):
+class TransferOut(_Class):
     pass
 
 
@@ -231,7 +234,7 @@ class ZeroEventDef(EventDef):
     pass
 
 
-class Undeveloped(Class):
+class Undeveloped(_Class):
     pass
 
 
@@ -280,36 +283,35 @@ class UnsafeControlAction_Def(Situation):
     harmPotential: relation_many[HarmPotential]
 
 
-class Actuator(Property):
+class Actuator(_Property):
     pass
 
 
-from gaphor.UML.uml import DataType
 class Signal():
     pass
 
 
-class ControlAction(Class, DataType, Signal):
+class ControlAction(Signal, _Class, _DataType):
     pass
 
 
-class ControlStructure(Block, Class):
+class ControlStructure(_Block, _Class):
     pass
 
 
-class ControlledProcess(Property):
+class ControlledProcess(_Property):
     pass
 
 
-class Controller(Property):
+class Controller(_Property):
     pass
 
 
-class Feedback(Class, DataType, Signal):
+class Feedback(Signal, _Class, _DataType):
     pass
 
 
-class Sensor(Property):
+class Sensor(_Property):
     pass
 
 
@@ -321,11 +323,11 @@ class FailureMode():
     pass
 
 
-class UnsafeControlAction(Class, FailureMode):
+class UnsafeControlAction(FailureMode, _Class):
     pass
 
 
-class OperationalSituation(Class):
+class OperationalSituation(_Class):
     pass
 
 
@@ -403,7 +405,7 @@ class Less(AnyMalfunction):
     pass
 
 
-class MalfunctioningBehavior(Class, FailureMode):
+class MalfunctioningBehavior(FailureMode, _Class):
     pass
 
 
@@ -440,17 +442,16 @@ class Inverted(AnyMalfunction):
     pass
 
 
-from gaphor.UML.uml import Diagram
-class FTADiagram(Diagram):
+class FTADiagram(_Diagram):
     diagramType: _attribute[str] = _attribute("diagramType", str, default="fta")
 
 
-class STPADiagram(Diagram):
+class STPADiagram(_Diagram):
     diagramType: _attribute[str] = _attribute("diagramType", str, default="stpa")
 
 
 
-ControllingMeasure.affects = association("affects", Property)
+ControllingMeasure.affects = association("affects", _Property, composite=True)
 AnySituation.to = association("to", AnySituation, opposite="from_")
 AnySituation.from_ = association("from_", AnySituation, opposite="to")
 AbstractCause.error = association("error", DysfunctionalEvent, opposite="fault")

--- a/gaphor/RAAML/raaml.py
+++ b/gaphor/RAAML/raaml.py
@@ -27,6 +27,7 @@ from gaphor.UML.uml import Property as _Property
 from gaphor.UML.uml import DataType as _DataType
 from gaphor.UML.uml import Diagram as _Diagram
 
+
 class Situation(_Block, _Class):
     pass
 

--- a/gaphor/RAAML/raaml.py
+++ b/gaphor/RAAML/raaml.py
@@ -25,16 +25,16 @@ class Situation(Block, Class):
 
 
 from gaphor.SysML.sysml import DirectedRelationshipPropertyPath
-from gaphor.UML.uml import Dependency as _Dependency
-class RelevantTo(DirectedRelationshipPropertyPath, _Dependency):
+from gaphor.UML.uml import Dependency
+class RelevantTo(Dependency, DirectedRelationshipPropertyPath):
     pass
 
 
-class ControllingMeasure(DirectedRelationshipPropertyPath, _Dependency):
+class ControllingMeasure(Dependency, DirectedRelationshipPropertyPath):
     affects: relation_many[Property]
 
 
-class Violates(_Dependency):
+class Violates(Dependency):
     pass
 
 
@@ -89,7 +89,6 @@ class AbstractRisk(Scenario):
     trigger: relation_many[AbstractEvent]
 
 
-from gaphor.UML.uml import Dependency
 class Detection(ControllingMeasure, Dependency):
     pass
 
@@ -191,8 +190,8 @@ class TopEvent(Class):
     pass
 
 
-from gaphor.UML.uml import Property as _Property
-class TransferIn(_Property):
+from gaphor.UML.uml import Property
+class TransferIn(Property):
     pass
 
 
@@ -281,7 +280,6 @@ class UnsafeControlAction_Def(Situation):
     harmPotential: relation_many[HarmPotential]
 
 
-from gaphor.UML.uml import Property
 class Actuator(Property):
     pass
 
@@ -452,7 +450,7 @@ class STPADiagram(Diagram):
 
 
 
-ControllingMeasure.affects = association("affects", _Property, composite=True)
+ControllingMeasure.affects = association("affects", Property)
 AnySituation.to = association("to", AnySituation, opposite="from_")
 AnySituation.from_ = association("from_", AnySituation, opposite="to")
 AbstractCause.error = association("error", DysfunctionalEvent, opposite="fault")

--- a/gaphor/SysML/blocks/block.py
+++ b/gaphor/SysML/blocks/block.py
@@ -32,8 +32,8 @@ class BlockItem(Classified, ElementPresentation[Block]):
             "subject[UML:NamedElement].name"
         ).watch("subject[UML:NamedElement].name").watch(
             "subject[UML:NamedElement].namespace.name"
-        ).watch("subject[Classifier].isAbstract", self.update_shapes).watch(
-            "subject[Class].ownedAttribute.aggregation", self.update_shapes
+        ).watch("subject[UML:Classifier].isAbstract", self.update_shapes).watch(
+            "subject[UML:Class].ownedAttribute.aggregation", self.update_shapes
         )
         operation_watches(self, "Block")
         stereotype_watches(self)

--- a/gaphor/SysML/blocks/group.py
+++ b/gaphor/SysML/blocks/group.py
@@ -1,5 +1,6 @@
 from gaphor.diagram.group import group, ungroup
-from gaphor.SysML.sysml import Block, Property
+from gaphor.SysML.sysml import Block
+from gaphor.UML import Property
 
 
 @group.register(Block, Property)

--- a/gaphor/SysML/blocks/interfaceblock.py
+++ b/gaphor/SysML/blocks/interfaceblock.py
@@ -31,8 +31,8 @@ class InterfaceBlockItem(Classified, ElementPresentation[InterfaceBlock]):
             "subject[UML:NamedElement].name"
         ).watch("subject[UML:NamedElement].name").watch(
             "subject[UML:NamedElement].namespace.name"
-        ).watch("subject[Classifier].isAbstract", self.update_shapes).watch(
-            "subject[Class].ownedAttribute.aggregation", self.update_shapes
+        ).watch("subject[UML:Classifier].isAbstract", self.update_shapes).watch(
+            "subject[UML:Class].ownedAttribute.aggregation", self.update_shapes
         )
         operation_watches(self, "Block")
         stereotype_watches(self)

--- a/gaphor/SysML/blocks/property.py
+++ b/gaphor/SysML/blocks/property.py
@@ -16,12 +16,12 @@ class PropertyItem(Named, ElementPresentation[UML.Property]):
         super().__init__(diagram, id)
 
         self.watch("show_stereotypes", self.update_shapes)
-        self.watch("subject[Property].name")
-        self.watch("subject[Property].type.name")
-        self.watch("subject[Property].typeValue")
-        self.watch("subject[Property].lowerValue")
-        self.watch("subject[Property].upperValue")
-        self.watch("subject[Property].aggregation", self.update_shapes)
+        self.watch("subject[UML:Property].name")
+        self.watch("subject[UML:Property].type.name")
+        self.watch("subject[UML:Property].typeValue")
+        self.watch("subject[UML:Property].lowerValue")
+        self.watch("subject[UML:Property].upperValue")
+        self.watch("subject[UML:Property].aggregation", self.update_shapes)
         stereotype_watches(self)
 
     show_stereotypes: attribute[int] = attribute("show_stereotypes", int)

--- a/gaphor/SysML/blocks/tests/test_connectors.py
+++ b/gaphor/SysML/blocks/tests/test_connectors.py
@@ -19,7 +19,7 @@ def block_item(diagram, element_factory):
 @pytest.fixture
 def property_item(diagram, element_factory):
     type = element_factory.create(sysml.Block)
-    prop = diagram.create(PropertyItem, subject=element_factory.create(sysml.Property))
+    prop = diagram.create(PropertyItem, subject=element_factory.create(UML.Property))
     prop.subject.type = type
     return prop
 

--- a/gaphor/SysML/blocks/tests/test_group.py
+++ b/gaphor/SysML/blocks/tests/test_group.py
@@ -1,5 +1,6 @@
 from gaphor.diagram.group import group, ungroup
-from gaphor.SysML.sysml import Block, Property
+from gaphor.SysML.sysml import Block
+from gaphor.UML import Property
 
 
 def test_group(element_factory):

--- a/gaphor/SysML/propertypages.py
+++ b/gaphor/SysML/propertypages.py
@@ -202,7 +202,7 @@ class InterfaceBlockPage(PropertyPageBase):
             self.item.show_values = button.get_active()
 
 
-@PropertyPages.register(sysml.Property)
+@PropertyPages.register(UML.Property)
 class PropertyAggregationPropertyPage(PropertyPageBase):
     """An editor for Properties (a.k.a.
 
@@ -213,7 +213,7 @@ class PropertyAggregationPropertyPage(PropertyPageBase):
 
     AGGREGATION = ("none", "shared", "composite")
 
-    def __init__(self, subject: sysml.Property, event_manager):
+    def __init__(self, subject: UML.Property, event_manager):
         super().__init__()
         self.subject = subject
         self.event_manager = event_manager
@@ -240,13 +240,13 @@ class PropertyAggregationPropertyPage(PropertyPageBase):
 
 
 @PropertyPages.register(UML.Association)
-@PropertyPages.register(sysml.Connector)
+@PropertyPages.register(UML.Connector)
 class ItemFlowPropertyPage(PropertyPageBase):
     """Item Flow on Connectors."""
 
     order = 35
 
-    def __init__(self, subject: UML.Association | sysml.Connector, event_manager):
+    def __init__(self, subject: UML.Association | UML.Connector, event_manager):
         super().__init__()
         self.subject = subject
         self.event_manager = event_manager
@@ -254,7 +254,7 @@ class ItemFlowPropertyPage(PropertyPageBase):
     @property
     def information_flow(self):
         subject = self.subject
-        if isinstance(subject, sysml.Connector):
+        if isinstance(subject, UML.Connector):
             iflows = subject.informationFlow
         elif isinstance(subject, UML.Relationship):
             iflows = subject.abstraction
@@ -310,7 +310,7 @@ class ItemFlowPropertyPage(PropertyPageBase):
         iflow = self.information_flow
         with Transaction(self.event_manager):
             if active and not iflow:
-                if isinstance(subject, sysml.Connector):
+                if isinstance(subject, UML.Connector):
                     subject.informationFlow = create_item_flow(subject)
                 elif isinstance(subject, UML.Relationship):
                     subject.abstraction = create_item_flow(subject)
@@ -351,13 +351,13 @@ class ItemFlowPropertyPage(PropertyPageBase):
             )
 
 
-def create_item_flow(subject: UML.Association | sysml.Connector) -> sysml.ItemFlow:
+def create_item_flow(subject: UML.Association | UML.Connector) -> sysml.ItemFlow:
     iflow = subject.model.create(sysml.ItemFlow)
-    if isinstance(subject, sysml.Connector):
+    if isinstance(subject, UML.Connector):
         iflow.informationSource = subject.end[0].role
         iflow.informationTarget = subject.end[1].role
-    elif isinstance(subject, UML.Relationship):
+    elif isinstance(subject, UML.Association):
         iflow.informationSource = subject.memberEnd[0]
         iflow.informationTarget = subject.memberEnd[1]
-    iflow.itemProperty = subject.model.create(sysml.Property)
+    iflow.itemProperty = subject.model.create(UML.Property)
     return iflow

--- a/gaphor/SysML/requirements/requirement.py
+++ b/gaphor/SysML/requirements/requirement.py
@@ -34,7 +34,7 @@ class RequirementItem(Classified, ElementPresentation[Requirement]):
             "show_operations", self.update_shapes
         ).watch("subject[UML:NamedElement].name").watch(
             "subject[UML:NamedElement].namespace.name"
-        ).watch("subject[Classifier].isAbstract", self.update_shapes).watch(
+        ).watch("subject[UML:Classifier].isAbstract", self.update_shapes).watch(
             "subject[AbstractRequirement].externalId", self.update_shapes
         ).watch("subject[AbstractRequirement].text", self.update_shapes)
         attribute_watches(self, "Requirement")

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -401,17 +401,16 @@ DirectedRelationshipPropertyPath.sourcePropertyPath = association("sourcePropert
 DirectedRelationshipPropertyPath.targetPropertyPath = association("targetPropertyPath", _Property)
 DirectedRelationshipPropertyPath.targetContext = association("targetContext", _Classifier, upper=1, opposite="targetDirectedRelationshipPropertyPath_")
 DirectedRelationshipPropertyPath.sourceContext = association("sourceContext", _Classifier, upper=1)
-from gaphor.UML.uml import Element
-Element.owner.add(DirectedRelationshipPropertyPath.targetContext)  # type: ignore[attr-defined]
+_Element.owner.add(DirectedRelationshipPropertyPath.targetContext)  # type: ignore[attr-defined]
 _Property.itemFlow = association("itemFlow", ItemFlow, upper=1, opposite="itemProperty")
-Element.owner.add(_Property.itemFlow)  # type: ignore[attr-defined]
+_Element.owner.add(_Property.itemFlow)  # type: ignore[attr-defined]
 ConnectorProperty.connector = association("connector", _Connector, upper=1, composite=True)
 ParticipantProperty.end_ = association("end_", _Property, upper=1, composite=True)
 ValueType.unit = association("unit", _InstanceSpecification, upper=1)
 ValueType.quantityKind = association("quantityKind", _InstanceSpecification, upper=1)
 ElementPropertyPath.propertyPath = association("propertyPath", _Property, lower=1)
 _Classifier.targetDirectedRelationshipPropertyPath_ = association("targetDirectedRelationshipPropertyPath_", DirectedRelationshipPropertyPath, composite=True, opposite="targetContext")
-Element.ownedElement.add(_Classifier.targetDirectedRelationshipPropertyPath_)  # type: ignore[attr-defined]
+_Element.ownedElement.add(_Classifier.targetDirectedRelationshipPropertyPath_)  # type: ignore[attr-defined]
 BoundReference.boundend = association("boundend", _ConnectorEnd, composite=True)
 BoundReference.bindingPath = derivedunion("bindingPath", _Property, lower=1)
 AdjuntProperty.principal = association("principal", _Element, upper=1)
@@ -428,4 +427,4 @@ ElementGroup.member = derivedunion("member", _Element)
 ElementGroup.orderedMember = association("orderedMember", _Element, composite=True)
 Rate.rate = association("rate", _InstanceSpecification, composite=True)
 ItemFlow.itemProperty = association("itemProperty", _Property, upper=1, composite=True, opposite="itemFlow")
-Element.ownedElement.add(ItemFlow.itemProperty)  # type: ignore[attr-defined]
+_Element.ownedElement.add(ItemFlow.itemProperty)  # type: ignore[attr-defined]

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -38,17 +38,17 @@ class FlowDirectionKind(enum.StrEnum):
     out = "out"
 
 
-from gaphor.UML.uml import NamedElement
-class AbstractRequirement(NamedElement):
+from gaphor.UML.uml import NamedElement as _NamedElement
+class AbstractRequirement(_NamedElement):
     derived: derived[AbstractRequirement]
     derivedFrom: derived[AbstractRequirement]
     externalId: _attribute[str] = _attribute("externalId", str)
     master: derived[AbstractRequirement]
-    refinedBy: derived[NamedElement]
-    satisfiedBy: derived[NamedElement]
+    refinedBy: derived[_NamedElement]
+    satisfiedBy: derived[_NamedElement]
     text: _attribute[str] = _attribute("text", str)
-    tracedTo: derived[NamedElement]
-    verifiedBy: derived[NamedElement]
+    tracedTo: derived[_NamedElement]
+    verifiedBy: derived[_NamedElement]
 
 
 from gaphor.UML.uml import Class as _Class
@@ -56,16 +56,16 @@ class Requirement(AbstractRequirement, _Class):
     pass
 
 
-from gaphor.UML.uml import DirectedRelationship
-class DirectedRelationshipPropertyPath(DirectedRelationship):
+from gaphor.UML.uml import DirectedRelationship as _DirectedRelationship
+class DirectedRelationshipPropertyPath(_DirectedRelationship):
     sourceContext: relation_one[Classifier]
     sourcePropertyPath: relation_many[Property]
     targetContext: relation_one[Classifier]
     targetPropertyPath: relation_many[Property]
 
 
-from gaphor.UML.uml import Dependency
-class Trace(Dependency, DirectedRelationshipPropertyPath):
+from gaphor.UML.uml import Dependency as _Dependency
+class Trace(_Dependency, DirectedRelationshipPropertyPath):
     pass
 
 
@@ -85,8 +85,8 @@ class Satisfy(Trace):
     pass
 
 
-from gaphor.UML.uml import Behavior
-class TestCase(Behavior):
+from gaphor.UML.uml import Behavior as _Behavior
+class TestCase(_Behavior):
     pass
 
 
@@ -94,69 +94,69 @@ class Block(_Class):
     isEncapsulated: _attribute[bool] = _attribute("isEncapsulated", bool, default=False)
 
 
-from gaphor.UML.uml import Property
-class ConnectorProperty(Property):
+from gaphor.UML.uml import Property as _Property
+class ConnectorProperty(_Property):
     connector: relation_one[Connector]
 
 
-class ParticipantProperty(Property):
-    end_: relation_one[Property]
+class ParticipantProperty(_Property):
+    end_: relation_one[_Property]
 
 
-class DistributedProperty(Property):
+class DistributedProperty(_Property):
     pass
 
 
-from gaphor.UML.uml import DataType
-class ValueType(DataType):
+from gaphor.UML.uml import DataType as _DataType
+class ValueType(_DataType):
     quantityKind: relation_one[InstanceSpecification]
     unit: relation_one[InstanceSpecification]
 
 
-from gaphor.UML.uml import InstanceSpecification
-from gaphor.UML.uml import Element
-class ElementPropertyPath(Element):
-    propertyPath: relation_many[Property]
+from gaphor.UML.uml import InstanceSpecification as _InstanceSpecification
+from gaphor.UML.uml import Element as _Element
+class ElementPropertyPath(_Element):
+    propertyPath: relation_many[_Property]
 
 
-from gaphor.UML.uml import Connector
-class BindingConnector(Connector):
+from gaphor.UML.uml import Connector as _Connector
+class BindingConnector(_Connector):
     pass
 
 
-from gaphor.UML.uml import ConnectorEnd
-class NestedConnectorEnd(ConnectorEnd, ElementPropertyPath):
+from gaphor.UML.uml import ConnectorEnd as _ConnectorEnd
+class NestedConnectorEnd(_ConnectorEnd, ElementPropertyPath):
     pass
 
 
-from gaphor.UML.uml import Classifier
-class PropertySpecificType(Classifier):
+from gaphor.UML.uml import Classifier as _Classifier
+class PropertySpecificType(_Classifier):
     pass
 
 
-class EndPathMultiplicity(Property):
+class EndPathMultiplicity(_Property):
     pass
 
 
 class BoundReference(EndPathMultiplicity):
-    bindingPath: relation_many[Property]
-    boundend: relation_many[ConnectorEnd]
+    bindingPath: relation_many[_Property]
+    boundend: relation_many[_ConnectorEnd]
 
 
-class AdjuntProperty(Property):
-    principal: relation_one[Element]
+class AdjuntProperty(_Property):
+    principal: relation_one[_Element]
 
 
-from gaphor.UML.uml import Port
-class ProxyPort(Port):
+from gaphor.UML.uml import Port as _Port
+class ProxyPort(_Port):
     pass
 
 
-class FullPort(Port):
+class FullPort(_Port):
     pass
 
 
-class FlowProperty(Property):
+class FlowProperty(_Property):
     direction = _enumeration("direction", FlowDirectionKind, FlowDirectionKind.inout)
 
 
@@ -164,39 +164,39 @@ class InterfaceBlock(Block):
     pass
 
 
-from gaphor.UML.uml import InvocationAction
-from gaphor.UML.uml import Trigger
-from gaphor.UML.uml import AddStructuralFeatureValueAction
-class InvocationOnNestedPortAction(ElementPropertyPath, InvocationAction):
-    onNestedPort: relation_many[Port]
+from gaphor.UML.uml import InvocationAction as _InvocationAction
+from gaphor.UML.uml import Trigger as _Trigger
+from gaphor.UML.uml import AddStructuralFeatureValueAction as _AddStructuralFeatureValueAction
+class InvocationOnNestedPortAction(ElementPropertyPath, _InvocationAction):
+    onNestedPort: relation_many[_Port]
 
 
-class TriggerOnNestedPort(ElementPropertyPath, Trigger):
-    onNestedPort: relation_many[Port]
+class TriggerOnNestedPort(ElementPropertyPath, _Trigger):
+    onNestedPort: relation_many[_Port]
 
 
-class AddFlowPropertyValueOnNestedPortAction(AddStructuralFeatureValueAction, ElementPropertyPath):
+class AddFlowPropertyValueOnNestedPortAction(_AddStructuralFeatureValueAction, ElementPropertyPath):
     pass
 
 
-from gaphor.UML.uml import ChangeEvent
-class ChangeSructuralFeatureEvent(ChangeEvent):
+from gaphor.UML.uml import ChangeEvent as _ChangeEvent
+class ChangeSructuralFeatureEvent(_ChangeEvent):
     structuralFeature: relation_one[StructuralFeature]
 
 
-from gaphor.UML.uml import StructuralFeature
-from gaphor.UML.uml import AcceptEventAction
-class AcceptChangeStructuralFeatureEventAction(AcceptEventAction):
+from gaphor.UML.uml import StructuralFeature as _StructuralFeature
+from gaphor.UML.uml import AcceptEventAction as _AcceptEventAction
+class AcceptChangeStructuralFeatureEventAction(_AcceptEventAction):
     pass
 
 
-from gaphor.UML.uml import Feature
-class DirectedFeature(Feature):
+from gaphor.UML.uml import Feature as _Feature
+class DirectedFeature(_Feature):
     featureDirection = _enumeration("featureDirection", FeatureDirectionKind, FeatureDirectionKind.provided)
 
 
-from gaphor.UML.uml import Generalization
-class Conform(Generalization):
+from gaphor.UML.uml import Generalization as _Generalization
+class Conform(_Generalization):
     pass
 
 
@@ -208,51 +208,51 @@ class View(_Class):
 class Viewpoint(_Class):
     concernList: relation_many[Comment]
     language: _attribute[str] = _attribute("language", str)
-    method: relation_many[Behavior]
+    method: relation_many[_Behavior]
     presentation: _attribute[str] = _attribute("presentation", str)
     purpose: _attribute[str] = _attribute("purpose", str)
     stakeholder: relation_many[Stakeholder]
 
 
-class Stakeholder(Classifier):
+class Stakeholder(_Classifier):
     concernList: relation_many[Comment]
 
 
-class Expose(Dependency):
+class Expose(_Dependency):
     pass
 
 
-from gaphor.UML.uml import Comment
-class Rationale(Comment):
+from gaphor.UML.uml import Comment as _Comment
+class Rationale(_Comment):
     pass
 
 
-class Problem(Comment):
+class Problem(_Comment):
     pass
 
 
-class ElementGroup(Comment):
-    member: relation_many[Element]
+class ElementGroup(_Comment):
+    member: relation_many[_Element]
     name: _attribute[str] = _attribute("name", str)
-    orderedMember: relation_many[Element]
+    orderedMember: relation_many[_Element]
 
 
 class ConstraintBlock(Block):
     pass
 
 
-from gaphor.UML.uml import Parameter
-from gaphor.UML.uml import ActivityEdge
-from gaphor.UML.uml import ParameterSet
-class Optional(Parameter):
+from gaphor.UML.uml import Parameter as _Parameter
+from gaphor.UML.uml import ActivityEdge as _ActivityEdge
+from gaphor.UML.uml import ParameterSet as _ParameterSet
+class Optional(_Parameter):
     pass
 
 
-class Rate(ActivityEdge, Parameter):
-    rate: relation_many[InstanceSpecification]
+class Rate(_ActivityEdge, _Parameter):
+    rate: relation_many[_InstanceSpecification]
 
 
-class Probability(ActivityEdge, ParameterSet):
+class Probability(_ActivityEdge, _ParameterSet):
     probability: _attribute[str] = _attribute("probability", str)
 
 
@@ -264,52 +264,55 @@ class Discrete(Rate):
     pass
 
 
-from gaphor.UML.uml import Operation
-from gaphor.UML.uml import ObjectNode
-class ControlOperator(Behavior):
+from gaphor.UML.uml import Operation as _Operation
+from gaphor.UML.uml import ObjectNode as _ObjectNode
+class ControlOperator(_Behavior):
     pass
 
 
-class NoBuffer(ObjectNode):
+class NoBuffer(_ObjectNode):
     pass
 
 
-class Overwrite(ObjectNode):
+class Overwrite(_ObjectNode):
     pass
 
 
-from gaphor.UML.uml import Abstraction
-class Allocate(Abstraction, DirectedRelationshipPropertyPath):
+from gaphor.UML.uml import Abstraction as _Abstraction
+class Allocate(_Abstraction, DirectedRelationshipPropertyPath):
     pass
 
 
-from gaphor.UML.uml import ActivityPartition
-class AllocateActivityPartition(ActivityPartition):
+from gaphor.UML.uml import ActivityPartition as _ActivityPartition
+class AllocateActivityPartition(_ActivityPartition):
     pass
 
 
-class Refine(Dependency, DirectedRelationshipPropertyPath):
+class Refine(_Dependency, DirectedRelationshipPropertyPath):
     pass
 
 
-class Tagged(Property):
+class Tagged(_Property):
     nonunique: _attribute[bool] = _attribute("nonunique", bool)
     ordered: _attribute[bool] = _attribute("ordered", bool)
     subsets: _attribute[str] = _attribute("subsets", str)
 
 
-class ClassifierBehaviorProperty(Property):
+class ClassifierBehaviorProperty(_Property):
     pass
 
 
-from gaphor.UML.uml import InformationFlow
-class ItemFlow(InformationFlow):
-    itemProperty: relation_one[Property]
+from gaphor.UML.uml import InformationFlow as _InformationFlow
+class ItemFlow(_InformationFlow):
+    itemProperty: relation_one[_Property]
 
 
-from gaphor.UML.uml import Diagram
-from gaphor.UML.uml import Class
-class SysMLDiagram(Diagram):
+from gaphor.UML.uml import Diagram as _Diagram
+class Class():
+    pass
+
+
+class SysMLDiagram(_Diagram):
     pass
 
 
@@ -376,54 +379,55 @@ AbstractRequirement.derivedFrom = derived("derivedFrom", AbstractRequirement, 0,
 AbstractRequirement.master = derived("master", AbstractRequirement, 0, "*",
     _directed_relationship_property_path_target_source(Copy))
 
-# 41: override AbstractRequirement.refinedBy: derived[NamedElement]
+# 41: override AbstractRequirement.refinedBy: derived[_NamedElement]
 
-AbstractRequirement.refinedBy = derived("refinedBy", NamedElement, 0, "*",
+AbstractRequirement.refinedBy = derived("refinedBy", _NamedElement, 0, "*",
     _directed_relationship_property_path_target_source(Refine))
 
-# 46: override AbstractRequirement.satisfiedBy: derived[NamedElement]
+# 46: override AbstractRequirement.satisfiedBy: derived[_NamedElement]
 
-AbstractRequirement.satisfiedBy = derived("satisfiedBy", NamedElement, 0, "*",
+AbstractRequirement.satisfiedBy = derived("satisfiedBy", _NamedElement, 0, "*",
     _directed_relationship_property_path_target_source(Satisfy))
 
-# 51: override AbstractRequirement.tracedTo: derived[NamedElement]
+# 51: override AbstractRequirement.tracedTo: derived[_NamedElement]
 
-AbstractRequirement.tracedTo = derived("tracedTo", NamedElement, 0, "*",
+AbstractRequirement.tracedTo = derived("tracedTo", _NamedElement, 0, "*",
     _directed_relationship_property_path_target_source(Trace))
 
-# 56: override AbstractRequirement.verifiedBy: derived[NamedElement]
+# 56: override AbstractRequirement.verifiedBy: derived[_NamedElement]
 
-AbstractRequirement.verifiedBy = derived("verifiedBy", NamedElement, 0, "*",
+AbstractRequirement.verifiedBy = derived("verifiedBy", _NamedElement, 0, "*",
     _directed_relationship_property_path_target_source(Verify))
 
-DirectedRelationshipPropertyPath.sourcePropertyPath = association("sourcePropertyPath", Property)
-DirectedRelationshipPropertyPath.targetPropertyPath = association("targetPropertyPath", Property)
-DirectedRelationshipPropertyPath.targetContext = association("targetContext", Classifier, upper=1, opposite="targetDirectedRelationshipPropertyPath_")
-DirectedRelationshipPropertyPath.sourceContext = association("sourceContext", Classifier, upper=1)
+DirectedRelationshipPropertyPath.sourcePropertyPath = association("sourcePropertyPath", _Property)
+DirectedRelationshipPropertyPath.targetPropertyPath = association("targetPropertyPath", _Property)
+DirectedRelationshipPropertyPath.targetContext = association("targetContext", _Classifier, upper=1, opposite="targetDirectedRelationshipPropertyPath_")
+DirectedRelationshipPropertyPath.sourceContext = association("sourceContext", _Classifier, upper=1)
+from gaphor.UML.uml import Element
 Element.owner.add(DirectedRelationshipPropertyPath.targetContext)  # type: ignore[attr-defined]
-Property.itemFlow = association("itemFlow", ItemFlow, upper=1, opposite="itemProperty")
-Element.owner.add(Property.itemFlow)  # type: ignore[attr-defined]
-ConnectorProperty.connector = association("connector", Connector, upper=1, composite=True)
-ParticipantProperty.end_ = association("end_", Property, upper=1, composite=True)
-ValueType.unit = association("unit", InstanceSpecification, upper=1)
-ValueType.quantityKind = association("quantityKind", InstanceSpecification, upper=1)
-ElementPropertyPath.propertyPath = association("propertyPath", Property, lower=1)
-Classifier.targetDirectedRelationshipPropertyPath_ = association("targetDirectedRelationshipPropertyPath_", DirectedRelationshipPropertyPath, composite=True, opposite="targetContext")
-Element.ownedElement.add(Classifier.targetDirectedRelationshipPropertyPath_)  # type: ignore[attr-defined]
-BoundReference.boundend = association("boundend", ConnectorEnd, composite=True)
-BoundReference.bindingPath = derivedunion("bindingPath", Property, lower=1)
-AdjuntProperty.principal = association("principal", Element, upper=1)
-InvocationOnNestedPortAction.onNestedPort = association("onNestedPort", Port, lower=1)
-TriggerOnNestedPort.onNestedPort = association("onNestedPort", Port, lower=1)
-ChangeSructuralFeatureEvent.structuralFeature = association("structuralFeature", StructuralFeature, upper=1)
+_Property.itemFlow = association("itemFlow", ItemFlow, upper=1, opposite="itemProperty")
+Element.owner.add(_Property.itemFlow)  # type: ignore[attr-defined]
+ConnectorProperty.connector = association("connector", _Connector, upper=1, composite=True)
+ParticipantProperty.end_ = association("end_", _Property, upper=1, composite=True)
+ValueType.unit = association("unit", _InstanceSpecification, upper=1)
+ValueType.quantityKind = association("quantityKind", _InstanceSpecification, upper=1)
+ElementPropertyPath.propertyPath = association("propertyPath", _Property, lower=1)
+_Classifier.targetDirectedRelationshipPropertyPath_ = association("targetDirectedRelationshipPropertyPath_", DirectedRelationshipPropertyPath, composite=True, opposite="targetContext")
+Element.ownedElement.add(_Classifier.targetDirectedRelationshipPropertyPath_)  # type: ignore[attr-defined]
+BoundReference.boundend = association("boundend", _ConnectorEnd, composite=True)
+BoundReference.bindingPath = derivedunion("bindingPath", _Property, lower=1)
+AdjuntProperty.principal = association("principal", _Element, upper=1)
+InvocationOnNestedPortAction.onNestedPort = association("onNestedPort", _Port, lower=1)
+TriggerOnNestedPort.onNestedPort = association("onNestedPort", _Port, lower=1)
+ChangeSructuralFeatureEvent.structuralFeature = association("structuralFeature", _StructuralFeature, upper=1)
 View.stakeholder = derivedunion("stakeholder", Stakeholder)
 View.viewpoint = derivedunion("viewpoint", Viewpoint, upper=1)
-Viewpoint.concernList = association("concernList", Comment, composite=True)
-Viewpoint.method = derivedunion("method", Behavior)
+Viewpoint.concernList = association("concernList", _Comment, composite=True)
+Viewpoint.method = derivedunion("method", _Behavior)
 Viewpoint.stakeholder = association("stakeholder", Stakeholder, composite=True)
-Stakeholder.concernList = association("concernList", Comment, composite=True)
-ElementGroup.member = derivedunion("member", Element)
-ElementGroup.orderedMember = association("orderedMember", Element, composite=True)
-Rate.rate = association("rate", InstanceSpecification, composite=True)
-ItemFlow.itemProperty = association("itemProperty", Property, upper=1, composite=True, opposite="itemFlow")
+Stakeholder.concernList = association("concernList", _Comment, composite=True)
+ElementGroup.member = derivedunion("member", _Element)
+ElementGroup.orderedMember = association("orderedMember", _Element, composite=True)
+Rate.rate = association("rate", _InstanceSpecification, composite=True)
+ItemFlow.itemProperty = association("itemProperty", _Property, upper=1, composite=True, opposite="itemFlow")
 Element.ownedElement.add(ItemFlow.itemProperty)  # type: ignore[attr-defined]

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -39,6 +39,37 @@ class FlowDirectionKind(enum.StrEnum):
 
 
 from gaphor.UML.uml import NamedElement as _NamedElement
+from gaphor.UML.uml import Class as _Class
+from gaphor.UML.uml import DirectedRelationship as _DirectedRelationship
+from gaphor.UML.uml import Dependency as _Dependency
+from gaphor.UML.uml import Behavior as _Behavior
+from gaphor.UML.uml import Property as _Property
+from gaphor.UML.uml import DataType as _DataType
+from gaphor.UML.uml import InstanceSpecification as _InstanceSpecification
+from gaphor.UML.uml import Element as _Element
+from gaphor.UML.uml import Connector as _Connector
+from gaphor.UML.uml import ConnectorEnd as _ConnectorEnd
+from gaphor.UML.uml import Classifier as _Classifier
+from gaphor.UML.uml import Port as _Port
+from gaphor.UML.uml import InvocationAction as _InvocationAction
+from gaphor.UML.uml import Trigger as _Trigger
+from gaphor.UML.uml import AddStructuralFeatureValueAction as _AddStructuralFeatureValueAction
+from gaphor.UML.uml import ChangeEvent as _ChangeEvent
+from gaphor.UML.uml import StructuralFeature as _StructuralFeature
+from gaphor.UML.uml import AcceptEventAction as _AcceptEventAction
+from gaphor.UML.uml import Feature as _Feature
+from gaphor.UML.uml import Generalization as _Generalization
+from gaphor.UML.uml import Comment as _Comment
+from gaphor.UML.uml import Parameter as _Parameter
+from gaphor.UML.uml import ActivityEdge as _ActivityEdge
+from gaphor.UML.uml import ParameterSet as _ParameterSet
+from gaphor.UML.uml import Operation as _Operation
+from gaphor.UML.uml import ObjectNode as _ObjectNode
+from gaphor.UML.uml import Abstraction as _Abstraction
+from gaphor.UML.uml import ActivityPartition as _ActivityPartition
+from gaphor.UML.uml import InformationFlow as _InformationFlow
+from gaphor.UML.uml import Diagram as _Diagram
+
 class AbstractRequirement(_NamedElement):
     derived: derived[AbstractRequirement]
     derivedFrom: derived[AbstractRequirement]
@@ -51,20 +82,17 @@ class AbstractRequirement(_NamedElement):
     verifiedBy: derived[_NamedElement]
 
 
-from gaphor.UML.uml import Class as _Class
 class Requirement(AbstractRequirement, _Class):
     pass
 
 
-from gaphor.UML.uml import DirectedRelationship as _DirectedRelationship
 class DirectedRelationshipPropertyPath(_DirectedRelationship):
-    sourceContext: relation_one[Classifier]
-    sourcePropertyPath: relation_many[Property]
-    targetContext: relation_one[Classifier]
-    targetPropertyPath: relation_many[Property]
+    sourceContext: relation_one[_Classifier]
+    sourcePropertyPath: relation_many[_Property]
+    targetContext: relation_one[_Classifier]
+    targetPropertyPath: relation_many[_Property]
 
 
-from gaphor.UML.uml import Dependency as _Dependency
 class Trace(DirectedRelationshipPropertyPath, _Dependency):
     pass
 
@@ -85,7 +113,6 @@ class Satisfy(Trace):
     pass
 
 
-from gaphor.UML.uml import Behavior as _Behavior
 class TestCase(_Behavior):
     pass
 
@@ -94,9 +121,8 @@ class Block(_Class):
     isEncapsulated: _attribute[bool] = _attribute("isEncapsulated", bool, default=False)
 
 
-from gaphor.UML.uml import Property as _Property
 class ConnectorProperty(_Property):
-    connector: relation_one[Connector]
+    connector: relation_one[_Connector]
 
 
 class ParticipantProperty(_Property):
@@ -107,29 +133,23 @@ class DistributedProperty(_Property):
     pass
 
 
-from gaphor.UML.uml import DataType as _DataType
 class ValueType(_DataType):
-    quantityKind: relation_one[InstanceSpecification]
-    unit: relation_one[InstanceSpecification]
+    quantityKind: relation_one[_InstanceSpecification]
+    unit: relation_one[_InstanceSpecification]
 
 
-from gaphor.UML.uml import InstanceSpecification as _InstanceSpecification
-from gaphor.UML.uml import Element as _Element
 class ElementPropertyPath(_Element):
     propertyPath: relation_many[_Property]
 
 
-from gaphor.UML.uml import Connector as _Connector
 class BindingConnector(_Connector):
     pass
 
 
-from gaphor.UML.uml import ConnectorEnd as _ConnectorEnd
 class NestedConnectorEnd(ElementPropertyPath, _ConnectorEnd):
     pass
 
 
-from gaphor.UML.uml import Classifier as _Classifier
 class PropertySpecificType(_Classifier):
     pass
 
@@ -147,7 +167,6 @@ class AdjuntProperty(_Property):
     principal: relation_one[_Element]
 
 
-from gaphor.UML.uml import Port as _Port
 class ProxyPort(_Port):
     pass
 
@@ -164,9 +183,6 @@ class InterfaceBlock(Block):
     pass
 
 
-from gaphor.UML.uml import InvocationAction as _InvocationAction
-from gaphor.UML.uml import Trigger as _Trigger
-from gaphor.UML.uml import AddStructuralFeatureValueAction as _AddStructuralFeatureValueAction
 class InvocationOnNestedPortAction(ElementPropertyPath, _InvocationAction):
     onNestedPort: relation_many[_Port]
 
@@ -179,23 +195,18 @@ class AddFlowPropertyValueOnNestedPortAction(ElementPropertyPath, _AddStructural
     pass
 
 
-from gaphor.UML.uml import ChangeEvent as _ChangeEvent
 class ChangeSructuralFeatureEvent(_ChangeEvent):
-    structuralFeature: relation_one[StructuralFeature]
+    structuralFeature: relation_one[_StructuralFeature]
 
 
-from gaphor.UML.uml import StructuralFeature as _StructuralFeature
-from gaphor.UML.uml import AcceptEventAction as _AcceptEventAction
 class AcceptChangeStructuralFeatureEventAction(_AcceptEventAction):
     pass
 
 
-from gaphor.UML.uml import Feature as _Feature
 class DirectedFeature(_Feature):
     featureDirection = _enumeration("featureDirection", FeatureDirectionKind, FeatureDirectionKind.provided)
 
 
-from gaphor.UML.uml import Generalization as _Generalization
 class Conform(_Generalization):
     pass
 
@@ -206,7 +217,7 @@ class View(_Class):
 
 
 class Viewpoint(_Class):
-    concernList: relation_many[Comment]
+    concernList: relation_many[_Comment]
     language: _attribute[str] = _attribute("language", str)
     method: relation_many[_Behavior]
     presentation: _attribute[str] = _attribute("presentation", str)
@@ -215,14 +226,13 @@ class Viewpoint(_Class):
 
 
 class Stakeholder(_Classifier):
-    concernList: relation_many[Comment]
+    concernList: relation_many[_Comment]
 
 
 class Expose(_Dependency):
     pass
 
 
-from gaphor.UML.uml import Comment as _Comment
 class Rationale(_Comment):
     pass
 
@@ -241,9 +251,6 @@ class ConstraintBlock(Block):
     pass
 
 
-from gaphor.UML.uml import Parameter as _Parameter
-from gaphor.UML.uml import ActivityEdge as _ActivityEdge
-from gaphor.UML.uml import ParameterSet as _ParameterSet
 class Optional(_Parameter):
     pass
 
@@ -264,8 +271,6 @@ class Discrete(Rate):
     pass
 
 
-from gaphor.UML.uml import Operation as _Operation
-from gaphor.UML.uml import ObjectNode as _ObjectNode
 class ControlOperator(_Behavior):
     pass
 
@@ -278,12 +283,10 @@ class Overwrite(_ObjectNode):
     pass
 
 
-from gaphor.UML.uml import Abstraction as _Abstraction
 class Allocate(DirectedRelationshipPropertyPath, _Abstraction):
     pass
 
 
-from gaphor.UML.uml import ActivityPartition as _ActivityPartition
 class AllocateActivityPartition(_ActivityPartition):
     pass
 
@@ -302,12 +305,10 @@ class ClassifierBehaviorProperty(_Property):
     pass
 
 
-from gaphor.UML.uml import InformationFlow as _InformationFlow
 class ItemFlow(_InformationFlow):
     itemProperty: relation_one[_Property]
 
 
-from gaphor.UML.uml import Diagram as _Diagram
 class SysMLDiagram(_Diagram):
     pass
 

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -65,7 +65,7 @@ class DirectedRelationshipPropertyPath(_DirectedRelationship):
 
 
 from gaphor.UML.uml import Dependency as _Dependency
-class Trace(_Dependency, DirectedRelationshipPropertyPath):
+class Trace(DirectedRelationshipPropertyPath, _Dependency):
     pass
 
 
@@ -125,7 +125,7 @@ class BindingConnector(_Connector):
 
 
 from gaphor.UML.uml import ConnectorEnd as _ConnectorEnd
-class NestedConnectorEnd(_ConnectorEnd, ElementPropertyPath):
+class NestedConnectorEnd(ElementPropertyPath, _ConnectorEnd):
     pass
 
 
@@ -175,7 +175,7 @@ class TriggerOnNestedPort(ElementPropertyPath, _Trigger):
     onNestedPort: relation_many[_Port]
 
 
-class AddFlowPropertyValueOnNestedPortAction(_AddStructuralFeatureValueAction, ElementPropertyPath):
+class AddFlowPropertyValueOnNestedPortAction(ElementPropertyPath, _AddStructuralFeatureValueAction):
     pass
 
 
@@ -279,7 +279,7 @@ class Overwrite(_ObjectNode):
 
 
 from gaphor.UML.uml import Abstraction as _Abstraction
-class Allocate(_Abstraction, DirectedRelationshipPropertyPath):
+class Allocate(DirectedRelationshipPropertyPath, _Abstraction):
     pass
 
 
@@ -288,7 +288,7 @@ class AllocateActivityPartition(_ActivityPartition):
     pass
 
 
-class Refine(_Dependency, DirectedRelationshipPropertyPath):
+class Refine(DirectedRelationshipPropertyPath, _Dependency):
     pass
 
 
@@ -308,10 +308,6 @@ class ItemFlow(_InformationFlow):
 
 
 from gaphor.UML.uml import Diagram as _Diagram
-class Class():
-    pass
-
-
 class SysMLDiagram(_Diagram):
     pass
 

--- a/gaphor/SysML/sysml.py
+++ b/gaphor/SysML/sysml.py
@@ -26,18 +26,6 @@ def _directed_relationship_property_path_target_source(type):
         if element.sourceContext is self and element.targetContext
     ]
 
-class FeatureDirectionKind(enum.StrEnum):
-    provided = "provided"
-    providedRequired = "providedRequired"
-    required = "required"
-
-
-class FlowDirectionKind(enum.StrEnum):
-    in_ = "in"
-    inout = "inout"
-    out = "out"
-
-
 from gaphor.UML.uml import NamedElement as _NamedElement
 from gaphor.UML.uml import Class as _Class
 from gaphor.UML.uml import DirectedRelationship as _DirectedRelationship
@@ -69,6 +57,19 @@ from gaphor.UML.uml import Abstraction as _Abstraction
 from gaphor.UML.uml import ActivityPartition as _ActivityPartition
 from gaphor.UML.uml import InformationFlow as _InformationFlow
 from gaphor.UML.uml import Diagram as _Diagram
+
+
+class FeatureDirectionKind(enum.StrEnum):
+    provided = "provided"
+    providedRequired = "providedRequired"
+    required = "required"
+
+
+class FlowDirectionKind(enum.StrEnum):
+    in_ = "in"
+    inout = "inout"
+    out = "out"
+
 
 class AbstractRequirement(_NamedElement):
     derived: derived[AbstractRequirement]

--- a/gaphor/SysML/tests/test_propertypages.py
+++ b/gaphor/SysML/tests/test_propertypages.py
@@ -138,7 +138,7 @@ def test_compartment_property_page_show_values(diagram, element_factory, event_m
 
 
 def test_property_aggregation_page(element_factory, event_manager):
-    subject = element_factory.create(SysML.sysml.Property)
+    subject = element_factory.create(UML.Property)
     property_page = PropertyAggregationPropertyPage(subject, event_manager)
 
     widget = property_page.construct()
@@ -200,7 +200,7 @@ def test_connector_item_flow(connector, event_manager):
 
 
 def test_disable_item_flow(element_factory, event_manager):
-    subject = element_factory.create(SysML.sysml.Connector)
+    subject = element_factory.create(UML.Connector)
     property_page = ItemFlowPropertyPage(subject, event_manager)
 
     widget = property_page.construct()

--- a/gaphor/UML/classes/stereotype.py
+++ b/gaphor/UML/classes/stereotype.py
@@ -7,11 +7,11 @@ from gaphor.diagram.shapes import Box, CssNode, Text, draw_top_separator
 
 def stereotype_watches(presentation: ElementPresentation) -> None:
     presentation.watch(
-        "subject[Element].appliedStereotype", presentation.update_shapes
-    ).watch("subject[Element].appliedStereotype.classifier.name").watch(
-        "subject[Element].appliedStereotype.slot", presentation.update_shapes
-    ).watch("subject[Element].appliedStereotype.slot.definingFeature.name").watch(
-        "subject[Element].appliedStereotype.slot.value", presentation.update_shapes
+        "subject[UML:Element].appliedStereotype", presentation.update_shapes
+    ).watch("subject[UML:Element].appliedStereotype.classifier.name").watch(
+        "subject[UML:Element].appliedStereotype.slot", presentation.update_shapes
+    ).watch("subject[UML:Element].appliedStereotype.slot.definingFeature.name").watch(
+        "subject[UML:Element].appliedStereotype.slot.value", presentation.update_shapes
     )
 
 

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -104,6 +104,8 @@ class VisibilityKind(enum.StrEnum):
 
 
 from gaphor.core.modeling.base import Base as _Base
+from gaphor.core.modeling.diagram import Diagram as _Diagram
+
 class Element(_Base):
     appliedStereotype: relation_many[InstanceSpecification]
     comment: relation_many[Comment]
@@ -938,7 +940,6 @@ class Comment(Element):
     body: _attribute[str] = _attribute("body", str)
 
 
-from gaphor.core.modeling.diagram import Diagram as _Diagram
 class Diagram(NamedElement, _Diagram):
     element: relation_one[Element]
 

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -939,7 +939,7 @@ class Comment(Element):
 
 
 from gaphor.core.modeling.diagram import Diagram as _Diagram
-class Diagram(_Diagram, NamedElement):
+class Diagram(NamedElement, _Diagram):
     element: relation_one[Element]
 
 

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -22,6 +22,9 @@ from typing import Callable
 
 from gaphor.core.modeling import UnlimitedNatural
 
+from gaphor.core.modeling.base import Base as _Base
+from gaphor.core.modeling.diagram import Diagram as _Diagram
+
 
 class AggregationKind(enum.StrEnum):
     none = "none"
@@ -102,9 +105,6 @@ class VisibilityKind(enum.StrEnum):
     package = "package"
     protected = "protected"
 
-
-from gaphor.core.modeling.base import Base as _Base
-from gaphor.core.modeling.diagram import Diagram as _Diagram
 
 class Element(_Base):
     appliedStereotype: relation_many[InstanceSpecification]
@@ -1005,10 +1005,10 @@ class SequenceDiagram(InteractionDiagram):
     diagramType: _attribute[str] = _attribute("diagramType", str, default="sd")
 
 
-# 67: override Lifeline.parse: Callable[[Lifeline, str], None]
+# 66: override Lifeline.parse: Callable[[Lifeline, str], None]
 # defined in umloverrides.py
 
-# 70: override Lifeline.render: Callable[[Lifeline], str]
+# 69: override Lifeline.render: Callable[[Lifeline], str]
 # defined in umloverrides.py
 
 
@@ -1023,7 +1023,7 @@ NamedElement.clientDependency = association("clientDependency", Dependency, comp
 NamedElement.supplierDependency = association("supplierDependency", Dependency, opposite="supplier")
 NamedElement.memberNamespace = derivedunion("memberNamespace", Namespace, upper=1)
 NamedElement.namespace = derivedunion("namespace", Namespace, upper=1)
-# 20: override NamedElement.qualifiedName: property
+# 19: override NamedElement.qualifiedName: property
 # defined in umloverrides.py
 
 NamedElement.memberNamespace.add(NamedElement.namespace)  # type: ignore[attr-defined]
@@ -1057,7 +1057,7 @@ Element.owner.add(PackageMerge.mergingPackage)  # type: ignore[attr-defined]
 DirectedRelationship.target.add(PackageMerge.mergedPackage)  # type: ignore[attr-defined]
 RedefinableElement.redefinedElement = derivedunion("redefinedElement", RedefinableElement)
 RedefinableElement.redefinitionContext = derivedunion("redefinitionContext", Classifier)
-# 55: override Namespace.importedMember: derivedunion[PackageableElement]
+# 54: override Namespace.importedMember: derivedunion[PackageableElement]
 Namespace.importedMember = derivedunion('importedMember', PackageableElement, 0, '*')
 
 Namespace.elementImport = association("elementImport", ElementImport, composite=True, opposite="importingNamespace")
@@ -1078,11 +1078,11 @@ Classifier.instanceSpecification = association("instanceSpecification", Instance
 Classifier.ownedUseCase = association("ownedUseCase", UseCase, composite=True)
 Classifier.specialization = association("specialization", Generalization, opposite="general")
 Classifier.redefinedClassifier = association("redefinedClassifier", Classifier)
-# 46: override Classifier.inheritedMember: derivedunion[NamedElement]
+# 45: override Classifier.inheritedMember: derivedunion[NamedElement]
 Classifier.inheritedMember = derivedunion('inheritedMember', NamedElement, 0, '*')
 
 Classifier.attribute = derivedunion("attribute", Property)
-# 49: override Classifier.general(Generalization.general): derived[Classifier]
+# 48: override Classifier.general(Generalization.general): derived[Classifier]
 Classifier.general = derived('general', Classifier, 0, '*', lambda self: [g.general for g in self.generalization])
 
 Classifier.useCase = association("useCase", UseCase, opposite="subject")
@@ -1097,7 +1097,7 @@ Namespace.member.add(Classifier.inheritedMember)  # type: ignore[attr-defined]
 Classifier.feature.add(Classifier.attribute)  # type: ignore[attr-defined]
 NamedElement.namespace.add(Classifier.nestingClass)  # type: ignore[attr-defined]
 RedefinableElement.redefinitionContext.add(Classifier.nestingClass)  # type: ignore[attr-defined]
-# 23: override Association.endType(Association.memberEnd, Property.type): derived[Type]
+# 22: override Association.endType(Association.memberEnd, Property.type): derived[Type]
 
 # References the classifiers that are used as types of the ends of the
 # association.
@@ -1113,7 +1113,7 @@ Association.memberEnd.add(Association.ownedEnd)  # type: ignore[attr-defined]
 Namespace.ownedMember.add(Association.ownedEnd)  # type: ignore[attr-defined]
 Namespace.member.add(Association.memberEnd)  # type: ignore[attr-defined]
 Association.ownedEnd.add(Association.navigableOwnedEnd)  # type: ignore[attr-defined]
-# 43: override Extension.metaclass(Extension.ownedEnd, Association.memberEnd): property
+# 42: override Extension.metaclass(Extension.ownedEnd, Association.memberEnd): property
 # defined in umloverrides.py
 
 Extension.ownedEnd = association("ownedEnd", ExtensionEnd, upper=1, composite=True)
@@ -1185,7 +1185,7 @@ Element.owner.add(Generalization.specific)  # type: ignore[attr-defined]
 StructuredClassifier.role = derivedunion("role", ConnectableElement)
 StructuredClassifier.ownedConnector = association("ownedConnector", Connector, composite=True, opposite="structuredClassifier")
 StructuredClassifier.ownedAttribute = association("ownedAttribute", Property, composite=True, opposite="structuredClassifier")
-# 82: override StructuredClassifier.part: property
+# 81: override StructuredClassifier.part: property
 StructuredClassifier.part = property(lambda self: tuple(a for a in self.ownedAttribute if a.isComposite), doc="""
     Properties owned by a classifier by composition.
 """)
@@ -1201,7 +1201,7 @@ StructuredClassifier.role.add(EncapsulatedClassifier.ownedPort)  # type: ignore[
 Classifier.attribute.add(EncapsulatedClassifier.ownedPort)  # type: ignore[attr-defined]
 Namespace.ownedMember.add(EncapsulatedClassifier.ownedPort)  # type: ignore[attr-defined]
 Class.ownedOperation = association("ownedOperation", Operation, composite=True, opposite="class_")
-# 31: override Class.extension(Extension.metaclass): property
+# 30: override Class.extension(Extension.metaclass): property
 # See https://www.omg.org/spec/UML/2.5/PDF, section 11.8.3.6, page 219
 # It defines `Extension.allInstances()`, which basically means we have to query the element factory.
 
@@ -1213,7 +1213,7 @@ Class.extension = property(lambda self: self.model.lselect(lambda e: e.isKindOf(
 metaclass. The property is derived from the extensions whose memberEnds
 are typed by the Class.""")
 
-# 52: override Class.superClass: derived[Classifier]
+# 51: override Class.superClass: derived[Classifier]
 Class.superClass = Classifier.general
 
 Class.nestedClassifier = association("nestedClassifier", Classifier, composite=True, opposite="nestingClass")
@@ -1242,12 +1242,12 @@ Element.owner.add(InputPin.opaqueAction)  # type: ignore[attr-defined]
 Manifestation.artifact = association("artifact", Artifact, upper=1, opposite="manifestation")
 Dependency.client.add(Manifestation.artifact)  # type: ignore[attr-defined]
 Element.owner.add(Manifestation.artifact)  # type: ignore[attr-defined]
-# 73: override Component.provided: property
+# 72: override Component.provided: property
 # defined in umloverrides.py
 
 Component.packagedElement = association("packagedElement", PackageableElement, composite=True, opposite="component")
 Component.realization = association("realization", ComponentRealization, opposite="abstraction")
-# 76: override Component.required: property
+# 75: override Component.required: property
 # defined in umloverrides.py
 
 Namespace.ownedMember.add(Component.packagedElement)  # type: ignore[attr-defined]
@@ -1285,7 +1285,7 @@ Property.interface_ = association("interface_", Interface, upper=1, opposite="ow
 Property.association = association("association", Association, upper=1, opposite="memberEnd")
 Property.owningAssociation = association("owningAssociation", Association, upper=1, opposite="ownedEnd")
 Property.classifier = derivedunion("classifier", Classifier, upper=1)
-# 58: override Property.isComposite(Property.aggregation): derived[bool]
+# 57: override Property.isComposite(Property.aggregation): derived[bool]
 Property.isComposite = derived('isComposite', bool, 0, 1, lambda obj: [obj.aggregation == 'composite'])
 
 Property.datatype = association("datatype", DataType, upper=1, opposite="ownedAttribute")
@@ -1294,7 +1294,7 @@ Property.defaultValue = association("defaultValue", ValueSpecification, upper=1,
 Property.subsettedProperty = association("subsettedProperty", Property)
 Property.opposite = derivedunion("opposite", Property, upper=1)
 Property.artifact = association("artifact", Artifact, upper=1, opposite="ownedAttribute")
-# 61: override Property.navigability(Property.opposite, Property.association): derived[bool | None]
+# 60: override Property.navigability(Property.opposite, Property.association): derived[bool | None]
 # defined in umloverrides.py
 
 Property.structuredClassifier = association("structuredClassifier", StructuredClassifier, upper=1, opposite="ownedAttribute")
@@ -1414,7 +1414,7 @@ Operation.redefinedOperation = association("redefinedOperation", Operation)
 Operation.raisedException = association("raisedException", Type)
 Operation.bodyCondition = association("bodyCondition", Constraint, upper=1, composite=True)
 Operation.datatype = association("datatype", DataType, upper=1, opposite="ownedOperation")
-# 64: override Operation.type: derivedunion[DataType]
+# 63: override Operation.type: derivedunion[DataType]
 Operation.type = derivedunion('type', DataType, 0, 1)
 
 Operation.artifact = association("artifact", Artifact, upper=1, opposite="ownedOperation")
@@ -1499,7 +1499,7 @@ Lifeline.coveredBy = association("coveredBy", InteractionFragment, opposite="cov
 Lifeline.selector = association("selector", ValueSpecification, upper=1, composite=True, opposite="lifeline")
 Lifeline.represents = association("represents", ConnectableElement, upper=1, opposite="lifeline")
 NamedElement.namespace.add(Lifeline.interaction)  # type: ignore[attr-defined]
-# 79: override Message.messageKind: property
+# 78: override Message.messageKind: property
 # defined in umloverrides.py
 
 Message.sendEvent = association("sendEvent", MessageEnd, upper=1, composite=True, opposite="sendMessage")
@@ -1604,11 +1604,11 @@ Collaboration.collaborationRole = association("collaborationRole", ConnectableEl
 StructuredClassifier.role.add(Collaboration.collaborationRole)  # type: ignore[attr-defined]
 Trigger.event = association("event", Event, upper=1)
 Trigger.port = association("port", Port)
-# 91: override ExecutionSpecification.finish(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
+# 90: override ExecutionSpecification.finish(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
 ExecutionSpecification.finish = derived('finish', OccurrenceSpecification, 0, 1,
     lambda obj: [eos for i, eos in enumerate(obj.executionOccurrenceSpecification) if i == 1])
 
-# 87: override ExecutionSpecification.start(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
+# 86: override ExecutionSpecification.start(ExecutionSpecification.executionOccurrenceSpecification): relation_one[ExecutionOccurrenceSpecification]
 ExecutionSpecification.start = derived('start', OccurrenceSpecification, 0, 1,
     lambda obj: [eos for i, eos in enumerate(obj.executionOccurrenceSpecification) if i == 0])
 

--- a/gaphor/UML/uml.py
+++ b/gaphor/UML/uml.py
@@ -103,8 +103,8 @@ class VisibilityKind(enum.StrEnum):
     protected = "protected"
 
 
-from gaphor.core.modeling.base import Base
-class Element(Base):
+from gaphor.core.modeling.base import Base as _Base
+class Element(_Base):
     appliedStereotype: relation_many[InstanceSpecification]
     comment: relation_many[Comment]
     note: _attribute[str] = _attribute("note", str)
@@ -939,7 +939,7 @@ class Comment(Element):
 
 
 from gaphor.core.modeling.diagram import Diagram as _Diagram
-class Diagram(NamedElement, _Diagram):
+class Diagram(_Diagram, NamedElement):
     element: relation_one[Element]
 
 

--- a/gaphor/codegen/coder.py
+++ b/gaphor/codegen/coder.py
@@ -216,7 +216,7 @@ def class_declaration(class_: UML.Class):
         c.name
         for c in sorted(
             bases(class_),
-            key=lambda c: c.name[1:] if c.name.startswith("_") else c.name,
+            key=lambda c: c.name,
         )
     )
     return f"class {class_.name}({base_classes}):"

--- a/gaphor/codegen/coder.py
+++ b/gaphor/codegen/coder.py
@@ -162,10 +162,6 @@ def coder(
 
     already_imported = set()
     for c in classes:
-        if overrides and overrides.has_override(c.name):
-            yield overrides.get_override(c.name)
-            continue
-
         if not any(bases(c)):
             element_type, cls = in_super_model(c, super_models)
             if element_type and cls:
@@ -175,6 +171,17 @@ def coder(
                 yield line
                 already_imported.add(line)
                 continue
+
+    yield ""
+
+    for c in classes:
+        if c.name.startswith("_"):
+            # imported from super model
+            continue
+
+        if overrides and overrides.has_override(c.name):
+            yield overrides.get_override(c.name)
+            continue
 
         yield class_declaration(c)
         if properties := list(variables(c, overrides)):

--- a/gaphor/codegen/coder.py
+++ b/gaphor/codegen/coder.py
@@ -146,9 +146,6 @@ def coder(
     if overrides and overrides.header:
         yield overrides.header
 
-    for enum in sorted((model.select(UML.Enumeration)), key=lambda e: e.name):
-        yield from enumeration(enum)
-
     classes = list(
         order_classes(
             c
@@ -173,6 +170,10 @@ def coder(
                 continue
 
     yield ""
+    yield ""
+
+    for enum in sorted((model.select(UML.Enumeration)), key=lambda e: e.name):
+        yield from enumeration(enum)
 
     for c in classes:
         if c.name.startswith("_"):

--- a/gaphor/codegen/tests/test_coder.py
+++ b/gaphor/codegen/tests/test_coder.py
@@ -3,7 +3,6 @@ import pytest
 from gaphor import UML
 from gaphor.codegen.coder import (
     associations,
-    attribute,
     bases,
     class_declaration,
     is_in_profile,
@@ -13,6 +12,7 @@ from gaphor.codegen.coder import (
     load_modeling_language,
     order_classes,
     resolve_attribute_type_values,
+    superset_attribute,
     variables,
 )
 from gaphor.core.format import parse
@@ -302,7 +302,7 @@ def test_attribute_from_super_model(
     class_.name = "Package"
     class_.owningPackage = package
 
-    element_type, base = attribute(
+    element_type, base = superset_attribute(
         class_,
         "member",
         {

--- a/gaphor/codegen/tests/test_coder.py
+++ b/gaphor/codegen/tests/test_coder.py
@@ -302,11 +302,11 @@ def test_attribute_from_super_model(
     element_type, base = attribute(
         class_,
         "member",
-        [
+        {
             # Order matters! Base model first.
-            (CoreModelingLanguage(), core_metamodel),
-            (UMLModelingLanguage(), uml_metamodel),
-        ],
+            "Core": (CoreModelingLanguage(), core_metamodel),
+            "UML": (UMLModelingLanguage(), uml_metamodel),
+        },
     )
 
     assert element_type is UML.Package

--- a/gaphor/codegen/tests/test_coder.py
+++ b/gaphor/codegen/tests/test_coder.py
@@ -296,8 +296,11 @@ def test_coder_write_association_opposite_not_navigable(
 def test_attribute_from_super_model(
     uml_metamodel: ElementFactory, core_metamodel: ElementFactory
 ):
+    package = UML.Package()
+    package.name = "UML"
     class_ = UML.Class()
     class_.name = "Package"
+    class_.owningPackage = package
 
     element_type, base = attribute(
         class_,

--- a/gaphor/core/modeling/coremodel.py
+++ b/gaphor/core/modeling/coremodel.py
@@ -18,11 +18,12 @@ from gaphor.core.modeling.properties import (
 )
 
 
+
+
 class ChangeKind(enum.StrEnum):
     add = "add"
     remove = "remove"
     update = "update"
-
 
 
 # 1: override Base

--- a/gaphor/core/modeling/coremodel.py
+++ b/gaphor/core/modeling/coremodel.py
@@ -24,6 +24,7 @@ class ChangeKind(enum.StrEnum):
     update = "update"
 
 
+
 # 1: override Base
 from gaphor.core.modeling.base import Base
 

--- a/gaphor/core/modeling/elementfactory.py
+++ b/gaphor/core/modeling/elementfactory.py
@@ -181,7 +181,7 @@ class ElementFactory(Service):
 
     def is_empty(self) -> bool:
         """Returns ``True`` if the factory holds no elements."""
-        return bool(self._elements)
+        return not bool(self._elements)
 
     @property
     def style_sheet(self) -> StyleSheet | None:

--- a/models/C4Model.gaphor
+++ b/models/C4Model.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="https://gaphor.org/model" xmlns:Core="https://gaphor.org/modelinglanguage/Core" xmlns:UML="https://gaphor.org/modelinglanguage/UML" version="4" gaphor-version="3.0.0">
+<gaphor xmlns="https://gaphor.org/model" xmlns:Core="https://gaphor.org/modelinglanguage/Core" xmlns:UML="https://gaphor.org/modelinglanguage/UML" version="4" gaphor-version="3.1.0">
 <model>
 <Core:StyleSheet id="2e656716-6cae-11eb-aee1-750f3fed8beb"/>
 <UML:Package id="2e656717-6cae-11eb-aee1-750f3fed8beb">
@@ -354,6 +354,7 @@
 <ref refid="905056c0-6cae-11eb-aee1-750f3fed8beb"/>
 <ref refid="b680213a-6d81-11eb-bdd8-859c1b7b5447"/>
 <ref refid="33dce120-b7cc-11ef-b2d8-be7f4daace40"/>
+<ref refid="abb942dc-4932-11ef-8312-be7f4daace3f"/>
 </reflist>
 </ownedType>
 <packagedElement>
@@ -361,6 +362,7 @@
 <ref refid="905056c0-6cae-11eb-aee1-750f3fed8beb"/>
 <ref refid="b680213a-6d81-11eb-bdd8-859c1b7b5447"/>
 <ref refid="33dce120-b7cc-11ef-b2d8-be7f4daace40"/>
+<ref refid="abb942dc-4932-11ef-8312-be7f4daace3f"/>
 </reflist>
 </packagedElement>
 <presentation>
@@ -423,9 +425,6 @@
 </specialization>
 </UML:Stereotype>
 <UML:Property id="dff5b962-6d81-11eb-bdd8-859c1b7b5447">
-<class_>
-<ref refid="d7d28eb8-6d81-11eb-bdd8-859c1b7b5447"/>
-</class_>
 <name>
 <val>description</val>
 </name>
@@ -437,9 +436,6 @@
 </typeValue>
 </UML:Property>
 <UML:Property id="e3249522-6d81-11eb-bdd8-859c1b7b5447">
-<class_>
-<ref refid="d7d28eb8-6d81-11eb-bdd8-859c1b7b5447"/>
-</class_>
 <name>
 <val>location</val>
 </name>
@@ -451,9 +447,6 @@
 </typeValue>
 </UML:Property>
 <UML:Property id="e6f6ef88-6d81-11eb-bdd8-859c1b7b5447">
-<class_>
-<ref refid="d7d28eb8-6d81-11eb-bdd8-859c1b7b5447"/>
-</class_>
 <name>
 <val>technology</val>
 </name>
@@ -696,9 +689,6 @@
 <association>
 <ref refid="2daf9a4b-6dde-11eb-bdd8-859c1b7b5447"/>
 </association>
-<class_>
-<ref refid="d7d28eb8-6d81-11eb-bdd8-859c1b7b5447"/>
-</class_>
 <lowerValue>
 <ref refid="a45703bb-e403-11ef-992b-14abc554333b"/>
 </lowerValue>
@@ -738,9 +728,6 @@
 <association>
 <ref refid="2daf9a4b-6dde-11eb-bdd8-859c1b7b5447"/>
 </association>
-<class_>
-<ref refid="d7d28eb8-6d81-11eb-bdd8-859c1b7b5447"/>
-</class_>
 <name>
 <val>owningContainer</val>
 </name>
@@ -829,9 +816,6 @@
 <association>
 <ref refid="8fa07206-6dde-11eb-bdd8-859c1b7b5447"/>
 </association>
-<class_>
-<ref refid="86a99614-6dde-11eb-bdd8-859c1b7b5447"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -849,9 +833,6 @@
 <association>
 <ref refid="8fa07206-6dde-11eb-bdd8-859c1b7b5447"/>
 </association>
-<class_>
-<ref refid="8b905b0e-6dde-11eb-bdd8-859c1b7b5447"/>
-</class_>
 <structuredClassifier>
 <ref refid="8b905b0e-6dde-11eb-bdd8-859c1b7b5447"/>
 </structuredClassifier>
@@ -860,9 +841,6 @@
 </type>
 </UML:ExtensionEnd>
 <UML:Property id="95b4032e-6dde-11eb-bdd8-859c1b7b5447">
-<class_>
-<ref refid="86a99614-6dde-11eb-bdd8-859c1b7b5447"/>
-</class_>
 <name>
 <val>subsets</val>
 </name>
@@ -958,9 +936,6 @@
 </value>
 </UML:Slot>
 <UML:Property id="db6499c8-6ddf-11eb-bdd8-859c1b7b5447">
-<class_>
-<ref refid="872907b8-6cae-11eb-aee1-750f3fed8beb"/>
-</class_>
 <name>
 <val>description</val>
 </name>
@@ -972,9 +947,6 @@
 </typeValue>
 </UML:Property>
 <UML:Property id="e17a5dac-6ddf-11eb-bdd8-859c1b7b5447">
-<class_>
-<ref refid="872907b8-6cae-11eb-aee1-750f3fed8beb"/>
-</class_>
 <name>
 <val>location</val>
 </name>
@@ -986,9 +958,6 @@
 </typeValue>
 </UML:Property>
 <UML:Property id="f1db5b42-6ddf-11eb-bdd8-859c1b7b5447">
-<class_>
-<ref refid="d7d28eb8-6d81-11eb-bdd8-859c1b7b5447"/>
-</class_>
 <name>
 <val>type</val>
 </name>
@@ -1046,9 +1015,6 @@
 <association>
 <ref refid="2b94e4ac-4bc0-11ec-aa3d-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="872907b8-6cae-11eb-aee1-750f3fed8beb"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -1066,9 +1032,6 @@
 <association>
 <ref refid="2b94e4ac-4bc0-11ec-aa3d-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="905056c0-6cae-11eb-aee1-750f3fed8beb"/>
-</class_>
 <structuredClassifier>
 <ref refid="905056c0-6cae-11eb-aee1-750f3fed8beb"/>
 </structuredClassifier>
@@ -1102,9 +1065,6 @@
 <association>
 <ref refid="30f4593c-4bc0-11ec-aa3d-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="d7d28eb8-6d81-11eb-bdd8-859c1b7b5447"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -1122,9 +1082,6 @@
 <association>
 <ref refid="30f4593c-4bc0-11ec-aa3d-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="b680213a-6d81-11eb-bdd8-859c1b7b5447"/>
-</class_>
 <structuredClassifier>
 <ref refid="b680213a-6d81-11eb-bdd8-859c1b7b5447"/>
 </structuredClassifier>
@@ -1155,10 +1112,10 @@
 </reflist>
 </ownedAttribute>
 <owningPackage>
-<ref refid="d7ed613e-899d-11ef-b9b9-be7f4daace40"/>
+<ref refid="336043b6-6caf-11eb-aee1-750f3fed8beb"/>
 </owningPackage>
 <package>
-<ref refid="d7ed613e-899d-11ef-b9b9-be7f4daace40"/>
+<ref refid="336043b6-6caf-11eb-aee1-750f3fed8beb"/>
 </package>
 <presentation>
 <reflist>
@@ -1264,9 +1221,6 @@
 </subject>
 </UML:ClassItem>
 <UML:Property id="dfc6da9e-4932-11ef-8312-be7f4daace3f">
-<class_>
-<ref refid="cfe5e55c-4932-11ef-8312-be7f4daace3f"/>
-</class_>
 <name>
 <val>technology</val>
 </name>
@@ -1303,9 +1257,6 @@
 <association>
 <ref refid="f3942770-4932-11ef-8312-be7f4daace3f"/>
 </association>
-<class_>
-<ref refid="cfe5e55c-4932-11ef-8312-be7f4daace3f"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -1323,9 +1274,6 @@
 <association>
 <ref refid="f3942770-4932-11ef-8312-be7f4daace3f"/>
 </association>
-<class_>
-<ref refid="abb942dc-4932-11ef-8312-be7f4daace3f"/>
-</class_>
 <structuredClassifier>
 <ref refid="abb942dc-4932-11ef-8312-be7f4daace3f"/>
 </structuredClassifier>
@@ -1333,21 +1281,6 @@
 <ref refid="cfe5e55c-4932-11ef-8312-be7f4daace3f"/>
 </type>
 </UML:ExtensionEnd>
-<UML:Package id="d7ed613e-899d-11ef-b9b9-be7f4daace40">
-<name>
-<val>Core</val>
-</name>
-<ownedType>
-<reflist>
-<ref refid="abb942dc-4932-11ef-8312-be7f4daace3f"/>
-</reflist>
-</ownedType>
-<packagedElement>
-<reflist>
-<ref refid="abb942dc-4932-11ef-8312-be7f4daace3f"/>
-</reflist>
-</packagedElement>
-</UML:Package>
 <UML:Class id="33dce120-b7cc-11ef-b2d8-be7f4daace40">
 <name>
 <val>Diagram</val>
@@ -1484,9 +1417,6 @@
 </specific>
 </UML:Generalization>
 <UML:Property id="6b0eb420-b7cc-11ef-b2d8-be7f4daace40">
-<class_>
-<ref refid="447d659a-b7cc-11ef-b2d8-be7f4daace40"/>
-</class_>
 <defaultValue>
 <ref refid="df45331f-e403-11ef-bccf-14abc554333b"/>
 </defaultValue>

--- a/models/RAAML.gaphor
+++ b/models/RAAML.gaphor
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gaphor xmlns="https://gaphor.org/model" xmlns:Core="https://gaphor.org/modelinglanguage/Core" xmlns:SysML="https://gaphor.org/modelinglanguage/SysML" xmlns:UML="https://gaphor.org/modelinglanguage/UML" version="4" gaphor-version="3.0.0">
+<gaphor xmlns="https://gaphor.org/model" xmlns:Core="https://gaphor.org/modelinglanguage/Core" xmlns:SysML="https://gaphor.org/modelinglanguage/SysML" xmlns:UML="https://gaphor.org/modelinglanguage/UML" version="4" gaphor-version="3.1.0">
 <model>
 <UML:Package id="fc2ee07e-235c-11ea-ab0b-c72c0738acd2">
 <name>
@@ -49,19 +49,15 @@
 </ownedDiagram>
 <ownedType>
 <reflist>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 <ref refid="dde0bab8-235f-11ea-ab0b-c72c0738acd2"/>
-<ref refid="05b6e65c-2360-11ea-ab0b-c72c0738acd2"/>
 <ref refid="989e516c-2360-11ea-ab0b-c72c0738acd2"/>
-<ref refid="e23fcb5d-2360-11ea-ab0b-c72c0738acd2"/>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
 <ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
 <ref refid="dc6a99a2-2363-11ea-ab0b-c72c0738acd2"/>
-<ref refid="bbd667ee-5f7a-11eb-bf7c-d51178c71081"/>
-<ref refid="4bdf1b10-5f7b-11eb-bf7c-d51178c71081"/>
-<ref refid="f5cd4480-5f7b-11eb-bf7c-d51178c71081"/>
 <ref refid="fa408864-b5a8-11eb-9e03-18cf5efc6bb9"/>
-<ref refid="e62006e6-2a82-11ea-99a7-7d79dbbd423e"/>
+<ref refid="01d57fce-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="123a3b84-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="26e590ba-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="e10e1a5c-6d49-11f0-a782-be7f4daace3f"/>
 </reflist>
 </ownedType>
 <owningPackage>
@@ -69,19 +65,15 @@
 </owningPackage>
 <packagedElement>
 <reflist>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 <ref refid="dde0bab8-235f-11ea-ab0b-c72c0738acd2"/>
-<ref refid="05b6e65c-2360-11ea-ab0b-c72c0738acd2"/>
 <ref refid="989e516c-2360-11ea-ab0b-c72c0738acd2"/>
-<ref refid="e23fcb5d-2360-11ea-ab0b-c72c0738acd2"/>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
 <ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
 <ref refid="dc6a99a2-2363-11ea-ab0b-c72c0738acd2"/>
-<ref refid="bbd667ee-5f7a-11eb-bf7c-d51178c71081"/>
-<ref refid="4bdf1b10-5f7b-11eb-bf7c-d51178c71081"/>
-<ref refid="f5cd4480-5f7b-11eb-bf7c-d51178c71081"/>
 <ref refid="fa408864-b5a8-11eb-9e03-18cf5efc6bb9"/>
-<ref refid="e62006e6-2a82-11ea-99a7-7d79dbbd423e"/>
+<ref refid="01d57fce-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="123a3b84-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="26e590ba-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="e10e1a5c-6d49-11f0-a782-be7f4daace3f"/>
 </reflist>
 </packagedElement>
 <presentation>
@@ -201,10 +193,10 @@
 </reflist>
 </ownedAttribute>
 <owningPackage>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+<ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
 </owningPackage>
 <package>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+<ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
 </package>
 <presentation>
 <reflist>
@@ -305,10 +297,10 @@
 </reflist>
 </ownedAttribute>
 <owningPackage>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+<ref refid="4c25a5de-6d3c-11f0-a1fd-be7f4daace3f"/>
 </owningPackage>
 <package>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+<ref refid="4c25a5de-6d3c-11f0-a1fd-be7f4daace3f"/>
 </package>
 <presentation>
 <reflist>
@@ -335,7 +327,7 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="bbd796dc-5f7a-11eb-bf7c-d51178c71081"/>
+<ref refid="01d592fc-6d49-11f0-a782-be7f4daace3f"/>
 </reflist>
 </ownedAttribute>
 <owningPackage>
@@ -355,10 +347,10 @@
 <val>DirectedRelationshipPropertyPath</val>
 </name>
 <owningPackage>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+<ref refid="4c25a5de-6d3c-11f0-a1fd-be7f4daace3f"/>
 </owningPackage>
 <package>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+<ref refid="4c25a5de-6d3c-11f0-a1fd-be7f4daace3f"/>
 </package>
 <presentation>
 <reflist>
@@ -406,31 +398,6 @@
 </reflist>
 </presentation>
 </UML:Package>
-<UML:Class id="6019a6d2-2362-11ea-ab0b-c72c0738acd2">
-<name>
-<val>Dependency</val>
-</name>
-<ownedAttribute>
-<reflist>
-<ref refid="bbd81c10-5f7a-11eb-bf7c-d51178c71081"/>
-<ref refid="4be099a4-5f7b-11eb-bf7c-d51178c71081"/>
-<ref refid="f5cec576-5f7b-11eb-bf7c-d51178c71081"/>
-</reflist>
-</ownedAttribute>
-<owningPackage>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
-</owningPackage>
-<package>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="9b4704ca-5f7a-11eb-bf7c-d51178c71081"/>
-<ref refid="3a5a4c2a-5f7b-11eb-bf7c-d51178c71081"/>
-<ref refid="e8768c56-5f7b-11eb-bf7c-d51178c71081"/>
-</reflist>
-</presentation>
-</UML:Class>
 <UML:Stereotype id="7833aba0-2362-11ea-ab0b-c72c0738acd2">
 <generalization>
 <reflist>
@@ -442,8 +409,8 @@
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="dc3332e2-2362-11ea-ab0b-c72c0738acd2"/>
-<ref refid="4be016be-5f7b-11eb-bf7c-d51178c71081"/>
+<ref refid="123a4f3e-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="e10e87e4-6d49-11f0-a782-be7f4daace3f"/>
 </reflist>
 </ownedAttribute>
 <owningPackage>
@@ -470,58 +437,13 @@
 </reflist>
 </specialization>
 </UML:Stereotype>
-<UML:LiteralInteger id="2a9efce7-e494-11ef-b98b-14abc554333b">
-<name>
-<val>0</val>
-</name>
-<owningLower>
-<ref refid="dc3332e2-2362-11ea-ab0b-c72c0738acd2"/>
-</owningLower>
-<value>
-<val>0</val>
-</value>
-</UML:LiteralInteger>
-<UML:LiteralUnlimitedNatural id="2a9f048a-e494-11ef-97b3-14abc554333b">
-<name>
-<val>*</val>
-</name>
-<owningUpper>
-<ref refid="dc3332e2-2362-11ea-ab0b-c72c0738acd2"/>
-</owningUpper>
-<value>
-<val>*</val>
-</value>
-</UML:LiteralUnlimitedNatural>
-<UML:Property id="dc3332e2-2362-11ea-ab0b-c72c0738acd2">
-<class_>
-<ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
-</class_>
-<lowerValue>
-<ref refid="2a9efce7-e494-11ef-b98b-14abc554333b"/>
-</lowerValue>
-<name>
-<val>affects</val>
-</name>
-<structuredClassifier>
-<ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
-</structuredClassifier>
-<typeValue>
-<val>Property</val>
-</typeValue>
-<upperValue>
-<ref refid="2a9f048a-e494-11ef-97b3-14abc554333b"/>
-</upperValue>
-<visibility>
-<val>private</val>
-</visibility>
-</UML:Property>
 <UML:Stereotype id="dc6a99a2-2363-11ea-ab0b-c72c0738acd2">
 <name>
 <val>Violates</val>
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="f5ce443e-5f7b-11eb-bf7c-d51178c71081"/>
+<ref refid="26e5a55a-6d49-11f0-a782-be7f4daace3f"/>
 </reflist>
 </ownedAttribute>
 <owningPackage>
@@ -1811,12 +1733,10 @@ Figure 9.12</val>
 </ownedDiagram>
 <ownedType>
 <reflist>
-<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
 <ref refid="3e1f60be-242d-11ea-99a7-7d79dbbd423e"/>
 <ref refid="8cfc6894-242d-11ea-99a7-7d79dbbd423e"/>
 <ref refid="f620de22-242d-11ea-99a7-7d79dbbd423e"/>
 <ref refid="2741c35e-242e-11ea-99a7-7d79dbbd423e"/>
-<ref refid="5349fd22-242e-11ea-99a7-7d79dbbd423e"/>
 <ref refid="5ae20764-242e-11ea-99a7-7d79dbbd423e"/>
 <ref refid="e696af52-5480-11eb-a85e-18cf5efc6bb9"/>
 <ref refid="b940d698-7962-11eb-9356-18cf5efc6bb9"/>
@@ -1833,12 +1753,10 @@ Figure 9.12</val>
 </owningPackage>
 <packagedElement>
 <reflist>
-<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
 <ref refid="3e1f60be-242d-11ea-99a7-7d79dbbd423e"/>
 <ref refid="8cfc6894-242d-11ea-99a7-7d79dbbd423e"/>
 <ref refid="f620de22-242d-11ea-99a7-7d79dbbd423e"/>
 <ref refid="2741c35e-242e-11ea-99a7-7d79dbbd423e"/>
-<ref refid="5349fd22-242e-11ea-99a7-7d79dbbd423e"/>
 <ref refid="5ae20764-242e-11ea-99a7-7d79dbbd423e"/>
 <ref refid="e696af52-5480-11eb-a85e-18cf5efc6bb9"/>
 <ref refid="b940d698-7962-11eb-9356-18cf5efc6bb9"/>
@@ -2544,9 +2462,6 @@ Figure 9.15</val>
 <association>
 <ref refid="718a5d72-2398-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="ed4ae9c4-2364-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <lowerValue>
 <ref refid="2aa558f3-e494-11ef-b331-14abc554333b"/>
 </lowerValue>
@@ -2589,9 +2504,6 @@ Figure 9.15</val>
 <association>
 <ref refid="718a5d72-2398-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="ed4ae9c4-2364-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <lowerValue>
 <ref refid="2aa57205-e494-11ef-8ab0-14abc554333b"/>
 </lowerValue>
@@ -2771,9 +2683,6 @@ Figure 9.18</val>
 <association>
 <ref refid="0b59009e-239a-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="d3cc842e-2370-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2aa5b0c5-e494-11ef-98e9-14abc554333b"/>
 </lowerValue>
@@ -2816,9 +2725,6 @@ Figure 9.18</val>
 <association>
 <ref refid="0b59009e-239a-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="d3cc842e-2370-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2aa5b4ab-e494-11ef-afcc-14abc554333b"/>
 </lowerValue>
@@ -2976,9 +2882,6 @@ Figure 9.18</val>
 <association>
 <ref refid="55ddf24f-239a-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="d3cc842e-2370-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2aa5e793-e494-11ef-960e-14abc554333b"/>
 </lowerValue>
@@ -3021,9 +2924,6 @@ Figure 9.18</val>
 <association>
 <ref refid="55ddf24f-239a-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="d3cc842e-2370-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2aa5eb8f-e494-11ef-b52e-14abc554333b"/>
 </lowerValue>
@@ -3628,9 +3528,6 @@ Figure 9.21</val>
 <association>
 <ref refid="cff5bc02-242a-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="a76ab094-242a-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2aa6e6ff-e494-11ef-b72e-14abc554333b"/>
 </lowerValue>
@@ -4071,9 +3968,6 @@ Figure 9.22</val>
 <association>
 <ref refid="95e37dd2-242b-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="7e68fa60-242b-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2aa8114a-e494-11ef-8055-14abc554333b"/>
 </lowerValue>
@@ -4154,9 +4048,6 @@ Figure 9.22</val>
 <association>
 <ref refid="990932cc-242b-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="7e68fa60-242b-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2aa81758-e494-11ef-9c4b-14abc554333b"/>
 </lowerValue>
@@ -4237,9 +4128,6 @@ Figure 9.22</val>
 <association>
 <ref refid="9b074d49-242b-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="7e68fa60-242b-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2aa81bbe-e494-11ef-9bd2-14abc554333b"/>
 </lowerValue>
@@ -4439,13 +4327,16 @@ Figure 9.23</val>
 <ref refid="f107477e-7962-11eb-9356-18cf5efc6bb9"/>
 <ref refid="f8f1b550-7962-11eb-9356-18cf5efc6bb9"/>
 <ref refid="ff018dda-7962-11eb-9356-18cf5efc6bb9"/>
+<ref refid="01d59554-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="123a5182-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="26e5a7c6-6d49-11f0-a782-be7f4daace3f"/>
 </reflist>
 </ownedAttribute>
 <owningPackage>
-<ref refid="8ec88584-2394-11ea-99a7-7d79dbbd423e"/>
+<ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
 </owningPackage>
 <package>
-<ref refid="8ec88584-2394-11ea-99a7-7d79dbbd423e"/>
+<ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
 </package>
 <presentation>
 <reflist>
@@ -4453,6 +4344,9 @@ Figure 9.23</val>
 <ref refid="7e677d00-242d-11ea-99a7-7d79dbbd423e"/>
 <ref refid="ed93f334-242d-11ea-99a7-7d79dbbd423e"/>
 <ref refid="21e4df90-242e-11ea-99a7-7d79dbbd423e"/>
+<ref refid="ffc65884-6d48-11f0-a782-be7f4daace3f"/>
+<ref refid="107d313e-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="23224dd8-6d49-11f0-a782-be7f4daace3f"/>
 </reflist>
 </presentation>
 </UML:Class>
@@ -5253,10 +5147,10 @@ Figure 9.31</val>
 </reflist>
 </ownedAttribute>
 <owningPackage>
-<ref refid="8ec88584-2394-11ea-99a7-7d79dbbd423e"/>
+<ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
 </owningPackage>
 <package>
-<ref refid="8ec88584-2394-11ea-99a7-7d79dbbd423e"/>
+<ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
 </package>
 <presentation>
 <reflist>
@@ -5344,9 +5238,6 @@ Figure 9.32</val>
 <association>
 <ref refid="3168cb56-242f-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="7fe2a870-2370-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2aaaa590-e494-11ef-975a-14abc554333b"/>
 </lowerValue>
@@ -5389,9 +5280,6 @@ Figure 9.32</val>
 <association>
 <ref refid="3168cb56-242f-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="d3cc842e-2370-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2aaaada1-e494-11ef-8331-14abc554333b"/>
 </lowerValue>
@@ -5925,7 +5813,7 @@ Figure 9.43</val>
 <ref refid="e81b0e54-4bd3-11ec-8adf-0456e5e540ed"/>
 <ref refid="fb8c552e-4bd3-11ec-8adf-0456e5e540ed"/>
 <ref refid="7551a94c-538e-11ec-a31e-0456e5e540ed"/>
-<ref refid="c365f70a-538e-11ec-a31e-0456e5e540ed"/>
+<ref refid="ed883502-6d48-11f0-a782-be7f4daace3f"/>
 </reflist>
 </ownedType>
 <owningPackage>
@@ -5969,7 +5857,7 @@ Figure 9.43</val>
 <ref refid="e81b0e54-4bd3-11ec-8adf-0456e5e540ed"/>
 <ref refid="fb8c552e-4bd3-11ec-8adf-0456e5e540ed"/>
 <ref refid="7551a94c-538e-11ec-a31e-0456e5e540ed"/>
-<ref refid="c365f70a-538e-11ec-a31e-0456e5e540ed"/>
+<ref refid="ed883502-6d48-11f0-a782-be7f4daace3f"/>
 </reflist>
 </packagedElement>
 <presentation>
@@ -9982,39 +9870,13 @@ Figure 9.79</val>
 </name>
 <ownedPresentation>
 <reflist>
-<ref refid="e62006e7-2a82-11ea-99a7-7d79dbbd423e"/>
 <ref refid="f918b22b-2a82-11ea-99a7-7d79dbbd423e"/>
 <ref refid="40a79216-2a83-11ea-99a7-7d79dbbd423e"/>
+<ref refid="ea9a19b4-6d48-11f0-a782-be7f4daace3f"/>
 <ref refid="fe8b1694-2a82-11ea-99a7-7d79dbbd423e"/>
 </reflist>
 </ownedPresentation>
 </UML:Diagram>
-<UML:ClassItem id="e62006e7-2a82-11ea-99a7-7d79dbbd423e">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 133.59597778320312, 30.201385498046875)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>101.0</val>
-</width>
-<height>
-<val>74.0</val>
-</height>
-<diagram>
-<ref refid="e1154abc-2a82-11ea-99a7-7d79dbbd423e"/>
-</diagram>
-<show_attributes>
-<val>0</val>
-</show_attributes>
-<show_operations>
-<val>0</val>
-</show_operations>
-<subject>
-<ref refid="e62006e6-2a82-11ea-99a7-7d79dbbd423e"/>
-</subject>
-</UML:ClassItem>
 <UML:ClassItem id="f918b22b-2a82-11ea-99a7-7d79dbbd423e">
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 118.78375244140625, 156.3256378173828)</val>
@@ -10052,16 +9914,16 @@ Figure 9.79</val>
 <val>1</val>
 </orthogonal>
 <subject>
-<ref refid="c365f70a-538e-11ec-a31e-0456e5e540ed"/>
+<ref refid="ed883502-6d48-11f0-a782-be7f4daace3f"/>
 </subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 187.12625122070312, 104.20138549804688)</val>
 </matrix>
 <points>
-<val>[(-6.342498779296875, 0.0), (-6.342498779296875, 52.12425231933594), (-3.140533447265625, 52.12425231933594)]</val>
+<val>[(-3.140533447265625, -9.713104248046875), (-3.140533447265625, 52.12425231933594), (-3.140533447265625, 52.12425231933594)]</val>
 </points>
 <head-connection>
-<ref refid="e62006e7-2a82-11ea-99a7-7d79dbbd423e"/>
+<ref refid="ea9a19b4-6d48-11f0-a782-be7f4daace3f"/>
 </head-connection>
 <tail-connection>
 <ref refid="f918b22b-2a82-11ea-99a7-7d79dbbd423e"/>
@@ -10087,34 +9949,13 @@ Figure 9.79</val>
 <ref refid="40a79215-2a83-11ea-99a7-7d79dbbd423e"/>
 </subject>
 </UML:CommentItem>
-<UML:Class id="e62006e6-2a82-11ea-99a7-7d79dbbd423e">
-<name>
-<val>Property</val>
-</name>
-<ownedAttribute>
-<reflist>
-<ref refid="c3660d3a-538e-11ec-a31e-0456e5e540ed"/>
-</reflist>
-</ownedAttribute>
-<owningPackage>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
-</owningPackage>
-<package>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="e62006e7-2a82-11ea-99a7-7d79dbbd423e"/>
-</reflist>
-</presentation>
-</UML:Class>
 <UML:Stereotype id="f918b22a-2a82-11ea-99a7-7d79dbbd423e">
 <name>
 <val>TransferIn</val>
 </name>
 <ownedAttribute>
 <reflist>
-<ref refid="c3660592-538e-11ec-a31e-0456e5e540ed"/>
+<ref refid="ed884d44-6d48-11f0-a782-be7f4daace3f"/>
 </reflist>
 </ownedAttribute>
 <owningPackage>
@@ -13537,9 +13378,6 @@ Figure 9.59</val>
 <association>
 <ref refid="9a348ccc-5540-11eb-a85e-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d73d7086-7645-11eb-9fe2-18cf5efc6bb9"/>
-</class_>
 <lowerValue>
 <ref refid="2ac01aef-e494-11ef-b097-14abc554333b"/>
 </lowerValue>
@@ -14089,9 +13927,9 @@ Figure 9.4</val>
 <ownedPresentation>
 <reflist>
 <ref refid="95d77880-5f7a-11eb-bf7c-d51178c71081"/>
-<ref refid="9b4704ca-5f7a-11eb-bf7c-d51178c71081"/>
 <ref refid="a6d2cedc-5f7a-11eb-bf7c-d51178c71081"/>
 <ref refid="eac1cc88-5f7a-11eb-bf7c-d51178c71081"/>
+<ref refid="ffc65884-6d48-11f0-a782-be7f4daace3f"/>
 <ref refid="ba4dd2ae-5f7a-11eb-bf7c-d51178c71081"/>
 <ref refid="c4bb6f9e-5f7a-11eb-bf7c-d51178c71081"/>
 </reflist>
@@ -14121,32 +13959,6 @@ Figure 9.4</val>
 </show_operations>
 <subject>
 <ref refid="989e516c-2360-11ea-ab0b-c72c0738acd2"/>
-</subject>
-</UML:ClassItem>
-<UML:ClassItem id="9b4704ca-5f7a-11eb-bf7c-d51178c71081">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 49.0, 130.0)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>154.0</val>
-</width>
-<height>
-<val>74.0</val>
-</height>
-<diagram>
-<ref refid="8ee428ca-5f7a-11eb-bf7c-d51178c71081"/>
-</diagram>
-<show_attributes>
-<val>0</val>
-</show_attributes>
-<show_operations>
-<val>0</val>
-</show_operations>
-<subject>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
 </subject>
 </UML:ClassItem>
 <UML:ClassItem id="a6d2cedc-5f7a-11eb-bf7c-d51178c71081">
@@ -14186,16 +13998,16 @@ Figure 9.4</val>
 <val>False</val>
 </orthogonal>
 <subject>
-<ref refid="bbd667ee-5f7a-11eb-bf7c-d51178c71081"/>
+<ref refid="01d57fce-6d49-11f0-a782-be7f4daace3f"/>
 </subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 149.0, 172.0)</val>
 </matrix>
 <points>
-<val>[(0.6454545454545411, 32.0), (0.5, 110.0)]</val>
+<val>[(0.5, 32.0), (0.5, 110.0)]</val>
 </points>
 <head-connection>
-<ref refid="9b4704ca-5f7a-11eb-bf7c-d51178c71081"/>
+<ref refid="ffc65884-6d48-11f0-a782-be7f4daace3f"/>
 </head-connection>
 <tail-connection>
 <ref refid="95d77880-5f7a-11eb-bf7c-d51178c71081"/>
@@ -14247,62 +14059,6 @@ Figure 9.4</val>
 <ref refid="eac1ac26-5f7a-11eb-bf7c-d51178c71081"/>
 </subject>
 </UML:CommentItem>
-<UML:Extension id="bbd667ee-5f7a-11eb-bf7c-d51178c71081">
-<memberEnd>
-<reflist>
-<ref refid="bbd796dc-5f7a-11eb-bf7c-d51178c71081"/>
-<ref refid="bbd81c10-5f7a-11eb-bf7c-d51178c71081"/>
-</reflist>
-</memberEnd>
-<ownedEnd>
-<ref refid="bbd81c10-5f7a-11eb-bf7c-d51178c71081"/>
-</ownedEnd>
-<owningPackage>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
-</owningPackage>
-<package>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="ba4dd2ae-5f7a-11eb-bf7c-d51178c71081"/>
-</reflist>
-</presentation>
-</UML:Extension>
-<UML:Property id="bbd796dc-5f7a-11eb-bf7c-d51178c71081">
-<association>
-<ref refid="bbd667ee-5f7a-11eb-bf7c-d51178c71081"/>
-</association>
-<class_>
-<ref refid="989e516c-2360-11ea-ab0b-c72c0738acd2"/>
-</class_>
-<name>
-<val>baseClass</val>
-</name>
-<structuredClassifier>
-<ref refid="989e516c-2360-11ea-ab0b-c72c0738acd2"/>
-</structuredClassifier>
-<type>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
-</type>
-</UML:Property>
-<UML:ExtensionEnd id="bbd81c10-5f7a-11eb-bf7c-d51178c71081">
-<aggregation>
-<val>composite</val>
-</aggregation>
-<association>
-<ref refid="bbd667ee-5f7a-11eb-bf7c-d51178c71081"/>
-</association>
-<class_>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
-</class_>
-<structuredClassifier>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
-</structuredClassifier>
-<type>
-<ref refid="989e516c-2360-11ea-ab0b-c72c0738acd2"/>
-</type>
-</UML:ExtensionEnd>
 <UML:Generalization id="c5a9e2fa-5f7a-11eb-bf7c-d51178c71081">
 <general>
 <ref refid="e23fcb5d-2360-11ea-ab0b-c72c0738acd2"/>
@@ -14337,17 +14093,19 @@ Figure 9.5</val>
 <ownedPresentation>
 <reflist>
 <ref refid="30c874ca-5f7b-11eb-bf7c-d51178c71081"/>
-<ref refid="3a5a4c2a-5f7b-11eb-bf7c-d51178c71081"/>
 <ref refid="5380ac94-5f7b-11eb-bf7c-d51178c71081"/>
 <ref refid="c5525818-5f7b-11eb-bf7c-d51178c71081"/>
+<ref refid="107d313e-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="d7607108-6d49-11f0-a782-be7f4daace3f"/>
 <ref refid="4680edec-5f7b-11eb-bf7c-d51178c71081"/>
 <ref refid="b972b2c2-5f7b-11eb-bf7c-d51178c71081"/>
+<ref refid="dfe92c34-6d49-11f0-a782-be7f4daace3f"/>
 </reflist>
 </ownedPresentation>
 </UML:Diagram>
 <UML:ClassItem id="30c874ca-5f7b-11eb-bf7c-d51178c71081">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 147.0, 206.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 147.140625, 205.5)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -14368,32 +14126,6 @@ Figure 9.5</val>
 <ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
 </subject>
 </UML:ClassItem>
-<UML:ClassItem id="3a5a4c2a-5f7b-11eb-bf7c-d51178c71081">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 59.0, 56.0)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>156.0</val>
-</width>
-<height>
-<val>58.0</val>
-</height>
-<diagram>
-<ref refid="1636e506-5f7b-11eb-bf7c-d51178c71081"/>
-</diagram>
-<show_attributes>
-<val>0</val>
-</show_attributes>
-<show_operations>
-<val>0</val>
-</show_operations>
-<subject>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
-</subject>
-</UML:ClassItem>
 <UML:ExtensionItem id="4680edec-5f7b-11eb-bf7c-d51178c71081">
 <diagram>
 <ref refid="1636e506-5f7b-11eb-bf7c-d51178c71081"/>
@@ -14405,16 +14137,16 @@ Figure 9.5</val>
 <val>False</val>
 </orthogonal>
 <subject>
-<ref refid="4bdf1b10-5f7b-11eb-bf7c-d51178c71081"/>
+<ref refid="123a3b84-6d49-11f0-a782-be7f4daace3f"/>
 </subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 181.0, 75.0)</val>
 </matrix>
 <points>
-<val>[(4.415106951871664, 39.0), (5.263754843254674, 131.0)]</val>
+<val>[(5.263754843254674, 47.0), (5.404379843254674, 130.5)]</val>
 </points>
 <head-connection>
-<ref refid="3a5a4c2a-5f7b-11eb-bf7c-d51178c71081"/>
+<ref refid="107d313e-6d49-11f0-a782-be7f4daace3f"/>
 </head-connection>
 <tail-connection>
 <ref refid="30c874ca-5f7b-11eb-bf7c-d51178c71081"/>
@@ -14431,7 +14163,7 @@ Figure 9.5</val>
 <val>279.0</val>
 </width>
 <height>
-<val>58.0</val>
+<val>66.0</val>
 </height>
 <diagram>
 <ref refid="1636e506-5f7b-11eb-bf7c-d51178c71081"/>
@@ -14463,7 +14195,7 @@ Figure 9.5</val>
 <val>(1.0, 0.0, 0.0, 1.0, 302.0, 89.0)</val>
 </matrix>
 <points>
-<val>[(0.8021501068376082, 117.0), (1.4140625, 25.0)]</val>
+<val>[(0.9427751068375869, 116.5), (1.4140625, 33.0)]</val>
 </points>
 <head-connection>
 <ref refid="30c874ca-5f7b-11eb-bf7c-d51178c71081"/>
@@ -14492,62 +14224,6 @@ Figure 9.5</val>
 <ref refid="c55235b8-5f7b-11eb-bf7c-d51178c71081"/>
 </subject>
 </UML:CommentItem>
-<UML:Extension id="4bdf1b10-5f7b-11eb-bf7c-d51178c71081">
-<memberEnd>
-<reflist>
-<ref refid="4be016be-5f7b-11eb-bf7c-d51178c71081"/>
-<ref refid="4be099a4-5f7b-11eb-bf7c-d51178c71081"/>
-</reflist>
-</memberEnd>
-<ownedEnd>
-<ref refid="4be099a4-5f7b-11eb-bf7c-d51178c71081"/>
-</ownedEnd>
-<owningPackage>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
-</owningPackage>
-<package>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="4680edec-5f7b-11eb-bf7c-d51178c71081"/>
-</reflist>
-</presentation>
-</UML:Extension>
-<UML:Property id="4be016be-5f7b-11eb-bf7c-d51178c71081">
-<association>
-<ref refid="4bdf1b10-5f7b-11eb-bf7c-d51178c71081"/>
-</association>
-<class_>
-<ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
-</class_>
-<name>
-<val>baseClass</val>
-</name>
-<structuredClassifier>
-<ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
-</structuredClassifier>
-<type>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
-</type>
-</UML:Property>
-<UML:ExtensionEnd id="4be099a4-5f7b-11eb-bf7c-d51178c71081">
-<aggregation>
-<val>composite</val>
-</aggregation>
-<association>
-<ref refid="4bdf1b10-5f7b-11eb-bf7c-d51178c71081"/>
-</association>
-<class_>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
-</class_>
-<structuredClassifier>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
-</structuredClassifier>
-<type>
-<ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
-</type>
-</UML:ExtensionEnd>
 <UML:Comment id="c55235b8-5f7b-11eb-bf7c-d51178c71081">
 <body>
 <val>RAAML 1.0
@@ -14569,15 +14245,15 @@ Figure 9.6</val>
 <ownedPresentation>
 <reflist>
 <ref refid="e608ea40-5f7b-11eb-bf7c-d51178c71081"/>
-<ref refid="e8768c56-5f7b-11eb-bf7c-d51178c71081"/>
 <ref refid="fdc179e0-5f7b-11eb-bf7c-d51178c71081"/>
+<ref refid="23224dd8-6d49-11f0-a782-be7f4daace3f"/>
 <ref refid="f4c47d10-5f7b-11eb-bf7c-d51178c71081"/>
 </reflist>
 </ownedPresentation>
 </UML:Diagram>
 <UML:ClassItem id="e608ea40-5f7b-11eb-bf7c-d51178c71081">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 138.0, 264.0)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 135.00746268656718, 264.0)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -14601,32 +14277,6 @@ Figure 9.6</val>
 <ref refid="dc6a99a2-2363-11ea-ab0b-c72c0738acd2"/>
 </subject>
 </UML:ClassItem>
-<UML:ClassItem id="e8768c56-5f7b-11eb-bf7c-d51178c71081">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 135.0, 133.0)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>104.0</val>
-</width>
-<height>
-<val>74.0</val>
-</height>
-<diagram>
-<ref refid="de98b04c-5f7b-11eb-bf7c-d51178c71081"/>
-</diagram>
-<show_attributes>
-<val>0</val>
-</show_attributes>
-<show_operations>
-<val>0</val>
-</show_operations>
-<subject>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
-</subject>
-</UML:ClassItem>
 <UML:ExtensionItem id="f4c47d10-5f7b-11eb-bf7c-d51178c71081">
 <diagram>
 <ref refid="de98b04c-5f7b-11eb-bf7c-d51178c71081"/>
@@ -14638,16 +14288,16 @@ Figure 9.6</val>
 <val>False</val>
 </orthogonal>
 <subject>
-<ref refid="f5cd4480-5f7b-11eb-bf7c-d51178c71081"/>
+<ref refid="26e590ba-6d49-11f0-a782-be7f4daace3f"/>
 </subject>
 <matrix>
 <val>(1.0, 0.0, 0.0, 1.0, 183.0, 163.0)</val>
 </matrix>
 <points>
-<val>[(1.374538200088665, 44.0), (2.007462686567166, 101.0)]</val>
+<val>[(2.0074626865671803, 50.578125), (2.5074626865671803, 101.0)]</val>
 </points>
 <head-connection>
-<ref refid="e8768c56-5f7b-11eb-bf7c-d51178c71081"/>
+<ref refid="23224dd8-6d49-11f0-a782-be7f4daace3f"/>
 </head-connection>
 <tail-connection>
 <ref refid="e608ea40-5f7b-11eb-bf7c-d51178c71081"/>
@@ -14673,62 +14323,6 @@ Figure 9.6</val>
 <ref refid="fdc1562c-5f7b-11eb-bf7c-d51178c71081"/>
 </subject>
 </UML:CommentItem>
-<UML:Extension id="f5cd4480-5f7b-11eb-bf7c-d51178c71081">
-<memberEnd>
-<reflist>
-<ref refid="f5ce443e-5f7b-11eb-bf7c-d51178c71081"/>
-<ref refid="f5cec576-5f7b-11eb-bf7c-d51178c71081"/>
-</reflist>
-</memberEnd>
-<ownedEnd>
-<ref refid="f5cec576-5f7b-11eb-bf7c-d51178c71081"/>
-</ownedEnd>
-<owningPackage>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
-</owningPackage>
-<package>
-<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="f4c47d10-5f7b-11eb-bf7c-d51178c71081"/>
-</reflist>
-</presentation>
-</UML:Extension>
-<UML:Property id="f5ce443e-5f7b-11eb-bf7c-d51178c71081">
-<association>
-<ref refid="f5cd4480-5f7b-11eb-bf7c-d51178c71081"/>
-</association>
-<class_>
-<ref refid="dc6a99a2-2363-11ea-ab0b-c72c0738acd2"/>
-</class_>
-<name>
-<val>baseClass</val>
-</name>
-<structuredClassifier>
-<ref refid="dc6a99a2-2363-11ea-ab0b-c72c0738acd2"/>
-</structuredClassifier>
-<type>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
-</type>
-</UML:Property>
-<UML:ExtensionEnd id="f5cec576-5f7b-11eb-bf7c-d51178c71081">
-<aggregation>
-<val>composite</val>
-</aggregation>
-<association>
-<ref refid="f5cd4480-5f7b-11eb-bf7c-d51178c71081"/>
-</association>
-<class_>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
-</class_>
-<structuredClassifier>
-<ref refid="6019a6d2-2362-11ea-ab0b-c72c0738acd2"/>
-</structuredClassifier>
-<type>
-<ref refid="dc6a99a2-2363-11ea-ab0b-c72c0738acd2"/>
-</type>
-</UML:ExtensionEnd>
 <UML:Comment id="fdc1562c-5f7b-11eb-bf7c-d51178c71081">
 <body>
 <val>RAAML 1.0
@@ -15666,9 +15260,6 @@ Figure 10.8</val>
 </value>
 </UML:LiteralUnlimitedNatural>
 <UML:Property id="f9707148-6e5d-11eb-a785-8f7ffa17c191">
-<class_>
-<ref refid="05b6e65c-2360-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <lowerValue>
 <ref refid="2ac379ee-e494-11ef-aa92-14abc554333b"/>
 </lowerValue>
@@ -15940,9 +15531,6 @@ Figure 10.8</val>
 <association>
 <ref refid="08c1ba68-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="a8a6d79e-2a7e-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -15960,9 +15548,6 @@ Figure 10.8</val>
 <association>
 <ref refid="08c1ba68-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -15996,9 +15581,6 @@ Figure 10.8</val>
 <association>
 <ref refid="2124a8c2-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="8fcb654e-2a80-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16016,9 +15598,6 @@ Figure 10.8</val>
 <association>
 <ref refid="2124a8c2-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16052,9 +15631,6 @@ Figure 10.8</val>
 <association>
 <ref refid="57857c34-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="be3e986e-2a7c-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16072,9 +15648,6 @@ Figure 10.8</val>
 <association>
 <ref refid="57857c34-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16108,9 +15681,6 @@ Figure 10.8</val>
 <association>
 <ref refid="74ad831a-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="2cc75cb0-2a7f-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16128,9 +15698,6 @@ Figure 10.8</val>
 <association>
 <ref refid="74ad831a-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16164,9 +15731,6 @@ Figure 10.8</val>
 <association>
 <ref refid="a7794450-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="793e66f8-2a82-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16184,9 +15748,6 @@ Figure 10.8</val>
 <association>
 <ref refid="a7794450-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16220,9 +15781,6 @@ Figure 10.8</val>
 <association>
 <ref refid="bfbf949c-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="1c21e8d2-2a82-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16240,9 +15798,6 @@ Figure 10.8</val>
 <association>
 <ref refid="bfbf949c-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16276,9 +15831,6 @@ Figure 10.8</val>
 <association>
 <ref refid="d8b4b612-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="45c581ee-2a82-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16296,9 +15848,6 @@ Figure 10.8</val>
 <association>
 <ref refid="d8b4b612-7961-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16332,9 +15881,6 @@ Figure 10.8</val>
 <association>
 <ref refid="34af353c-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="68b145cc-2a81-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16352,9 +15898,6 @@ Figure 10.8</val>
 <association>
 <ref refid="34af353c-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16388,9 +15931,6 @@ Figure 10.8</val>
 <association>
 <ref refid="47d425b4-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="ab3f0a54-2a82-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16408,9 +15948,6 @@ Figure 10.8</val>
 <association>
 <ref refid="47d425b4-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16444,9 +15981,6 @@ Figure 10.8</val>
 <association>
 <ref refid="632e7184-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="1d94e560-2a83-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16464,9 +15998,6 @@ Figure 10.8</val>
 <association>
 <ref refid="632e7184-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16500,9 +16031,6 @@ Figure 10.8</val>
 <association>
 <ref refid="9d2f5eb6-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="9e5e1448-2a81-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16520,9 +16048,6 @@ Figure 10.8</val>
 <association>
 <ref refid="9d2f5eb6-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16556,9 +16081,6 @@ Figure 10.8</val>
 <association>
 <ref refid="b0e0e1dc-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="e6019eda-2a7e-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16576,9 +16098,6 @@ Figure 10.8</val>
 <association>
 <ref refid="b0e0e1dc-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16612,9 +16131,6 @@ Figure 10.8</val>
 <association>
 <ref refid="b940d698-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="5ae20764-242e-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16632,9 +16148,6 @@ Figure 10.8</val>
 <association>
 <ref refid="b940d698-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="5349fd22-242e-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="5349fd22-242e-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -16668,9 +16181,6 @@ Figure 10.8</val>
 <association>
 <ref refid="c1fe79f2-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="f620de22-242d-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16688,9 +16198,6 @@ Figure 10.8</val>
 <association>
 <ref refid="c1fe79f2-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -16724,9 +16231,6 @@ Figure 10.8</val>
 <association>
 <ref refid="dacccb46-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="501b63c4-2a7e-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16744,9 +16248,6 @@ Figure 10.8</val>
 <association>
 <ref refid="dacccb46-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16780,9 +16281,6 @@ Figure 10.8</val>
 <association>
 <ref refid="e85e23f4-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="1a8a724c-2a81-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16800,9 +16298,6 @@ Figure 10.8</val>
 <association>
 <ref refid="e85e23f4-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -16836,9 +16331,6 @@ Figure 10.8</val>
 <association>
 <ref refid="f106969e-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="2741c35e-242e-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16856,9 +16348,6 @@ Figure 10.8</val>
 <association>
 <ref refid="f106969e-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -16892,9 +16381,6 @@ Figure 10.8</val>
 <association>
 <ref refid="f8f112bc-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="8cfc6894-242d-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16912,9 +16398,6 @@ Figure 10.8</val>
 <association>
 <ref refid="f8f112bc-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -16948,9 +16431,6 @@ Figure 10.8</val>
 <association>
 <ref refid="ff00dc96-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="3e1f60be-242d-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -16968,9 +16448,6 @@ Figure 10.8</val>
 <association>
 <ref refid="ff00dc96-7962-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -17076,9 +16553,6 @@ Figure 10.8</val>
 <association>
 <ref refid="9ca76af4-7964-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d6eeddb0-2a81-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -17096,9 +16570,6 @@ Figure 10.8</val>
 <association>
 <ref refid="9ca76af4-7964-11eb-9356-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -17236,8 +16707,6 @@ Figure 10.8</val>
 <ownedType>
 <reflist>
 <ref refid="a3bbdc28-2b34-11ea-99a7-7d79dbbd423e"/>
-<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
-<ref refid="a0d1c54a-2b2f-11ea-99a7-7d79dbbd423e"/>
 <ref refid="a71884c0-2b2f-11ea-99a7-7d79dbbd423e"/>
 <ref refid="c0cc2962-2b2f-11ea-99a7-7d79dbbd423e"/>
 <ref refid="7f89cd6e-5938-11eb-a344-18cf5efc6bb9"/>
@@ -17266,8 +16735,6 @@ Figure 10.8</val>
 <packagedElement>
 <reflist>
 <ref refid="a3bbdc28-2b34-11ea-99a7-7d79dbbd423e"/>
-<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
-<ref refid="a0d1c54a-2b2f-11ea-99a7-7d79dbbd423e"/>
 <ref refid="a71884c0-2b2f-11ea-99a7-7d79dbbd423e"/>
 <ref refid="c0cc2962-2b2f-11ea-99a7-7d79dbbd423e"/>
 <ref refid="7f89cd6e-5938-11eb-a344-18cf5efc6bb9"/>
@@ -17581,13 +17048,14 @@ Figure 9.100</val>
 <ref refid="03abfa74-b026-11eb-a838-18cf5efc6bb9"/>
 <ref refid="fb1bfa78-538e-11ec-a31e-0456e5e540ed"/>
 <ref refid="13a70056-538f-11ec-a31e-0456e5e540ed"/>
+<ref refid="ed884fce-6d48-11f0-a782-be7f4daace3f"/>
 </reflist>
 </ownedAttribute>
 <owningPackage>
-<ref refid="9ffe6170-b024-11eb-a838-18cf5efc6bb9"/>
+<ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
 </owningPackage>
 <package>
-<ref refid="9ffe6170-b024-11eb-a838-18cf5efc6bb9"/>
+<ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
 </package>
 <presentation>
 <reflist>
@@ -17595,6 +17063,8 @@ Figure 9.100</val>
 <ref refid="a45266a8-b025-11eb-a838-18cf5efc6bb9"/>
 <ref refid="b4adf2e2-b025-11eb-a838-18cf5efc6bb9"/>
 <ref refid="03a7fd66-b026-11eb-a838-18cf5efc6bb9"/>
+<ref refid="ea9a19b4-6d48-11f0-a782-be7f4daace3f"/>
+<ref refid="d7607108-6d49-11f0-a782-be7f4daace3f"/>
 </reflist>
 </presentation>
 </UML:Class>
@@ -17605,9 +17075,6 @@ Figure 9.100</val>
 <association>
 <ref refid="aade869a-2b34-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -17641,9 +17108,6 @@ Figure 9.100</val>
 <association>
 <ref refid="aade869a-2b34-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="a3bbdc28-2b34-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -17724,7 +17188,7 @@ Figure 9.100</val>
 </UML:ClassItem>
 <UML:ClassItem id="45908028-b025-11eb-a838-18cf5efc6bb9">
 <matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 192.48886108398438, 50.25799560546875)</val>
+<val>(1.0, 0.0, 0.0, 1.0, 193.20761108398438, 50.25799560546875)</val>
 </matrix>
 <top-left>
 <val>(0.0, 0.0)</val>
@@ -17765,7 +17229,7 @@ Figure 9.100</val>
 <val>(1.0, 0.0, 0.0, 1.0, 244.35403442382812, 108.25799560546875)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (-1.14642333984375, 68.02313232421875)]</val>
+<val>[(0.71875, 0.0), (-1.14642333984375, 68.02313232421875)]</val>
 </points>
 <head-connection>
 <ref refid="45908028-b025-11eb-a838-18cf5efc6bb9"/>
@@ -17785,7 +17249,7 @@ Figure 9.100</val>
 <val>100.0</val>
 </width>
 <height>
-<val>58.0</val>
+<val>66.0</val>
 </height>
 <diagram>
 <ref refid="3746a146-b025-11eb-a838-18cf5efc6bb9"/>
@@ -17869,7 +17333,7 @@ Figure 9.100</val>
 <val>(1.0, 0.0, 0.0, 1.0, 89.97061157226562, 108.25799560546875)</val>
 </matrix>
 <points>
-<val>[(0.0, 0.0), (0.0, 42.600494384765625), (113.40875244140625, 42.600494384765625), (113.40875244140625, 68.02313232421875)]</val>
+<val>[(0.0, 8.0), (0.0, 42.600494384765625), (113.40875244140625, 42.600494384765625), (113.40875244140625, 68.02313232421875)]</val>
 </points>
 <head-connection>
 <ref refid="4591276c-b025-11eb-a838-18cf5efc6bb9"/>
@@ -17926,9 +17390,6 @@ Figure 9.100</val>
 <association>
 <ref refid="c9b1779e-2b2f-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="c0cc2962-2b2f-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -17968,9 +17429,6 @@ Figure 9.100</val>
 <association>
 <ref refid="c9b1779e-2b2f-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="a0d1c54a-2b2f-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="a0d1c54a-2b2f-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -17989,10 +17447,10 @@ Figure 9.100</val>
 </reflist>
 </ownedAttribute>
 <owningPackage>
-<ref refid="9ffe6170-b024-11eb-a838-18cf5efc6bb9"/>
+<ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
 </owningPackage>
 <package>
-<ref refid="9ffe6170-b024-11eb-a838-18cf5efc6bb9"/>
+<ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
 </package>
 <presentation>
 <reflist>
@@ -18005,9 +17463,6 @@ Figure 9.100</val>
 <association>
 <ref refid="cc08b98a-2b2f-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="c0cc2962-2b2f-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -18047,9 +17502,6 @@ Figure 9.100</val>
 <association>
 <ref refid="cc08b98a-2b2f-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="a71884c0-2b2f-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="a71884c0-2b2f-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -18084,9 +17536,6 @@ Figure 9.100</val>
 <association>
 <ref refid="ce7b3224-2b2f-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="c0cc2962-2b2f-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -18126,9 +17575,6 @@ Figure 9.100</val>
 <association>
 <ref refid="ce7b3224-2b2f-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -18393,9 +17839,6 @@ Figure 9.103</val>
 <association>
 <ref refid="7acea9e0-b025-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="7f89cd6e-5938-11eb-a344-18cf5efc6bb9"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -18413,9 +17856,6 @@ Figure 9.103</val>
 <association>
 <ref refid="7acea9e0-b025-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -19000,9 +18440,6 @@ Figure 9.97</val>
 <association>
 <ref refid="cd90094e-b025-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="a60c2656-2b32-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -19020,9 +18457,6 @@ Figure 9.97</val>
 <association>
 <ref refid="cd90094e-b025-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -19056,9 +18490,6 @@ Figure 9.97</val>
 <association>
 <ref refid="cd947ace-b025-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="a60c2656-2b32-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -19076,9 +18507,6 @@ Figure 9.97</val>
 <association>
 <ref refid="cd947ace-b025-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="a71884c0-2b2f-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="a71884c0-2b2f-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -19112,9 +18540,6 @@ Figure 9.97</val>
 <association>
 <ref refid="cd9798f8-b025-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="a60c2656-2b32-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -19132,9 +18557,6 @@ Figure 9.97</val>
 <association>
 <ref refid="cd9798f8-b025-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="a0d1c54a-2b2f-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="a0d1c54a-2b2f-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -19315,9 +18737,6 @@ Figure 9.101</val>
 <association>
 <ref refid="03ab94a8-b026-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="c649e1fe-2b34-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -19335,9 +18754,6 @@ Figure 9.101</val>
 <association>
 <ref refid="03ab94a8-b026-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -20047,9 +19463,6 @@ Figure 9.98</val>
 <association>
 <ref refid="e0a1ffb4-b026-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="fa59cb86-2b33-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -20067,9 +19480,6 @@ Figure 9.98</val>
 <association>
 <ref refid="e0a1ffb4-b026-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -20389,9 +19799,6 @@ Figure 9.151</val>
 <association>
 <ref refid="7673ebc4-b027-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="851c1d1c-2b0e-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -20409,9 +19816,6 @@ Figure 9.151</val>
 <association>
 <ref refid="7673ebc4-b027-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -20785,9 +20189,6 @@ Figure 9.151</val>
 <association>
 <ref refid="662f6cb8-2b10-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="4bb49462-2b10-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>conditions</val>
 </name>
@@ -21874,9 +21275,6 @@ Figure 9.82</val>
 <aggregation>
 <val>shared</val>
 </aggregation>
-<class_>
-<ref refid="9e91f0ea-2b3c-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>Context</val>
 </name>
@@ -21916,9 +21314,6 @@ Figure 9.82</val>
 <aggregation>
 <val>shared</val>
 </aggregation>
-<class_>
-<ref refid="9e91f0ea-2b3c-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2ad2e01f-e494-11ef-af84-14abc554333b"/>
 </lowerValue>
@@ -22472,9 +21867,6 @@ Figure 9.95</val>
 <association>
 <ref refid="f765e7ce-2b39-11ea-99a7-7d79dbbd423e"/>
 </association>
-<class_>
-<ref refid="33817b19-2b3a-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2ad3b436-e494-11ef-bcef-14abc554333b"/>
 </lowerValue>
@@ -23765,9 +23157,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="da873c42-b031-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="33817b19-2b3a-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2ad620e8-e494-11ef-b0bc-14abc554333b"/>
 </lowerValue>
@@ -23848,9 +23237,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="e15005f4-b031-11eb-a838-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="33817b19-2b3a-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <lowerValue>
 <ref refid="2ad6262c-e494-11ef-ac60-14abc554333b"/>
 </lowerValue>
@@ -23904,9 +23290,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="fa408864-b5a8-11eb-9e03-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="dde0bab8-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -23924,9 +23307,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="fa408864-b5a8-11eb-9e03-18cf5efc6bb9"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -24091,9 +23471,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="e81b0e54-4bd3-11ec-8adf-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="04ba25c4-2a7d-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -24111,9 +23488,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="e81b0e54-4bd3-11ec-8adf-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -24147,9 +23521,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="fb8c552e-4bd3-11ec-8adf-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="064abb50-2a7e-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -24167,9 +23538,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="fb8c552e-4bd3-11ec-8adf-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -24262,9 +23630,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="babc42fc-52d1-11ec-867f-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="4dfb3d16-2a70-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>topEvent</val>
 </name>
@@ -24335,9 +23700,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="7551a94c-538e-11ec-a31e-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="b040b14a-2a70-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -24355,70 +23717,11 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="7551a94c-538e-11ec-a31e-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
 <type>
 <ref refid="b040b14a-2a70-11ea-99a7-7d79dbbd423e"/>
-</type>
-</UML:ExtensionEnd>
-<UML:Extension id="c365f70a-538e-11ec-a31e-0456e5e540ed">
-<memberEnd>
-<reflist>
-<ref refid="c3660592-538e-11ec-a31e-0456e5e540ed"/>
-<ref refid="c3660d3a-538e-11ec-a31e-0456e5e540ed"/>
-</reflist>
-</memberEnd>
-<ownedEnd>
-<ref refid="c3660d3a-538e-11ec-a31e-0456e5e540ed"/>
-</ownedEnd>
-<owningPackage>
-<ref refid="70528a36-2a70-11ea-99a7-7d79dbbd423e"/>
-</owningPackage>
-<package>
-<ref refid="70528a36-2a70-11ea-99a7-7d79dbbd423e"/>
-</package>
-<presentation>
-<reflist>
-<ref refid="fe8b1694-2a82-11ea-99a7-7d79dbbd423e"/>
-</reflist>
-</presentation>
-</UML:Extension>
-<UML:Property id="c3660592-538e-11ec-a31e-0456e5e540ed">
-<association>
-<ref refid="c365f70a-538e-11ec-a31e-0456e5e540ed"/>
-</association>
-<class_>
-<ref refid="f918b22a-2a82-11ea-99a7-7d79dbbd423e"/>
-</class_>
-<name>
-<val>baseClass</val>
-</name>
-<structuredClassifier>
-<ref refid="f918b22a-2a82-11ea-99a7-7d79dbbd423e"/>
-</structuredClassifier>
-<type>
-<ref refid="e62006e6-2a82-11ea-99a7-7d79dbbd423e"/>
-</type>
-</UML:Property>
-<UML:ExtensionEnd id="c3660d3a-538e-11ec-a31e-0456e5e540ed">
-<aggregation>
-<val>composite</val>
-</aggregation>
-<association>
-<ref refid="c365f70a-538e-11ec-a31e-0456e5e540ed"/>
-</association>
-<class_>
-<ref refid="e62006e6-2a82-11ea-99a7-7d79dbbd423e"/>
-</class_>
-<structuredClassifier>
-<ref refid="e62006e6-2a82-11ea-99a7-7d79dbbd423e"/>
-</structuredClassifier>
-<type>
-<ref refid="f918b22a-2a82-11ea-99a7-7d79dbbd423e"/>
 </type>
 </UML:ExtensionEnd>
 <UML:Extension id="fb1bad8e-538e-11ec-a31e-0456e5e540ed">
@@ -24447,9 +23750,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="fb1bad8e-538e-11ec-a31e-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="75cfdfee-2b34-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -24467,9 +23767,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="fb1bad8e-538e-11ec-a31e-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -24503,9 +23800,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="13a6e9ae-538f-11ec-a31e-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="ec641f12-2b34-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -24523,9 +23817,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="13a6e9ae-538f-11ec-a31e-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
-</class_>
 <structuredClassifier>
 <ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
 </structuredClassifier>
@@ -24585,9 +23876,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="837b6b22-257d-11ed-99f6-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="e696af52-5480-11eb-a85e-18cf5efc6bb9"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -24605,9 +23893,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="837b6b22-257d-11ed-99f6-0456e5e540ed"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -24917,9 +24202,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="6dcb2c4c-ce99-11ee-8b5f-97627a542234"/>
 </association>
-<class_>
-<ref refid="6495c68a-ce99-11ee-8388-97627a542234"/>
-</class_>
 <name>
 <val>baseClass</val>
 </name>
@@ -24937,9 +24219,6 @@ Figure x (No Figure)</val>
 <association>
 <ref refid="6dcb2c4c-ce99-11ee-8b5f-97627a542234"/>
 </association>
-<class_>
-<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
-</class_>
 <structuredClassifier>
 <ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
 </structuredClassifier>
@@ -25744,9 +25023,6 @@ Figure 9.130</val>
 <association>
 <ref refid="794251d3-ce9b-11ee-b5ff-97627a542234"/>
 </association>
-<class_>
-<ref refid="7343e411-ce9a-11ee-bb61-97627a542234"/>
-</class_>
 <name>
 <val>malfunctioningBehavior</val>
 </name>
@@ -25824,9 +25100,6 @@ Figure 9.130</val>
 <association>
 <ref refid="57005a0b-ce9b-11ee-9dd6-97627a542234"/>
 </association>
-<class_>
-<ref refid="7343e411-ce9a-11ee-bb61-97627a542234"/>
-</class_>
 <lowerValue>
 <ref refid="2ad8ec24-e494-11ef-b997-14abc554333b"/>
 </lowerValue>
@@ -27436,18 +26709,23 @@ Figure 9.138</val>
 <name>
 <val>UML</val>
 </name>
-<ownedDiagram>
-<reflist>
-<ref refid="cc97453a-b7af-11ef-b58f-be7f4daace40"/>
-</reflist>
-</ownedDiagram>
 <ownedType>
 <reflist>
+<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
+<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
+<ref refid="5349fd22-242e-11ea-99a7-7d79dbbd423e"/>
+<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
+<ref refid="a0d1c54a-2b2f-11ea-99a7-7d79dbbd423e"/>
 <ref refid="d1ab440e-b7af-11ef-b58f-be7f4daace40"/>
 </reflist>
 </ownedType>
 <packagedElement>
 <reflist>
+<ref refid="d5df4848-235f-11ea-ab0b-c72c0738acd2"/>
+<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
+<ref refid="5349fd22-242e-11ea-99a7-7d79dbbd423e"/>
+<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
+<ref refid="a0d1c54a-2b2f-11ea-99a7-7d79dbbd423e"/>
 <ref refid="d1ab440e-b7af-11ef-b58f-be7f4daace40"/>
 </reflist>
 </packagedElement>
@@ -27477,22 +26755,6 @@ Figure 9.138</val>
 <ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
 </subject>
 </UML:PackageItem>
-<UML:Diagram id="cc97453a-b7af-11ef-b58f-be7f4daace40">
-<diagramType>
-<val></val>
-</diagramType>
-<element>
-<ref refid="9f50d2d0-b7af-11ef-a190-be7f4daace40"/>
-</element>
-<name>
-<val>UML</val>
-</name>
-<ownedPresentation>
-<reflist>
-<ref refid="d1ab98b4-b7af-11ef-b58f-be7f4daace40"/>
-</reflist>
-</ownedPresentation>
-</UML:Diagram>
 <UML:Class id="d1ab440e-b7af-11ef-b58f-be7f4daace40">
 <name>
 <val>Diagram</val>
@@ -27505,7 +26767,6 @@ Figure 9.138</val>
 </package>
 <presentation>
 <reflist>
-<ref refid="d1ab98b4-b7af-11ef-b58f-be7f4daace40"/>
 <ref refid="e0c436f8-b7af-11ef-b58f-be7f4daace40"/>
 </reflist>
 </presentation>
@@ -27516,32 +26777,6 @@ Figure 9.138</val>
 </reflist>
 </specialization>
 </UML:Class>
-<UML:ClassItem id="d1ab98b4-b7af-11ef-b58f-be7f4daace40">
-<matrix>
-<val>(1.0, 0.0, 0.0, 1.0, 145.0, 176.0)</val>
-</matrix>
-<top-left>
-<val>(0.0, 0.0)</val>
-</top-left>
-<width>
-<val>100.0</val>
-</width>
-<height>
-<val>55.0</val>
-</height>
-<diagram>
-<ref refid="cc97453a-b7af-11ef-b58f-be7f4daace40"/>
-</diagram>
-<show_attributes>
-<val>0</val>
-</show_attributes>
-<show_operations>
-<val>0</val>
-</show_operations>
-<subject>
-<ref refid="d1ab440e-b7af-11ef-b58f-be7f4daace40"/>
-</subject>
-</UML:ClassItem>
 <UML:Diagram id="dc1aaf92-b7af-11ef-b58f-be7f4daace40">
 <diagramType>
 <val></val>
@@ -27765,9 +27000,6 @@ Figure 9.138</val>
 </specific>
 </UML:Generalization>
 <UML:Property id="b65366cc-b7bf-11ef-91cc-be7f4daace40">
-<class_>
-<ref refid="e591db9a-b7af-11ef-b58f-be7f4daace40"/>
-</class_>
 <defaultValue>
 <ref refid="539b73ee-e494-11ef-8d3f-14abc554333b"/>
 </defaultValue>
@@ -27782,9 +27014,6 @@ Figure 9.138</val>
 </typeValue>
 </UML:Property>
 <UML:Property id="c1c2ee24-b7bf-11ef-91cc-be7f4daace40">
-<class_>
-<ref refid="f2bd02fe-b7af-11ef-b58f-be7f4daace40"/>
-</class_>
 <defaultValue>
 <ref refid="672448bb-e494-11ef-9847-14abc554333b"/>
 </defaultValue>
@@ -27820,5 +27049,442 @@ Figure 9.138</val>
 <val>"stpa"</val>
 </value>
 </UML:LiteralString>
+<UML:Package id="4c25a5de-6d3c-11f0-a1fd-be7f4daace3f">
+<name>
+<val>SysML</val>
+</name>
+<ownedType>
+<reflist>
+<ref refid="05b6e65c-2360-11ea-ab0b-c72c0738acd2"/>
+<ref refid="e23fcb5d-2360-11ea-ab0b-c72c0738acd2"/>
+</reflist>
+</ownedType>
+<packagedElement>
+<reflist>
+<ref refid="05b6e65c-2360-11ea-ab0b-c72c0738acd2"/>
+<ref refid="e23fcb5d-2360-11ea-ab0b-c72c0738acd2"/>
+</reflist>
+</packagedElement>
+</UML:Package>
+<UML:ClassItem id="ea9a19b4-6d48-11f0-a782-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 133.9857177734375, 28.48828125)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>66.0</val>
+</height>
+<diagram>
+<ref refid="e1154abc-2a82-11ea-99a7-7d79dbbd423e"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
+</subject>
+</UML:ClassItem>
+<UML:Extension id="ed883502-6d48-11f0-a782-be7f4daace3f">
+<memberEnd>
+<reflist>
+<ref refid="ed884d44-6d48-11f0-a782-be7f4daace3f"/>
+<ref refid="ed884fce-6d48-11f0-a782-be7f4daace3f"/>
+</reflist>
+</memberEnd>
+<ownedEnd>
+<ref refid="ed884fce-6d48-11f0-a782-be7f4daace3f"/>
+</ownedEnd>
+<owningPackage>
+<ref refid="70528a36-2a70-11ea-99a7-7d79dbbd423e"/>
+</owningPackage>
+<package>
+<ref refid="70528a36-2a70-11ea-99a7-7d79dbbd423e"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="fe8b1694-2a82-11ea-99a7-7d79dbbd423e"/>
+</reflist>
+</presentation>
+</UML:Extension>
+<UML:Property id="ed884d44-6d48-11f0-a782-be7f4daace3f">
+<association>
+<ref refid="ed883502-6d48-11f0-a782-be7f4daace3f"/>
+</association>
+<name>
+<val>baseClass</val>
+</name>
+<structuredClassifier>
+<ref refid="f918b22a-2a82-11ea-99a7-7d79dbbd423e"/>
+</structuredClassifier>
+<type>
+<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
+</type>
+</UML:Property>
+<UML:ExtensionEnd id="ed884fce-6d48-11f0-a782-be7f4daace3f">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="ed883502-6d48-11f0-a782-be7f4daace3f"/>
+</association>
+<structuredClassifier>
+<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
+</structuredClassifier>
+<type>
+<ref refid="f918b22a-2a82-11ea-99a7-7d79dbbd423e"/>
+</type>
+</UML:ExtensionEnd>
+<UML:ClassItem id="ffc65884-6d48-11f0-a782-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 99.0, 130.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>101.0</val>
+</width>
+<height>
+<val>74.0</val>
+</height>
+<diagram>
+<ref refid="8ee428ca-5f7a-11eb-bf7c-d51178c71081"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
+</subject>
+</UML:ClassItem>
+<UML:Extension id="01d57fce-6d49-11f0-a782-be7f4daace3f">
+<memberEnd>
+<reflist>
+<ref refid="01d592fc-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="01d59554-6d49-11f0-a782-be7f4daace3f"/>
+</reflist>
+</memberEnd>
+<ownedEnd>
+<ref refid="01d59554-6d49-11f0-a782-be7f4daace3f"/>
+</ownedEnd>
+<owningPackage>
+<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+</owningPackage>
+<package>
+<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="ba4dd2ae-5f7a-11eb-bf7c-d51178c71081"/>
+</reflist>
+</presentation>
+</UML:Extension>
+<UML:Property id="01d592fc-6d49-11f0-a782-be7f4daace3f">
+<association>
+<ref refid="01d57fce-6d49-11f0-a782-be7f4daace3f"/>
+</association>
+<name>
+<val>baseClass</val>
+</name>
+<structuredClassifier>
+<ref refid="989e516c-2360-11ea-ab0b-c72c0738acd2"/>
+</structuredClassifier>
+<type>
+<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
+</type>
+</UML:Property>
+<UML:ExtensionEnd id="01d59554-6d49-11f0-a782-be7f4daace3f">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="01d57fce-6d49-11f0-a782-be7f4daace3f"/>
+</association>
+<structuredClassifier>
+<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
+</structuredClassifier>
+<type>
+<ref refid="989e516c-2360-11ea-ab0b-c72c0738acd2"/>
+</type>
+</UML:ExtensionEnd>
+<UML:ClassItem id="107d313e-6d49-11f0-a782-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 120.2265625, 40.0)</val>
+</matrix>
+<top-left>
+<val>(-34.2265625, 16.0)</val>
+</top-left>
+<width>
+<val>134.2265625</val>
+</width>
+<height>
+<val>66.0</val>
+</height>
+<diagram>
+<ref refid="1636e506-5f7b-11eb-bf7c-d51178c71081"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
+</subject>
+</UML:ClassItem>
+<UML:Extension id="123a3b84-6d49-11f0-a782-be7f4daace3f">
+<memberEnd>
+<reflist>
+<ref refid="123a4f3e-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="123a5182-6d49-11f0-a782-be7f4daace3f"/>
+</reflist>
+</memberEnd>
+<ownedEnd>
+<ref refid="123a5182-6d49-11f0-a782-be7f4daace3f"/>
+</ownedEnd>
+<owningPackage>
+<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+</owningPackage>
+<package>
+<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="4680edec-5f7b-11eb-bf7c-d51178c71081"/>
+</reflist>
+</presentation>
+</UML:Extension>
+<UML:Property id="123a4f3e-6d49-11f0-a782-be7f4daace3f">
+<association>
+<ref refid="123a3b84-6d49-11f0-a782-be7f4daace3f"/>
+</association>
+<name>
+<val>baseClass</val>
+</name>
+<structuredClassifier>
+<ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
+</structuredClassifier>
+<type>
+<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
+</type>
+</UML:Property>
+<UML:ExtensionEnd id="123a5182-6d49-11f0-a782-be7f4daace3f">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="123a3b84-6d49-11f0-a782-be7f4daace3f"/>
+</association>
+<structuredClassifier>
+<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
+</structuredClassifier>
+<type>
+<ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
+</type>
+</UML:ExtensionEnd>
+<UML:ClassItem id="23224dd8-6d49-11f0-a782-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 135.00746268656718, 131.578125)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>82.0</val>
+</height>
+<diagram>
+<ref refid="de98b04c-5f7b-11eb-bf7c-d51178c71081"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
+</subject>
+</UML:ClassItem>
+<UML:Extension id="26e590ba-6d49-11f0-a782-be7f4daace3f">
+<memberEnd>
+<reflist>
+<ref refid="26e5a55a-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="26e5a7c6-6d49-11f0-a782-be7f4daace3f"/>
+</reflist>
+</memberEnd>
+<ownedEnd>
+<ref refid="26e5a7c6-6d49-11f0-a782-be7f4daace3f"/>
+</ownedEnd>
+<owningPackage>
+<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+</owningPackage>
+<package>
+<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="f4c47d10-5f7b-11eb-bf7c-d51178c71081"/>
+</reflist>
+</presentation>
+</UML:Extension>
+<UML:Property id="26e5a55a-6d49-11f0-a782-be7f4daace3f">
+<association>
+<ref refid="26e590ba-6d49-11f0-a782-be7f4daace3f"/>
+</association>
+<name>
+<val>baseClass</val>
+</name>
+<structuredClassifier>
+<ref refid="dc6a99a2-2363-11ea-ab0b-c72c0738acd2"/>
+</structuredClassifier>
+<type>
+<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
+</type>
+</UML:Property>
+<UML:ExtensionEnd id="26e5a7c6-6d49-11f0-a782-be7f4daace3f">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="26e590ba-6d49-11f0-a782-be7f4daace3f"/>
+</association>
+<structuredClassifier>
+<ref refid="2a3a749e-242d-11ea-99a7-7d79dbbd423e"/>
+</structuredClassifier>
+<type>
+<ref refid="dc6a99a2-2363-11ea-ab0b-c72c0738acd2"/>
+</type>
+</UML:ExtensionEnd>
+<UML:ClassItem id="d7607108-6d49-11f0-a782-be7f4daace3f">
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 459.78515625, 206.0)</val>
+</matrix>
+<top-left>
+<val>(0.0, 0.0)</val>
+</top-left>
+<width>
+<val>100.0</val>
+</width>
+<height>
+<val>82.0</val>
+</height>
+<diagram>
+<ref refid="1636e506-5f7b-11eb-bf7c-d51178c71081"/>
+</diagram>
+<show_attributes>
+<val>0</val>
+</show_attributes>
+<show_operations>
+<val>0</val>
+</show_operations>
+<subject>
+<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
+</subject>
+</UML:ClassItem>
+<UML:AssociationItem id="dfe92c34-6d49-11f0-a782-be7f4daace3f">
+<diagram>
+<ref refid="1636e506-5f7b-11eb-bf7c-d51178c71081"/>
+</diagram>
+<head_subject>
+<ref refid="e10e7f38-6d49-11f0-a782-be7f4daace3f"/>
+</head_subject>
+<horizontal>
+<val>False</val>
+</horizontal>
+<orthogonal>
+<val>False</val>
+</orthogonal>
+<subject>
+<ref refid="e10e1a5c-6d49-11f0-a782-be7f4daace3f"/>
+</subject>
+<tail_subject>
+<ref refid="e10e87e4-6d49-11f0-a782-be7f4daace3f"/>
+</tail_subject>
+<matrix>
+<val>(1.0, 0.0, 0.0, 1.0, 327.0, 249.5)</val>
+</matrix>
+<points>
+<val>[(6.140625, -0.5), (132.78515625, 0.0)]</val>
+</points>
+<head-connection>
+<ref refid="30c874ca-5f7b-11eb-bf7c-d51178c71081"/>
+</head-connection>
+<tail-connection>
+<ref refid="d7607108-6d49-11f0-a782-be7f4daace3f"/>
+</tail-connection>
+</UML:AssociationItem>
+<UML:Association id="e10e1a5c-6d49-11f0-a782-be7f4daace3f">
+<memberEnd>
+<reflist>
+<ref refid="e10e7f38-6d49-11f0-a782-be7f4daace3f"/>
+<ref refid="e10e87e4-6d49-11f0-a782-be7f4daace3f"/>
+</reflist>
+</memberEnd>
+<owningPackage>
+<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+</owningPackage>
+<package>
+<ref refid="20ec8dba-235f-11ea-ab0b-c72c0738acd2"/>
+</package>
+<presentation>
+<reflist>
+<ref refid="dfe92c34-6d49-11f0-a782-be7f4daace3f"/>
+</reflist>
+</presentation>
+</UML:Association>
+<UML:Property id="e10e7f38-6d49-11f0-a782-be7f4daace3f">
+<association>
+<ref refid="e10e1a5c-6d49-11f0-a782-be7f4daace3f"/>
+</association>
+<type>
+<ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
+</type>
+</UML:Property>
+<UML:Property id="e10e87e4-6d49-11f0-a782-be7f4daace3f">
+<aggregation>
+<val>composite</val>
+</aggregation>
+<association>
+<ref refid="e10e1a5c-6d49-11f0-a782-be7f4daace3f"/>
+</association>
+<name>
+<val>affects</val>
+</name>
+<structuredClassifier>
+<ref refid="7833aba0-2362-11ea-ab0b-c72c0738acd2"/>
+</structuredClassifier>
+<type>
+<ref refid="6ece1030-2b34-11ea-99a7-7d79dbbd423e"/>
+</type>
+<upperValue>
+<ref refid="eff5adf0-6d49-11f0-a782-be7f4daace3f"/>
+</upperValue>
+</UML:Property>
+<UML:LiteralUnlimitedNatural id="eff5adf0-6d49-11f0-a782-be7f4daace3f">
+<name>
+<val>*</val>
+</name>
+<owningUpper>
+<ref refid="e10e87e4-6d49-11f0-a782-be7f4daace3f"/>
+</owningUpper>
+<value>
+<val>*</val>
+</value>
+</UML:LiteralUnlimitedNatural>
 </model>
 </gaphor>

--- a/models/SysML.gaphor
+++ b/models/SysML.gaphor
@@ -82,7 +82,6 @@
 <ref refid="3f40e394-2141-11ea-ab0b-c72c0738acd2"/>
 <ref refid="3b0d35d4-2141-11ea-ab0b-c72c0738acd2"/>
 <ref refid="3165eeb9-2141-11ea-ab0b-c72c0738acd2"/>
-<ref refid="f6ed61ee-292a-11ee-aad9-e38f5215237c"/>
 </reflist>
 </ownedType>
 <owningPackage>
@@ -106,7 +105,6 @@
 <ref refid="3f40e394-2141-11ea-ab0b-c72c0738acd2"/>
 <ref refid="3b0d35d4-2141-11ea-ab0b-c72c0738acd2"/>
 <ref refid="3165eeb9-2141-11ea-ab0b-c72c0738acd2"/>
-<ref refid="f6ed61ee-292a-11ee-aad9-e38f5215237c"/>
 </reflist>
 </packagedElement>
 <presentation>
@@ -14215,17 +14213,6 @@ otherwise MRO can not be resolved.</val>
 <ref refid="19ddfa39-292b-11ee-aad9-e38f5215237c"/>
 </reflist>
 </specialization>
-</UML:Class>
-<UML:Class id="f6ed61ee-292a-11ee-aad9-e38f5215237c">
-<name>
-<val>Class</val>
-</name>
-<owningPackage>
-<ref refid="2b8d10da-20e1-11ea-9209-e76c3117c943"/>
-</owningPackage>
-<package>
-<ref refid="2b8d10da-20e1-11ea-9209-e76c3117c943"/>
-</package>
 </UML:Class>
 <UML:Package id="fd10d6be-292a-11ee-aad9-e38f5215237c">
 <name>

--- a/models/SysML.override
+++ b/models/SysML.override
@@ -38,22 +38,22 @@ override AbstractRequirement.master: derived[AbstractRequirement]
 AbstractRequirement.master = derived("master", AbstractRequirement, 0, "*",
     _directed_relationship_property_path_target_source(Copy))
 %%
-override AbstractRequirement.refinedBy: derived[NamedElement]
+override AbstractRequirement.refinedBy: derived[_NamedElement]
 
-AbstractRequirement.refinedBy = derived("refinedBy", NamedElement, 0, "*",
+AbstractRequirement.refinedBy = derived("refinedBy", _NamedElement, 0, "*",
     _directed_relationship_property_path_target_source(Refine))
 %%
-override AbstractRequirement.satisfiedBy: derived[NamedElement]
+override AbstractRequirement.satisfiedBy: derived[_NamedElement]
 
-AbstractRequirement.satisfiedBy = derived("satisfiedBy", NamedElement, 0, "*",
+AbstractRequirement.satisfiedBy = derived("satisfiedBy", _NamedElement, 0, "*",
     _directed_relationship_property_path_target_source(Satisfy))
 %%
-override AbstractRequirement.tracedTo: derived[NamedElement]
+override AbstractRequirement.tracedTo: derived[_NamedElement]
 
-AbstractRequirement.tracedTo = derived("tracedTo", NamedElement, 0, "*",
+AbstractRequirement.tracedTo = derived("tracedTo", _NamedElement, 0, "*",
     _directed_relationship_property_path_target_source(Trace))
 %%
-override AbstractRequirement.verifiedBy: derived[NamedElement]
+override AbstractRequirement.verifiedBy: derived[_NamedElement]
 
-AbstractRequirement.verifiedBy = derived("verifiedBy", NamedElement, 0, "*",
+AbstractRequirement.verifiedBy = derived("verifiedBy", _NamedElement, 0, "*",
     _directed_relationship_property_path_target_source(Verify))

--- a/models/UML.override
+++ b/models/UML.override
@@ -15,7 +15,6 @@ header
 from typing import Callable
 
 from gaphor.core.modeling import UnlimitedNatural
-
 %%
 override NamedElement.qualifiedName: property
 # defined in umloverrides.py


### PR DESCRIPTION
Builds on #3979 

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Models are a bit loose (e.g. you can import `Class` from the SysML model, although it's defined in UML).

This breaks as soon as we add another modeling language: KerML or SysMLv2.

Issue Number: N/A

### What is the new behavior?

This PR creates some prerequisites needed to make working with KerML and SysML2 models easier. Those models have similarly named types as our current UML/SysML model and should therefore be strictly namespaced.

The import mechanism has been simplified: imported packages should exist in a package with a name similar to the model name (entry point name). This makes importing types from super-models more predictable.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

You can only import classes from their authoritative model.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
