### PR TITLE
Fix missing translation files in wheel and flatpak packages

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -156,7 +156,7 @@ jobs:
     needs: lint
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-49
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
       options: --privileged
     steps:
       - name: Harden Runner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+3.3.2
+-----
+
+Bug fixes:
+
+- Fix translations missing for wheel and flatpak installers
+- Set html-report default zoom level to 1
+- Add missing html-report files to Windows and macOS installers
+
+Internal changes:
+
+- Fix wrong repository access for website deploy update
+
 3.3.1
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug fixes:
 Internal changes:
 
 - Fix wrong repository access for website deploy update
+- Simplify readthedocs install process
 
 3.3.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Bug fixes:
 
 - Fix translations missing for wheel and flatpak installers
+- Fix missing translations for French and Chinese
 - Set html-report default zoom level to 1
 - Add missing html-report files to Windows and macOS installers
 

--- a/data/org.gaphor.Gaphor.appdata.xml
+++ b/data/org.gaphor.Gaphor.appdata.xml
@@ -99,6 +99,21 @@
     </p>
   </description>
   <releases>
+    <release version="3.3.2" date="2026-04-25">
+      <description>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>Fix translations missing for wheel and flatpak installers</li>
+          <li>Set html-report default zoom level to 1</li>
+          <li>Add missing html-report files to Windows and macOS installers</li>
+        </ul>
+        <p>Internal changes:</p>
+        <ul>
+          <li>Fix wrong repository access for website deploy update</li>
+        </ul>
+      </description>
+      <url>https://github.com/gaphor/gaphor/releases/tag/3.3.2</url>
+    </release>
     <release version="3.3.1" date="2026-04-15">
       <description>
         <p>Bug fixes:</p>

--- a/data/org.gaphor.Gaphor.appdata.xml
+++ b/data/org.gaphor.Gaphor.appdata.xml
@@ -99,11 +99,12 @@
     </p>
   </description>
   <releases>
-    <release version="3.3.2" date="2026-04-25">
+    <release version="3.3.2" date="2026-04-28">
       <description>
         <p>Bug fixes:</p>
         <ul>
           <li>Fix translations missing for wheel and flatpak installers</li>
+          <li>Fix missing translations for French and Chinese</li>
           <li>Set html-report default zoom level to 1</li>
           <li>Add missing html-report files to Windows and macOS installers</li>
         </ul>

--- a/data/org.gaphor.Gaphor.appdata.xml
+++ b/data/org.gaphor.Gaphor.appdata.xml
@@ -99,7 +99,7 @@
     </p>
   </description>
   <releases>
-    <release version="3.3.2" date="2026-04-28">
+    <release version="3.3.2" date="2026-05-02">
       <description>
         <p>Bug fixes:</p>
         <ul>
@@ -111,6 +111,7 @@
         <p>Internal changes:</p>
         <ul>
           <li>Fix wrong repository access for website deploy update</li>
+          <li>Simplify readthedocs install process</li>
         </ul>
       </description>
       <url>https://github.com/gaphor/gaphor/releases/tag/3.3.2</url>

--- a/org.gaphor.Gaphor.json
+++ b/org.gaphor.Gaphor.json
@@ -68,9 +68,9 @@
       "name": "gaphor",
       "buildsystem": "simple",
       "build-commands": [
+        "for po in po/*.po; do lang=$(basename \"$po\" .po); mkdir -p \"gaphor/locale/$lang/LC_MESSAGES\"; pybabel compile -i \"$po\" -o \"gaphor/locale/$lang/LC_MESSAGES/gaphor.mo\" -l \"$lang\" -D gaphor; done",
         "pip3 install --no-cache-dir --ignore-installed --prefix=${FLATPAK_DEST} .",
-        "gaphor install-schemas --schemas-dir=/app/share/glib-2.0/schemas",
-        "for po in po/*.po; do lang=$(basename \"$po\" .po); mkdir -p \"${FLATPAK_DEST}/share/locale/$lang/LC_MESSAGES\"; ${FLATPAK_DEST}/bin/pybabel compile -i \"$po\" -o \"${FLATPAK_DEST}/share/locale/$lang/LC_MESSAGES/gaphor.mo\" -l \"$lang\" -D gaphor; done"
+        "gaphor install-schemas --schemas-dir=/app/share/glib-2.0/schemas"
       ],
       "sources": [
         {

--- a/org.gaphor.Gaphor.json
+++ b/org.gaphor.Gaphor.json
@@ -1,7 +1,8 @@
 {
   "app-id": "org.gaphor.Gaphor.Devel",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "49",
+  "runtime-version": "50",
+  "separate-locales": false,
   "tags": [
     "devel",
     "development",
@@ -68,7 +69,8 @@
       "buildsystem": "simple",
       "build-commands": [
         "pip3 install --no-cache-dir --ignore-installed --prefix=${FLATPAK_DEST} .",
-        "gaphor install-schemas --schemas-dir=/app/share/glib-2.0/schemas"
+        "gaphor install-schemas --schemas-dir=/app/share/glib-2.0/schemas",
+        "for po in po/*.po; do lang=$(basename \"$po\" .po); mkdir -p \"${FLATPAK_DEST}/share/locale/$lang/LC_MESSAGES\"; ${FLATPAK_DEST}/bin/pybabel compile -i \"$po\" -o \"${FLATPAK_DEST}/share/locale/$lang/LC_MESSAGES/gaphor.mo\" -l \"$lang\" -D gaphor; done"
       ],
       "sources": [
         {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ install-schemas = "gaphor.ui.installschemas:install_schemas_parser"
 requires-poetry = ">=2.0"
 include = [
     { path = "gaphor/locale/*/LC_MESSAGES/*", format = ["sdist", "wheel"] },
-    { path = "data/org.gaphor.Gaphor*", format = ["sdist", "wheel"] },
+    { path = "data/org.gaphor.Gaphor*", format = "sdist" },
 ]
 exclude = ["**/tests", "gaphor/conftest.py" ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,8 +121,8 @@ install-schemas = "gaphor.ui.installschemas:install_schemas_parser"
 [tool.poetry]
 requires-poetry = ">=2.0"
 include = [
-    { path = "gaphor/locale/*/LC_MESSAGES/*" },
-    { path = "data/org.gaphor.Gaphor*", format = "sdist" },
+    { path = "gaphor/locale/*/LC_MESSAGES/*", format = ["sdist", "wheel"] },
+    { path = "data/org.gaphor.Gaphor*", format = ["sdist", "wheel"] },
 ]
 exclude = ["**/tests", "gaphor/conftest.py" ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gaphor"
-version = "3.3.1"
+version = "3.3.2"
 description = "Gaphor is the simple modeling tool written in Python."
 authors = [
     { name = "Arjan Molenaar", email = "gaphor@gmail.com" },


### PR DESCRIPTION
Along with https://github.com/flathub/org.gaphor.Gaphor/pull/128 fixes #4265.

The .mo files were not being included in our published wheels. Our flatpaks are built from the wheels, so they were also missing in our published flatpaks on Flathub.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4265

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
