### PR TITLE
Fix PyGObject API docs location

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,7 +224,7 @@ epub_exclude_files = ["search.html"]
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "gnome": ("https://amolenaar.pages.gitlab.gnome.org/pygobject-docs", None),
+    "gnome": ("https://api.pygobject.gnome.org", None),
     "pygobject": ("https://pygobject.gnome.org", None),
     "gaphas": ("https://gaphas.readthedocs.io/en/stable", None),
     "python": ("https://docs.python.org/3", None),


### PR DESCRIPTION
I noticed that our docs builds were failing due to a 404 redirect. This PR updates the PyGObject API docs to the new home.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
