### PR TITLE
Fix pin multiplicity bounds

### DIFF
--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -12,7 +12,7 @@ from gaphor.diagram.propertypages import (
     unsubscribe_all_on_destroy,
 )
 from gaphor.transaction import Transaction
-from gaphor.UML import LiteralString
+from gaphor.UML import recipes
 from gaphor.UML.actions.activitynodes import DecisionNodeItem, ForkNodeItem
 from gaphor.UML.actions.objectnode import ObjectNodeItem
 
@@ -367,16 +367,14 @@ class PinPropertyPage(PropertyPageBase):
         dropdown.connect("notify::selected", self._on_type_changed)
 
         multiplicity_lower = builder.get_object("multiplicity-lower")
-        if isinstance(subject.lowerValue, LiteralString):
-            multiplicity_lower.set_text(subject.lowerValue.value or "")
-        else:
-            multiplicity_lower.set_text(subject.lowerValue or "")
+        multiplicity_lower.set_text(
+            recipes.get_multiplicity_lower_value_as_string(subject) or ""
+        )
 
         multiplicity_upper = builder.get_object("multiplicity-upper")
-        if isinstance(subject.upperValue, LiteralString):
-            multiplicity_upper.set_text(subject.upperValue.value or "")
-        else:
-            multiplicity_upper.set_text(subject.upperValue or "")
+        multiplicity_upper.set_text(
+            recipes.get_multiplicity_upper_value_as_string(subject) or ""
+        )
 
         return builder.get_object("pin-editor")
 
@@ -405,15 +403,9 @@ class PinPropertyPage(PropertyPageBase):
     def _on_multiplicity_lower_change(self, entry):
         value = entry.get_text().strip()
         with Transaction(self.event_manager, context="editing"):
-            try:
-                self.subject.lowerValue.value = value
-            except AttributeError:
-                self.subject.lowerValue = LiteralString(value)
+            recipes.set_multiplicity_lower_value(self.subject, value)
 
     def _on_multiplicity_upper_change(self, entry):
         value = entry.get_text().strip()
         with Transaction(self.event_manager, context="editing"):
-            try:
-                self.subject.upperValue.value = value
-            except AttributeError:
-                self.subject.upperValue = LiteralString(value)
+            recipes.set_multiplicity_upper_value(self.subject, value)

--- a/gaphor/UML/recipes.py
+++ b/gaphor/UML/recipes.py
@@ -525,10 +525,15 @@ def set_multiplicity_lower_value(
     """Set lower value of a multiplicity."""
     if element.lowerValue:
         element.lowerValue.unlink()
-    if value is None:
+    if value is None or "":
         return
+    try:
+        value = int(value)
+    except ValueError:
+        return
+
     lower_value = element.model.create(LiteralInteger)
-    lower_value.value = int(value)
+    lower_value.value = value
     lower_value.name = str(value)
     element.lowerValue = lower_value
 
@@ -561,10 +566,15 @@ def set_multiplicity_upper_value(
     """Set upper value of a multiplicity."""
     if element.upperValue:
         element.upperValue.unlink()
-    if value is None:
+    if value is None or value == "":
+        return
+    try:
+        if value != "*":
+            value = int(value)
+    except ValueError:
         return
     upper_value = element.model.create(LiteralUnlimitedNatural)
-    upper_value.value = "*" if value == "*" else int(value)
+    upper_value.value = value
     upper_value.name = str(value)
     element.upperValue = upper_value
 


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->
Pin multiplicity bounds can now be specified.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Multilpicity bounds on pins could not be set
Issue Number: 4046

### What is the new behavior?
Multiplicity bounds can now be set. 
(two instances of the type drop down still present - I think there is one for each bound ? Even though they must be the same)

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
