### PR TITLE
macos: allow to use the integrated GPU for OpenGL rendering

### DIFF
--- a/_packaging/gaphor.spec
+++ b/_packaging/gaphor.spec
@@ -137,6 +137,7 @@ app = BUNDLE(  # type: ignore
         "NSHumanReadableCopyright": COPYRIGHT,
         "LSMinimumSystemVersion": "10.15",
         "NSHighResolutionCapable": True,
+        "NSSupportsAutomaticGraphicsSwitching": True,
         "LSApplicationCategoryType": "public.app-category.developer-tools",
         "NSPrincipalClass": "NSApplication",
         "CFBundleDocumentTypes": [


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/gtk/-/issues/7676.

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

on macOS the heavy GPU (Radeon) is used, which consumes more resources than the integrated (Intel) 

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
