### PR TITLE
Add SignPath as a sponsor for Windows cert signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,8 @@ Licensed under the [Apache License v2](LICENSES/Apache-2.0.txt).
 Summary: You can do what you like with Gaphor, as long as you include the
 required notices. This permissive license contains a patent license from the
 contributors of the code.
+
+## 🤝 Sponsors
+
+- Free code signing provided by [SignPath.io](https://about.signpath.io),
+  certificate by [SignPath Foundation](signpath.org)


### PR DESCRIPTION
I submitted a request on behalf of Gaphor to get a free SignPath.io subscription in order to use their service for Windows certificate support. As part of the request, we need to agree to the SignPath [Code of Conduct](https://signpath.org/terms) since they would vouching for our project and signing our Windows executable. This PR adds a code policy blurb as required on the repository. A 2nd PR is needed for our website that links to the signed executable.

I would think we would want to wait to merge this until SignPath agrees to give us a subscription.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
