### PR TITLE
Fix Winget recipe arch undetermined

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -447,7 +447,7 @@ jobs:
           VERSION: ${{ needs.publish-to-pypi.outputs.version }}
         run: |
           $installerUrl = "https://github.com/gaphor/gaphor/releases/download/$env:VERSION/gaphor-$env:VERSION-installer.exe"
-          .\wingetcreate.exe update Gaphor.Gaphor --version $env:VERSION --urls $installerUrl --submit --token $env:WINGET_PAT
+          .\wingetcreate.exe update Gaphor.Gaphor --version $env:VERSION --urls "${installerUrl}|x64" --submit --token $env:WINGET_PAT
 
   trigger-website-version-update:
     name: ⏩ gaphor.org version update


### PR DESCRIPTION
When doing the release today, we got a Winget version architecture error that it couldn't be determined from the NSIS installer. This update passes in the architecture as part of the update request.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
