### PR TITLE
Apply  undershoot effect to diagram view

### DIFF
--- a/gaphor/ui/diagrampage.ui
+++ b/gaphor/ui/diagrampage.ui
@@ -10,6 +10,10 @@
         </child>
         <style>
           <class name="view"/>
+          <class name="undershoot-top"/>
+          <class name="undershoot-bottom"/>
+          <class name="undershoot-start"/>
+          <class name="undershoot-end"/>
         </style>
       </object>
     </child>


### PR DESCRIPTION
Makes it look like it floats a bit and gives a bounce effect on the edge.

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

To test: open a dragram and scroll/swipe completely to the left/right/top. The bottom effect does not seem to work: it needs a widget below the diagram for that to work.