### PR TITLE
Rename umlproperty

### DIFF
--- a/gaphor/core/modeling/base.py
+++ b/gaphor/core/modeling/base.py
@@ -12,7 +12,7 @@ from uuid import uuid1
 
 from gaphor.core.modeling.collection import collection
 from gaphor.core.modeling.event import ElementTypeUpdated, ElementUpdated
-from gaphor.core.modeling.properties import relation_many, umlproperty
+from gaphor.core.modeling.properties import modelproperty, relation_many
 
 if TYPE_CHECKING:
     from gaphor.core.modeling.diagram import Diagram
@@ -104,13 +104,13 @@ class Base:
         )
 
     @classproperty
-    def __properties__(cls) -> Iterator[umlproperty]:
+    def __properties__(cls) -> Iterator[modelproperty]:
         """Iterate over all attributes, associations, etc."""
-        umlprop = umlproperty
+        modelprop = modelproperty
         for propname in dir(cls):
             if not propname.startswith("_"):
                 prop = getattr(cls, propname)
-                if isinstance(prop, umlprop):
+                if isinstance(prop, modelprop):
                     yield prop
 
     def __str__(self) -> str:

--- a/gaphor/core/modeling/elementdispatcher.py
+++ b/gaphor/core/modeling/elementdispatcher.py
@@ -14,7 +14,7 @@ from gaphor.core.modeling.event import (
     ElementUpdated,
     ModelReady,
 )
-from gaphor.core.modeling.properties import umlproperty
+from gaphor.core.modeling.properties import modelproperty
 
 log = logging.getLogger(__name__)
 
@@ -109,11 +109,11 @@ class ElementDispatcher(Service):
 
         # Table used to fire events:
         # (event.element, event.property): { handler: set(path, ..), ..}
-        self._handlers: dict[tuple[Base, umlproperty], dict[Handler, set]] = {}
+        self._handlers: dict[tuple[Base, modelproperty], dict[Handler, set]] = {}
 
         # Fast resolution when handlers are disconnected
         # handler: [(element, property), ..]
-        self._reverse: dict[Handler, list[tuple[Base, umlproperty]]] = {}
+        self._reverse: dict[Handler, list[tuple[Base, modelproperty]]] = {}
 
         self.event_manager.subscribe(self.on_model_loaded)
         self.event_manager.subscribe(self.on_element_change_event)
@@ -140,7 +140,7 @@ class ElementDispatcher(Service):
                     del self._handlers[key]
         del self._reverse[handler]
 
-    def _path_to_properties(self, element: Base, path: str) -> tuple[umlproperty]:
+    def _path_to_properties(self, element: Base, path: str) -> tuple[modelproperty]:
         """Given a start element and a path, return a tuple of properties
         (association, attribute, etc.) representing the path."""
         c = type(element)
@@ -166,7 +166,9 @@ class ElementDispatcher(Service):
                 c = prop.type
         return tuple(tpath)
 
-    def _add_handlers(self, element: Base, props: tuple[umlproperty], handler: Handler):
+    def _add_handlers(
+        self, element: Base, props: tuple[modelproperty], handler: Handler
+    ):
         """Provided an element and a path of properties (props), register the
         handler for each property."""
         property, remainder = props[0], props[1:]

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -176,6 +176,10 @@ class modelproperty:
             d.propagate(event)
 
 
+# For backwards compatibility:
+umlproperty = modelproperty
+
+
 class subsettable:
     """Mixin class for properties that can be subsetted."""
 

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -62,8 +62,15 @@ log = logging.getLogger(__name__)
 
 UnlimitedNatural = int | Literal["*"]
 
+Lower = Literal[0] | Literal[1] | Literal[2]
+Upper = Literal[1] | Literal[2] | Literal["*"]
+
 
 E = TypeVar("E")
+
+
+class propagable(Protocol):
+    def propagate(self, event): ...
 
 
 class relation_one(Protocol[E]):
@@ -107,9 +114,6 @@ relation = relation_one | relation_many
 
 T = TypeVar("T")
 
-Lower = Literal[0] | Literal[1] | Literal[2]
-Upper = Literal[1] | Literal[2] | Literal["*"]
-
 
 class umlproperty:
     """Superclass for an attribute, enumeration, and association.
@@ -127,7 +131,7 @@ class umlproperty:
     upper: Upper = 1
 
     def __init__(self, name: str):
-        self.dependent_properties: set[subsettable_umlproperty | redefine] = set()
+        self.dependent_properties: set[propagable] = set()
         self.name = name
         self._name = f"_{name}"
 
@@ -172,16 +176,15 @@ class umlproperty:
             d.propagate(event)
 
 
-class subsettable_umlproperty(umlproperty):
-    """Base class for properties that can be subsetted"""
+class subsettable:
+    """Mixin class for properties that can be subsetted."""
 
-    subsets: set[umlproperty]
+    name: str
+    lower: Lower
+    upper: Upper
+    subsets: set[association | derived | redefine]
 
-    def __init__(self, name: str):
-        super().__init__(name)
-        self.subsets = set()
-
-    def add(self, subset):
+    def add(self, subset: association | derived | redefine):
         if self.upper == 1 and subset.upper == "*":
             log.warning(
                 "Modeling error: Cannot add a multiplicity * subset "
@@ -323,7 +326,7 @@ class enumeration(umlproperty):
             self.handle(AttributeUpdated(obj, self, old, self.default))
 
 
-class association(subsettable_umlproperty):
+class association(subsettable, umlproperty):
     """Association, both uni- and bi-directional.
 
     Element.assoc = association('assoc', Element, opposite='other')
@@ -397,6 +400,7 @@ class association(subsettable_umlproperty):
         self.composite = composite
         self.opposite = opposite
         self.stub: associationstub | None = None
+        self.subsets = set()
 
     def save(self, obj, save_func: Callable[[str, object], None]):
         if hasattr(obj, self._name):
@@ -700,7 +704,7 @@ class unioncache:
     version: int
 
 
-class derived[T](subsettable_umlproperty):
+class derived[T](subsettable, umlproperty):
     """Base class for derived properties, both derived unions and custom
     properties.
 
@@ -721,7 +725,7 @@ class derived[T](subsettable_umlproperty):
         lower: Lower,
         upper: Upper,
         filter: Callable[[Any], list[T | None]],
-        *subsets: relation,
+        *subsets: association | derived | redefine,
     ) -> None:
         super().__init__(name)
         self.version = 1
@@ -729,6 +733,7 @@ class derived[T](subsettable_umlproperty):
         self.lower = lower
         self.upper = upper
         self.filter = filter
+        self.subsets = set()
 
         for s in subsets:
             self.add(s)
@@ -846,7 +851,7 @@ class derivedunion(derived[T]):
         type: type[T],
         lower: Lower = 0,
         upper: Upper = "*",
-        *subsets: relation,
+        *subsets: association | derived | redefine,
     ):
         super().__init__(name, type, lower, upper, self._union, *subsets)
 

--- a/gaphor/core/modeling/properties.py
+++ b/gaphor/core/modeling/properties.py
@@ -115,7 +115,7 @@ relation = relation_one | relation_many
 T = TypeVar("T")
 
 
-class umlproperty:
+class modelproperty:
     """Superclass for an attribute, enumeration, and association.
 
     The subclasses should define a ``name`` attribute that contains the name
@@ -201,7 +201,7 @@ class subsettable:
     def propagate(self, event): ...
 
 
-class attribute[T](umlproperty):
+class attribute[T](modelproperty):
     """Attribute.
 
     Element.attr = attribute('attr', str, '')
@@ -277,7 +277,7 @@ class attribute[T](umlproperty):
             self.handle(AttributeUpdated(obj, self, old, self.default))
 
 
-class enumeration(umlproperty):
+class enumeration(modelproperty):
     """Enumeration.
 
       Element.enum = enumeration('enum', EnumKind, 'one')
@@ -326,7 +326,7 @@ class enumeration(umlproperty):
             self.handle(AttributeUpdated(obj, self, old, self.default))
 
 
-class association(subsettable, umlproperty):
+class association(subsettable, modelproperty):
     """Association, both uni- and bi-directional.
 
     Element.assoc = association('assoc', Element, opposite='other')
@@ -534,7 +534,7 @@ class association(subsettable, umlproperty):
             if not self.stub:
                 self.stub = associationstub(self)
                 # Do not let property start with underscore, or it will not be found
-                # as an umlproperty.
+                # as an modelproperty.
                 setattr(self.type, f"GAPHOR__associationstub__{id(self):x}", self.stub)
             self.stub.set(value, obj)
 
@@ -581,7 +581,9 @@ class association(subsettable, umlproperty):
                 if do_notify:
                     self.handle(AssociationDeleted(obj, self, value, index))
                 for subset in self.subsets:
-                    col: collection[umlproperty] | umlproperty | None = subset.get(obj)
+                    col: collection[modelproperty] | modelproperty | None = subset.get(
+                        obj
+                    )
                     if isinstance(col, collection) and value in col:
                         subset.delete(obj, value)
 
@@ -645,12 +647,12 @@ class AssociationStubError(Exception):
     pass
 
 
-class associationstub(umlproperty):
+class associationstub(modelproperty):
     """An association stub is an internal thingy that ensures all associations
     are always bidirectional.
 
     This helps the application when one end of the association is
-    unlinked. On unlink() of an element all `umlproperty`'s are iterated
+    unlinked. On unlink() of an element all `modelproperty`'s are iterated
     and called by their unlink() method.
     """
 
@@ -704,7 +706,7 @@ class unioncache:
     version: int
 
 
-class derived[T](subsettable, umlproperty):
+class derived[T](subsettable, modelproperty):
     """Base class for derived properties, both derived unions and custom
     properties.
 
@@ -927,7 +929,7 @@ class derivedunion(derived[T]):
             log.error(f"Don't know how to handle event {event} for derived union")
 
 
-class redefine(umlproperty):
+class redefine(modelproperty):
     """Redefined association.
 
       Element.redefine = redefine(Element, 'redefine', Class, Element.assoc)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -8,7 +8,7 @@ import gaphor.RAAML.diagramitems
 import gaphor.SysML.diagramitems
 import gaphor.UML.diagramitems
 from gaphor.core.modeling import Base
-from gaphor.core.modeling.properties import umlproperty
+from gaphor.core.modeling.properties import modelproperty
 
 
 def presentations(module):
@@ -44,7 +44,7 @@ def test_extract_presentations():
 def test_property_name_matches_assigned_name(element_type):
     for name in dir(element_type):
         prop = getattr(element_type, name)
-        if isinstance(prop, umlproperty):
+        if isinstance(prop, modelproperty):
             assert name == prop.name, (
                 f"No matching property name for {element_type}.{name}"
             )


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [ ] Feature
- [x] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

The base property for models is called `umlproperty`. This was an okay-ish name when we had only one model in use. Now with multiple models, and SysML v2 on the way, a more generic name would be better.

Also turn the "subsettable" feature into a mixin, allowing it to be applied to the appropriate types.

`umlproperty` is still there, for backwards compatibility.