### PR TITLE
Fix codeSpaces/devcontainer startup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,5 +4,5 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:debian
 RUN apt-get update -qq && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install -qq --no-install-recommends libcairo2-dev \
     pkg-config python3-dev gir1.2-gtk-4.0 libgirepository-2.0-dev \
-    libgtksourceview-5-dev libadwaita-1-dev graphviz-dev\
+    libgtksourceview-5-dev libadwaita-1-dev graphviz \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Changing to Debian base image allows CodeSpace to build without error.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
github codespace fails to build.
Issue Number: fixes #4107

### What is the new behavior?
github codespace builds without error
### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
