### PR TITLE
Fix issue where multiplicity could show as "None"

### DIFF
--- a/gaphor/UML/recipes.py
+++ b/gaphor/UML/recipes.py
@@ -514,7 +514,10 @@ def get_multiplicity_lower_value_as_string(
     """Get lower value of a multiplicity as a string."""
     if multiplicity.lowerValue is None:
         return None
-    if isinstance(multiplicity.lowerValue, LiteralInteger):
+    if (
+        isinstance(multiplicity.lowerValue, LiteralInteger)
+        and multiplicity.lowerValue.value is not None
+    ):
         return str(multiplicity.lowerValue.value)
     return None
 
@@ -555,7 +558,10 @@ def get_multiplicity_upper_value_as_string(
     """Get upper value of a multiplicity as a string."""
     if element.upperValue is None:
         return None
-    if isinstance(element.upperValue, LiteralUnlimitedNatural):
+    if (
+        isinstance(element.upperValue, LiteralUnlimitedNatural)
+        and element.upperValue.value is not None
+    ):
         return str(element.upperValue.value)
     return None
 

--- a/gaphor/UML/tests/test_umlfmt.py
+++ b/gaphor/UML/tests/test_umlfmt.py
@@ -90,6 +90,16 @@ def test_association_end(factory, text, name_part, mult_part):
     assert (name_part, mult_part) == format_association_end(a)
 
 
+def test_association_end_text_deleted(factory):
+    """Test simple attribute formatting."""
+    a = factory.create(UML.Property)
+    a.association = factory.create(UML.Association)
+    parse(a, "myattr[0..1]")
+    parse(a, "")
+
+    assert ("", "") == format_association_end(a)
+
+
 def test_attribute_with_type(factory):
     """Test simple attribute formatting."""
     a = factory.create(UML.Property)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Adding and removing text for an association shows multiplicity as `0..None`.

Issue Number: fixes #4144 

### What is the new behavior?

Multiplicity is shown as expected.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
