### PR TITLE
Fix window glitches on macOS

### DIFF
--- a/gaphor/ui/styling-macos.css
+++ b/gaphor/ui/styling-macos.css
@@ -15,7 +15,7 @@
 
 .csd {
   box-shadow: none;
-  border-radius: 0;
+  border-radius: 1px;
 }
 
 .csd:backdrop {


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix
- [ ] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?

Issue Number: #4245

### What is the new behavior?

We did set the border radius on macOS to 0.
Normally, with border radius > 0, a "Radius Corner" node is added to GTK's frame graph. With border radius == 0, no such node is added, casing Transform and Opacity nodes to end up at the top level. Somehow this interferes with the rendering on macOS. The simple solution is to set a small radius value.

### Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
