### PR TITLE
Css change: Justify contet to start when nodes have items

### DIFF
--- a/gaphor/diagram.css
+++ b/gaphor/diagram.css
@@ -61,6 +61,10 @@ diagramframe {
   padding: 4;
 }
 
+:has(.item) compartment:first-child {
+  justify-content: start;
+}
+
 /* Relationships */
 
 commentline,


### PR DESCRIPTION
Only impact default visualization, css now dinamically change the name's justification when something is inside.


### PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [ x] I have read, and I understand the GNOME [Code of Conduct](https://conduct.gnome.org/)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

<img width="303" height="232" alt="image" src="https://github.com/user-attachments/assets/ea93612f-53ff-4a7d-98be-7f2f3369d776" />

Issue Number: N/A

### What is the new behavior?
<img width="296" height="244" alt="image" src="https://github.com/user-attachments/assets/873f7ce7-4ae5-4588-a6e8-27a48c28be90" />

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
