### PR TITLE
Fix item not found in keychain

### DIFF
--- a/.github/actions/macos_dmg/action.yml
+++ b/.github/actions/macos_dmg/action.yml
@@ -51,11 +51,16 @@ runs:
         P12FILE=$(mktemp)
         PASSWORD=$(openssl rand -base64 24)
         security create-keychain -p "$PASSWORD" temp.keychain
+        security default-keychain -s temp.keychain
+        security unlock-keychain -p "$PASSWORD" temp.keychain
         echo "$P12BASE64" | base64 -D -o "$P12FILE"
         security import "$P12FILE" -k temp.keychain -f pkcs12 -T /usr/bin/codesign -T /usr/bin/security -P "$P12PASSWORD"
         rm -f "$P12FILE"
         security set-key-partition-list -S "apple-tool:,apple:" -k "$PASSWORD" temp.keychain
         security list-keychains -d user -s temp.keychain login.keychain
+        security set-keychain-settings -lut 21600 temp.keychain
+        echo "Available signing identities:"
+        security find-identity -v -p codesigning temp.keychain
       shell: bash
     - name: Create Signed macOS Application
       if: inputs.sign_app == 'true'


### PR DESCRIPTION
Attempt fix for macOS runners to ensure the certificate is unlocked and available on the keychain.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
