### PR TITLE
Fix wrong repository access for website deploy update

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -465,8 +465,10 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: generate-token
         with:
-          app-id: ${{ secrets.GAPHOR_UPDATER_APP_ID }}
+          client-id: ${{ secrets.GAPHOR_UPDATER_APP_ID }}
           private-key: ${{ secrets.GAPHOR_UPDATER_APP_PRIVATE_KEY }}
+          repositories: |
+            gaphor.github.io
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:


### PR DESCRIPTION
Since no owner or repository was listed, the create-github-app-token action was defaulting to a scope of gaphor/gaphor only. This caused changing the released version on the website to fail. Also `app-id` is deprecated and is called `client-id` now.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [X] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
