### PR TITLE
Set html-report default zoom level to 1

### DIFF
--- a/gaphor/plugins/htmlreport/report.js
+++ b/gaphor/plugins/htmlreport/report.js
@@ -176,10 +176,6 @@
     var svg = doc.documentElement;
     if (!svg || svg.nodeName !== "svg") return;
 
-    // Let the SVG scale to fill its container via CSS; the viewBox
-    // attribute (preserved) handles the internal coordinate mapping
-    svg.removeAttribute("width");
-    svg.removeAttribute("height");
     // adoptNode transfers ownership from the parsed document to ours,
     // avoiding a cross-document insertion error
     content.appendChild(document.adoptNode(svg));
@@ -205,9 +201,23 @@
           zoomScaleSensitivity: 0.3
         });
 
+        // Prevent small diagrams from being scaled up beyond 100%
+        var realZoom = currentPanZoom.getSizes().realZoom;
+        var cappedZoom = realZoom > 1 ? currentPanZoom.getZoom() / realZoom : null;
+        if (cappedZoom !== null) {
+          currentPanZoom.zoom(cappedZoom);
+          currentPanZoom.center();
+        }
+
         $("#zoom-in").addEventListener("click", function() { currentPanZoom.zoomIn(); });
         $("#zoom-out").addEventListener("click", function() { currentPanZoom.zoomOut(); });
-        $("#zoom-reset").addEventListener("click", function() { currentPanZoom.reset(); });
+        $("#zoom-reset").addEventListener("click", function() {
+          currentPanZoom.reset();
+          if (cappedZoom !== null) {
+            currentPanZoom.zoom(cappedZoom);
+            currentPanZoom.center();
+          }
+        });
       }
     });
 

--- a/gaphor/plugins/htmlreport/report.js
+++ b/gaphor/plugins/htmlreport/report.js
@@ -190,15 +190,16 @@
     // layout and the SVG has real dimensions for getScreenCTM()
     requestAnimationFrame(function() {
       if (typeof svgPanZoom === "function") {
-        currentPanZoom = svgPanZoom(svg, {
+        var zoomScaleSensitivity = 0.3;
+        var currentPanZoom = svgPanZoom(svg, {
           zoomEnabled: true,
           panEnabled: true,
           controlIconsEnabled: false,
           fit: true,
-          center: true,
+          center: false,
           minZoom: 0.1,
           maxZoom: 20,
-          zoomScaleSensitivity: 0.3
+          zoomScaleSensitivity: zoomScaleSensitivity
         });
 
         // Prevent small diagrams from being scaled up beyond 100%
@@ -206,17 +207,21 @@
         var cappedZoom = realZoom > 1 ? currentPanZoom.getZoom() / realZoom : null;
         if (cappedZoom !== null) {
           currentPanZoom.zoom(cappedZoom);
-          currentPanZoom.center();
+          currentPanZoom.pan({ x: 0, y: 0 });
         }
 
-        $("#zoom-in").addEventListener("click", function() { currentPanZoom.zoomIn(); });
-        $("#zoom-out").addEventListener("click", function() { currentPanZoom.zoomOut(); });
+        function zoomFromTopLeft(zoomIn) {
+          var zoomFactor = 1 + zoomScaleSensitivity;
+          var factor = zoomIn ? zoomFactor : 1 / zoomFactor;
+          currentPanZoom.zoomAtPointBy(factor, { x: 0, y: 0 });
+        }
+
+        $("#zoom-in").addEventListener("click", function() { zoomFromTopLeft(true); });
+        $("#zoom-out").addEventListener("click", function() { zoomFromTopLeft(false); });
         $("#zoom-reset").addEventListener("click", function() {
           currentPanZoom.reset();
-          if (cappedZoom !== null) {
-            currentPanZoom.zoom(cappedZoom);
-            currentPanZoom.center();
-          }
+          currentPanZoom.zoom(cappedZoom);
+          currentPanZoom.pan({ x: 0, y: 0 });
         });
       }
     });


### PR DESCRIPTION
This prevents small diagrams from being blown up. This change only affects the default zoom level.

Fixes #4228

<!-- Please add an overview of the PR here -->


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

<img width="3268" height="1950" alt="image" src="https://github.com/user-attachments/assets/c54518a6-a6b1-49c9-9751-c90e88b8c9a3" />

 
 Diagrams in the html report are always zoomed to the full canvas

Issue Number: #4228 

### What is the new behavior?

<img width="2996" height="1642" alt="image" src="https://github.com/user-attachments/assets/6c885c47-2ece-4166-9792-b7b295a663d7" />



The zoom level is always set to 1 by default

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
