### PR TITLE
Windows: when building installer override installed wheels

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -238,6 +238,8 @@ Then build your installer using:
 
 ```PowerShell
 poetry install --only main,packaging,automation
+poetry run pip install --force-reinstall (Resolve-Path C:\gtk\wheels\PyGObject*.whl)
+poetry run pip install --force-reinstall (Resolve-Path C:\gtk\wheels\pycairo*.whl)
 poetry build
 poetry run poe package
 poetry run poe win-installer


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [x] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In `main/docs/windows.md`, Step `Packaging for Windows`,
Then build your installer using:
```PowerShell
poetry install --only main,packaging,automation
poetry build
poetry run poe package
poetry run poe win-installer
```
Issue Number: N/A

### What is the new behavior?
In `main/docs/windows.md`, Step `Packaging for Windows`,
Then build your installer using:
```PowerShell
poetry install --only main,packaging,automation
poetry run pip install --force-reinstall (Resolve-Path C:\gtk\wheels\PyGObject*.whl)
poetry run pip install --force-reinstall (Resolve-Path C:\gtk\wheels\pycairo*.whl)
poetry build
poetry run poe package
poetry run poe win-installer
```
Issue Number: N/A

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

### Other information
