### PR TITLE
Dependency Version Bumps - virtualenv, pygobject

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1972,13 +1972,13 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pygobject"
-version = "3.54.5"
+version = "3.56.0"
 description = "Python bindings for GObject Introspection"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pygobject-3.54.5.tar.gz", hash = "sha256:b6656f6348f5245606cf15ea48c384c7f05156c75ead206c1b246c80a22fb585"},
+    {file = "pygobject-3.56.0.tar.gz", hash = "sha256:4fbb5bf47524e01026f8e309dd54233eb0f75f2281392c5bf0df5d9041cc7891"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
Some builds fail with the following error:

```
    | Unable to find installation candidates for virtualenv (20.37.0)
```

and

```
Failed to install pycairo>=1.16, meson-python>=0.12.1.
```

Issue Number: N/A

### What is the new behavior?

CI builds are OK again

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

### Other information

Update done via `poetry update --no-cache virtualenv`