### PR TITLE
Fix objectNode upperbound value should be a string

### DIFF
--- a/gaphor/UML/actions/objectnode.py
+++ b/gaphor/UML/actions/objectnode.py
@@ -42,7 +42,7 @@ class ObjectNodeItem(Named, ElementPresentation):
                     Text(
                         text=lambda: self.subject.upperBound
                         not in (None, "", DEFAULT_UPPER_BOUND)
-                        and f"{{ {diagram.gettext('upperBound')} = {self.subject.upperBound} }}"
+                        and f"{{ {diagram.gettext('upperBound')} = {self.subject.upperBound.value} }}"
                         or ""
                     ),
                 ),


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->
objectNode upperbound value now resolves to string instead of literal_string reference

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: 4047

### What is the new behavior?
Upper bound value resolves to the entered string.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
