### PR TITLE
Fix licensing info for console, hash-bangs, and file permissions

### DIFF
--- a/LICENSES/PSF-2.0.txt
+++ b/LICENSES/PSF-2.0.txt
@@ -1,0 +1,47 @@
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 Python Software Foundation;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -16,6 +16,12 @@ SPDX-FileCopyrightText = ["2012 Simon Sapin", "2017 Guillaume Ayoub", "2020 The 
 SPDX-License-Identifier = "BSD-3-Clause"
 
 [[annotations]]
+path = "gaphor/plugins/console/console.py"
+precedence = "aggregate"
+SPDX-FileCopyrightText = ["2003 Jon Anderson", "2020 The Gaphor Development Team"]
+SPDX-License-Identifier = "PSF-2.0"
+
+[[annotations]]
 path = "_packaging/hook-pydot.py"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2021 PyInstaller Development Team"

--- a/examples/list_classes.py
+++ b/examples/list_classes.py
@@ -1,9 +1,7 @@
-#!/usr/bin/python
-
-# ruff: noqa: T201
-
 """This script lists classes and optionally attributes from UML model created
 with Gaphor."""
+
+# ruff: noqa: T201
 
 import optparse
 import sys

--- a/gaphor/core/modeling/base.py
+++ b/gaphor/core/modeling/base.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Base class for model elements."""
 
 from __future__ import annotations

--- a/gaphor/plugins/console/console.py
+++ b/gaphor/plugins/console/console.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Based on:
 #  GTK Interactive Console
 #  (C) 2003, Jon Anderson, PSF-2.0 licensed

--- a/gaphor/plugins/console/console.py
+++ b/gaphor/plugins/console/console.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
+# Based on:
 #  GTK Interactive Console
-#  (C) 2003, Jon Anderson
-#  See www.python.org/2.2/license.html for
-#  license details.
+#  (C) 2003, Jon Anderson, PSF-2.0 licensed
 #
-#  Took some good ideas from the GEdit Python Console:
+# Took some good ideas from the GEdit Python Console:
 #  https://gitlab.gnome.org/GNOME/gedit/-/blob/master/plugins/pythonconsole/pythonconsole/console.py
-#  Licensed under GPL
 
 
 import code

--- a/gaphor/plugins/console/consolewindow.py
+++ b/gaphor/plugins/console/consolewindow.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 
 from gi.repository import Adw, Gdk, Gtk

--- a/gaphor/plugins/diagramexport/exportcli.py
+++ b/gaphor/plugins/diagramexport/exportcli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import argparse
 import logging
 import re


### PR DESCRIPTION
Clear up the license for `console.py`

Fixes #4273, #4274