### PR TITLE
Bump minimal Python version to 3.12

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2933,7 +2933,7 @@ version = "2.2.1"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["automation", "packaging"]
+groups = ["automation"]
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -2968,7 +2968,6 @@ files = [
     {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
     {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
 ]
-markers = {packaging = "<empty>"}
 
 [[package]]
 name = "tornado"
@@ -3134,4 +3133,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.14"
-content-hash = "e75c22ab83c255ec71dc373f23c24011455801bc9e871649631ee28cb9aca87c"
+content-hash = "6099c7ca7dbf2dacf938137301e90828fa7576554496347cf5258487099f405d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,6 @@ optional=true
 pyinstaller = ">=6.13.0"
 pyinstaller-versionfile = "^2.0.0"
 semver = ">=2.13,<4.0"
-tomli = { version = ">=1.2,<3.0", python = "<3.11" }
 dmgbuild = {version = "^1.6.2", markers = "sys_platform == 'darwin'" }
 
 [tool.poe.tasks]
@@ -228,7 +227,7 @@ addopts = [
 junit_family = "xunit1"
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 warn_redundant_casts = true


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

With the new enumerations in place, you'll need Python 3.12 or newer.

### What is the new behavior?

Enforce Python 3.12+.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
