### PR TITLE
Add winget package updater

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -386,8 +386,6 @@ jobs:
           files: |
             ${{ needs.windows.outputs.installer }}
 
-
-
   publish-to-pypi:
     name: 🧀 Publish to PyPI (release only)
     needs: [ linux-wheel, linux-flatpak-devel, check-macos-app, check-windows-installer ]
@@ -443,10 +441,16 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: generate-token
+        with:
+          app-id: ${{ secrets.GAPHOR_UPDATER_APP_ID }}
+          private-key: ${{ secrets.GAPHOR_UPDATER_APP_PRIVATE_KEY }}
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@5fc4efd1a4797ddb68ffd0714a238564e4cc0e6f # v4.0.0
         with:
-          token: ${{ secrets.WEBSITE_DISPATCH_TOKEN }} # Expires 2024-07-08
+          token: ${{ steps.generate-token.outputs.token }}
           repository: gaphor/gaphor.github.io
           event-type: version-update
           client-payload: '{ "version": "${{ needs.publish-to-pypi.outputs.version }}" }'


### PR DESCRIPTION
Right now we have to manually update the Gaphor winget package following a release, or someone from the community has to. This PR adds a workflow to automatically update the winget package on release.

Also the website dispatch is using a Personal Access Token. I updated it to use the Gaphor Updater app so that we have one less token to manage and regenerate.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
winget releases are manual

Issue Number: N/A

### What is the new behavior?
A PR is created in winget-pkgs to update the version.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
