### PR TITLE
Fix reordering of class' attributes

### DIFF
--- a/gaphor/UML/classes/tests/test_classespropertypages.py
+++ b/gaphor/UML/classes/tests/test_classespropertypages.py
@@ -120,6 +120,30 @@ def test_attribute_create_model(element_factory, event_manager):
     assert list_store[2].attr is attr3
 
 
+def test_attribute_change_order(element_factory, event_manager):
+    subject = element_factory.create(UML.Class)
+
+    attr1 = element_factory.create(UML.Property)
+    attr1.name = "attr1"
+    subject.ownedAttribute = attr1
+    attr2 = element_factory.create(UML.Property)
+    attr2.name = "attr2"
+    subject.ownedAttribute = attr2
+    attr3 = element_factory.create(UML.Property)
+    attr3.name = "attr3"
+    subject.ownedAttribute = attr3
+
+    property_page = AttributesPage(subject, event_manager)
+    widget = property_page.construct()
+    list_store = find(widget, "attributes-list").get_model()
+
+    subject.ownedAttribute.swap(attr1, attr2)
+
+    assert list_store[0].attr is attr2
+    assert list_store[1].attr is attr1
+    assert list_store[2].attr is attr3
+
+
 def test_show_operations_page(diagram, element_factory, event_manager):
     item = diagram.create(
         UML.classes.InterfaceItem, subject=element_factory.create(UML.Interface)

--- a/gaphor/core/modeling/collection.py
+++ b/gaphor/core/modeling/collection.py
@@ -124,12 +124,12 @@ class collection(Generic[T]):
         except (IndexError, ValueError):
             return False
         else:
-            self.object.handle(AssociationUpdated(self.object, self.property))
+            self.property.handle(AssociationUpdated(self.object, self.property))
             return True
 
     def order(self, key):
         self.items.sort(key=key)
-        self.object.handle(AssociationUpdated(self.object, self.property))
+        self.property.handle(AssociationUpdated(self.object, self.property))
 
 
 _recurseproxy_trigger = slice(None, None, None)

--- a/gaphor/core/modeling/event.py
+++ b/gaphor/core/modeling/event.py
@@ -156,7 +156,11 @@ class DerivedDeleted(AssociationDeleted, DerivedUpdated):
         super().__init__(element, association, old_value, index=-1)
 
 
-class RedefinedSet(AssociationSet):
+class RedefinedUpdated(AssociationUpdated):
+    """A derived property has changed."""
+
+
+class RedefinedSet(AssociationSet, RedefinedUpdated):
     """A redefined property has been set."""
 
     def __init__(self, element, association, old_value, new_value):
@@ -170,7 +174,7 @@ class RedefinedSet(AssociationSet):
         super().__init__(element, association, old_value, new_value)
 
 
-class RedefinedAdded(AssociationAdded):
+class RedefinedAdded(AssociationAdded, RedefinedUpdated):
     """A redefined property has been added."""
 
     def __init__(self, element, association, new_value):
@@ -184,7 +188,7 @@ class RedefinedAdded(AssociationAdded):
         super().__init__(element, association, new_value)
 
 
-class RedefinedDeleted(AssociationDeleted):
+class RedefinedDeleted(AssociationDeleted, RedefinedUpdated):
     """A redefined property has been deleted."""
 
     def __init__(self, element, association, old_value, index):

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -52,6 +52,7 @@ from gaphor.core.modeling.event import (
     RedefinedAdded,
     RedefinedDeleted,
     RedefinedSet,
+    RedefinedUpdated,
 )
 
 __all__ = ["attribute", "enumeration", "association", "derivedunion", "redefine"]
@@ -1015,6 +1016,8 @@ class redefine(umlproperty):
                 self.handle(
                     RedefinedDeleted(event.element, self, event.old_value, event.index)
                 )
+            elif isinstance(event, AssociationUpdated):
+                self.handle(RedefinedUpdated(event.element, self))
             else:
                 log.error(
                     "Don't know how to handle event "

--- a/gaphor/core/modeling/tests/test_collection.py
+++ b/gaphor/core/modeling/tests/test_collection.py
@@ -20,6 +20,9 @@ class MockProperty:
     def set(self, object, value):
         self.values.append((object, value))
 
+    def handle(self, event):
+        event.element.handle(event)
+
 
 def test_append():
     p = MockProperty()
@@ -121,7 +124,8 @@ def test_not_empty():
 
 def test_swap():
     o = MockElement()
-    c: collection[str] = collection(None, o, str)
+    p = MockProperty()
+    c: collection[str] = collection(p, o, str)
     c.items = ["a", "b", "c"]  # type: ignore[assignment]
     c.swap("a", "c")
     assert c.items == ["c", "b", "a"]


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Reordering for attributes of a class does not work from the property editor.

Issue Number: fixes #4001 

### What is the new behavior?

It works again.
