### PR TITLE
Fix join spec field disappears

### DIFF
--- a/gaphor/UML/actions/actionspropertypages.py
+++ b/gaphor/UML/actions/actionspropertypages.py
@@ -257,7 +257,9 @@ class JoinNodePropertyPage(PropertyPageBase):
         )
 
         join_spec = builder.get_object("join-spec")
-        join_spec.set_text(subject.joinSpec or "")
+        join_spec.set_text(
+            UML.recipes.get_literal_value_as_string(subject.joinSpec) or ""
+        )
 
         return builder.get_object("join-node-editor")
 


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->
Retrieve string from literal so that redisplay of join spec happens.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes #4048

### What is the new behavior?
Join spec field remains after a value is entered.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
