### PR TITLE
Defafult to windows-2022 image

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -278,7 +278,7 @@ jobs:
   windows:
     name: 🪟 Windows
     needs: lint
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       INCLUDE: C:\gtk\include;C:\gtk\include\cairo;C:\gtk\include\glib-2.0;C:\gtk\include\gobject-introspection-1.0;C:\gtk\lib\glib-2.0\include;
       LIB: C:\gtk\lib


### PR DESCRIPTION

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes


### Other information

Windows-latest has been updated to 2025 as per Sep 2nd, but this image doesn't have NSIS pre-installed.

This is the quickest way to fix this.
