### PR TITLE
Fix Chinese Simplified not mapped to translation

### DIFF
--- a/scripts/build_babel.py
+++ b/scripts/build_babel.py
@@ -2,6 +2,7 @@
 """Babel gettext helpers for Gaphor."""
 
 import json
+import shutil
 import subprocess
 import sys
 import urllib.request
@@ -42,6 +43,10 @@ def compile_mo_file(path: Path):
     )
     mo_path.parent.mkdir(parents=True, exist_ok=True)
     run_babel("compile", path, mo_path, path.stem)
+    if path.stem == "zh_Hans":
+        zh_cn = mo_path.parent.parent.parent / "zh_CN" / "LC_MESSAGES" / "gaphor.mo"
+        zh_cn.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(mo_path, zh_cn)
 
 
 def compile_mo_all():


### PR DESCRIPTION
Fixes #4303 by mapping zh_CN (the language_territory) from the OS to zh_Hans (the lagnugage_script) which is what Weblate uses.


### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
