### PR TITLE
Disable Fedora openh264 repository

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -99,7 +99,7 @@ jobs:
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install Linux Dependencies
         run: >
-          dnf install -y gcc git pipx graphviz pkg-config python-launcher upx
+          dnf install -y --disablerepo=fedora-cisco-openh264 gcc git pipx graphviz pkg-config python-launcher upx
           mutter dbus-x11 gtksourceview5 libadwaita
           cairo-gobject-devel python${{ matrix.python_version }}-devel
       - name: Switch Primary Python to ${{ matrix.python_version }}


### PR DESCRIPTION
openh264 is pulled in as a transient requirement and not used by Gaphor. These packages are built by Fedora but hosted by Cisco due to some agreement related to codec licensing feeds. Most likely the Cisco servers are a bit spotty.

Fixes:

Failed to download packages
 Librepo error: Cannot download Packages/o/openh264-2.6.0-2.fc43.x86_64.rpm: All mirrors were tried

<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [ ] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
