### PR TITLE
Fix GTK version used by pygobject-stubs

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,0 @@
-[installer.build-config-settings.pygobject-stubs]
-"--config-settings=" = "config=Gtk3,Gdk3,Soup2"


### PR DESCRIPTION
Should be GTK 4, obviously.

<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [ ] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
