### PR TITLE
Cancel placement tool with right-button click

### DIFF
--- a/gaphor/diagram/event.py
+++ b/gaphor/diagram/event.py
@@ -1,9 +1,14 @@
+from dataclasses import dataclass
+
+
+@dataclass
 class ToolCompleted:
-    pass
+    cancelled: bool = False
 
 
 class DiagramItemPlaced(ToolCompleted):
     def __init__(self, item):
+        super().__init__(False)
         self.item = item
 
 

--- a/gaphor/diagram/tools/__init__.py
+++ b/gaphor/diagram/tools/__init__.py
@@ -11,6 +11,7 @@ from gaphor.diagram.tools.dropzone import drop_zone_tool
 from gaphor.diagram.tools.itemtool import find_item_and_handle_at_point, item_tool
 from gaphor.diagram.tools.magnet import magnet_tool
 from gaphor.diagram.tools.placement import placement_tool
+from gaphor.diagram.tools.reset import reset_tool
 from gaphor.diagram.tools.textedit import text_edit_tools
 from gaphor.diagram.tools.txtool import transactional_tool
 
@@ -35,6 +36,7 @@ def apply_magnet_tool_set(view, modeling_language, event_manager):
     view.add_controller(
         *transactional_tool(magnet_tool(event_manager), event_manager=event_manager)
     )
+    view.add_controller(reset_tool(event_manager))
     add_basic_tools(view, modeling_language, event_manager)
 
 
@@ -49,6 +51,7 @@ def apply_placement_tool_set(
             event_manager=event_manager,
         )
     )
+    view.add_controller(reset_tool(event_manager))
     view.add_controller(
         drop_zone_tool(item_factory.item_class, item_factory.subject_class)
     )

--- a/gaphor/diagram/tools/reset.py
+++ b/gaphor/diagram/tools/reset.py
@@ -1,0 +1,14 @@
+from gi.repository import Gtk
+
+from gaphor.diagram.event import ToolCompleted
+
+
+def reset_tool(event_manager):
+    click = Gtk.GestureClick.new()
+    click.set_button(3)
+    click.connect("released", on_released, event_manager)
+    return click
+
+
+def on_released(gesture, n_press: int, _x: float, _y: float, event_manager) -> None:
+    event_manager.handle(ToolCompleted(cancelled=True))

--- a/gaphor/ui/toolbox.py
+++ b/gaphor/ui/toolbox.py
@@ -159,8 +159,8 @@ class Toolbox(UIComponent):
                     self.event_manager.handle(ToolSelected(tool_name))
 
     @event_handler(ToolCompleted)
-    def _on_diagram_item_placed(self, event) -> None:
-        if settings.reset_tool_after_create:
+    def _on_diagram_item_placed(self, event: ToolCompleted) -> None:
+        if event.cancelled or settings.reset_tool_after_create:
             # Select tool from an idle handler, so the original tool can complete properly.
             GLib.idle_add(self.select_tool, "toolbox-pointer")
 


### PR DESCRIPTION

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [x] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Right-click when using a placement tool doesn't do anything.

Issue Number: fixes #3998

### What is the new behavior?

This is a shortcut, and alternative to pressing `Esc` and resets the mouse to the pointer tool.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
