### PR TITLE
Make shortcuts work inside the toolbox pane

### DIFF
--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -44,6 +44,15 @@ class Toolbox(UIComponent):
         self.event_manager.subscribe(self._on_diagram_item_placed)
         self.event_manager.subscribe(self._on_modeling_language_changed)
         self.event_manager.subscribe(self._on_current_diagram_changed)
+
+        ctrl = Gtk.EventControllerKey.new()
+        self._toolbox_container.add_controller(ctrl)
+
+        def on_shortcut(_ctrl, keyval, _keycode, state):
+            return self.activate_shortcut(keyval, state)
+
+        ctrl.connect("key-pressed", on_shortcut)
+
         self.select_tool("toolbox-pointer")
         return self._toolbox_container
 


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

When you select a tool in the toolbox with your mouse, you can not reset it (press `Esc`) or select another tool via the keyboard.

Issue Number: #3998 

### What is the new behavior?

Pressing a key when the toolbox has "focus" works the same as when a diagram has "focus".

